### PR TITLE
templates: CMS Physics Objects link fix

### DIFF
--- a/invenio_opendata/base/templates/about_cms.html
+++ b/invenio_opendata/base/templates/about_cms.html
@@ -179,7 +179,7 @@
           <div class="about-box">
             <h2 id="what-data">What data?</h2>
             <ul class="col-md-12">
-              <li>AOD (Analysis Object Data) files contain the information that is needed for analysis:
+              <li>AOD (Analysis Object Data) files contain the information that is needed for analysis:
                 <div>
                   <ul>
                     <li>all the high-level <a href="{{ url_for('about/CMS-Physics-Objects')}}">physics objects</a> (such as muons, electrons, etc.);</li>
@@ -188,10 +188,10 @@
                   </ul>
                 </div>
               </li>
-              <li>It is not the final event interpretation with a simple list of particles.
+              <li>It is not the final event interpretation with a simple list of particles.
                 <div>
                   <ul>
-                    <li>It contains several instances of the same physics object (i.e. a jet reconstructed with different algorithms).</li>
+                    <li>It contains several instances of the same physics object (i.e. a jet reconstructed with different algorithms).</li>
                     <li>It may have double-counting (i.e. a physics object may appear as a single object of its own type, but it may also be part of a jet).</li>
                     <li>Additional knowledge is needed to define a "good" physics object.</li>
                     <li>Definition of same objects is different in each analysis.</li>

--- a/invenio_opendata/base/templates/get_started.html
+++ b/invenio_opendata/base/templates/get_started.html
@@ -157,7 +157,7 @@
             <div class="heading">"I have installed the CERN Virtual Machine: now what?"</div>
             <div class="body">
               <p>
-                First, have you <a href="{{url_for('VM#validate')}}">validated</a> the Virtual machine after installation? This step is very important! The CMSSW command <kbd>cmsrel CMSSW_4_2_8</kbd> you executed during validation ensures that you have the right version of CMSSW running: to analyse CMS data collected in 2010, you need <strong>version 4.2.8</strong>, supported only on <strong>Scientific Linux 5</strong>.
+                First, have you <a href="{{ url_for('VM#validate') }}">validated</a> the Virtual machine after installation? This step is very important! The CMSSW command <kbd>cmsrel CMSSW_4_2_8</kbd> you executed during validation ensures that you have the right version of CMSSW running: to analyse CMS data collected in 2010, you need <strong>version 4.2.8</strong>, supported only on <strong>Scientific Linux 5</strong>.
               </p>
               <p>
                 Then, make sure that you are always in the <strong>CMSSW_4_2_8/src/</strong> directory by entering the following command in the terminal (you must do so every time you boot the VM before you can proceed):
@@ -173,7 +173,7 @@
                 It is best if we start off with a quick introduction to <strong><a href="http://root.cern.ch">ROOT</a></strong>. ROOT is the framework used by several particle-physics experiments to work with the collected data. Although analysis is not itself performed within the ROOT GUI, it is instructive to understand how these files are structured and what data and collections they contain.
               </p>
               <p>
-                The CMS data provided on the CERN Open Data Portal is in a format called "<a href="{{url_for('about/CMS#what-data')}}">Analysis Object Data</a>" or AOD for short. These AOD files are prepared by piecing raw data collected by various sub-detectors of CMS and contain all the information that is needed for analysis. The files cannot be opened and understood as simple data tables but require ROOT in order to be read.
+                The CMS data provided on the CERN Open Data Portal is in a format called "<a href="{{ url_for('about/CMS#what-data') }}">Analysis Object Data</a>" or AOD for short. These AOD files are prepared by piecing raw data collected by various sub-detectors of CMS and contain all the information that is needed for analysis. The files cannot be opened and understood as simple data tables but require ROOT in order to be read.
               </p>
               <p>
                 So, let's see what an AOD file looks like and take ROOT for a spin!
@@ -198,14 +198,14 @@
               <pre class="editor-colors lang-text"><div class="line"><span class="text plain"><span class="meta paragraph text"><span>TBrowser&nbsp;t</span></span></span></div></pre>
 
               <p>
-                Excellent! You have successfully opened a CMS AOD file in ROOT. If this was the first time you've done so, pat yourself on the back. Now, to see what is inside this file, let us take a closer look at some collections of <a href="{{url_for('/about/CMS-Physics-Objects')}}">physics objects</a>.
+                Excellent! You have successfully opened a CMS AOD file in ROOT. If this was the first time you've done so, pat yourself on the back. Now, to see what is inside this file, let us take a closer look at some collections of <a href="{{ url_for('about/CMS-Physics-Objects') }}">physics objects</a>.
               </p>
               <p>
                 On the left window of ROOT (see the screenshot below), double-click on the file name (<kbd>root://eospublic.cern.ch//eos/opendata/…</kbd>), followed by <kbd>Events</kbd> and then <kbd>Collections</kbd>. You should see a list of collections of physics objects.<br />
                 <img src="{{ url_for('static', filename='img/docs/Screenshot_001_Tbrowser_t.png') }}" alt="Screenshot: After running 'TBrowser t'" style="width:70%; padding: 20px;"/>
               </p>
               <p>
-                Let us take a peek, for example, at the following electron collection, as shown on the list of <a href="{{url_for('/about/CMS-Physics-Objects')}}">physics objects</a>: <kbd>recoGsfElectrons_gsfElectrons__RECO</kbd>. Look in there by double-clicking on that line and then double-clicking on <kbd>recoGsfElectrons_gsfElectrons__RECO.obj</kbd>. Here, you can have a look at various properties of this collection, such as the plot for the transverse momentum of the electrons: <kbd>recoGsfElectrons_gsfElectrons__RECO.obj.pt_</kbd>.
+                Let us take a peek, for example, at the following electron collection, as shown on the list of <a href="{{ url_for('about/CMS-Physics-Objects') }}">physics objects</a>: <kbd>recoGsfElectrons_gsfElectrons__RECO</kbd>. Look in there by double-clicking on that line and then double-clicking on <kbd>recoGsfElectrons_gsfElectrons__RECO.obj</kbd>. Here, you can have a look at various properties of this collection, such as the plot for the transverse momentum of the electrons: <kbd>recoGsfElectrons_gsfElectrons__RECO.obj.pt_</kbd>.
               </p>
               <p>
                 You can exit the ROOT browser through the GUI by clicking on <kbd>Browser</kbd> on the menu and then clicking on <kbd>Quit Root</kbd> or by entering <kbd>.q</kbd> in the terminal.
@@ -216,7 +216,7 @@
             <div class="heading">"Nice! But how do I analyse these data?"</div>
             <div class="body">
               <p>
-                In AOD files, reconstructed <a href="{{url_for('/about/CMS-Physics-Objects')}}">physics objects</a> are included without cheking their "quality", i.e. in case of our electron collection that you opened in ROOT, without ensuring that the reconstructed object is really an electron. In order to analyse only the "good quality" data, you must apply some selection criteria.
+                In AOD files, reconstructed <a href="{{ url_for('about/CMS-Physics-Objects') }}">physics objects</a> are included without cheking their "quality", i.e. in case of our electron collection that you opened in ROOT, without ensuring that the reconstructed object is really an electron. In order to analyse only the "good quality" data, you must apply some selection criteria.
               </p>
 
               <p>

--- a/invenio_opendata/base/templates/helpers/text/about_CMS_data.html
+++ b/invenio_opendata/base/templates/helpers/text/about_CMS_data.html
@@ -5,7 +5,7 @@
 <ul>
   <li>The open data are released under Creative Commons Zero (CC0). CMS or CERN do not endorse any works, scientific or otherwise, produced using these data.</li>
   <li>All releases will have a unique DOI that should be cited in any applications or publications.</li>
-  <li>The data being made available are referred to as "reconstructed data": fragmented data from various sub-detectors are processed or "reconstructed" to provide coherent information about individual <a href="{{url_for('/about/CMS-Physics-Objects')}}">physics objects</a> such as electrons or particle jets.<ul>
+  <li>The data being made available are referred to as "reconstructed data": fragmented data from various sub-detectors are processed or "reconstructed" to provide coherent information about individual <a href="{{ url_for('about/CMS-Physics-Objects') }}">physics objects</a> such as electrons or particle jets.<ul>
     <li>Despite being processed, these high-level data remain complex and selection criteria need to be applied in order to analyse them, requiring some understanding of particle physics and detector functioning.</li>
     <li>The data cannot be viewed in simple data tables for spreadsheet-based analyses. (More information below, under <em>What data?</em>)</li>
   </ul>
@@ -47,14 +47,14 @@
 </ol>
 <h2 id="what-data-">What data?</h2>
 <ul>
-  <li>AOD (Analysis Object Data) files contain the information that is needed for analysis:<ul>
-    <li>all the high-level <a href="{{url_for('/about/CMS-Physics-Objects')}}">physics objects</a> (such as muons, electrons, etc.);</li>
+  <li>AOD (Analysis Object Data) files contain the information that is needed for analysis:<ul>
+    <li>all the high-level <a href="{{ url_for('about/CMS-Physics-Objects') }}">physics objects</a> (such as muons, electrons, etc.);</li>
     <li>tracks with associated hits, calorimetric clusters with associated hits, vertices; and</li>
     <li>information about event selection (triggers), data needed for further selection and identification criteria for the physics objects.</li>
   </ul>
   </li>
-  <li>It is not the final event interpretation with a simple list of particles.<ul>
-    <li>It contains several instances of the same physics object (i.e. a jet reconstructed with different algorithms).</li>
+  <li>It is not the final event interpretation with a simple list of particles.<ul>
+    <li>It contains several instances of the same physics object (i.e. a jet reconstructed with different algorithms).</li>
     <li>It may have double-counting (i.e. a physics object may appear as a single object of its own type, but it may also be part of a jet).</li>
     <li>Additional knowledge is needed to define a "good" physics object.</li>
     <li>Definition of same objects is different in each analysis.</li>


### PR DESCRIPTION
- Fixes links to CMS Physics Objects page.
  (addresses #153) (addresses #198)
- In addition, removes `^L` and `^K` characters in the text.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
