### PR TITLE
CMS: typo fix `environemnt` in metadata

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-tools-ana.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-ana.xml
@@ -24,7 +24,7 @@
       <subfield code="a">Software to produce the intermediate data files, derived from the primary data sets, for a simple analysis on Z decays to two leptons and the ZZ decays to four leptons. </subfield>
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
-      <subfield code="a">CMSSW_4_2_8 software with the CMS open data VM environemnt</subfield>
+      <subfield code="a">CMSSW_4_2_8 software with the CMS open data VM environment</subfield>
       <subfield code="w">250</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
@@ -84,7 +84,7 @@
       <subfield code="a">Example code for a simple analysis on Z decays to two leptons and the ZZ decays to four leptons.</subfield>
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
-      <subfield code="a">CMSSW_4_2_8 software with the CMS open data VM environemnt</subfield>
+      <subfield code="a">CMSSW_4_2_8 software with the CMS open data VM environment</subfield>
       <subfield code="w">250</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">

--- a/invenio_opendata/testsuite/data/cms/cms-tools-ispy.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-ispy.xml
@@ -22,7 +22,7 @@
       <subfield code="a">Software to extract the data for the browser-based event display for the CMS experiment</subfield>
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
-      <subfield code="a">CMSSW_4_2_8 software with the CMS open data VM environemnt</subfield>
+      <subfield code="a">CMSSW_4_2_8 software with the CMS open data VM environment</subfield>
       <subfield code="w">250</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">


### PR DESCRIPTION
Signed-off-by: Tibor Simko tibor.simko@cern.ch
