### PR TITLE
UI: changed titles and links

### DIFF
--- a/invenio_opendata/base/static/css/record.css
+++ b/invenio_opendata/base/static/css/record.css
@@ -94,6 +94,9 @@
 #record_primary .rec_dedicated_details_in span {
   font-size: 30px;
 }
+#record_primary .rec_dedicated_details_in .collapsed span.fa-angle-up:before {
+  content: "\f107"
+}
 #record_primary .rec_dedicated_details_in.rdd-sel {
   background-color: #A2B2BD;
 }

--- a/invenio_opendata/base/templates/about_cms.html
+++ b/invenio_opendata/base/templates/about_cms.html
@@ -139,7 +139,7 @@
           <div class="about-box">
             <h2 class="col-md-12">Accessing the data and analysis tools</h2>
             <p class="col-md-12">The CMS data are available at different levels:</p>
-            <ol class="col-md-12">
+            <ul class="col-md-12">
               <li class="row">
                 <div class="col-md-12">1. Downloadable datasets</div>
                 <ul class="col-md-12">
@@ -171,7 +171,7 @@
                   <li>Can access remote data or downloaded local primary datasets</li>
                 </ul>
               </li>
-            </ol>
+            </ul>
           </div>
         </div>
 

--- a/invenio_opendata/base/templates/about_physics_objects.html
+++ b/invenio_opendata/base/templates/about_physics_objects.html
@@ -104,11 +104,11 @@
   <section class="infobar">
     <div class="container">
       <div class="pull-left">
-        <h3>External Resources</h3>
+        <h3>About CMS Physics Objects</h3>
       </div>
       <div class="pull-right">
         <ul class="exp-switch nav nav-tabs" role="tablist">
-          <li class="active"><a href="#CMS" role="tab" data-toggle="tab">CMS</a></li>
+          <li class="active r"><a href="#CMS" role="tab" data-toggle="tab">CMS</a></li>
         </ul>
       </div>
     </div>

--- a/invenio_opendata/base/templates/records/CMS-Primary-Datasets_dedicated.html
+++ b/invenio_opendata/base/templates/records/CMS-Primary-Datasets_dedicated.html
@@ -1,7 +1,7 @@
 <div class="row" style="margin: -25px -20px;">
   <div id="rec_dedicated_box" class="rec_dedicated_details col-md-12 panel-group">
     <div class="rec_dedicated_details_in rdd-sel panel">
-      <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How were these data selected?<span class="pull-right fa fa-angle-down"></span></div>
+      <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How were these data selected?<span class="pull-right fa fa-angle-up"></span></div>
       <div id="selection" class="info collapse">
         <div class="body">This data was selected by lorem ipsum dolor sit amet, consectetur adipisicing elit. Laborum repudiandae reiciendis modi sapiente amet.</div>
         <div class="links">
@@ -13,7 +13,7 @@
       </div>
     </div>
     <div class="rec_dedicated_details_in rdd-val panel">
-      <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">How were these data validated?<span class="pull-right fa fa-angle-down"></span></div>
+      <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">How were these data validated?<span class="pull-right fa fa-angle-up"></span></div>
       <div id="validation" class="info collapse">
         <div class="body">{{ record['action_note']['action'] }}</div>
         <div class="links"">
@@ -23,7 +23,7 @@
       </div>
     </div>
     <div class="rec_dedicated_details_in rdd-reuse panel">
-      <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#reusability">How can you use these data?<span class="pull-right fa fa-angle-down"></span></div>
+      <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#reusability">How can you use these data?<span class="pull-right fa fa-angle-up"></span></div>
       <div id="reusability" class="info collapse">
         <div class="links">
           <ul>
@@ -34,7 +34,7 @@
     </div>
     {% if record.get('documentation_note', '') %}
       <div class="rec_dedicated_details_in rdd-limits panel">
-        <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#limitations">Issues & Limitations<span class="pull-right fa fa-angle-down"></span></div>
+        <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#limitations">Issues & Limitations<span class="pull-right fa fa-angle-up"></span></div>
         <div id="limitations" class="info collapse">
           <div class="body">{{ record.get('documentation_note', {}).get('note', '') }}</div>
           <div class="links">

--- a/invenio_opendata/base/templates/records/CMS-Primary-Datasets_metadata.html
+++ b/invenio_opendata/base/templates/records/CMS-Primary-Datasets_metadata.html
@@ -41,7 +41,7 @@
       <div class="rec_title title">Files <a {% if 'files' in record %}class="disabled"{%endif%} href="{{ url_for('record.files', recid=recid) }}">(see all files)</a></div>
     </div>
     {% if record['files'] == [] %}
-      <div class="col-md-12" style="margin-top: 20px;font-size: 16px;color: #606D75;font-weight: 100;">The files can be accessed using the <a href="{{url_for('VMs')}}">Virtual Machine</a></div>
+      <div class="col-md-12" style="margin-top: 20px;font-size: 16px;color: #606D75;font-weight: 100;">The files can be accessed using the <a href="{{url_for('VM/CMS')}}">Virtual Machine</a></div>
     {% else %}
 
       <div class="col-md-12">

--- a/invenio_opendata/base/templates/records/CMS-Tools_dedicated.html
+++ b/invenio_opendata/base/templates/records/CMS-Tools_dedicated.html
@@ -1,8 +1,8 @@
 <div class="row" style="margin: -25px -20px;">
   <div id="rec_dedicated_box" class="rec_dedicated_details col-md-12 panel-group">
     <div class="rec_dedicated_details_in rdd-sel panel">
-      <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">Instructions<span class="pull-right fa fa-angle-down"></span></div>
-      <div id="selection" class="info ccollapse">
+      <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">Instructions<span class="pull-right fa fa-angle-up"></span></div>
+      <div id="selection" class="info collapse">
         <div class="body">This data was selected by lorem ipsum dolor sit amet, consectetur adipisicing elit. Laborum repudiandae reiciendis modi sapiente amet.</div>
         <div class="links">
           <ul>
@@ -13,8 +13,8 @@
       </div>
     </div>
     <div class="rec_dedicated_details_in rdd-val panel">
-      <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation<span class="pull-right fa fa-angle-down"></span></div>
-      <div id="validation" class="info ccollapse">
+      <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation<span class="pull-right fa fa-angle-up"></span></div>
+      <div id="validation" class="info collapse">
         <div class="body">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</div>
         <div class="links"">
           <ul>
@@ -26,8 +26,8 @@
     </div>
     {% if record.get('documentation_note', '') %}
       <div class="rec_dedicated_details_in rdd-limits panel">
-        <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#limitations">Issues & Limitations<span class="pull-right fa fa-angle-down"></span></div>
-        <div id="limitations" class="info ccollapse">
+        <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#limitations">Issues & Limitations<span class="pull-right fa fa-angle-up"></span></div>
+        <div id="limitations" class="info collapse">
           <div class="body">{{ record.get('documentation_note', {}).get('note', '') }}</div>
           <div class="links">
             {% if record.get('documentation_note.recid', '') %}


### PR DESCRIPTION
- “external resources” => “About CMS Physics Objects” (closes #171)
- “VM/CMS” link changed in Primary-Datasets (closes #178)
- FIXED double numbering in “about/CMS” (closes #179)
- FIXED up/down arrow on collapse/expand (closes #180)
