### PR TITLE
CMS: fix reuse information in primary datasets

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml
@@ -44,7 +44,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -101,7 +101,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -158,7 +158,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -215,7 +215,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -272,7 +272,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -329,7 +329,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -386,7 +386,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -443,7 +443,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -500,7 +500,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -557,7 +557,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -614,7 +614,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -671,7 +671,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -728,7 +728,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>
@@ -785,7 +785,7 @@
       <subfield code="u">http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf</subfield>
     </datafield>
     <datafield tag="774" ind1=" " ind2=" ">
-      <subfield code="a">For instructions on how to (re)use this data, please consult the following documentation: http://opendata.cern.ch/Achintya_s_getting_started.html</subfield>
+      <subfield code="a">See instructions in http://opendata.cern.ch/cms/getstarted</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2011</subfield>


### PR DESCRIPTION
- Fixes reuse information (tag `774`) in CMS Primary Datasets
  records.  (closes #149)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
