### PR TITLE
CMS: Reduced datasets become Derived datasets

### DIFF
--- a/invenio_opendata/base/fixtures/websearch.py
+++ b/invenio_opendata/base/fixtures/websearch.py
@@ -35,10 +35,10 @@ class CollectionData(DataSet):
         name = 'CMS Primary Dataset'
         dbquery = '980__a:"CMSPRIMARYDATASET"'
 
-    class CMSReducedDataset(siteCollection):
+    class CMSDerivedDataset(siteCollection):
         id = 4
-        name = 'CMS Reduced Dataset'
-        dbquery = '980__a:"CMSREDUCEDDATASET"'
+        name = 'CMS Derived Dataset'
+        dbquery = '980__a:"CMSDERIVEDDATASET"'
 
     class ALICE(siteCollection):
         id = 5
@@ -75,9 +75,9 @@ class CollectionCollectionData(DataSet):
         score = 0
         type = 'r'
 
-    class CMS_CMSReducedDataset:
+    class CMS_CMSDerivedDataset:
         dad = CollectionData.CMS
-        son = CollectionData.CMSReducedDataset
+        son = CollectionData.CMSDerivedDataset
         score = 1
         type = 'r'
 
@@ -174,7 +174,7 @@ class PortalboxData(DataSet):
         title = u'image'
 
     class Portalbox_7:
-        body = u'CMS Reduced Dataset.CMS Reduced Dataset.CMS Reduced Dataset.CMS Reduced Dataset.CMS Reduced Dataset.CMS Reduced Dataset.CMS Reduced Dataset.CMS Reduced Dataset.CMS Reduced Dataset.CMS Reduced Dataset'
+        body = u'CMS Derived Dataset.CMS Derived Dataset.CMS Derived Dataset.CMS Derived Dataset.CMS Derived Dataset.CMS Derived Dataset.CMS Derived Dataset.CMS Derived Dataset.CMS Derived Dataset.CMS Derived Dataset'
         id = 7
         title = u'description'
 
@@ -253,14 +253,14 @@ class CollectionPortalboxData(DataSet):
         position = u'r'
         id_portalbox = PortalboxData.Portalbox_7.ref('id')
         score = 100
-        id_collection = CollectionData.CMSReducedDataset.ref('id')
+        id_collection = CollectionData.CMSDerivedDataset.ref('id')
 
     class CollectionPortalbox_4_8_en:
         ln = u'en'
         position = u'r'
         id_portalbox = PortalboxData.Portalbox_8.ref('id')
         score = 100
-        id_collection = CollectionData.CMSReducedDataset.ref('id')
+        id_collection = CollectionData.CMSDerivedDataset.ref('id')
 
     class CollectionPortalbox_6_9_en:
         ln = u'en'

--- a/invenio_opendata/base/templates/helpers/collections_list.html
+++ b/invenio_opendata/base/templates/helpers/collections_list.html
@@ -15,14 +15,14 @@
 				</div>
 				<div class="details">
 					<span>Read more</span>
-				</div>	
+				</div>
 			</div>
 		</a>
 	</li>
 {% endmacro %}
 {% macro datasample_recbox(title, id, link=false, image='default.jpg') %}
 	<li class="col-md-4 col-xs-12 col-sm-6">
-		<a href="{{ url_for('record/'+id) if not link else link|safe}}">					
+		<a href="{{ url_for('record/'+id) if not link else link|safe}}">
 			<div class="recordbox">
 				<div class="top row">
 					<div class="col-md-2">
@@ -47,8 +47,8 @@
 	 <div class="tab-content">
 	 	<div class="tab-pane fade in active" id="CMS">
 	 		<ul class="row">
-	 			{% for r in cms %}	 				
-	 				{% if r['collections'][0]['primary'] in ['CMSREDUCEDDATASET','CMS'] %}
+	 			{% for r in cms %}
+	 				{% if r['collections'][0]['primary'] in ['CMSDERIVEDDATASET','CMS'] %}
 	 					{{ document_recbox(r['title']['title'], r['recid']|string) }}
 	 				{% elif r['collections'][0]['primary'] == 'CMSPRIMARYDATASET' %}
 						{{ datasample_recbox(r['title']['title'], r['recid']|string, image='img/opendata/ttbar-scaled.png' )  }}
@@ -110,9 +110,8 @@
 	</div>
 </div>
 
-<div class="collRecords">	
+<div class="collRecords">
 	<div class="container">
 			{{ record_samples(cms, alice) }}
 	</div>
 </div>
-

--- a/invenio_opendata/testsuite/data/cms/cms-derived-dataset-example.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-derived-dataset-example.xml
@@ -53,7 +53,7 @@
       <subfield code="c">could be Trigger</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
     </datafield>
   </record>
 </collection>

--- a/invenio_opendata/testsuite/data/cms/cms-derived-datasets.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-derived-datasets.xml
@@ -1,0 +1,33 @@
+<collection>
+  <record>
+    <datafield tag="100" ind1=" " ind2=" ">
+      <subfield code="a">CMS Collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Dimuon events with invariant mass range 2-5 GeV for public education and outreach</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="c">2012</subfield>
+    </datafield>
+    <datafield tag="500" ind1=" " ind2=" ">
+      <subfield code="a">The collaboration approved 2000 dimuon events around the J/psi for use in elabs and masterclasses. This document contains the necessary ig, csv, and root files for these use-cases.</subfield>
+    </datafield>
+    <datafield tag="653" ind1="1" ind2=" ">
+      <subfield code="9">CMS</subfield>
+      <subfield code="a">masterclass</subfield>
+    </datafield>
+    <datafield tag="653" ind1="1" ind2=" ">
+      <subfield code="9">CMS</subfield>
+      <subfield code="a">elab</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/dimuon_2-5GeV.json</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/dimuon_2-5GeV.csv</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml
@@ -13,7 +13,7 @@
       <subfield code="a">Example event display file for CMS BTau dataset</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=BTau.ig</subfield>
@@ -33,7 +33,7 @@
       <subfield code="a">Example event display file for CMS EGMonitor dataset</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=EGMonitor.ig</subfield>
@@ -53,7 +53,7 @@
       <subfield code="a">Example event display file for CMS Electron dataset</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=Electron.ig</subfield>
@@ -73,7 +73,7 @@
       <subfield code="a">Example event display file for CMS Jet dataset</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=Jet.ig</subfield>
@@ -93,7 +93,7 @@
       <subfield code="a">Example event display file for CMS JetMETTauMonitor dataset</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=JetMETTauMonitor.ig</subfield>
@@ -113,7 +113,7 @@
       <subfield code="a">Example event display file for CMS METFwd dataset</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=METFwd.ig</subfield>
@@ -133,7 +133,7 @@
       <subfield code="a">Example event display file for CMS Mu dataset</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=Mu.ig</subfield>
@@ -153,7 +153,7 @@
       <subfield code="a">Example event display file for CMS MuMonitor dataset</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=MuMonitor.ig</subfield>
@@ -173,7 +173,7 @@
       <subfield code="a">Example event display file for CMS MuOnia dataset</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=MuOnia.ig</subfield>
@@ -193,7 +193,7 @@
       <subfield code="a">Example event display file for CMS MultiJet dataset</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=MultiJet.ig</subfield>
@@ -213,7 +213,7 @@
       <subfield code="a">Example dataset for CMS Photon dataset</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
+      <subfield code="a">CMSDERIVEDDATASET</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=Photon.ig</subfield>

--- a/invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml
@@ -307,40 +307,4 @@
       <subfield code="a">CMSPRIMARYDATASET</subfield>
     </datafield>
   </record>
-  <record>
-    <controlfield tag="001">15</controlfield>
-    <datafield tag="024" ind1="7" ind2=" ">
-      <subfield code="2">DOI</subfield>
-      <subfield code="a">10.1234/EXAMPLE.HOHP.O0PH</subfield>
-    </datafield>
-    <datafield tag="100" ind1=" " ind2=" ">
-      <subfield code="a">CMS Collaboration</subfield>
-    </datafield>
-    <datafield tag="245" ind1=" " ind2=" ">
-      <subfield code="a">Dimuon events with invariant mass range 2-5 GeV for public education and outreach</subfield>
-    </datafield>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="c">2012</subfield>
-    </datafield>
-    <datafield tag="500" ind1=" " ind2=" ">
-      <subfield code="a">The collaboration approved 2000 dimuon events around the J/psi for use in elabs and masterclasses. This document contains the necessary ig, csv, and root files for these use-cases.</subfield>
-    </datafield>
-    <datafield tag="653" ind1="1" ind2=" ">
-      <subfield code="9">CMS</subfield>
-      <subfield code="a">masterclass</subfield>
-    </datafield>
-    <datafield tag="653" ind1="1" ind2=" ">
-      <subfield code="9">CMS</subfield>
-      <subfield code="a">elab</subfield>
-    </datafield>
-    <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/dimuon_2-5GeV.json</subfield>
-    </datafield>
-    <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/dimuon_2-5GeV.csv</subfield>
-    </datafield>
-    <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMSREDUCEDDATASET</subfield>
-    </datafield>
-  </record>
 </collection>


### PR DESCRIPTION
- Renames "CMS Reduced Dataset" to "CMS Derived Dataset".
  (closes #80)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
