### PR TITLE
base: JSON data model fix for external URLs

### DIFF
--- a/invenio_opendata/base/recordext/fields/opendata.cfg
+++ b/invenio_opendata/base/recordext/fields/opendata.cfg
@@ -213,6 +213,29 @@ other_relationship_entry:
 
 # 8564_s 8564_u
 
+url:
+    creator:
+        @only_if_master_value((not is_local_url(value['u']), ))
+        marc, "8564_", {'host_name': value['a'],
+                        'access_number': value['b'],
+                        'compression_information': value['c'],
+                        'path':value['d'],
+                        'electronic_name': value['f'],
+                        'request_processor': value['h'],
+                        'institution': value['i'],
+                        'eformart': value['q'],
+                        'settings': value['r'],
+                        'size': value['s'],
+                        'url': value['u'],
+                        'subformat':value['x'],
+                        'description':value['y'],
+                        'comment':value['z']}
+    producer:
+        json_for_marc(), {"8564_a": "host_name", "8564_b": "access_number", "8564_c": "compression_information", "8564_d": "path", "8564_f": "electronic_name", "8564_h": "request_processor", "8564_i": "institution", "8564_q": "eformat", "8564_r": "settings", "8564_s": "file_size", "8564_u": "url", "8564_x": "subformat", "8564_y": "description", "8564_z": "comment"}
+        json_for_dc(), {"dc:identifier": "url"}
+
+# files
+
 files:
     calculated:
         @parse_first('recid')


### PR DESCRIPTION
- Fixes JSON data model for external URLs (`8564`).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
