### PR TITLE
setup: canonical collection names with hyphens

### DIFF
--- a/invenio_opendata/base/fixtures/websearch.py
+++ b/invenio_opendata/base/fixtures/websearch.py
@@ -32,7 +32,7 @@ class CollectionData(DataSet):
 
     class CMSPrimaryDatasets(siteCollection):
         id = 3
-        name = 'CMSPrimaryDatasets'
+        name = 'CMS-Primary-Datasets'
         dbquery = '980__a:"CMSPRIMARYDATASET"'
         names = {
             ('en', 'ln'): u'CMS Primary Datasets',
@@ -40,7 +40,7 @@ class CollectionData(DataSet):
 
     class CMSDerivedDatasets(siteCollection):
         id = 4
-        name = 'CMSDerivedDatasets'
+        name = 'CMS-Derived-Datasets'
         dbquery = '980__a:"CMSDERIVEDDATASET"'
         names = {
             ('en', 'ln'): u'CMS Derived Datasets',
@@ -53,7 +53,7 @@ class CollectionData(DataSet):
 
     class ALICESimplifiedDatasets(siteCollection):
         id = 6
-        name = 'ALICESimplifiedDatasets'
+        name = 'ALICE-Simplified-Datasets'
         dbquery = '980__a:"ALICESIMPLIFIEDDATASET"'
         names = {
             ('en', 'ln'): u'ALICE Simplified Datasets',
@@ -61,7 +61,7 @@ class CollectionData(DataSet):
 
     class ALICEAnalyses(siteCollection):
         id = 7
-        name = 'ALICEAnalyses'
+        name = 'ALICE-Analyses'
         dbquery = '980__a:"ALICEANALYSIS"'
         names = {
             ('en', 'ln'): u'ALICE Analyses',
@@ -69,7 +69,7 @@ class CollectionData(DataSet):
 
     class CMSTools(siteCollection):
         id = 8
-        name = 'CMSTools'
+        name = 'CMS-Tools'
         dbquery = '980__a:"CMSTOOL"'
         names = {
             ('en', 'ln'): u'CMS Tools',
@@ -77,7 +77,7 @@ class CollectionData(DataSet):
 
     class CMSValidatedRuns(siteCollection):
         id = 9
-        name = 'CMSValidatedRuns'
+        name = 'CMS-Validated-Runs'
         dbquery = '980__a:"CMSVALIDATEDRUN"'
         names = {
             ('en', 'ln'): u'CMS Validated Runs',

--- a/invenio_opendata/base/templates/helpers/collections_list.html
+++ b/invenio_opendata/base/templates/helpers/collections_list.html
@@ -76,7 +76,7 @@
 	 				{% endfor %}
 	 			</ul>
 	 			<div class="seeall center-block">
-	 				<a href="{{ url_for('collection/CMSTools') }}" class="col-md-12">SEE ALL</a>
+	 				<a href="{{ url_for('collection/CMS-Tools') }}" class="col-md-12">SEE ALL</a>
 	 			</div>
 	 		</div>
 	 	</div>

--- a/invenio_opendata/base/templates/research.html
+++ b/invenio_opendata/base/templates/research.html
@@ -37,7 +37,7 @@
 					</div>
 					<ul>
 						<li><a href="{{ url_for('VMs') }}">Working Environments</a><span class="fa fa-chevron-circle-right"></span></li>
-						<li><a href="{{ url_for('collection/CMSTools') }}">Software & Tools</a><span class="fa fa-chevron-circle-right"></span></li>
+						<li><a href="{{ url_for('collection/CMS-Tools') }}">Software & Tools</a><span class="fa fa-chevron-circle-right"></span></li>
 					</ul>
 				</div>
 			</div>

--- a/invenio_opendata/base/views.py
+++ b/invenio_opendata/base/views.py
@@ -68,18 +68,18 @@ def index2():
 @blueprint.route('education', defaults={'exp':'all'})
 @blueprint.route('education/<string:exp>')
 def educate(exp):
-	cms_reclist = Collection.query.filter(Collection.name == 'CMSDerivedDatasets').first_or_404().reclist
+	cms_reclist = Collection.query.filter(Collection.name == 'CMS-Derived-Datasets').first_or_404().reclist
 	cms = []
 	for rec in cms_reclist[:6]:
 		cms.append(get_record(rec))
 
-	cmstools_reclist = Collection.query.filter(Collection.name == 'CMSTools').first_or_404().reclist
+	cmstools_reclist = Collection.query.filter(Collection.name == 'CMS-Tools').first_or_404().reclist
 	cmstools = []
 	for tool in cmstools_reclist[:3]:
 		cmstools.append(get_record(tool))
 
-	alice_reclist = Collection.query.filter(Collection.name == 'ALICESimplifiedDatasets').first_or_404().reclist
-	# alice_reclist = randomise(Collection.query.filter(Collection.name == 'ALICE Simplified Datasets').first_or_404().reclist, 6)
+	alice_reclist = Collection.query.filter(Collection.name == 'ALICE-Simplified-Datasets').first_or_404().reclist
+	# alice_reclist = randomise(Collection.query.filter(Collection.name == 'ALICE-Simplified-Datasets').first_or_404().reclist, 6)
 	alice = []
 	for rec in alice_reclist[:6]:
 		alice.append(get_record(rec))
@@ -92,17 +92,17 @@ def educate(exp):
 @blueprint.route('research', defaults={'exp':'all'})
 @blueprint.route('research/<string:exp>')
 def research(exp):
-	cms_reclist = Collection.query.filter(Collection.name == 'CMSPrimaryDatasets').first_or_404().reclist
+	cms_reclist = Collection.query.filter(Collection.name == 'CMS-Primary-Datasets').first_or_404().reclist
 	cms = []
 	for rec in cms_reclist[:6]:
 		cms.append(get_record(rec))
 
-	cmstools_reclist = Collection.query.filter(Collection.name == 'CMSTools').first_or_404().reclist
+	cmstools_reclist = Collection.query.filter(Collection.name == 'CMS-Tools').first_or_404().reclist
 	cmstools = []
 	for tool in cmstools_reclist[:3]:
 		cmstools.append(get_record(tool))
 
-	alice_reclist = Collection.query.filter(Collection.name == 'ALICEAnalyses').first_or_404().reclist
+	alice_reclist = Collection.query.filter(Collection.name == 'ALICE-Analyses').first_or_404().reclist
 	alice = []
 	for rec in alice_reclist[:6]:
 		alice.append(get_record(rec))


### PR DESCRIPTION
- Changes canonical collection names (hence URLs) once again to
  hyphenated forms for better readability.  Example:
  `/collection/CMSTools`.  (closes #131) (addresses #112)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
