### PR TITLE
templates: safer `record.{authors,title,abstract}`

### DIFF
--- a/invenio_opendata/base/templates/helpers/collections_list.html
+++ b/invenio_opendata/base/templates/helpers/collections_list.html
@@ -1,128 +1,128 @@
 {% macro document_recbox(title, id, author, description, collection, filenum, class='col-md-6', link=false, img_type='fa-file') %}
-	<li class="{{class}} col-xs-12 col-sm-6">
-			<div class="recordbox">
-				<div class="top col-md-12">
-					<a href="{{ url_for('record/'+id) if not link else link|safe}}"><h5>{{ title |safe }}</h5></a>
-				</div>
-				<div class="details col-md-12">
-					<ul class="row">
-						<li class="recbox-desc col-md-12">{{ description }}</li>
-						<li class="recbox-info col-md-12">
-							<div><span class="fa fa-user"></span>{{ author}}</div>
-							<div><span class="fa fa-folder-open"></span>{{ collection }}</div>
-							<div><span class="fa fa-file"></span>{{filenum}}</div>
-						</li>
-					</ul>
-				</div>
-			</div>
+        <li class="{{class}} col-xs-12 col-sm-6">
+                        <div class="recordbox">
+                                <div class="top col-md-12">
+                                        <a href="{{ url_for('record/'+id) if not link else link|safe}}"><h5>{{ title |safe }}</h5></a>
+                                </div>
+                                <div class="details col-md-12">
+                                        <ul class="row">
+                                                <li class="recbox-desc col-md-12">{{ description }}</li>
+                                                <li class="recbox-info col-md-12">
+                                                        <div><span class="fa fa-user"></span>{{ author}}</div>
+                                                        <div><span class="fa fa-folder-open"></span>{{ collection }}</div>
+                                                        <div><span class="fa fa-file"></span>{{filenum}}</div>
+                                                </li>
+                                        </ul>
+                                </div>
+                        </div>
 
-	</li>
+        </li>
 {% endmacro %}
 {% macro datasample_recbox(title, id, link=false, image='default.jpg') %}
-	<li class="col-md-4 col-xs-12 col-sm-6">
-		<a href="{{ url_for('record/'+id) if not link else link|safe}}">
-			<div class="recordbox">
-				<div class="top row">
-					<div class="col-md-2">
-						<span class="fa fa-database"></span>
-					</div>
-					<div class="col-md-10">
-						<h5>{{ title |safe }}</h5>
-					</div>
-				</div>
-				<div class="thumb">
-					<img src="{{ url_for('static', filename=image ) }}" alt="">
-				</div>
-				<div class="details">
-					<span>Read more</span>
-				</div>
-			</div>
-		</a>
-	</li>
+        <li class="col-md-4 col-xs-12 col-sm-6">
+                <a href="{{ url_for('record/'+id) if not link else link|safe}}">
+                        <div class="recordbox">
+                                <div class="top row">
+                                        <div class="col-md-2">
+                                                <span class="fa fa-database"></span>
+                                        </div>
+                                        <div class="col-md-10">
+                                                <h5>{{ title |safe }}</h5>
+                                        </div>
+                                </div>
+                                <div class="thumb">
+                                        <img src="{{ url_for('static', filename=image ) }}" alt="">
+                                </div>
+                                <div class="details">
+                                        <span>Read more</span>
+                                </div>
+                        </div>
+                </a>
+        </li>
 {% endmacro %}
 
 {% macro record_samples(cms, alice, cmstools, purpose, exp) %}
-	 <div class="tab-content">
-	 	<div class="tab-pane fade {%  if exp in ['CMS','all'] %}in active{% endif%}" id="CMS">
-	 		<div class="col-md-8 col-sm-12">
-	 			<div class="row">
-	 				<div class="title col-md-12">CMS Items</div>
-	 			</div>
-	 			<ul class="cms-list row">
-	 				{% for r in cms %}
-	 					{% if 'authors' in r %}
-							{{ document_recbox(r['title']['title'], r['recid']|string, r['authors'][0]['full_name'], r['abstract']['summary'], 'CMS Derived Datasets', r['files']|length) }}
-						{% elif '_first_corporate_name' in r %}
-							{{ document_recbox(r['title']['title'], r['recid']|string, r['_first_corporate_name']['name'], r['abstract']['summary'], 'CMS Derived Datasets', r['files']|length) }}
+         <div class="tab-content">
+                <div class="tab-pane fade {%  if exp in ['CMS','all'] %}in active{% endif%}" id="CMS">
+                        <div class="col-md-8 col-sm-12">
+                                <div class="row">
+                                        <div class="title col-md-12">CMS Items</div>
+                                </div>
+                                <ul class="cms-list row">
+                                        {% for r in cms %}
+                                                {% if 'authors' in r %}
+                                                        {{ document_recbox(r.get('title',{}).get('title',''), r['recid']|string, r.get('authors',[{}])[0].get('full_name',''), r.get('abstract',{}).get('summary',''), 'CMS Derived Datasets', r['files']|length) }}
+                                                {% elif '_first_corporate_name' in r %}
+                                                        {{ document_recbox(r.get('title',{}).get('title',''), r['recid']|string, r['_first_corporate_name']['name'], r.get('abstract',{}).get('summary',''), 'CMS Derived Datasets', r['files']|length) }}
 
-	 					{% endif %}
+                                                {% endif %}
 
-	 				{% endfor %}
-	 			</ul>
-	 			<div class="seeall center-block">
-	 				<a href="{{ url_for('collection/CMS') }}" class="col-md-12">SEE ALL</a>
-	 			</div>
-	 		</div>
-	 		<div class="col-md-4 col-sm-12">
-	 			<div class="row"><div class="title col-md-12">CMS Tools</div></div>
-	 			<ul class="row">
-	 				{% for t in cmstools %}
-	 				{% if 'comment' in t %}
-	 					{{ document_recbox(t['title']['title'], t['recid']|string, t['authors'][0]['full_name'],t['comment'] , 'CMS Tools', t['files']|length, "col-md-12" ) }}
-	 				{% else %}
-	 					{{ document_recbox(t['title']['title'], t['recid']|string, t['authors'][0]['full_name'], t['abstract']['summary'], 'CMS Tools', t['files']|length, "col-md-12" ) }}
-	 				{% endif%}
+                                        {% endfor %}
+                                </ul>
+                                <div class="seeall center-block">
+                                        <a href="{{ url_for('collection/CMS') }}" class="col-md-12">SEE ALL</a>
+                                </div>
+                        </div>
+                        <div class="col-md-4 col-sm-12">
+                                <div class="row"><div class="title col-md-12">CMS Tools</div></div>
+                                <ul class="row">
+                                        {% for t in cmstools %}
+                                        {% if 'comment' in t %}
+                                                {{ document_recbox(t.get('title',{}).get('title',''), t['recid']|string, t.get('authors',[{}])[0].get('full_name',''), t['comment'] , 'CMS Tools', t['files']|length, "col-md-12" ) }}
+                                        {% else %}
+                                                {{ document_recbox(t.get('title',{}).get('title',''), t['recid']|string, t.get('authors',[{}])[0].get('full_name',''), t.get('abstract',{}).get('summary',''), 'CMS Tools', t['files']|length, "col-md-12" ) }}
+                                        {% endif%}
 
-	 				{% endfor %}
-	 			</ul>
-	 			<div class="seeall center-block">
-	 				<a href="{{ url_for('collection/CMS-Tools') }}" class="col-md-12">SEE ALL</a>
-	 			</div>
-	 		</div>
-	 	</div>
-	 	<div class="tab-pane fade {%  if exp in ['ALICE'] %}in active{% endif%}" id="ALICE">
-	 		<ul class="row">
-	 			{% for r in alice %}
- 					{{ document_recbox(r['title']['title'], r['recid']|string, r['authors'][0]['full_name'], r['comment'], 'ALICE Analyses', r['files']|length) }}
-	 			{% endfor %}
-	 		</ul>
-	 		<div class="seeall">
-	 			<a href="{{ url_for('collection/ALICE') }}" class="col-md-2 col-md-offset-5">SEE ALL</a>
-	 		</div>
-	 	</div>
-	 </div>
+                                        {% endfor %}
+                                </ul>
+                                <div class="seeall center-block">
+                                        <a href="{{ url_for('collection/CMS-Tools') }}" class="col-md-12">SEE ALL</a>
+                                </div>
+                        </div>
+                </div>
+                <div class="tab-pane fade {%  if exp in ['ALICE'] %}in active{% endif%}" id="ALICE">
+                        <ul class="row">
+                                {% for r in alice %}
+                                        {{ document_recbox(r.get('title',{}).get('title',''), r['recid']|string, r.get('authors',[{}])[0].get('full_name',''), r['comment'], 'ALICE Analyses', r['files']|length) }}
+                                {% endfor %}
+                        </ul>
+                        <div class="seeall">
+                                <a href="{{ url_for('collection/ALICE') }}" class="col-md-2 col-md-offset-5">SEE ALL</a>
+                        </div>
+                </div>
+         </div>
 {% endmacro %}
 
 {% macro search_form() %}
-	{% block searchform %}
-	<div class="pull-right searchForm col-md-12">
-		<form action="{{ url_for('search') }}" method="get" name="searchForm" role="form" class="pull-right" id="searchForm">
-				<input type="text" name="p" placeholder="Looking for ..." class="form-control">
-				<button class="btn btn-search fa fa-search"></button>
-		</form>
-	</div>
-	{% endblock searchform %}
+        {% block searchform %}
+        <div class="pull-right searchForm col-md-12">
+                <form action="{{ url_for('search') }}" method="get" name="searchForm" role="form" class="pull-right" id="searchForm">
+                                <input type="text" name="p" placeholder="Looking for ..." class="form-control">
+                                <button class="btn btn-search fa fa-search"></button>
+                </form>
+        </div>
+        {% endblock searchform %}
 {% endmacro %}
 
 <!-- /////////// -->
 {% if show_navbar is sameas true %}
 <div class="nav collections-nav">
-	<div class="container">
-		<div class="row">
-			{% block leftside_actions %}
-			<ul class="pull-left col-md-7 nav nav-tabs" role="tablist">
-				<li {% if exp in ['CMS','all'] %} class="active" {% endif %}><a href="#CMS" role="tab" data-toggle="tab"></span>CMS</a></li>
-				<li {% if exp == 'ALICE' %} class="active" {% endif %}><a href="#ALICE" role="tab" data-toggle="tab"></span>ALICE</a></li>
-			</ul>
-			{% endblock leftside_actions %}
-		</div>
-	</div>
+        <div class="container">
+                <div class="row">
+                        {% block leftside_actions %}
+                        <ul class="pull-left col-md-7 nav nav-tabs" role="tablist">
+                                <li {% if exp in ['CMS','all'] %} class="active" {% endif %}><a href="#CMS" role="tab" data-toggle="tab"></span>CMS</a></li>
+                                <li {% if exp == 'ALICE' %} class="active" {% endif %}><a href="#ALICE" role="tab" data-toggle="tab"></span>ALICE</a></li>
+                        </ul>
+                        {% endblock leftside_actions %}
+                </div>
+        </div>
 </div>
 {% endif %}
 
 
 <div class="collRecords">
-	<div class="container">
-			{{ record_samples(cms, alice, cmstools, purpose, exp) }}
-	</div>
+        <div class="container">
+                        {{ record_samples(cms, alice, cmstools, purpose, exp) }}
+        </div>
 </div>

--- a/invenio_opendata/base/templates/records/ALICE-Analyses_metadata.html
+++ b/invenio_opendata/base/templates/records/ALICE-Analyses_metadata.html
@@ -1,65 +1,65 @@
 <div class="rec_header">
-	<div class="rec_details row">
-		<div class="title col-md-12">{{ record['title']['title'] }}<span>{{ record['imprint']['date']}}</span>
-		</div>
-		<div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
-			{% for auth in record['authors'] %}
-			<a href="#">{{ auth['full_name'] }}</a>
-			{% endfor %}
-		</div>
-	</div>
+        <div class="rec_details row">
+                <div class="title col-md-12">{{ record.get('title',{}).get('title','') }}<span>{{ record['imprint']['date']}}</span>
+                </div>
+                <div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
+                        {% for auth in record['authors'] %}
+                        <a href="#">{{ auth['full_name'] }}</a>
+                        {% endfor %}
+                </div>
+        </div>
 </div>
 <div class="rec_metadata rec_description">
-	<div class="row">
-		<div class="col-md-12">
-			<div class="rec_title title">Description</div>
-		</div>
-		<div class="col-md-12">
-			<div class="rec_desc">{{record['comment']}}</div>
-		</div>
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div class="rec_title title">Description</div>
+                </div>
+                <div class="col-md-12">
+                        <div class="rec_desc">{{record['comment']}}</div>
+                </div>
+        </div>
 </div>
 <div class="rec_metadata rec_preview">
-	<div class="row">
-		<div class="col-md-12">
-			<div class="rec_title title">Preview</div>
-		</div>
-		<div class="col-md-12">
-			<div class="rec_preview_box">
-				<iframe id="evd" width="100%" height="675" src="http://cern.ch/ispy-online"></iframe>
-			</div>
-		</div>
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div class="rec_title title">Preview</div>
+                </div>
+                <div class="col-md-12">
+                        <div class="rec_preview_box">
+                                <iframe id="evd" width="100%" height="675" src="http://cern.ch/ispy-online"></iframe>
+                        </div>
+                </div>
+        </div>
 </div>
 <div class="rec_metadata rec_files">
-	<div class="row">
-		<div class="col-md-12">
-			<div class="rec_title title">Files <a href="{{ url_for('record.files', recid=recid) }}">(see all files)</a></div>
-		</div>
-		<div class="col-md-12">
-			<div class="rec_file_box">
-				<ul class="row">
-					{% for file in record['files'] %}
-					<li class="col-md-4">
-						<div class="content_box">
-							<div class="row">
-								<div class="pull-left col-md-7">
-									<ul class="row">
-										<li class="col-md-12"><a href="{{file['url']}}">{{file['full_name']}}</a></li>
-										<li class="col-md-12"><b>Size:</b> {{ file['size'] | filesizeformat }}</li>
-										<li class="col-md-12"><b>Description:</b> {{ 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quaerat omnis laborum provident eveniet distinctio incidunt cupiditate'| truncate(50) }}</li>
-									</ul>
-								</div>
-								<div class="pull-right col-md-5">
-									<button class="btn">Download</button>
-									<button class="btn">Preview</button>
-								</div>
-							</div>
-						</div>
-					</li>
-					{% endfor %}
-				</ul>
-			</div>
-		</div>
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div class="rec_title title">Files <a href="{{ url_for('record.files', recid=recid) }}">(see all files)</a></div>
+                </div>
+                <div class="col-md-12">
+                        <div class="rec_file_box">
+                                <ul class="row">
+                                        {% for file in record['files'] %}
+                                        <li class="col-md-4">
+                                                <div class="content_box">
+                                                        <div class="row">
+                                                                <div class="pull-left col-md-7">
+                                                                        <ul class="row">
+                                                                                <li class="col-md-12"><a href="{{file['url']}}">{{file['full_name']}}</a></li>
+                                                                                <li class="col-md-12"><b>Size:</b> {{ file['size'] | filesizeformat }}</li>
+                                                                                <li class="col-md-12"><b>Description:</b> {{ 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quaerat omnis laborum provident eveniet distinctio incidunt cupiditate'| truncate(50) }}</li>
+                                                                        </ul>
+                                                                </div>
+                                                                <div class="pull-right col-md-5">
+                                                                        <button class="btn">Download</button>
+                                                                        <button class="btn">Preview</button>
+                                                                </div>
+                                                        </div>
+                                                </div>
+                                        </li>
+                                        {% endfor %}
+                                </ul>
+                        </div>
+                </div>
+        </div>
 </div>

--- a/invenio_opendata/base/templates/records/ALICE-Simplified-Datasets_metadata.html
+++ b/invenio_opendata/base/templates/records/ALICE-Simplified-Datasets_metadata.html
@@ -1,65 +1,65 @@
 <div class="rec_header">
-	<div class="rec_details row">
-		<div class="title col-md-12">{{ record['title']['title'] }}<span>{{ record['imprint']['date']}}</span>
-		</div>
-		<div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
-			{% for auth in record['authors'] %}
-			<a href="#">{{ auth['full_name'] }}</a>
-			{% endfor %}
-		</div>
-	</div>
+        <div class="rec_details row">
+                <div class="title col-md-12">{{ record.get('title',{}).get('title','') }}<span>{{ record['imprint']['date']}}</span>
+                </div>
+                <div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
+                        {% for auth in record['authors'] %}
+                        <a href="#">{{ auth['full_name'] }}</a>
+                        {% endfor %}
+                </div>
+        </div>
 </div>
 <div class="rec_metadata rec_description">
-	<div class="row">
-		<div class="col-md-12">
-			<div class="rec_title title">Description</div>
-		</div>
-		<div class="col-md-12">
-			<div class="rec_desc">{{record['comment']}}</div>
-		</div>
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div class="rec_title title">Description</div>
+                </div>
+                <div class="col-md-12">
+                        <div class="rec_desc">{{record['comment']}}</div>
+                </div>
+        </div>
 </div>
 <div class="rec_metadata rec_preview">
-	<div class="row">
-		<div class="col-md-12">
-			<div class="rec_title title">Preview</div>
-		</div>
-		<div class="col-md-12">
-			<div class="rec_preview_box">
-				<iframe id="evd" width="100%" height="675" src="http://cern.ch/ispy-online"></iframe>
-			</div>
-		</div>
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div class="rec_title title">Preview</div>
+                </div>
+                <div class="col-md-12">
+                        <div class="rec_preview_box">
+                                <iframe id="evd" width="100%" height="675" src="http://cern.ch/ispy-online"></iframe>
+                        </div>
+                </div>
+        </div>
 </div>
 <div class="rec_metadata rec_files">
-	<div class="row">
-		<div class="col-md-12">
-			<div class="rec_title title">Files <a href="{{ url_for('record.files', recid=recid) }}">(see all files)</a></div>
-		</div>
-		<div class="col-md-12">
-			<div class="rec_file_box">
-				<ul class="row">
-					{% for file in record['files'] %}
-					<li class="col-md-4">
-						<div class="content_box">
-							<div class="row">
-								<div class="pull-left col-md-7">
-									<ul class="row">
-										<li class="col-md-12"><a href="{{file['url']}}">{{file['full_name']}}</a></li>
-										<li class="col-md-12"><b>Size:</b> {{ file['size'] | filesizeformat }}</li>
-										<li class="col-md-12"><b>Description:</b> {{ 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quaerat omnis laborum provident eveniet distinctio incidunt cupiditate'| truncate(50) }}</li>
-									</ul>
-								</div>
-								<div class="pull-right col-md-5">
-									<button class="btn">Download</button>
-									<button class="btn">Preview</button>
-								</div>
-							</div>
-						</div>
-					</li>
-					{% endfor %}
-				</ul>
-			</div>
-		</div>
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div class="rec_title title">Files <a href="{{ url_for('record.files', recid=recid) }}">(see all files)</a></div>
+                </div>
+                <div class="col-md-12">
+                        <div class="rec_file_box">
+                                <ul class="row">
+                                        {% for file in record['files'] %}
+                                        <li class="col-md-4">
+                                                <div class="content_box">
+                                                        <div class="row">
+                                                                <div class="pull-left col-md-7">
+                                                                        <ul class="row">
+                                                                                <li class="col-md-12"><a href="{{file['url']}}">{{file['full_name']}}</a></li>
+                                                                                <li class="col-md-12"><b>Size:</b> {{ file['size'] | filesizeformat }}</li>
+                                                                                <li class="col-md-12"><b>Description:</b> {{ 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quaerat omnis laborum provident eveniet distinctio incidunt cupiditate'| truncate(50) }}</li>
+                                                                        </ul>
+                                                                </div>
+                                                                <div class="pull-right col-md-5">
+                                                                        <button class="btn">Download</button>
+                                                                        <button class="btn">Preview</button>
+                                                                </div>
+                                                        </div>
+                                                </div>
+                                        </li>
+                                        {% endfor %}
+                                </ul>
+                        </div>
+                </div>
+        </div>
 </div>

--- a/invenio_opendata/base/templates/records/CMS-Derived-Datasets_metadata.html
+++ b/invenio_opendata/base/templates/records/CMS-Derived-Datasets_metadata.html
@@ -1,65 +1,65 @@
 <div class="rec_header">
-	<div class="rec_details row">
-		<div class="title col-md-12">{{ record['title']['title'] }}<span>{{ record['imprint']['date']}}</span>
-		</div>
-		<div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
-			{% for auth in record['authors'] %}
-			<a href="#">{{ auth['full_name'] }}</a>
-			{% endfor %}
-		</div>
-	</div>
+        <div class="rec_details row">
+                <div class="title col-md-12">{{ record.get('title',{}).get('title','') }}<span>{{ record['imprint']['date']}}</span>
+                </div>
+                <div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
+                        {% for auth in record['authors'] %}
+                        <a href="#">{{ auth['full_name'] }}</a>
+                        {% endfor %}
+                </div>
+        </div>
 </div>
 <div class="rec_metadata rec_description">
-	<div class="row">
-		<div class="col-md-12">
-			<div class="rec_title title">Description</div>
-		</div>
-		<div class="col-md-12">
-			<div class="rec_desc">{{record['abstract']['summary']}}</div>
-		</div>
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div class="rec_title title">Description</div>
+                </div>
+                <div class="col-md-12">
+                        <div class="rec_desc">{{record.get('abstract',{}).get('summary','')}}</div>
+                </div>
+        </div>
 </div>
 <div class="rec_metadata rec_preview">
-	<div class="row">
-		<div class="col-md-12">
-			<div id="previewer" class="rec_title title">Preview</div>
-		</div>
-		<div class="col-md-12">
-			<div class="rec_preview_box">
-				<iframe id="evd" width="100%" height="675" src="http://cern.ch/ispy-online"></iframe>
-			</div>
-		</div>
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div id="previewer" class="rec_title title">Preview</div>
+                </div>
+                <div class="col-md-12">
+                        <div class="rec_preview_box">
+                                <iframe id="evd" width="100%" height="675" src="http://cern.ch/ispy-online"></iframe>
+                        </div>
+                </div>
+        </div>
 </div>
 <div class="rec_metadata rec_files">
-	<div class="row">
-		<div class="col-md-12">
-			<div class="rec_title title">Files <a href="{{ url_for('record.files', recid=recid) }}">(see all files)</a></div>
-		</div>
-		<div class="col-md-12">
-			<div class="rec_file_box">
-				<ul class="row">
-					{% for file in record['files'] %}
-					<li class="col-md-4">
-						<div class="content_box">
-							<div class="row">
-								<div class="pull-left col-md-7">
-									<ul class="row">
-										<li class="col-md-12"><a href="{{file['url']}}">{{file['full_name']}}</a></li>
-										<li class="col-md-12"><b>Size:</b> {{ file['size'] | filesizeformat }}</li>
-										<li class="col-md-12"><b>Description:</b> {{ 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quaerat omnis laborum provident eveniet distinctio incidunt cupiditate'| truncate(50) }}</li>
-									</ul>
-								</div>
-								<div class="pull-right col-md-5">
-        							<button class="btn" onClick="window.location.href='{{file["url"]}}'">Download</button>
-        							<button class="btn" onClick="window.location.href='#previewer'">Preview</button>
-								</div>
-							</div>
-						</div>
-					</li>
-					{% endfor %}
-				</ul>
-			</div>
-		</div>
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div class="rec_title title">Files <a href="{{ url_for('record.files', recid=recid) }}">(see all files)</a></div>
+                </div>
+                <div class="col-md-12">
+                        <div class="rec_file_box">
+                                <ul class="row">
+                                        {% for file in record['files'] %}
+                                        <li class="col-md-4">
+                                                <div class="content_box">
+                                                        <div class="row">
+                                                                <div class="pull-left col-md-7">
+                                                                        <ul class="row">
+                                                                                <li class="col-md-12"><a href="{{file['url']}}">{{file['full_name']}}</a></li>
+                                                                                <li class="col-md-12"><b>Size:</b> {{ file['size'] | filesizeformat }}</li>
+                                                                                <li class="col-md-12"><b>Description:</b> {{ 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quaerat omnis laborum provident eveniet distinctio incidunt cupiditate'| truncate(50) }}</li>
+                                                                        </ul>
+                                                                </div>
+                                                                <div class="pull-right col-md-5">
+                                                                <button class="btn" onClick="window.location.href='{{file["url"]}}'">Download</button>
+                                                                <button class="btn" onClick="window.location.href='#previewer'">Preview</button>
+                                                                </div>
+                                                        </div>
+                                                </div>
+                                        </li>
+                                        {% endfor %}
+                                </ul>
+                        </div>
+                </div>
+        </div>
 </div>

--- a/invenio_opendata/base/templates/records/CMS-Primary-Datasets_metadata.html
+++ b/invenio_opendata/base/templates/records/CMS-Primary-Datasets_metadata.html
@@ -1,74 +1,74 @@
 <div class="rec_header">
-	<div class="row rec_details">
-			<div>
-				<div class="title col-md-12">{{ record['title']['title'] }}<span>{{ record['imprint']['date']}}</span>
-				</div>
-				<div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
-					<kbd>{{ record['_first_corporate_name']['name'] }}</kbd>
-					{% for auth in record['authors'] %}
-					<a href="{{url_for('search', p='author:'+auth['last_name']+', '+auth['first_name'])}}">{{ auth['full_name'] }}</a>
-					{% endfor %}
-				</div>
-			</div>
-			<div class="col-md-12 ">
-				{% if record['doi'] %}
-				<div class="rec_thumb rec_doi">
-					<div class="n"><div class="t">DOI</div>{{ record['doi'] }}</div>
-				</div>
-				{% endif %}
-				<div class="rec_thumb rec_parentcol">
-					<div class="n"><div class="t">Parent Collection</div><a href="{{ url_for('collection/'+collection.name) }}">{{ collection.name }}</a></div>
-				</div>
-				<div class="rec_thumb rec_export">
-					{{ format_record(recid, of='HDACT', ln=g.ln)|safe }}
-				</div>
-			</div>
-	</div>
+        <div class="row rec_details">
+                        <div>
+                                <div class="title col-md-12">{{ record.get('title',{}).get('title','') }}<span>{{ record['imprint']['date']}}</span>
+                                </div>
+                                <div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
+                                        <kbd>{{ record['_first_corporate_name']['name'] }}</kbd>
+                                        {% for auth in record['authors'] %}
+                                        <a href="{{url_for('search', p='author:'+auth['last_name']+', '+auth['first_name'])}}">{{ auth['full_name'] }}</a>
+                                        {% endfor %}
+                                </div>
+                        </div>
+                        <div class="col-md-12 ">
+                                {% if record['doi'] %}
+                                <div class="rec_thumb rec_doi">
+                                        <div class="n"><div class="t">DOI</div>{{ record['doi'] }}</div>
+                                </div>
+                                {% endif %}
+                                <div class="rec_thumb rec_parentcol">
+                                        <div class="n"><div class="t">Parent Collection</div><a href="{{ url_for('collection/'+collection.name) }}">{{ collection.name }}</a></div>
+                                </div>
+                                <div class="rec_thumb rec_export">
+                                        {{ format_record(recid, of='HDACT', ln=g.ln)|safe }}
+                                </div>
+                        </div>
+        </div>
 </div>
 <div class="rec_metadata rec_description">
-	<div class="row">
-		<div class="col-md-12">
-			<div class="rec_title title">Description</div>
-		</div>
-		<div class="col-md-12">
-			<div class="rec_desc">{{record['abstract']['summary']}}</div>
-		</div>
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div class="rec_title title">Description</div>
+                </div>
+                <div class="col-md-12">
+                        <div class="rec_desc">{{record.get('abstract',{}).get('summary','')}}</div>
+                </div>
+        </div>
 </div>
 <div class="rec_metadata rec_files">
-	<div class="row">
-				<div class="col-md-12">
-			<div class="rec_title title">Files <a {% if 'files' in record %}class="disabled"{%endif%} href="{{ url_for('record.files', recid=recid) }}">(see all files)</a></div>
-		</div>
-		{% if record['files'] == [] %}
-			<div class="col-md-12" style="margin-top: 20px;font-size: 16px;color: #606D75;font-weight: 100;">The files can be accessed using the <a href="{{url_for('VMs')}}">Virtual Machine</a></div>
-		{% else %}
-		
-		<div class="col-md-12">
-			<div class="rec_file_box">
-				<ul class="row">
-					{% for file in record['files'] %}
-					<li class="col-md-4">
-						<div class="content_box">
-							<div class="row">
-								<div class="pull-left col-md-7">
-									<ul class="row">
-										<li class="col-md-12"><a href="{{file['url']}}">{{file['full_name']}}</a></li>
-										<li class="col-md-12"><b>Size:</b> {{ file['size'] | filesizeformat }}</li>
-										<li class="col-md-12"><b>Description:</b> {{ 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quaerat omnis laborum provident eveniet distinctio incidunt cupiditate'| truncate(50) }}</li>
-									</ul>
-								</div>
-								<div class="pull-right col-md-5">
-									<button class="btn">Download</button>
-									<button class="btn">Preview</button>
-								</div>
-							</div>
-						</div>
-					</li>
-					{% endfor %}
-				</ul>
-			</div>
-		</div>
-		{% endif %}
-	</div>
+        <div class="row">
+                                <div class="col-md-12">
+                        <div class="rec_title title">Files <a {% if 'files' in record %}class="disabled"{%endif%} href="{{ url_for('record.files', recid=recid) }}">(see all files)</a></div>
+                </div>
+                {% if record['files'] == [] %}
+                        <div class="col-md-12" style="margin-top: 20px;font-size: 16px;color: #606D75;font-weight: 100;">The files can be accessed using the <a href="{{url_for('VMs')}}">Virtual Machine</a></div>
+                {% else %}
+
+                <div class="col-md-12">
+                        <div class="rec_file_box">
+                                <ul class="row">
+                                        {% for file in record['files'] %}
+                                        <li class="col-md-4">
+                                                <div class="content_box">
+                                                        <div class="row">
+                                                                <div class="pull-left col-md-7">
+                                                                        <ul class="row">
+                                                                                <li class="col-md-12"><a href="{{file['url']}}">{{file['full_name']}}</a></li>
+                                                                                <li class="col-md-12"><b>Size:</b> {{ file['size'] | filesizeformat }}</li>
+                                                                                <li class="col-md-12"><b>Description:</b> {{ 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quaerat omnis laborum provident eveniet distinctio incidunt cupiditate'| truncate(50) }}</li>
+                                                                        </ul>
+                                                                </div>
+                                                                <div class="pull-right col-md-5">
+                                                                        <button class="btn">Download</button>
+                                                                        <button class="btn">Preview</button>
+                                                                </div>
+                                                        </div>
+                                                </div>
+                                        </li>
+                                        {% endfor %}
+                                </ul>
+                        </div>
+                </div>
+                {% endif %}
+        </div>
 </div>

--- a/invenio_opendata/base/templates/records/CMS-Tools_metadata.html
+++ b/invenio_opendata/base/templates/records/CMS-Tools_metadata.html
@@ -1,73 +1,73 @@
 <div class="rec_header">
-	<div class="row rec_details">
-			<div>
-				<div class="title col-md-12">{{ record['title']['title'] }}<span>{{ record['imprint']['date']}}</span>
-				</div>
-				<div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
-					{% for auth in record['authors'] %}
-					<a href="#">{{ auth['full_name'] }}</a>
-					{% endfor %}
-				</div>
-			</div>
-			<div class="col-md-12 ">
-				{% if record['doi'] %}
-				<div class="rec_thumb rec_doi">
-					<div class="n"><div class="t">DOI</div>{{ record['doi'] }}</div>
-				</div>
-				{% endif %}
-				<div class="rec_thumb rec_parentcol">
-					<div class="n"><div class="t">Parent Collection</div><a href="{{ url_for('collection/'+collection.name) }}">{{ collection.name }}</a></div>
-				</div>
-				<div class="rec_thumb rec_export">
-					{{ format_record(recid, of='HDACT', ln=g.ln)|safe }}
-				</div>
-			</div>
-	</div>
+        <div class="row rec_details">
+                        <div>
+                                <div class="title col-md-12">{{ record.get('title',{}).get('title','') }}<span>{{ record['imprint']['date']}}</span>
+                                </div>
+                                <div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
+                                        {% for auth in record['authors'] %}
+                                        <a href="#">{{ auth['full_name'] }}</a>
+                                        {% endfor %}
+                                </div>
+                        </div>
+                        <div class="col-md-12 ">
+                                {% if record['doi'] %}
+                                <div class="rec_thumb rec_doi">
+                                        <div class="n"><div class="t">DOI</div>{{ record['doi'] }}</div>
+                                </div>
+                                {% endif %}
+                                <div class="rec_thumb rec_parentcol">
+                                        <div class="n"><div class="t">Parent Collection</div><a href="{{ url_for('collection/'+collection.name) }}">{{ collection.name }}</a></div>
+                                </div>
+                                <div class="rec_thumb rec_export">
+                                        {{ format_record(recid, of='HDACT', ln=g.ln)|safe }}
+                                </div>
+                        </div>
+        </div>
 </div>
 <div class="rec_metadata rec_description">
-	<div class="row">
-		<div class="col-md-12">
-			<div class="rec_title title">Description</div>
-		</div>
-		<div class="col-md-12">
-			<div class="rec_desc">{{record['abstract']['summary']}}</div>
-		</div>
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div class="rec_title title">Description</div>
+                </div>
+                <div class="col-md-12">
+                        <div class="rec_desc">{{record.get('abstract', {}).get('summary', '')}}</div>
+                </div>
+        </div>
 </div>
 <div class="rec_metadata rec_files">
-	<div class="row">
-		<div class="col-md-12">
-			<div class="rec_title title">Files <a {% if 'files' in record %}class="disabled"{%endif%} href="{{ url_for('record.files', recid=recid) }}">(see all files)</a></div>
-		</div>
-		{% if record['files'] == [] %}
-			<div class="col-md-12" style="margin-top: 20px;font-size: 16px;color: #606D75;font-weight: 100;">There are no files for this record</div>
-		{% else %}
-		
-		<div class="col-md-12">
-			<div class="rec_file_box">
-				<ul class="row">
-					{% for file in record['files'] %}
-					<li class="col-md-4">
-						<div class="content_box">
-							<div class="row">
-								<div class="pull-left col-md-7">
-									<ul class="row">
-										<li class="col-md-12"><a href="{{file['url']}}">{{file['full_name']}}</a></li>
-										<li class="col-md-12"><b>Size:</b> {{ file['size'] | filesizeformat }}</li>
-										<li class="col-md-12"><b>Description:</b> {{ 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quaerat omnis laborum provident eveniet distinctio incidunt cupiditate'| truncate(50) }}</li>
-									</ul>
-								</div>
-								<div class="pull-right col-md-5">
-									<button class="btn">Download</button>
-									<button class="btn">Preview</button>
-								</div>
-							</div>
-						</div>
-					</li>
-					{% endfor %}
-				</ul>
-			</div>
-		</div>
-		{% endif %}
-	</div>
+        <div class="row">
+                <div class="col-md-12">
+                        <div class="rec_title title">Files <a {% if 'files' in record %}class="disabled"{%endif%} href="{{ url_for('record.files', recid=recid) }}">(see all files)</a></div>
+                </div>
+                {% if record['files'] == [] %}
+                        <div class="col-md-12" style="margin-top: 20px;font-size: 16px;color: #606D75;font-weight: 100;">There are no files for this record</div>
+                {% else %}
+
+                <div class="col-md-12">
+                        <div class="rec_file_box">
+                                <ul class="row">
+                                        {% for file in record['files'] %}
+                                        <li class="col-md-4">
+                                                <div class="content_box">
+                                                        <div class="row">
+                                                                <div class="pull-left col-md-7">
+                                                                        <ul class="row">
+                                                                                <li class="col-md-12"><a href="{{file['url']}}">{{file['full_name']}}</a></li>
+                                                                                <li class="col-md-12"><b>Size:</b> {{ file['size'] | filesizeformat }}</li>
+                                                                                <li class="col-md-12"><b>Description:</b> {{ 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quaerat omnis laborum provident eveniet distinctio incidunt cupiditate'| truncate(50) }}</li>
+                                                                        </ul>
+                                                                </div>
+                                                                <div class="pull-right col-md-5">
+                                                                        <button class="btn">Download</button>
+                                                                        <button class="btn">Preview</button>
+                                                                </div>
+                                                        </div>
+                                                </div>
+                                        </li>
+                                        {% endfor %}
+                                </ul>
+                        </div>
+                </div>
+                {% endif %}
+        </div>
 </div>

--- a/invenio_opendata/base/templates/records/files_base.html
+++ b/invenio_opendata/base/templates/records/files_base.html
@@ -24,103 +24,103 @@
 
 <div id="record_content">
 
-	<div class="rec_header">
-		<div class="row">
-			<div class="rec_details col-md-12">
-				<div class="row">
-					<div class="title col-md-12">{{ record['title']['title'] }}<span>{{ record['imprint']['date']}}</span></div>
-					<div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
-						{% for auth in record['authors'] %}
-						<a href="#">{{ auth['full_name'] }}</a>
-						{% endfor %}
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
-	<div class="rec_metadata rec_files pull-left">
-		<div class="row">
-      		<div class="col-md-12">
-        		<div class="rec_title title pull-left">Files</div>
-        		<div class="pull-right">
-					<div class="ch_display">
-						<button type="button" class="btn fa fa-th-large for-boxes"></button>
-						<button type="button" class="btn fa fa-th-list for-list"></button>
-					</div>
-				</div>
-        	</div>
-        	<div id="rec_files_boxes" class="rec_file_box col-md-12">
-        		<ul class="row">
-        			{% for file in record['files'] %}
-        			<li class="col-md-4">
-        				<div class="content_box col-md-12">
-        					<div class="row">
-        						<div class="recdet pull-left col-md-7 ">
-        							<ul class="row">
-        								<li class="rectitle col-md-12"><a href="{{file['url']}}">{{file['full_name']}}</a></li>
-        								<li class="recsize col-md-12"><b>Size:</b> {{ file['size'] | filesizeformat }}</li>
-        								<li class="recdesc col-md-12"><b>Description:</b> {{ 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quaerat omnis laborum provident eveniet distinctio incidunt cupiditate'| truncate(50) }}</li>
-        							</ul>
-        						</div>
-        						<div class="recbut pull-right col-md-5">
-        							<button class="btn" onClick="window.location.href='{{file["url"]}}'">Download</button>
-        							<button class="btn" onClick="window.location.href='#previewer'">Preview</button>
-        						</div>
-        					</div>
-        				</div>
-        			</li>
-        			{% endfor %}
-        		</ul>
-        	</div>
+        <div class="rec_header">
+                <div class="row">
+                        <div class="rec_details col-md-12">
+                                <div class="row">
+                                        <div class="title col-md-12">{{ record.get('title',{}).get('title','') }}<span>{{ record['imprint']['date']}}</span></div>
+                                        <div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
+                                                {% for auth in record['authors'] %}
+                                                <a href="#">{{ auth['full_name'] }}</a>
+                                                {% endfor %}
+                                        </div>
+                                </div>
+                        </div>
+                </div>
         </div>
-	</div>
+        <div class="rec_metadata rec_files pull-left">
+                <div class="row">
+                <div class="col-md-12">
+                        <div class="rec_title title pull-left">Files</div>
+                        <div class="pull-right">
+                                        <div class="ch_display">
+                                                <button type="button" class="btn fa fa-th-large for-boxes"></button>
+                                                <button type="button" class="btn fa fa-th-list for-list"></button>
+                                        </div>
+                                </div>
+                </div>
+                <div id="rec_files_boxes" class="rec_file_box col-md-12">
+                        <ul class="row">
+                                {% for file in record['files'] %}
+                                <li class="col-md-4">
+                                        <div class="content_box col-md-12">
+                                                <div class="row">
+                                                        <div class="recdet pull-left col-md-7 ">
+                                                                <ul class="row">
+                                                                        <li class="rectitle col-md-12"><a href="{{file['url']}}">{{file['full_name']}}</a></li>
+                                                                        <li class="recsize col-md-12"><b>Size:</b> {{ file['size'] | filesizeformat }}</li>
+                                                                        <li class="recdesc col-md-12"><b>Description:</b> {{ 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quaerat omnis laborum provident eveniet distinctio incidunt cupiditate'| truncate(50) }}</li>
+                                                                </ul>
+                                                        </div>
+                                                        <div class="recbut pull-right col-md-5">
+                                                                <button class="btn" onClick="window.location.href='{{file["url"]}}'">Download</button>
+                                                                <button class="btn" onClick="window.location.href='#previewer'">Preview</button>
+                                                        </div>
+                                                </div>
+                                        </div>
+                                </li>
+                                {% endfor %}
+                        </ul>
+                </div>
+        </div>
+        </div>
 
-	<div class="rec_metadata rec_preview">
-		<div class="row">
-			<div class="col-md-12">
-        		<div id="previewer"  class="rec_title title pull-left">Preview</div>
-        		<div class="pull-right">
-					<div class="ch_display">
-						<button type="button" class="btn fa fa-search-minus"></button>
-						<button type="button" class="btn fa fa-search-plus"></button>
-						<button type="button" class="btn fa fa-gear"></button>
-						<button type="button" class="btn fa fa-question"></button>
-					</div>
-				</div>
-        	</div>
-        	<div class="col-md-12">
-        		<div  class="rec_preview_box">
-        			<iframe id="evd" width="100%" height="675" src="http://cern.ch/ispy-online"></iframe>
-        		</div>
-        	</div>
-		</div>
-	</div>
+        <div class="rec_metadata rec_preview">
+                <div class="row">
+                        <div class="col-md-12">
+                        <div id="previewer"  class="rec_title title pull-left">Preview</div>
+                        <div class="pull-right">
+                                        <div class="ch_display">
+                                                <button type="button" class="btn fa fa-search-minus"></button>
+                                                <button type="button" class="btn fa fa-search-plus"></button>
+                                                <button type="button" class="btn fa fa-gear"></button>
+                                                <button type="button" class="btn fa fa-question"></button>
+                                        </div>
+                                </div>
+                </div>
+                <div class="col-md-12">
+                        <div  class="rec_preview_box">
+                                <iframe id="evd" width="100%" height="675" src="http://cern.ch/ispy-online"></iframe>
+                        </div>
+                </div>
+                </div>
+        </div>
 </div>
 {% endblock %}
 
 {%- block javascript %}
 <script type="text/javascript">
 $(function(){
-	$("#rec_authors_rdmore").readmore({
-		maxHeight: 20,
-		moreLink: '<div class="pull-left"><a href="" class="fa fa-caret-square-o-down"></a></div>',
-		lessLink: '<div class="pull-left"><a href="" class="fa fa-caret-square-o-up"></a></div>',
-	});
-	var forboxes = $(".for-boxes"),
-	forlist = $(".for-list"),
-	container = $("#rec_files_boxes");
+        $("#rec_authors_rdmore").readmore({
+                maxHeight: 20,
+                moreLink: '<div class="pull-left"><a href="" class="fa fa-caret-square-o-down"></a></div>',
+                lessLink: '<div class="pull-left"><a href="" class="fa fa-caret-square-o-up"></a></div>',
+        });
+        var forboxes = $(".for-boxes"),
+        forlist = $(".for-list"),
+        container = $("#rec_files_boxes");
 
-	forboxes.on("click", function(){
-		if (container.hasClass("display_list")){
-			container.removeClass("display_list")
-		}
-	});
+        forboxes.on("click", function(){
+                if (container.hasClass("display_list")){
+                        container.removeClass("display_list")
+                }
+        });
 
-	forlist.on("click", function(){
-		if (!container.hasClass("display_list") ){
-			container.addClass(" display_list");
-		}
-	});
+        forlist.on("click", function(){
+                if (!container.hasClass("display_list") ){
+                        container.addClass(" display_list");
+                }
+        });
 });
 </script>
 {% endblock %}

--- a/invenio_opendata/base/templates/records/metadata_base.html
+++ b/invenio_opendata/base/templates/records/metadata_base.html
@@ -27,7 +27,7 @@
     <div class="row">
       <div class="rec_details col-md-12">
         <div class="row">
-          <div class="title col-md-12">{{ record['title']['title'] }}<span>{{ record['imprint']['date']}}</span></div>
+          <div class="title col-md-12">{{ record.get('title',{}).get('title','') }}<span>{{ record['imprint']['date']}}</span></div>
           <div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
             {% for auth in record['authors'] %}
             <a href="#">{{ auth['full_name'] }}</a>


### PR DESCRIPTION
- Changes calls to record's authors, title, abstract values to safer
  defaults.  Notably, makes sure that in the absence of a field, an
  empty string is returned instead of an exception raised.  Note: could
  be generalised even further.  (closes #119)
- Untabifies touched template files as well.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
