### PR TITLE
CMS: correct event display file names

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml
@@ -40,6 +40,7 @@
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=BTau.ig</subfield>
+      <subfield code="n">BTau</subfield>
     </datafield>
   </record>
   <record>
@@ -83,6 +84,7 @@
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=EGMonitor.ig</subfield>
+      <subfield code="n">EGMonitor</subfield>
     </datafield>
   </record>
   <record>
@@ -126,6 +128,7 @@
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=Electron.ig</subfield>
+      <subfield code="n">Electron</subfield>
     </datafield>
   </record>
   <record>
@@ -169,6 +172,7 @@
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=Jet.ig</subfield>
+      <subfield code="n">Jet</subfield>
     </datafield>
   </record>
   <record>
@@ -212,6 +216,7 @@
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=JetMETTauMonitor.ig</subfield>
+      <subfield code="n">JetMETTauMonitor</subfield>
     </datafield>
   </record>
   <record>
@@ -255,6 +260,7 @@
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=METFwd.ig</subfield>
+      <subfield code="n">METFwd</subfield>
     </datafield>
   </record>
   <record>
@@ -298,6 +304,7 @@
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=Mu.ig</subfield>
+      <subfield code="n">Mu</subfield>
     </datafield>
   </record>
   <record>
@@ -341,6 +348,7 @@
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=MuMonitor.ig</subfield>
+      <subfield code="n">MuMonitor</subfield>
     </datafield>
   </record>
   <record>
@@ -384,6 +392,7 @@
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=MuOnia.ig</subfield>
+      <subfield code="n">MuOnia</subfield>
     </datafield>
   </record>
   <record>
@@ -424,6 +433,7 @@
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=MultiJet.ig</subfield>
+      <subfield code="n">MultiJet</subfield>
     </datafield>
   </record>
   <record>
@@ -467,6 +477,7 @@
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;version=1&amp;filename=Photon.ig</subfield>
+      <subfield code="n">Photon</subfield>
     </datafield>
   </record>
 </collection>


### PR DESCRIPTION
- Adds explicit file names as they are not detected well from CMS DocDB
  download URLs.  (closes #108)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
