### PR TITLE
ALICE: separation of ALICE Reconstructed Data

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -57,6 +57,7 @@ opendata.cern.ch overlay:
                                         -f invenio_opendata/testsuite/data/cms/cms-masterclass-files.xml \
                                         -f invenio_opendata/testsuite/data/cms/cms-csv-files.xml \
                                         -f invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml \
+                                        -f invenio_opendata/testsuite/data/alice/alice-reconstructed-data.xml \
                                         -f invenio_opendata/testsuite/data/alice/alice-analysis-modules.xml \
                                         -e force-recids" \
         ./invenio2-kickstart --yes-i-know --yes-i-really-know
@@ -127,6 +128,7 @@ re-populate your site anew to have your updated records, you can do:
          -f invenio_opendata/testsuite/data/cms/cms-masterclass-files.xml \
          -f invenio_opendata/testsuite/data/cms/cms-csv-files.xml \
          -f invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml \
+         -f invenio_opendata/testsuite/data/alice/alice-reconstructed-data.xml \
          -f invenio_opendata/testsuite/data/alice/alice-analysis-modules.xml \
          -e force-recids
 

--- a/invenio_opendata/base/fixtures/websearch.py
+++ b/invenio_opendata/base/fixtures/websearch.py
@@ -91,6 +91,14 @@ class CollectionData(DataSet):
             ('en', 'ln'): u'CMS External Resources',
         }
 
+    class ALICEReconstructedData(siteCollection):
+        id = 11
+        name = 'ALICE-Reconstructed-Data'
+        dbquery = '980__a:"ALICE-Reconstructed-Data"'
+        names = {
+            ('en', 'ln'): u'ALICE Reconstructed Data',
+        }
+
 
 class CollectionCollectionData(DataSet):
 
@@ -172,10 +180,16 @@ class CollectionCollectionData(DataSet):
         score = 0
         type = 'r'
 
+    class ALICE_ALICEReconstructedData:
+        dad = CollectionData.ALICE
+        son = CollectionData.ALICEReconstructedData
+        score = 1
+        type = 'r'
+
     class ALICE_ALICETools:
         dad = CollectionData.ALICE
         son = CollectionData.ALICETools
-        score = 1
+        score = 2
         type = 'r'
 
     class siteCollection_ALICEDerivedDatasets:
@@ -184,10 +198,16 @@ class CollectionCollectionData(DataSet):
         score = 5
         type = 'r'
 
+    class siteCollection_ALICEReconstructedData:
+        dad = CollectionData.siteCollection
+        son = CollectionData.ALICEReconstructedData
+        score = 6
+        type = 'r'
+
     class siteCollection_ALICETools:
         dad = CollectionData.siteCollection
         son = CollectionData.ALICETools
-        score = 6
+        score = 7
         type = 'r'
 
 
@@ -303,6 +323,12 @@ class PortalboxData(DataSet):
         id = 15
         title = u'description'
 
+    class Portalbox_16:
+        body = u'This collection includes ALICE reconstructed data.'
+        id = 16
+        title = u'description'
+
+
 class CollectionPortalboxData(DataSet):
 
     class CollectionPortalbox_2_1_en:
@@ -409,6 +435,13 @@ class CollectionPortalboxData(DataSet):
         id_portalbox = PortalboxData.Portalbox_15.ref('id')
         score = 100
         id_collection = CollectionData.CMSExternalResources.ref('id')
+
+    class CollectionPortalbox_11_16_en:
+        ln = u'en'
+        position = u'r'
+        id_portalbox = PortalboxData.Portalbox_16.ref('id')
+        score = 100
+        id_collection = CollectionData.ALICEReconstructedData.ref('id')
 
 
 class FacetCollectionData(DataSet):

--- a/invenio_opendata/base/templates/records/ALICE-Reconstructed-Data_dedicated.html
+++ b/invenio_opendata/base/templates/records/ALICE-Reconstructed-Data_dedicated.html
@@ -1,0 +1,100 @@
+{% from "records/macros.html" import create_export_modal with context %}
+<div class="row" style="margin: -25px -20px;">
+  <div class="rec_dedicated_top col-md-12">
+    <div class="row">
+      {% if record['doi'] %}
+        <div class="rec_doi col-md-12">
+          <div class="n"><div class="t col-md-2">DOI</div>{{ record['doi'] }}</div>
+        </div>
+      {% endif %}
+      <div class="col-md-12">
+        {{ create_export_modal("exportModal", record, ['__meta_metadata__', 'restriction']) }}
+      </div>
+      <div class="col-md-12 rec_parentcol">
+        <div class="n"><div class="t col-md-4">Parent Collection</div><a href="{{ url_for('collection/'+collection.name) }}">{{ collection.names[g.ln, 'ln'] }}</a></div>
+      </div>
+    </div>
+  </div>
+  <div id="rec_dedicated_box" class="rec_dedicated_details col-md-12 panel-group">
+    {% if record.get('methodology_note', '') %}
+      <div class="rec_dedicated_details_in rdd-sel panel">
+        <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#selection">How were these data selected?</div>
+        <div id="selection" class="info  ccollapse">
+          <div class="body">{{ record.get('methodology_note', {}).get('note', '') }}</div>
+          <div class="links">
+            {% if record.get('methodology_note.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('methodology_note.recid', '')) }}">Record {{ record.get('methodology_note.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+    {% if record.get('action_note', '') %}
+      <div class="rec_dedicated_details_in rdd-val panel">
+        <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#validation">Validation</div>
+        <div id="validation" class="info ccollapse">
+          <div class="body">{{ record.get('action_note', {}).get('action', '') }}</div>
+          <div class="links"">
+            {% if record.get('action_note.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('action_note.recid', '')) }}">Record {{ record.get('action_note.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+            {% if record.get('action_note.url', '') %}
+              <ul>
+                {% for u in record.get('action_note').get('url', []) %}
+                  <li><a href="{{ u }}">{{ u }}</a></li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+    {% if record.get('constituent_unit_entry', '') %}
+      <div class="rec_dedicated_details_in rdd-reuse panel">
+        <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#reusability">How to reuse?</div>
+        <div id="reusability" class="info ccollapse">
+          <div class="body">{{ record.get('constituent_unit_entry', {}).get('heading', '') }}</div>
+          <div class="links">
+            {% if record.get('constituent_unit_entry.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('constituent_unit_entry.recid', '')) }}">Record {{ record.get('constituent_unit_entry.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+    {% if record.get('documentation_note', '') %}
+      <div class="rec_dedicated_details_in rdd-limits panel">
+        <div class="title" data-toggle="collapse" data-parent="#rec_dedicated_box" data-target="#limitations">Issues & Limitations </div>
+        <div id="limitations" class="info  ccollapse">
+          <div class="body">{{ record.get('documentation_note', {}).get('note', '') }}</div>
+          <div class="links">
+            {% if record.get('documentation_note.recid', '') %}
+              <ul>
+                <li><a href="{{ url_for('record.metadata', recid=record.get('documentation_note.recid', '')) }}">Record {{ record.get('documentation_note.recid', '') }}</a></li>
+              </ul>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    {% endif %}
+    <div class="rec_dedicated_details_in rdd-disclaimer panel">
+      <div class="title">Disclaimer</div>
+      <div id="disclaimer" class="info">
+        <div class="row">
+          <div class="body col-md-12">The open data are released under Creative Commons Zero (CC0). CERN do not endorse any works, scientific or otherwise, produced using these data.</br>
+            All releases will have a unique DOI that should be cited in any applications or publications.</div>
+          <div class="col-md-12">
+            <div class="ccommons">
+              <img src="{{ url_for('static', filename='img/cc-zero.svg') }}" alt="">
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/invenio_opendata/base/templates/records/ALICE-Reconstructed-Data_metadata.html
+++ b/invenio_opendata/base/templates/records/ALICE-Reconstructed-Data_metadata.html
@@ -1,0 +1,71 @@
+<div class="rec_header">
+  <div class="rec_details row">
+    <div class="title col-md-12">{{ record.get('title',{}).get('title','') }}<span>{{ record.get('imprint', {}).get('date', '') }}</span>
+    </div>
+    <div class="rec_authors {% if (record['authors']|length) < 5 %} col-md-12" {% else %} " id="rec_authors_rdmore" {% endif %} >
+      {% for auth in record['authors'] %}
+        <a href="#">{{ auth['full_name'] }}</a>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+<div class="rec_metadata rec_description">
+  <div class="row">
+    <div class="col-md-12">
+      <div class="rec_title title">Description</div>
+    </div>
+    <div class="col-md-12">
+      <div class="rec_desc">{{ record.get('abstract',{}).get('summary','') }}</div>
+    </div>
+  </div>
+</div>
+{% if record.get('url',[]) != [] %}
+  <div class="rec_metadata rec_urls">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="rec_title title">URLs</div>
+      </div>
+      <div class="col-md-12" style="margin-top: 20px;font-size: 16px;color: #606D75;font-weight: 100;">
+        <div class="row">
+          {% if record.get('url').get('url') is not string %}
+            {% for u in record.get('url').get('url') %}
+              <a class="col-md-12" href="{{ u }}">{{ u }}</a>
+            {% endfor %}
+          {% else %}
+            <a class="col-md-12" href="{{ record.get('url','').get('url','') }}">{{ record.get('url','').get('url','') }}</a>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endif %}
+{% if record['files'] != [] %}
+  <div class="rec_metadata rec_files">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="rec_title title">Files <a {% if 'files' in record %}class="disabled"{%endif%} href="{{ url_for('record.files', recid=recid) }}">(see all files)</a></div>
+      </div>
+      <div class="col-md-12">
+        <div class="rec_file_box">
+          <ul class="row">
+            {% for file in record['files'] %}
+              <li class="col-md-4">
+                <div class="content_box">
+                  <div class="row">
+                    <div class="pull-left col-md-7">
+                      <ul class="row">
+                        <li class="col-md-12"><a href="{{ file.get('url','') }}">{{ file.get('full_name','') }}</a></li>
+                        <li class="col-md-12"><b>Size:</b> {{ file.get('size','') | filesizeformat }}</li>
+                        {{ '<li class="col-md-12"><b>Description:</b>'+(file.get('description')|truncate(50))+'</li>' if (file.get('description', '') != '') }}
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              </li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endif %}

--- a/invenio_opendata/base/templates/records/ALICE-Reconstructed-Data_record.html
+++ b/invenio_opendata/base/templates/records/ALICE-Reconstructed-Data_record.html
@@ -1,0 +1,41 @@
+{% extends 'page.html' %}
+
+{#
+{% set title = title %}
+#}
+{% block title %}
+{% endblock title %}
+
+
+{% block body %}
+
+  {% include 'search/form/index.html' %}
+
+  {% block record_restriction_flag %}
+    {% if g.bibrec.is_restricted %}
+      <div class="alert alert-danger">
+        <div class="container"><b>{{ _('Restricted') }}</b>
+          {%- if g.bibrec.is_processed %}
+          {{ _('Processed Record') }}
+          {%- endif -%}
+        </div>
+      </div>
+    {% endif %}
+  {% endblock %}
+
+
+  <section id="record_reduced" class="content record">
+    <div class="container">
+      <div class="record-content clearfix">
+        <div class="col-md-8 col-sm-12 main clearfix">
+          {% include 'records/ALICE-Reconstructed-Data_metadata.html' %}
+        </div>
+        <div class="col-md-4 col-sm-12 sidebar clearfix">
+          {% include 'records/ALICE-Reconstructed-Data_dedicated.html' %}
+        </div>
+      </div>
+    </div>
+  </section>
+
+
+{% endblock %}

--- a/invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml
+++ b/invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml
@@ -1,53 +1,5 @@
 <collection>
   <record>
-    <controlfield tag="001">1100</controlfield>
-    <datafield tag="100" ind1=" " ind2=" ">
-      <subfield code="a">ALICE Collaboration</subfield>
-    </datafield>
-    <datafield tag="245" ind1=" " ind2=" ">
-      <subfield code="a">LHC2010b_pp_ESD_117222</subfield>
-    </datafield>
-    <datafield tag="256" ind1=" " ind2=" ">
-      <subfield code="a">Dataset (2 files, FIXME events, 484934275 bytes in total)</subfield>
-    </datafield>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="c">2012</subfield>
-    </datafield>
-    <datafield tag="520" ind1=" " ind2=" ">
-      <subfield code="a">Proton-Proton ESD data sample at 3.5 TeV</subfield>
-    </datafield>
-    <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">ALICE-Derived-Datasets</subfield>
-    </datafield>
-    <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/LHC2010b_pp_ESD_117222.json</subfield>
-    </datafield>
-  </record>
-  <record>
-    <controlfield tag="001">1101</controlfield>
-    <datafield tag="100" ind1=" " ind2=" ">
-      <subfield code="a">ALICE Collaboration</subfield>
-    </datafield>
-    <datafield tag="245" ind1=" " ind2=" ">
-      <subfield code="a">LHC2010h_PbPb_ESD_138275</subfield>
-    </datafield>
-    <datafield tag="256" ind1=" " ind2=" ">
-      <subfield code="a">Dataset (3 files, FIXME events, 649070529 bytes in total)</subfield>
-    </datafield>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="c">2012</subfield>
-    </datafield>
-    <datafield tag="520" ind1=" " ind2=" ">
-      <subfield code="a">Pb-Pb ESD data sample at 3.5 TeV</subfield>
-    </datafield>
-    <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">ALICE-Derived-Datasets</subfield>
-    </datafield>
-    <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/LHC2010h_PbPb_ESD_138275.json</subfield>
-    </datafield>
-  </record>
-  <record>
     <controlfield tag="001">1102</controlfield>
     <datafield tag="100" ind1=" " ind2=" ">
       <subfield code="a">ALICE Collaboration</subfield>

--- a/invenio_opendata/testsuite/data/alice/alice-reconstructed-data.xml
+++ b/invenio_opendata/testsuite/data/alice/alice-reconstructed-data.xml
@@ -1,0 +1,50 @@
+<collection>
+  <record>
+    <controlfield tag="001">1100</controlfield>
+    <datafield tag="100" ind1=" " ind2=" ">
+      <subfield code="a">ALICE Collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">LHC2010b_pp_ESD_117222</subfield>
+    </datafield>
+    <datafield tag="256" ind1=" " ind2=" ">
+      <subfield code="a">Dataset (2 files, FIXME events, 484934275 bytes in total)</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="c">2012</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">Proton-Proton ESD data sample at 3.5 TeV</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">ALICE-Reconstructed-Data</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/eos-file-indexes/LHC2010b_pp_ESD_117222.json</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">1101</controlfield>
+    <datafield tag="100" ind1=" " ind2=" ">
+      <subfield code="a">ALICE Collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">LHC2010h_PbPb_ESD_138275</subfield>
+    </datafield>
+    <datafield tag="256" ind1=" " ind2=" ">
+      <subfield code="a">Dataset (3 files, FIXME events, 649070529 bytes in total)</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="c">2012</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">Pb-Pb ESD data sample at 3.5 TeV</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">ALICE-Reconstructed-Data</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/eos-file-indexes/LHC2010h_PbPb_ESD_138275.json</subfield>
+    </datafield>
+  </record>
+</collection>


### PR DESCRIPTION
- Separates ESD records into a new `ALICE Reconstructed Data`
  collection.  VSD record stays in the `ALICE Derived Datasets`
  collection.  (addresses #353)
- Amends record templates accordingly.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
