### PR TITLE
CMS: new collection of Validated Runs

### DIFF
--- a/invenio_opendata/base/fixtures/websearch.py
+++ b/invenio_opendata/base/fixtures/websearch.py
@@ -60,6 +60,11 @@ class CollectionData(DataSet):
         name = 'CMS Tools'
         dbquery = '980__a:"CMSTOOL"'
 
+    class CMSValidatedRuns(siteCollection):
+        id = 9
+        name = 'CMS Validated Runs'
+        dbquery = '980__a:"CMSVALIDATEDRUN"'
+
 
 class CollectionCollectionData(DataSet):
 


### PR DESCRIPTION
- Adds new collection "CMS Validated Runs".  Not attached in the
  collection tree anywhere so that it remains "hidden".  (addresses #34)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
