### PR TITLE
templates: propagation of "selection" information

### DIFF
--- a/invenio_opendata/base/templates/records/ALICE-Analyses_dedicated.html
+++ b/invenio_opendata/base/templates/records/ALICE-Analyses_dedicated.html
@@ -15,18 +15,21 @@
     </div>
   </div>
   <div id="rec_dedicated_box" class="rec_dedicated_details col-md-12 panel-group">
-    <div class="rec_dedicated_details_in rdd-sel panel">
-      <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How data is selected?</div>
-      <div id="selection" class="info  ccollapse">
-        <div class="body">This data was selected by lorem ipsum dolor sit amet, consectetur adipisicing elit. Laborum repudiandae reiciendis modi sapiente amet.</div>
-        <div class="links">
-          <ul>
-            <li><a href="#">Link 1</a></li>
-            <li><a href="#">Link2</a></li>
-          </ul>
+    {% if record.get('methodology_note', '') %}
+      <div class="rec_dedicated_details_in rdd-sel panel">
+        <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How were these data selected?</div>
+        <div id="selection" class="info  ccollapse">
+          <div class="body">{{ record.get('methodology_note', {}).get('note', '') }}</div>
+          {% if record.get('methodology_note.recid', '') %}
+            <div class="links">
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('methodology_note.recid', '')) }}">Record {{ record.get('methodology_note.recid', '') }}</a></li>
+              </ul>
+            </div>
+          {% endif %}
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="rec_dedicated_details_in rdd-val panel">
       <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
       <div id="validation" class="info ccollapse">

--- a/invenio_opendata/base/templates/records/ALICE-Simplified-Datasets_dedicated.html
+++ b/invenio_opendata/base/templates/records/ALICE-Simplified-Datasets_dedicated.html
@@ -15,18 +15,21 @@
     </div>
   </div>
   <div id="rec_dedicated_box" class="rec_dedicated_details col-md-12 panel-group">
-    <div class="rec_dedicated_details_in rdd-sel panel">
-      <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How data is selected?</div>
-      <div id="selection" class="info  ccollapse">
-        <div class="body">This data was selected by lorem ipsum dolor sit amet, consectetur adipisicing elit. Laborum repudiandae reiciendis modi sapiente amet.</div>
-        <div class="links">
-          <ul>
-            <li><a href="#">Link 1</a></li>
-            <li><a href="#">Link2</a></li>
-          </ul>
+    {% if record.get('methodology_note', '') %}
+      <div class="rec_dedicated_details_in rdd-sel panel">
+        <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How were these data selected?</div>
+        <div id="selection" class="info  ccollapse">
+          <div class="body">{{ record.get('methodology_note', {}).get('note', '') }}</div>
+          <div class="links">
+            {% if record.get('methodology_note.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('methodology_note.recid', '')) }}">Record {{ record.get('methodology_note.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="rec_dedicated_details_in rdd-val panel">
       <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
       <div id="validation" class="info ccollapse">

--- a/invenio_opendata/base/templates/records/CMS-Derived-Datasets_dedicated.html
+++ b/invenio_opendata/base/templates/records/CMS-Derived-Datasets_dedicated.html
@@ -15,18 +15,21 @@
     </div>
   </div>
   <div id="rec_dedicated_box" class="rec_dedicated_details col-md-12 panel-group">
-    <div class="rec_dedicated_details_in rdd-sel panel">
-      <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How were these data selected?</div>
-      <div id="selection" class="info  ccollapse">
-        <div class="body">This data was selected by lorem ipsum dolor sit amet, consectetur adipisicing elit. Laborum repudiandae reiciendis modi sapiente amet.</div>
-        <div class="links">
-          <ul>
-            <li><a href="#">Link 1</a></li>
-            <li><a href="#">Link2</a></li>
-          </ul>
+    {% if record.get('methodology_note', '') %}
+      <div class="rec_dedicated_details_in rdd-sel panel">
+        <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How were these data selected?</div>
+        <div id="selection" class="info  ccollapse">
+          <div class="body">{{ record.get('methodology_note', {}).get('note', '') }}</div>
+          <div class="links">
+            {% if record.get('methodology_note.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('methodology_note.recid', '')) }}">Record {{ record.get('methodology_note.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="rec_dedicated_details_in rdd-val panel">
       <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
       <div id="validation" class="info ccollapse">

--- a/invenio_opendata/base/templates/records/CMS-Primary-Datasets_dedicated.html
+++ b/invenio_opendata/base/templates/records/CMS-Primary-Datasets_dedicated.html
@@ -1,17 +1,20 @@
 <div class="row" style="margin: -25px -20px;">
   <div id="rec_dedicated_box" class="rec_dedicated_details col-md-12 panel-group">
-    <div class="rec_dedicated_details_in rdd-sel panel">
-      <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How were these data selected?<span class="pull-right fa fa-angle-up"></span></div>
-      <div id="selection" class="info collapse">
-        <div class="body">This data was selected by lorem ipsum dolor sit amet, consectetur adipisicing elit. Laborum repudiandae reiciendis modi sapiente amet.</div>
-        <div class="links">
-          <ul>
-            <li><a href="#">Link 1</a></li>
-            <li><a href="#">Link2</a></li>
-          </ul>
+    {% if record.get('methodology_note', '') %}
+      <div class="rec_dedicated_details_in rdd-sel panel">
+        <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How were these data selected?<span class="pull-right fa fa-angle-up"></span></div>
+        <div id="selection" class="info collapse">
+          <div class="body">{{ record.get('methodology_note', {}).get('note', '') }}</div>
+          <div class="links">
+            {% if record.get('methodology_note.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('methodology_note.recid', '')) }}">Record {{ record.get('methodology_note.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="rec_dedicated_details_in rdd-val panel">
       <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">How were these data validated?<span class="pull-right fa fa-angle-up"></span></div>
       <div id="validation" class="info collapse">

--- a/invenio_opendata/base/templates/records/CMS-Tools_dedicated.html
+++ b/invenio_opendata/base/templates/records/CMS-Tools_dedicated.html
@@ -1,17 +1,20 @@
 <div class="row" style="margin: -25px -20px;">
   <div id="rec_dedicated_box" class="rec_dedicated_details col-md-12 panel-group">
-    <div class="rec_dedicated_details_in rdd-sel panel">
-      <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">Instructions<span class="pull-right fa fa-angle-up"></span></div>
-      <div id="selection" class="info collapse">
-        <div class="body">This data was selected by lorem ipsum dolor sit amet, consectetur adipisicing elit. Laborum repudiandae reiciendis modi sapiente amet.</div>
-        <div class="links">
-          <ul>
-            <li><a href="#">Link 1</a></li>
-            <li><a href="#">Link2</a></li>
-          </ul>
+    {% if record.get('methodology_note', '') %}
+      <div class="rec_dedicated_details_in rdd-sel panel">
+        <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">Instructions<span class="pull-right fa fa-angle-up"></span></div>
+        <div id="selection" class="info collapse">
+          <div class="body">{{ record.get('methodology_note', {}).get('note', '') }}</div>
+          <div class="links">
+            {% if record.get('methodology_note.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('methodology_note.recid', '')) }}">Record {{ record.get('methodology_note.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="rec_dedicated_details_in rdd-val panel">
       <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation<span class="pull-right fa fa-angle-up"></span></div>
       <div id="validation" class="info collapse">

--- a/invenio_opendata/base/templates/records/base_base.html
+++ b/invenio_opendata/base/templates/records/base_base.html
@@ -92,18 +92,21 @@
           </div>
         </div>
         <div id="rec_dedicated_box" class="rec_dedicated_details col-md-12 panel-group">
-          <div class="rec_dedicated_details_in rdd-sel panel">
-            <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How data is selected?</div>
-            <div id="selection" class="info  ccollapse">
-              <div class="body">This data was selected by lorem ipsum dolor sit amet, consectetur adipisicing elit. Laborum repudiandae reiciendis modi sapiente amet.</div>
-              <div class="links">
-                <ul>
-                  <li><a href="#">Link 1</a></li>
-                  <li><a href="#">Link2</a></li>
-                </ul>
+          {% if record.get('methodology_note', '') %}
+            <div class="rec_dedicated_details_in rdd-sel panel">
+              <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How these data were selected?</div>
+              <div id="selection" class="info  ccollapse">
+                <div class="body">{{ record.get('methodology_note', {}).get('note', '') }}</div>
+                <div class="links">
+                  {% if record.get('methodology_note.recid', '') %}
+                    <ul>
+                      <li><a href="{{ url_for('record.metadata', recid=record.get('methodology_note.recid', '')) }}">Record {{ record.get('methodology_note.recid', '') }}</a></li>
+                    </ul>
+                  {% endif %}
+                </div>
               </div>
             </div>
-          </div>
+          {% endif %}
           <div class="rec_dedicated_details_in rdd-val panel">
             <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
             <div id="validation" class="info ccollapse">


### PR DESCRIPTION
- Propagates "selection" metadata information (taken from JSON field
  `methodology_note` aka MARC tag `567`) into various detailed record
  page templates.  (addresses #120)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
