### PR TITLE
templates: propagation of "validation" information

### DIFF
--- a/invenio_opendata/base/templates/records/ALICE-Analyses_dedicated.html
+++ b/invenio_opendata/base/templates/records/ALICE-Analyses_dedicated.html
@@ -30,18 +30,28 @@
         </div>
       </div>
     {% endif %}
-    <div class="rec_dedicated_details_in rdd-val panel">
-      <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
-      <div id="validation" class="info ccollapse">
-        <div class="body">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</div>
-        <div class="links"">
-          <ul>
-            <li><a href="#">Link 1</a></li>
-            <li><a href="#">Link2</a></li>
-          </ul>
+    {% if record.get('action_note', '') %}
+      <div class="rec_dedicated_details_in rdd-val panel">
+        <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
+        <div id="validation" class="info ccollapse">
+          <div class="body">{{ record.get('action_note', {}).get('action', '') }}</div>
+          <div class="links"">
+            {% if record.get('action_note.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('action_note.recid', '')) }}">Record {{ record.get('action_note.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+            {% if record.get('action_note.url', '') %}
+              <ul>
+                {% for u in record.get('action_note').get('url', []) %}
+                  <li><a href="{{ u }}">{{ u }}</a></li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="rec_dedicated_details_in rdd-reuse panel">
       <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#reusability">How to reuse?</div>
       <div id="reusability" class="info ccollapse">

--- a/invenio_opendata/base/templates/records/ALICE-Simplified-Datasets_dedicated.html
+++ b/invenio_opendata/base/templates/records/ALICE-Simplified-Datasets_dedicated.html
@@ -30,18 +30,28 @@
         </div>
       </div>
     {% endif %}
-    <div class="rec_dedicated_details_in rdd-val panel">
-      <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
-      <div id="validation" class="info ccollapse">
-        <div class="body">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</div>
-        <div class="links"">
-          <ul>
-            <li><a href="#">Link 1</a></li>
-            <li><a href="#">Link2</a></li>
-          </ul>
+    {% if record.get('action_note', '') %}
+      <div class="rec_dedicated_details_in rdd-val panel">
+        <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
+        <div id="validation" class="info ccollapse">
+          <div class="body">{{ record.get('action_note', {}).get('action', '') }}</div>
+          <div class="links"">
+            {% if record.get('action_note.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('action_note.recid', '')) }}">Record {{ record.get('action_note.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+            {% if record.get('action_note.url', '') %}
+              <ul>
+                {% for u in record.get('action_note').get('url', []) %}
+                  <li><a href="{{ u }}">{{ u }}</a></li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="rec_dedicated_details_in rdd-reuse panel">
       <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#reusability">How to reuse?</div>
       <div id="reusability" class="info ccollapse">

--- a/invenio_opendata/base/templates/records/CMS-Derived-Datasets_dedicated.html
+++ b/invenio_opendata/base/templates/records/CMS-Derived-Datasets_dedicated.html
@@ -30,18 +30,28 @@
         </div>
       </div>
     {% endif %}
-    <div class="rec_dedicated_details_in rdd-val panel">
-      <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
-      <div id="validation" class="info ccollapse">
-        <div class="body">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</div>
-        <div class="links"">
-          <ul>
-            <li><a href="#">Link 1</a></li>
-            <li><a href="#">Link2</a></li>
-          </ul>
+    {% if record.get('action_note', '') %}
+      <div class="rec_dedicated_details_in rdd-val panel">
+        <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
+        <div id="validation" class="info ccollapse">
+          <div class="body">{{ record.get('action_note', {}).get('action', '') }}</div>
+          <div class="links"">
+            {% if record.get('action_note.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('action_note.recid', '')) }}">Record {{ record.get('action_note.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+            {% if record.get('action_note.url', '') %}
+              <ul>
+                {% for u in record.get('action_note').get('url', []) %}
+                  <li><a href="{{ u }}">{{ u }}</a></li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="rec_dedicated_details_in rdd-reuse panel">
       <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#reusability">How can you use these data?</div>
       <div id="reusability" class="info ccollapse">

--- a/invenio_opendata/base/templates/records/CMS-Primary-Datasets_dedicated.html
+++ b/invenio_opendata/base/templates/records/CMS-Primary-Datasets_dedicated.html
@@ -15,16 +15,28 @@
         </div>
       </div>
     {% endif %}
-    <div class="rec_dedicated_details_in rdd-val panel">
-      <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">How were these data validated?<span class="pull-right fa fa-angle-up"></span></div>
-      <div id="validation" class="info collapse">
-        <div class="body">{{ record['action_note']['action'] }}</div>
-        <div class="links"">
-          <ul>
-          </ul>
+    {% if record.get('action_note', '') %}
+      <div class="rec_dedicated_details_in rdd-val panel">
+        <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">How were these data validated?<span class="pull-right fa fa-angle-up"></span></div>
+        <div id="validation" class="info collapse">
+          <div class="body">{{ record.get('action_note', {}).get('action', '') }}</div>
+          <div class="links"">
+            {% if record.get('action_note.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('action_note.recid', '')) }}">Record {{ record.get('action_note.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+            {% if record.get('action_note.url', '') %}
+              <ul>
+                {% for u in record.get('action_note').get('url', []) %}
+                  <li><a href="{{ u }}">{{ u }}</a></li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     <div class="rec_dedicated_details_in rdd-reuse panel">
       <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#reusability">How can you use these data?<span class="pull-right fa fa-angle-up"></span></div>
       <div id="reusability" class="info collapse">

--- a/invenio_opendata/base/templates/records/CMS-Tools_dedicated.html
+++ b/invenio_opendata/base/templates/records/CMS-Tools_dedicated.html
@@ -15,18 +15,28 @@
         </div>
       </div>
     {% endif %}
-    <div class="rec_dedicated_details_in rdd-val panel">
-      <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation<span class="pull-right fa fa-angle-up"></span></div>
-      <div id="validation" class="info collapse">
-        <div class="body">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</div>
-        <div class="links"">
-          <ul>
-            <li><a href="#">Link 1</a></li>
-            <li><a href="#">Link2</a></li>
-          </ul>
+    {% if record.get('action_note', '') %}
+      <div class="rec_dedicated_details_in rdd-val panel">
+        <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation<span class="pull-right fa fa-angle-up"></span></div>
+        <div id="validation" class="info collapse">
+          <div class="body">{{ record.get('action_note', {}).get('action', '') }}</div>
+          <div class="links"">
+            {% if record.get('action_note.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('action_note.recid', '')) }}">Record {{ record.get('action_note.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+            {% if record.get('action_note.url', '') %}
+              <ul>
+                {% for u in record.get('action_note').get('url', []) %}
+                  <li><a href="{{ u }}">{{ u }}</a></li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </div>
         </div>
       </div>
-    </div>
+    {% endif %}
     {% if record.get('documentation_note', '') %}
       <div class="rec_dedicated_details_in rdd-limits panel">
         <div class="panel-title title collapsed" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#limitations">Issues & Limitations<span class="pull-right fa fa-angle-up"></span></div>

--- a/invenio_opendata/base/templates/records/base_base.html
+++ b/invenio_opendata/base/templates/records/base_base.html
@@ -107,18 +107,28 @@
               </div>
             </div>
           {% endif %}
-          <div class="rec_dedicated_details_in rdd-val panel">
-            <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
-            <div id="validation" class="info ccollapse">
-              <div class="body">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</div>
-              <div class="links">
-                <ul>
-                  <li><a href="#">Link 1</a></li>
-                  <li><a href="#">Link2</a></li>
-                </ul>
+          {% if record.get('action_note', '') %}
+            <div class="rec_dedicated_details_in rdd-val panel">
+              <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
+              <div id="validation" class="info ccollapse">
+                <div class="body">{{ record.get('action_note', {}).get('action', '') }}</div>
+                <div class="links">
+                  {% if record.get('action_note.recid', '') %}
+                    <ul>
+                      <li><a href="{{ url_for('record.metadata', recid=record.get('action_note.recid', '')) }}">Record {{ record.get('action_note.recid', '') }}</a></li>
+                    </ul>
+                  {% endif %}
+                  {% if record.get('action_note.url', '') %}
+                    <ul>
+                      {% for u in record.get('action_note').get('url', []) %}
+                        <li><a href="{{ u }}">{{ u }}</a></li>
+                      {% endfor %}
+                    </ul>
+                  {% endif %}
+                </div>
               </div>
             </div>
-          </div>
+          {% endif %}
           <div class="rec_dedicated_details_in rdd-reuse panel">
             <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#reusability">How to reuse?</div>
             <div id="reusability" class="info ccollapse">


### PR DESCRIPTION
- Propagates "validation" metadata information (taken from JSON field
  `action_note` aka MARC tag `583`) into various detailed record page
  templates.  (addresses #120)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
