### PR TITLE
CMS: fix validated runs info in primary datasets

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml
@@ -31,7 +31,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -88,7 +88,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -145,7 +145,7 @@
       <subfield code="a">CC0 license</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -202,7 +202,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -259,7 +259,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -316,7 +316,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -373,7 +373,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -430,7 +430,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -487,7 +487,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -544,7 +544,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -601,7 +601,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -658,7 +658,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -715,7 +715,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
@@ -772,7 +772,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">The validation results can be found at</subfield>
+      <subfield code="a">This dataset contains all runs from 2010 RunB. The list of validated runs, which must be applied to all analyses, can be found in</subfield>
       <subfield code="w">1000</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">


### PR DESCRIPTION
- Fixes validated runs information (tag `556`) in CMS Primary Datasets
  records.  (closes #150)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
