### PR TITLE
CMS: new tools record describing event displays

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ helper script and proceed as follows:
                                         -f invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana.xml \
                                         -f invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml \
                                         -f invenio_opendata/testsuite/data/cms/cms-tools-ana.xml \
+                                        -f invenio_opendata/testsuite/data/cms/cms-tools-ispy.xml \
                                         -f invenio_opendata/testsuite/data/cms/cms-tools-vm-image.xml \
                                         -e force-recids" \
         ./invenio2-kickstart --yes-i-know --yes-i-really-know

--- a/invenio_opendata/testsuite/data/cms/cms-tools-ispy.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-ispy.xml
@@ -1,0 +1,95 @@
+<collection>
+  <record>
+    <controlfield tag="001">550</controlfield>
+    <datafield tag="024" ind1="7" ind2=" ">
+      <subfield code="2">DOI</subfield>
+      <subfield code="a">10.1234/EXAMPLE.Eventdisplay.123</subfield>
+    </datafield>
+    <datafield tag="100" ind1=" " ind2=" ">
+      <subfield code="a">McCauley, Thomas</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Software to extract the event display format from the CMS primary data set</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2014</subfield>
+    </datafield>
+    <datafield tag="516" ind1=" " ind2=" ">
+      <subfield code="a">Use this with any of the CMS primary datasets</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">Software to extract the data for the browser-based event display for the CMS experiment</subfield>
+    </datafield>
+    <datafield tag="538" ind1=" " ind2=" ">
+      <subfield code="a">CMSSW_4_2_8 software with the CMS open data VM environemnt</subfield>
+      <subfield code="w">250</subfield>
+    </datafield>
+    <datafield tag="567" ind1=" " ind2=" ">
+      <subfield code="a">The software produces the objects to be displayed. The configuration file https://github.com/cms-outreach/ispy-analyzers/blob/Run2010B/python/ISpy_AOD_Producer_cff.py defines the objects to write out, which is done in the corresponding cc files in the src directory. No event selection, apart accepting only the validated runs, is applied..</subfield>
+    </datafield>
+    <datafield tag="583" ind1=" " ind2=" ">
+      <subfield code="a">Only the list of validated runs have been accepted:</subfield>
+      <subfield code="w">1000</subfield>
+    </datafield>
+    <datafield tag="710" ind1=" " ind2=" ">
+      <subfield code="g">CMS Collaboration</subfield>
+    </datafield>
+    <datafield tag="774" ind1=" " ind2=" ">
+      <subfield code="a">See the run instructions in https://github.com/cms-outreach/ispy-analyzers/blob/Run2010B/README.md</subfield>
+    </datafield>
+    <datafield tag="787" ind1=" " ind2=" ">
+      <subfield code="a">The output are files in json format</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">https://github.com/cms-outreach/ispy-analyzers/tree/Run2010B</subfield>
+      <subfield code="u">https://github.com/cms-outreach/ispy-services</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMSTOOL</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">555</controlfield>
+    <datafield tag="024" ind1="7" ind2=" ">
+      <subfield code="2">DOI</subfield>
+      <subfield code="a">10.1234/EXAMPLE.iSpy.123</subfield>
+    </datafield>
+    <datafield tag="100" ind1=" " ind2=" ">
+      <subfield code="a">McCauley, Thomas</subfield>
+      <subfield code="a">Hategan, Mihael</subfield>
+      <subfield code="a">Nguyen, Phong</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">iSpy</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2012</subfield>
+    </datafield>
+    <datafield tag="516" ind1=" " ind2=" ">
+      <subfield code="a">Use this with derived data in event display format</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">A browser-based event display for the CMS experiment</subfield>
+    </datafield>
+    <datafield tag="538" ind1=" " ind2=" ">
+      <subfield code="a">The application is written using JavaScript, HTML, and CSS. It reads a JSON event format and uses the JavaScript 3D rendering engine pre3d. The only requirement is a modern browser using HTML5 canvas.</subfield>
+    </datafield>
+    <datafield tag="710" ind1=" " ind2=" ">
+      <subfield code="g">CMS Collaboration</subfield>
+    </datafield>
+    <datafield tag="774" ind1=" " ind2=" ">
+      <subfield code="a">Download from https://github.com/cms-outreach/ispy-online</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMSTOOL</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Education</subfield>
+    </datafield>
+  </record>
+</collection>


### PR DESCRIPTION
- Adds new record to CMS Tools collection describing event display
  tools.  (addresses #34) (addresses #126) (addresses #58)
- Merge note: installation instructions amended accordingly.

Reviewed-by: Tibor Simko tibor.simko@cern.ch
