### PR TITLE
CMS: EOS URI for derived PAT tuple records

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana.xml
@@ -1,6 +1,6 @@
 <collection>
   <record>
-  <controlfield tag="001">201</controlfield>
+    <controlfield tag="001">201</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.DERIVED.1234</subfield>
@@ -44,9 +44,33 @@
       <subfield code="a">/Mu/Run-2010B-Apr21ReReco-v1/AOD</subfield>
       <subfield code="w">9</subfield>
     </datafield>
-     <datafield tag="774" ind1=" " ind2=" ">
+    <datafield tag="774" ind1=" " ind2=" ">
       <subfield code="a">The data can be further analysed with the analysis example code available in</subfield>
       <subfield code="w">200</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/PATtuples/Mu_PAT_data_500files_1.root</subfield>
+      <subfield code="s">21574062582</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/PATtuples/Mu_PAT_data_500files_2.root</subfield>
+      <subfield code="s">20485419850</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/PATtuples/Mu_PAT_data_500files_3.root</subfield>
+      <subfield code="s">24166677571</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/PATtuples/Mu_PAT_data_500files_4.root</subfield>
+      <subfield code="s">26810149325</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/PATtuples/Mu_PAT_data_500files_5.root</subfield>
+      <subfield code="s">24718884897</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/PATtuples/Mu_PAT_data_500files_6.root</subfield>
+      <subfield code="s">17184641930</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMSDERIVEDDATASET</subfield>
@@ -55,7 +79,7 @@
       <subfield code="b">RESEARCH</subfield>
     </datafield>
   </record>
-    <record>
+  <record>
     <controlfield tag="001">202</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
@@ -100,9 +124,33 @@
       <subfield code="a">/Electron/Run-2010B-Apr21ReReco-v1/AOD</subfield>
       <subfield code="w">3</subfield>
     </datafield>
-     <datafield tag="774" ind1=" " ind2=" ">
+    <datafield tag="774" ind1=" " ind2=" ">
       <subfield code="a">The data can be further analysed with the analysis example code available in</subfield>
       <subfield code="w">200</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/PATtuples/Electron_PAT_data_500files_1.root</subfield>
+      <subfield code="s">12117591860</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/PATtuples/Electron_PAT_data_500files_2.root</subfield>
+      <subfield code="s">10585163531</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/PATtuples/Electron_PAT_data_500files_3.root</subfield>
+      <subfield code="s">11467675397</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/PATtuples/Electron_PAT_data_500files_4.root</subfield>
+      <subfield code="s">14426792142</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/PATtuples/Electron_PAT_data_500files_5.root</subfield>
+      <subfield code="s">13754970065</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/PATtuples/Electron_PAT_data_500files_6.root</subfield>
+      <subfield code="s">19878754480</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMSDERIVEDDATASET</subfield>


### PR DESCRIPTION
- Adds EOS URIs for CMS derived PAT tuple records.  (addresses #113)
- Indents whole XML file appropriately.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
