### PR TITLE
tests: demo site population

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,8 @@ helper script and proceed as follows:
         CFG_INVENIO2_VIRTUAL_ENV=opendata \
         CFG_INVENIO2_DATABASE_USER=opendata \
         CFG_INVENIO2_DATABASE_NAME=opendata \
+        CFG_INVENIO2_DEMOSITE_POPULATE="-f invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml \
+                                        -f invenio_opendata/testsuite/data/cms/cms-derived-datasets.xml" \
         ./invenio2-kickstart --yes-i-know --yes-i-really-know
 
 * Thirdly, go brew some tee, come back in twenty minutes, enjoy!

--- a/invenio_opendata/testsuite/data/cms/cms-derived-dataset-example.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-derived-dataset-example.xml
@@ -1,6 +1,5 @@
 <collection>
   <record>
-    <controlfield tag="001">15</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.HOHP.O0PH</subfield>

--- a/invenio_opendata/testsuite/data/cms/cms-derived-datasets.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-derived-datasets.xml
@@ -21,10 +21,10 @@
       <subfield code="a">elab</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/dimuon_2-5GeV.json</subfield>
+      <subfield code="a">/home/vagrant/.virtualenvs/opendata/src/open-data.cern.ch/invenio_opendata/testsuite/data/cms/dimuon_2-5GeV.json</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/dimuon_2-5GeV.csv</subfield>
+      <subfield code="a">/home/vagrant/.virtualenvs/opendata/src/open-data.cern.ch/invenio_opendata/testsuite/data/cms/dimuon_2-5GeV.csv</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMSDERIVEDDATASET</subfield>

--- a/invenio_opendata/testsuite/data/cms/cms-primary-dataset-example.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-primary-dataset-example.xml
@@ -1,6 +1,5 @@
 <collection>
   <record>
-   <controlfield tag="001">1</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.VOMA.I3AE</subfield>

--- a/invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml
@@ -1,6 +1,5 @@
 <collection>
   <record>
-    <controlfield tag="001">1</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.VOMA.I3AE</subfield>
@@ -22,7 +21,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">2</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.ZOO6.EUCH</subfield>
@@ -44,7 +42,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">3</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.THA4.YUUH</subfield>
@@ -66,7 +63,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">4</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.SOOH.7LOO</subfield>
@@ -88,7 +84,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">5</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.PAGU.8OHN</subfield>
@@ -110,7 +105,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">6</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.VI0A.EVIE</subfield>
@@ -132,7 +126,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">7</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.TEEC.HI2O</subfield>
@@ -154,7 +147,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">8</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.QUE9.IO9D</subfield>
@@ -176,7 +168,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">9</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.EET8.BOOC</subfield>
@@ -198,7 +189,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">10</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.EJA9.OHRE</subfield>
@@ -220,7 +210,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">11</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.APEE.GE1M</subfield>
@@ -242,7 +231,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">12</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.WA8A.HQUA</subfield>
@@ -264,7 +252,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">13</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.UU2T.HOSU</subfield>
@@ -286,7 +273,6 @@
     </datafield>
   </record>
   <record>
-    <controlfield tag="001">14</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.SHOT.H5CA</subfield>


### PR DESCRIPTION
- Amends test suite demo data examples: removes `001` MARC tag, sets FFT
  local path to suite VM vagrant box.  This makes demo site population
  to work.
- Adds example how to call `invenio2-kickstart` accordingly.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
