### PR TITLE
templates: CMS Items -> CMS Datasets

### DIFF
--- a/invenio_opendata/base/templates/helpers/collections_list.html
+++ b/invenio_opendata/base/templates/helpers/collections_list.html
@@ -46,7 +46,7 @@
                 <div class="tab-pane fade {%  if exp in ['CMS','all'] %}in active{% endif%}" id="CMS">
                         <div class="col-md-8 col-sm-12">
                                 <div class="row">
-                                        <div class="title col-md-12">CMS Items</div>
+                                        <div class="title col-md-12">CMS Datasets</div>
                                 </div>
                                 <ul class="cms-list row">
                                         {% for r in cms %}


### PR DESCRIPTION
- Renames `CMS Items` to `CMS Datasets`.  (closes #155)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
