### PR TITLE
templates: "Other CMS open data" above "Policies"

### DIFF
--- a/invenio_opendata/base/templates/about_cms.html
+++ b/invenio_opendata/base/templates/about_cms.html
@@ -95,7 +95,7 @@
         -webkit-column-gap: 10px;
         column-count: 2;
         column-gap: 10px;
-        width: 100%; 
+        width: 100%;
         display: inline-block;
       }
       #block-grid-container .block-grid-item {
@@ -104,7 +104,7 @@
         width: 100%;
         padding-left: 15px;
         padding-right: 15px;
-      }  
+      }
     }
     @media (max-width: 921px) {
       #block-grid-container {
@@ -114,7 +114,7 @@
         -webkit-column-gap: 10px;
         column-count: 1;
         column-gap: 10px;
-        width: 100%; 
+        width: 100%;
         display: inline-block;
       }
       #block-grid-container .block-grid-item {
@@ -123,9 +123,9 @@
         width: 100%;
         padding-left: 15px;
         padding-right: 15px;
-      }  
+      }
     }
-    
+
   </style>
   <script src="{{ url_for('static', filename='/vendors/masonry/masonry.js') }}"></script>
 
@@ -241,19 +241,19 @@
           </div>
           <div class="col-md-12">
             <div class="about-box">
-              <h2 id="policies">Policies</h2>
+              <h2 id="policies">Other CMS open data</h2>
               <ul class="col-md-12 no-padding">
-                <li><a href="https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/ShowDocument?docid=6032">Data preservation and open access policy</a></li>
-                <li><a href="https://cms-docdb.cern.ch/cgi-bin/DocDB/ShowDocument?docid=12242">Papers by CMS members using public data </a></li>
+                <li>All <a href="https://inspirehep.net/search?p=collaboration:' CMS'">CMS publications</a> are open access.</li>
+                <li>Some of these papers also include open data in the form of additional tables, plots, graphs and <a href="https://rivet.hepforge.org/">Rivet</a> packages.</li>
               </ul>
             </div>
           </div>
           <div class="col-md-12">
             <div class="about-box">
-              <h2 id="policies">Other CMS open data</h2>
+              <h2 id="policies">Policies</h2>
               <ul class="col-md-12 no-padding">
-                <li>All <a href="https://inspirehep.net/search?p=collaboration:' CMS'">CMS publications</a> are open access.</li>
-                <li>Some of these papers also include open data in the form of additional tables, plots, graphs and <a href="https://rivet.hepforge.org/">Rivet</a> packages.</li>
+                <li><a href="https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/ShowDocument?docid=6032">Data preservation and open access policy</a></li>
+                <li><a href="https://cms-docdb.cern.ch/cgi-bin/DocDB/ShowDocument?docid=12242">Papers by CMS members using public data </a></li>
               </ul>
             </div>
           </div>


### PR DESCRIPTION
Fixing error introduced in previous change. Policies are now at bottom of page.
