### PR TITLE
CMS: fix for missing FFT in event display records

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml
@@ -38,6 +38,9 @@
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
     </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=BTau.ig</subfield>
+    </datafield>
   </record>
   <record>
   <controlfield tag="001">601</controlfield>
@@ -77,6 +80,9 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=EGMonitor.ig</subfield>
     </datafield>
   </record>
   <record>
@@ -118,6 +124,9 @@
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
     </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=Electron.ig</subfield>
+    </datafield>
   </record>
   <record>
   <controlfield tag="001">603</controlfield>
@@ -157,6 +166,9 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=Jet.ig</subfield>
     </datafield>
   </record>
   <record>
@@ -198,6 +210,9 @@
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
     </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=JetMETTauMonitor.ig</subfield>
+    </datafield>
   </record>
   <record>
   <controlfield tag="001">605</controlfield>
@@ -237,6 +252,9 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=METFwd.ig</subfield>
     </datafield>
   </record>
   <record>
@@ -278,6 +296,9 @@
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
     </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=Mu.ig</subfield>
+    </datafield>
   </record>
   <record>
   <controlfield tag="001">607</controlfield>
@@ -317,6 +338,9 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=MuMonitor.ig</subfield>
     </datafield>
   </record>
   <record>
@@ -358,6 +382,9 @@
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
     </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=MuOnia.ig</subfield>
+    </datafield>
   </record>
   <record>
   <controlfield tag="001">609</controlfield>
@@ -394,6 +421,9 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMSDERIVEDDATASET</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=MultiJet.ig</subfield>
     </datafield>
   </record>
   <record>
@@ -434,6 +464,9 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=Photon.ig</subfield>
     </datafield>
   </record>
 </collection>


### PR DESCRIPTION
- After recent merge of richer metadata for event display files
  (PR #102), the `FFT` tags are gone, meaning no "*.ig" files on the
  demo site.  This commit fixes the problem by adding them back.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
