### PR TITLE
CMS: fix link to VM image

### DIFF
--- a/invenio_opendata/base/templates/helpers/text/vms_page.html
+++ b/invenio_opendata/base/templates/helpers/text/vms_page.html
@@ -30,7 +30,7 @@
     </div>
     <div class="row">
         <p class="col-md-12">
-        Next download the CMS-specific CernVM image as OVA file from: <a href="http://cernvm.cern.ch/releases/CMS-OpenData-RC4.ova">CMS OpenData (latest)</a>.
+        Next download the CMS-specific CernVM image as OVA file from: <a href="http://cernvm.cern.ch/releases/CMS-OpenData-1.0.0-rc4.ova">CMS OpenData (latest)</a>.
         </p>
     </div>
     <div class="row">

--- a/invenio_opendata/testsuite/data/cms/cms-tools-vm-image.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-vm-image.xml
@@ -18,7 +18,7 @@
       <subfield code="a">CMS-Tools</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">http://cernvm.cern.ch/releases/CMS-OpenData-RC4.ova</subfield>
+      <subfield code="a">http://cernvm.cern.ch/releases/CMS-OpenData-1.0.0-rc4.ova</subfield>
     </datafield>
   </record>
 </collection>


### PR DESCRIPTION
- Fixes link to CMS VM image that uses semantic versioning
  now (`CMS-OpenData-1.0.0-rc4.ova`).  (closes #331)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
