### PR TITLE
CMS: number of events for PAT tuple records

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana.xml
@@ -12,7 +12,7 @@
       <subfield code="a">Muons and electrons in PAT candidate format derived from /Mu/Run-2010B-Apr21ReReco-v1/AOD primary dataset</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
-      <subfield code="a">Dataset (6 files, x events, 130 GB in total)</subfield>
+      <subfield code="a">Dataset (6 files, 26718043 events, 134939836155 bytes in total)</subfield>
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
@@ -71,7 +71,7 @@
       <subfield code="a">Muons and electrons in PAT candidate format derived from /Electron/Run-2010B-Apr21ReReco-v1/AOD primary dataset</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
-      <subfield code="a">Dataset (6 files, x events, 80 GB in total)</subfield>
+      <subfield code="a">Dataset (6 files, 24668844 events, 82230947475 bytes in total)</subfield>
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>


### PR DESCRIPTION
- Updates CMS Derived Datasets PAT tuple records with precise
  information about number of events and total byte size.
  (closes #222)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
