### PR TITLE
CMS: fix FFT link for CMS Validate Runs record

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-validated-runs.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-validated-runs.xml
@@ -22,7 +22,7 @@
       <subfield code="a">CMS-Validated-Runs</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://github.com/ayrodrig/pattuples2010/blob/master/Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt</subfield>
+      <subfield code="a">https://raw.githubusercontent.com/ayrodrig/pattuples2010/master/Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt</subfield>
     </datafield>
   </record>
 </collection>


### PR DESCRIPTION
- Fixes FFT link for CMS Validated Runs record to point to JSON file
  itself, not to GitHub splash page.  (addresses #308)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
