### PR TITLE
testsuite: fix 001 and indentation in XML files

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml
@@ -1,6 +1,6 @@
 <collection>
   <record>
-  <controlfield tag="001">600</controlfield>
+    <controlfield tag="001">600</controlfield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">McCauley, Thomas</subfield>
     </datafield>
@@ -44,7 +44,7 @@
     </datafield>
   </record>
   <record>
-  <controlfield tag="001">601</controlfield>
+    <controlfield tag="001">601</controlfield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">McCauley, Thomas</subfield>
     </datafield>
@@ -88,7 +88,7 @@
     </datafield>
   </record>
   <record>
-  <controlfield tag="001">602</controlfield>
+    <controlfield tag="001">602</controlfield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">McCauley, Thomas</subfield>
     </datafield>
@@ -132,7 +132,7 @@
     </datafield>
   </record>
   <record>
-  <controlfield tag="001">603</controlfield>
+    <controlfield tag="001">603</controlfield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">McCauley, Thomas</subfield>
     </datafield>
@@ -176,7 +176,7 @@
     </datafield>
   </record>
   <record>
-  <controlfield tag="001">604</controlfield>
+    <controlfield tag="001">604</controlfield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">McCauley, Thomas</subfield>
     </datafield>
@@ -220,7 +220,7 @@
     </datafield>
   </record>
   <record>
-  <controlfield tag="001">605</controlfield>
+    <controlfield tag="001">605</controlfield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">McCauley, Thomas</subfield>
     </datafield>
@@ -264,7 +264,7 @@
     </datafield>
   </record>
   <record>
-  <controlfield tag="001">606</controlfield>
+    <controlfield tag="001">606</controlfield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">McCauley, Thomas</subfield>
     </datafield>
@@ -308,7 +308,7 @@
     </datafield>
   </record>
   <record>
-  <controlfield tag="001">607</controlfield>
+    <controlfield tag="001">607</controlfield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">McCauley, Thomas</subfield>
     </datafield>
@@ -352,7 +352,7 @@
     </datafield>
   </record>
   <record>
-  <controlfield tag="001">608</controlfield>
+    <controlfield tag="001">608</controlfield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">McCauley, Thomas</subfield>
     </datafield>
@@ -396,7 +396,7 @@
     </datafield>
   </record>
   <record>
-  <controlfield tag="001">609</controlfield>
+    <controlfield tag="001">609</controlfield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">McCauley, Thomas</subfield>
     </datafield>
@@ -437,7 +437,7 @@
     </datafield>
   </record>
   <record>
-  <controlfield tag="001">610</controlfield>
+    <controlfield tag="001">610</controlfield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">McCauley, Thomas</subfield>
     </datafield>

--- a/invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml
@@ -1,6 +1,6 @@
 <collection>
   <record>
-   <controlfield tag="001">1</controlfield>
+    <controlfield tag="001">1</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.VOMA.I3AE</subfield>
@@ -11,7 +11,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/BTau/Run-2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -35,7 +35,7 @@
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
-     <subfield code="a">Events stored in this primary data set were selected because of presence of more than one isolated tau in the event, or because of presence of low-energetic muons from b-quark decay.</subfield>
+      <subfield code="a">Events stored in this primary data set were selected because of presence of more than one isolated tau in the event, or because of presence of low-energetic muons from b-quark decay.</subfield>
     </datafield>
     <datafield tag="583" ind1=" " ind2=" ">
       <subfield code="a">During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, gamma, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:</subfield>
@@ -57,7 +57,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">13</controlfield>
+    <controlfield tag="001">13</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.SHOT.H5CA</subfield>
@@ -68,7 +68,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/ZeroBias/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -114,7 +114,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">2</controlfield>
+    <controlfield tag="001">2</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.ZOO6.EUCH</subfield>
@@ -125,7 +125,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/Commissioning/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -171,7 +171,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">3</controlfield>
+    <controlfield tag="001">3</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.THA4.YUUH</subfield>
@@ -182,7 +182,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/EGMonitor/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -228,7 +228,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">4</controlfield>
+    <controlfield tag="001">4</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.SOOH.7LOO</subfield>
@@ -239,7 +239,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/Electron/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -285,7 +285,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">5</controlfield>
+    <controlfield tag="001">5</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.PAGU.8OHN</subfield>
@@ -296,7 +296,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/Jet/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -342,7 +342,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">12</controlfield>
+    <controlfield tag="001">12</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.UU2T.HOSU</subfield>
@@ -353,7 +353,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/Photon/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -399,7 +399,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">11</controlfield>
+    <controlfield tag="001">11</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.WA8A.HQUA</subfield>
@@ -410,7 +410,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/MultiJet/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -456,7 +456,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">9</controlfield>
+    <controlfield tag="001">9</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.EJA9.OHRE</subfield>
@@ -467,7 +467,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/MuMonitor/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -513,7 +513,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">8</controlfield>
+    <controlfield tag="001">8</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.QUE9.IO9D</subfield>
@@ -524,7 +524,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/MinimumBias/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -570,7 +570,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">6</controlfield>
+    <controlfield tag="001">6</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.VI0A.EVIE</subfield>
@@ -581,7 +581,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/JetMETTauMonitor/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -627,7 +627,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">7</controlfield>
+    <controlfield tag="001">7</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.EET8.BOOC</subfield>
@@ -638,7 +638,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/METFwd/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -684,7 +684,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">10</controlfield>
+    <controlfield tag="001">10</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.SHAH.GH6O</subfield>
@@ -695,7 +695,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/MuOnia/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -741,7 +741,7 @@
     </datafield>
   </record>
   <record>
-   <controlfield tag="001">14</controlfield>
+    <controlfield tag="001">14</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.APEE.GE1M</subfield>
@@ -752,7 +752,7 @@
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">/Mu/Run2010B-Apr21ReReco-v1/AOD</subfield>
     </datafield>
-     <datafield tag="250" ind1=" " ind2=" ">
+    <datafield tag="250" ind1=" " ind2=" ">
       <subfield code="a">Release: CMSSW_4_2_1_patch1</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">

--- a/invenio_opendata/testsuite/data/cms/cms-tools-ana.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-ana.xml
@@ -1,6 +1,6 @@
 <collection>
   <record>
-  <controlfield tag="001">200</controlfield>
+    <controlfield tag="001">200</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.GITHUBCODE.123</subfield>
@@ -59,8 +59,8 @@
       <subfield code="b">Research</subfield>
     </datafield>
   </record>
-    <record>
-  <controlfield tag="001">101</controlfield>
+  <record>
+    <controlfield tag="001">101</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.1234/EXAMPLE.GITHUBCODE.234</subfield>
@@ -130,7 +130,7 @@ Each component is computed from Isodeposits in a cone of 0.3 around the muon dir
       <subfield code="a">The expected output is a histogram file</subfield>
       <subfield code="w">500</subfield>
     </datafield>
-     <datafield tag="774" ind1=" " ind2=" ">
+    <datafield tag="774" ind1=" " ind2=" ">
       <subfield code="a">See the run instructions in https://github.com/ayrodrig/OutreachExercise2010</subfield>
     </datafield>
     <datafield tag="856" ind1="4" ind2=" ">

--- a/invenio_opendata/testsuite/data/cms/cms-tools-vm-image.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-vm-image.xml
@@ -1,6 +1,6 @@
 <collection>
-<controlfield tag="001">250</controlfield>
   <record>
+    <controlfield tag="001">250</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS Collaboration</subfield>
     </datafield>


### PR DESCRIPTION
- Fixes misplaced `001` tag in `cms-tools-vm-image.xml`.
- Fixes XML indentation in all files.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
