### PR TITLE
Rearrange resources to move VISPA up

### DIFF
--- a/invenio_opendata/base/templates/helpers/text/learn_more_txt.html
+++ b/invenio_opendata/base/templates/helpers/text/learn_more_txt.html
@@ -15,6 +15,26 @@
   <h6>The CMS HEP Tutorial on the IPPOG Database</h6>
 </div>
 
+<h2>CMS analyses with VISPA</h2>
+
+<div class="col-md-12">
+  <p>
+    The Visual Physics Analysis (VISPA) project provides a graphical development environment for data analysis. It addresses the typical development cycle of re-designing, executing, and verifying an analysis.
+  </p>
+
+  <p>
+    VISPA is being used at RWTH Aachen University in Germany, where it was developed, to teach third-year undergraduate physics students how to analyse CMS data, as part of courses on particle and astroparticle physics. Among other things, they learn how to calculate the masses of particles produced at the LHC.
+  </p>
+
+  <p>
+    <a href="https://vispa.physik.rwth-aachen.de/CERN">Learn more about VISPA and the CMS measurements you can perform</a>
+  </p>
+</div>
+<div class="learn-img col-md-8 col-md-offset-2">
+  <img src="{{url_for('static', filename='img/VISPA.png')}}" />
+  <h6>The VISPA desktop interface</h6>
+</div>
+
 <h2>Particle Physics Playground</h2>
 
 <div class="col-md-12">
@@ -63,24 +83,4 @@
 <div class="learn-img col-md-8 col-md-offset-2">
   <img src="{{url_for('static', filename='img/CMSeLab.png')}}" />
   <h6>Project map of the CMS e-Lab</h6>
-</div>
-
-<h2>CMS analyses with VISPA</h2>
-
-<div class="col-md-12">
-  <p>
-    The Visual Physics Analysis (VISPA) project provides a graphical development environment for data analysis. It addresses the typical development cycle of re-designing, executing, and verifying an analysis.
-  </p>
-
-  <p>
-    VISPA is being used at RWTH Aachen University in Germany, where it was developed, to teach third-year undergraduate physics students how to analyse CMS data, as part of courses on particle and astroparticle physics. Among other things, they learn how to calculate the masses of particles produced at the LHC.
-  </p>
-
-  <p>
-    <a href="https://vispa.physik.rwth-aachen.de/">Learn more about VISPA and the CMS measurements you can perform</a>
-  </p>
-</div>
-<div class="learn-img col-md-8 col-md-offset-2">
-  <img src="{{url_for('static', filename='img/VISPA.png')}}" />
-  <h6>The VISPA desktop interface</h6>
 </div>


### PR DESCRIPTION
As discussed with @katilp, move "VISPA" to "Introduction to particle physics through CMS data".
