### PR TITLE
setup: new canonical collection names

### DIFF
--- a/invenio_opendata/base/fixtures/websearch.py
+++ b/invenio_opendata/base/fixtures/websearch.py
@@ -32,13 +32,19 @@ class CollectionData(DataSet):
 
     class CMSPrimaryDatasets(siteCollection):
         id = 3
-        name = 'CMS Primary Datasets'
+        name = 'CMSPrimaryDatasets'
         dbquery = '980__a:"CMSPRIMARYDATASET"'
+        names = {
+            ('en', 'ln'): u'CMS Primary Datasets',
+        }
 
     class CMSDerivedDatasets(siteCollection):
         id = 4
-        name = 'CMS Derived Datasets'
+        name = 'CMSDerivedDatasets'
         dbquery = '980__a:"CMSDERIVEDDATASET"'
+        names = {
+            ('en', 'ln'): u'CMS Derived Datasets',
+        }
 
     class ALICE(siteCollection):
         id = 5
@@ -47,23 +53,35 @@ class CollectionData(DataSet):
 
     class ALICESimplifiedDatasets(siteCollection):
         id = 6
-        name = 'ALICE Simplified Datasets'
+        name = 'ALICESimplifiedDatasets'
         dbquery = '980__a:"ALICESIMPLIFIEDDATASET"'
+        names = {
+            ('en', 'ln'): u'ALICE Simplified Datasets',
+        }
 
     class ALICEAnalyses(siteCollection):
         id = 7
-        name = 'ALICE Analyses'
+        name = 'ALICEAnalyses'
         dbquery = '980__a:"ALICEANALYSIS"'
+        names = {
+            ('en', 'ln'): u'ALICE Analyses',
+        }
 
     class CMSTools(siteCollection):
         id = 8
-        name = 'CMS Tools'
+        name = 'CMSTools'
         dbquery = '980__a:"CMSTOOL"'
+        names = {
+            ('en', 'ln'): u'CMS Tools',
+        }
 
     class CMSValidatedRuns(siteCollection):
         id = 9
-        name = 'CMS Validated Runs'
+        name = 'CMSValidatedRuns'
         dbquery = '980__a:"CMSVALIDATEDRUN"'
+        names = {
+            ('en', 'ln'): u'CMS Validated Runs',
+        }
 
 
 class CollectionCollectionData(DataSet):

--- a/invenio_opendata/base/templates/helpers/collections_list.html
+++ b/invenio_opendata/base/templates/helpers/collections_list.html
@@ -76,7 +76,7 @@
 	 				{% endfor %}
 	 			</ul>
 	 			<div class="seeall center-block">
-	 				<a href="{{ url_for('collection/CMS Tools') }}" class="col-md-12">SEE ALL</a>
+	 				<a href="{{ url_for('collection/CMSTools') }}" class="col-md-12">SEE ALL</a>
 	 			</div>
 	 		</div>
 	 	</div>

--- a/invenio_opendata/base/templates/research.html
+++ b/invenio_opendata/base/templates/research.html
@@ -37,7 +37,7 @@
 					</div>
 					<ul>
 						<li><a href="{{ url_for('VMs') }}">Working Environments</a><span class="fa fa-chevron-circle-right"></span></li>
-						<li><a href="{{ url_for('collection/CMS Tools') }}">Software & Tools</a><span class="fa fa-chevron-circle-right"></span></li>
+						<li><a href="{{ url_for('collection/CMSTools') }}">Software & Tools</a><span class="fa fa-chevron-circle-right"></span></li>
 					</ul>
 				</div>
 			</div>
@@ -76,5 +76,5 @@
 	<div class="slogan container">
 		<h3>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Aut incidunt pariatur repellat amet adipisci nostrum ex officia obcaecati illum dolorum, ipsum cumque molestiae aspernatur delectus enim numquam, tempora deleniti velit?</h3>
 	</div>
-</section>	
+</section>
 {% endblock body %}

--- a/invenio_opendata/base/views.py
+++ b/invenio_opendata/base/views.py
@@ -68,17 +68,17 @@ def index2():
 @blueprint.route('education', defaults={'exp':'all'})
 @blueprint.route('education/<string:exp>')
 def educate(exp):
-	cms_reclist = Collection.query.filter(Collection.name == 'CMS Derived Datasets').first_or_404().reclist
+	cms_reclist = Collection.query.filter(Collection.name == 'CMSDerivedDatasets').first_or_404().reclist
 	cms = []
 	for rec in cms_reclist[:6]:
 		cms.append(get_record(rec))
 
-	cmstools_reclist = Collection.query.filter(Collection.name == 'CMS Tools').first_or_404().reclist
+	cmstools_reclist = Collection.query.filter(Collection.name == 'CMSTools').first_or_404().reclist
 	cmstools = []
 	for tool in cmstools_reclist[:3]:
 		cmstools.append(get_record(tool))
 
-	alice_reclist = Collection.query.filter(Collection.name == 'ALICE Simplified Datasets').first_or_404().reclist
+	alice_reclist = Collection.query.filter(Collection.name == 'ALICESimplifiedDatasets').first_or_404().reclist
 	# alice_reclist = randomise(Collection.query.filter(Collection.name == 'ALICE Simplified Datasets').first_or_404().reclist, 6)
 	alice = []
 	for rec in alice_reclist[:6]:
@@ -92,17 +92,17 @@ def educate(exp):
 @blueprint.route('research', defaults={'exp':'all'})
 @blueprint.route('research/<string:exp>')
 def research(exp):
-	cms_reclist = Collection.query.filter(Collection.name == 'CMS Primary Datasets').first_or_404().reclist
+	cms_reclist = Collection.query.filter(Collection.name == 'CMSPrimaryDatasets').first_or_404().reclist
 	cms = []
 	for rec in cms_reclist[:6]:
 		cms.append(get_record(rec))
 
-	cmstools_reclist = Collection.query.filter(Collection.name == 'CMS Tools').first_or_404().reclist
+	cmstools_reclist = Collection.query.filter(Collection.name == 'CMSTools').first_or_404().reclist
 	cmstools = []
 	for tool in cmstools_reclist[:3]:
 		cmstools.append(get_record(tool))
 
-	alice_reclist = Collection.query.filter(Collection.name == 'ALICE Analyses').first_or_404().reclist
+	alice_reclist = Collection.query.filter(Collection.name == 'ALICEAnalyses').first_or_404().reclist
 	alice = []
 	for rec in alice_reclist[:6]:
 		alice.append(get_record(rec))


### PR DESCRIPTION
- Changes canonical collection names (hence URLs) to whitespace-less
  format.  Example: `/collection/CMSTools`.  (closes #131)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
