### PR TITLE
installation: new local FFT file cache

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -45,7 +45,7 @@ opendata.cern.ch overlay:
         CFG_INVENIO2_VIRTUAL_ENV=opendata \
         CFG_INVENIO2_DATABASE_USER=opendata \
         CFG_INVENIO2_DATABASE_NAME=opendata \
-        CFG_INVENIO2_DEMOSITE_POPULATE_BEFORE="rsync -a invenio_opendata/testsuite/data/*/eos-file-indexes /tmp/" \
+        CFG_INVENIO2_DEMOSITE_POPULATE_BEFORE="populate-fft-file-cache.sh" \
         CFG_INVENIO2_DEMOSITE_POPULATE="-f invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml \
                                         -f invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana.xml \
                                         -f invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml \

--- a/invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml
+++ b/invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml
@@ -20,7 +20,7 @@
       <subfield code="a">ALICE-Derived-Datasets</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/LHC2010h_PbPb_VSD_139036.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/alice-eos-file-indexes/LHC2010h_PbPb_VSD_139036.json</subfield>
     </datafield>
   </record>
 </collection>

--- a/invenio_opendata/testsuite/data/alice/alice-reconstructed-data.xml
+++ b/invenio_opendata/testsuite/data/alice/alice-reconstructed-data.xml
@@ -20,7 +20,7 @@
       <subfield code="a">ALICE-Reconstructed-Data</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/LHC2010b_pp_ESD_117222.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/alice-eos-file-indexes/LHC2010b_pp_ESD_117222.json</subfield>
     </datafield>
   </record>
   <record>
@@ -44,7 +44,7 @@
       <subfield code="a">ALICE-Reconstructed-Data</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/LHC2010h_PbPb_ESD_138275.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/alice-eos-file-indexes/LHC2010h_PbPb_ESD_138275.json</subfield>
     </datafield>
   </record>
 </collection>

--- a/invenio_opendata/testsuite/data/cms/cms-csv-files.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-csv-files.xml
@@ -22,47 +22,47 @@
  <subfield code="a">CMS-Derived-Datasets</subfield>
 </datafield>
 <datafield tag="FFT" ind1="" ind2="">
-  <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_0.csv</subfield>
+  <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_0.csv</subfield>
   <subfield code="n">MuRun2010B_0</subfield>
 </datafield>
 <datafield tag="FFT" ind1="" ind2="">
-  <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon.csv</subfield>
+  <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon.csv</subfield>
   <subfield code="n">MuRun2010B</subfield>
 </datafield>
 <datafield tag="FFT" ind1="" ind2="">
-  <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_1.csv</subfield>
+  <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_1.csv</subfield>
   <subfield code="n">MuRun2010B_1</subfield>
 </datafield>
 <datafield tag="FFT" ind1="" ind2="">
-  <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_2.csv</subfield>
+  <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_2.csv</subfield>
   <subfield code="n">MuRun2010B_2</subfield>
 </datafield>
 <datafield tag="FFT" ind1="" ind2="">
-  <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_3.csv</subfield>
+  <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_3.csv</subfield>
   <subfield code="n">MuRun2010B_3</subfield>
 </datafield>
 <datafield tag="FFT" ind1="" ind2="">
-  <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_4.csv</subfield>
+  <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_4.csv</subfield>
   <subfield code="n">MuRun2010B_4</subfield>
 </datafield>
 <datafield tag="FFT" ind1="" ind2="">
-  <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_5.csv</subfield>
+  <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_5.csv</subfield>
   <subfield code="n">MuRun2010B_5</subfield>
 </datafield>
 <datafield tag="FFT" ind1="" ind2="">
-  <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_6.csv</subfield>
+  <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_6.csv</subfield>
   <subfield code="n">MuRun2010B_6</subfield>
 </datafield>
 <datafield tag="FFT" ind1="" ind2="">
-  <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_7.csv</subfield>
+  <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_7.csv</subfield>
   <subfield code="n">MuRun2010B_7</subfield>
 </datafield>
 <datafield tag="FFT" ind1="" ind2="">
-  <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_8.csv</subfield>
+  <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_8.csv</subfield>
   <subfield code="n">MuRun2010B_8</subfield>
 </datafield>
 <datafield tag="FFT" ind1="" ind2="">
-  <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_9.csv</subfield>
+  <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_9.csv</subfield>
   <subfield code="n">MuRun2010B_9</subfield>
 </datafield>
 </record>

--- a/invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana.xml
@@ -68,7 +68,7 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Mu_PATtuples_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Mu_PATtuples_file_index.txt</subfield>
     </datafield>
   </record>
   <record>
@@ -140,7 +140,7 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Electron_PATtuples_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Electron_PATtuples_file_index.txt</subfield>
     </datafield>
   </record>
 </collection>

--- a/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml
@@ -48,7 +48,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=BTau.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/BTau.ig</subfield>
       <subfield code="n">BTau</subfield>
     </datafield>
   </record>
@@ -101,7 +101,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=EGMonitor.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/EGMonitor.ig</subfield>
       <subfield code="n">EGMonitor</subfield>
     </datafield>
   </record>
@@ -154,7 +154,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=Electron.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Electron.ig</subfield>
       <subfield code="n">Electron</subfield>
     </datafield>
   </record>
@@ -207,7 +207,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=Jet.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Jet.ig</subfield>
       <subfield code="n">Jet</subfield>
     </datafield>
   </record>
@@ -260,7 +260,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=JetMETTauMonitor.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/JetMETTauMonitor.ig</subfield>
       <subfield code="n">JetMETTauMonitor</subfield>
     </datafield>
   </record>
@@ -313,7 +313,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=METFwd.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/METFwd.ig</subfield>
       <subfield code="n">METFwd</subfield>
     </datafield>
   </record>
@@ -366,7 +366,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=Mu.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Mu.ig</subfield>
       <subfield code="n">Mu</subfield>
     </datafield>
   </record>
@@ -419,7 +419,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=MuMonitor.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/MuMonitor.ig</subfield>
       <subfield code="n">MuMonitor</subfield>
     </datafield>
   </record>
@@ -472,7 +472,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=MuOnia.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/MuOnia.ig</subfield>
       <subfield code="n">MuOnia</subfield>
     </datafield>
   </record>
@@ -522,7 +522,7 @@
       <subfield code="a">CMS-Derived-Datasets</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=MultiJet.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/MultiJet.ig</subfield>
       <subfield code="n">MultiJet</subfield>
     </datafield>
   </record>
@@ -575,7 +575,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=Photon.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Photon.ig</subfield>
       <subfield code="n">Photon</subfield>
     </datafield>
   </record>
@@ -624,7 +624,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=Commissioning.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Commissioning.ig</subfield>
       <subfield code="n">Commissioning</subfield>
     </datafield>
   </record>
@@ -673,7 +673,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=MinimumBias.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/MinimumBias.ig</subfield>
       <subfield code="n">MinimumBias</subfield>
     </datafield>
   </record>
@@ -722,7 +722,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12376&amp;filename=ZeroBias.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/ZeroBias.ig</subfield>
       <subfield code="n">ZeroBias</subfield>
     </datafield>
   </record>

--- a/invenio_opendata/testsuite/data/cms/cms-masterclass-files.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-masterclass-files.xml
@@ -22,27 +22,27 @@
       <subfield code="a">CMS-Derived-Datasets</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11976&amp;filename=4lepton.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/4lepton.csv</subfield>
       <subfield code="n">4lepton</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11976&amp;filename=4lepton.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/4lepton.ig</subfield>
       <subfield code="n">4lepton</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11976&amp;filename=4lepton.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/4lepton.json</subfield>
       <subfield code="n">4lepton</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11976&amp;filename=diphoton.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/diphoton.csv</subfield>
       <subfield code="n">diphoton</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11976&amp;filename=diphoton.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/diphoton.ig</subfield>
       <subfield code="n">diphoton</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11976&amp;filename=diphoton.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/diphoton.json</subfield>
       <subfield code="n">diphoton</subfield>
     </datafield>
   </record>
@@ -69,91 +69,91 @@
       <subfield code="a">CMS-Derived-Datasets</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi.csv</subfield>
       <subfield code="n">dimuon-Jpsi</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_7.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_7.ig</subfield>
       <subfield code="n">dimuon-Jpsi_7</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_8.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_8.ig</subfield>
       <subfield code="n">dimuon-Jpsi_8</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_9.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_9.ig</subfield>
       <subfield code="n">dimuon-Jpsi_9</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_10.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_10.ig</subfield>
       <subfield code="n">dimuon-Jpsi_10</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_11.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_11.ig</subfield>
       <subfield code="n">dimuon-Jpsi_11</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_12.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_12.ig</subfield>
       <subfield code="n">dimuon-Jpsi_12</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_13.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_13.ig</subfield>
       <subfield code="n">dimuon-Jpsi_13</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_14.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_14.ig</subfield>
       <subfield code="n">dimuon-Jpsi_14</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_15.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_15.ig</subfield>
       <subfield code="n">dimuon-Jpsi_15</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_16.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_16.ig</subfield>
       <subfield code="n">dimuon-Jpsi_16</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi.json</subfield>
       <subfield code="n">dimuon-Jpsi</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_17.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_17.ig</subfield>
       <subfield code="n">dimuon-Jpsi_17</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_18.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_18.ig</subfield>
       <subfield code="n">dimuon-Jpsi_18</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_19.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_19.ig</subfield>
       <subfield code="n">dimuon-Jpsi_19</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_0.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_0.ig</subfield>
       <subfield code="n">dimuon-Jpsi_0</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_1.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_1.ig</subfield>
       <subfield code="n">dimuon-Jpsi_1</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_2.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_2.ig</subfield>
       <subfield code="n">dimuon-Jpsi_2</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_3.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_3.ig</subfield>
       <subfield code="n">dimuon-Jpsi_3</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_4.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_4.ig</subfield>
       <subfield code="n">dimuon-Jpsi_4</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_5.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_5.ig</subfield>
       <subfield code="n">dimuon-Jpsi_5</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11580&amp;filename=dimuon-Jpsi_6.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon-Jpsi_6.ig</subfield>
       <subfield code="n">dimuon-Jpsi_6</subfield>
     </datafield>
   </record>
@@ -180,91 +180,91 @@
       <subfield code="a">CMS-Derived-Datasets</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_0.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_0.ig</subfield>
       <subfield code="n">dielectron-Jpsi_0</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_17.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_17.ig</subfield>
       <subfield code="n">dielectron-Jpsi_17</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_18.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_18.ig</subfield>
       <subfield code="n">dielectron-Jpsi_18</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_19.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_19.ig</subfield>
       <subfield code="n">dielectron-Jpsi_19</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_2.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_2.ig</subfield>
       <subfield code="n">dielectron-Jpsi_2</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_3.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_3.ig</subfield>
       <subfield code="n">dielectron-Jpsi_3</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_4.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_4.ig</subfield>
       <subfield code="n">dielectron-Jpsi_4</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_5.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_5.ig</subfield>
       <subfield code="n">dielectron-Jpsi_5</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_6.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_6.ig</subfield>
       <subfield code="n">dielectron-Jpsi_6</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_7.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_7.ig</subfield>
       <subfield code="n">dielectron-Jpsi_7</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_8.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_8.ig</subfield>
       <subfield code="n">dielectron-Jpsi_8</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_1.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_1.ig</subfield>
       <subfield code="n">dielectron-Jpsi_1</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_9.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_9.ig</subfield>
       <subfield code="n">dielectron-Jpsi_9</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_10.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_10.ig</subfield>
       <subfield code="n">dielectron-Jpsi_10</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_11.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_11.ig</subfield>
       <subfield code="n">dielectron-Jpsi_11</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_12.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_12.ig</subfield>
       <subfield code="n">dielectron-Jpsi_12</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_13.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_13.ig</subfield>
       <subfield code="n">dielectron-Jpsi_13</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_14.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_14.ig</subfield>
       <subfield code="n">dielectron-Jpsi_14</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_15.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_15.ig</subfield>
       <subfield code="n">dielectron-Jpsi_15</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi_16.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi_16.ig</subfield>
       <subfield code="n">dielectron-Jpsi_16</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi.csv</subfield>
       <subfield code="n">dielectron-Jpsi</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12064&amp;filename=dielectron-Jpsi.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Jpsi.json</subfield>
       <subfield code="n">dielectron-Jpsi</subfield>
     </datafield>
   </record>
@@ -291,51 +291,51 @@
       <subfield code="a">CMS-Derived-Datasets</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11583&amp;filename=dimuon100k.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon100k.json</subfield>
       <subfield code="n">dimuon</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11583&amp;filename=dimuon_7.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon_7.ig</subfield>
       <subfield code="n">dimuon_7</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11583&amp;filename=dimuon_8.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon_8.ig</subfield>
       <subfield code="n">dimuon_8</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11583&amp;filename=dimuon_9.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon_9.ig</subfield>
       <subfield code="n">dimuon_9</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11583&amp;filename=dimuon100k.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon100k.csv</subfield>
       <subfield code="n">dimuon</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11583&amp;filename=dimuon_0.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon_0.ig</subfield>
       <subfield code="n">dimuon_0</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11583&amp;filename=dimuon_1.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon_1.ig</subfield>
       <subfield code="n">dimuon_1</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11583&amp;filename=dimuon_2.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon_2.ig</subfield>
       <subfield code="n">dimuon_2</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11583&amp;filename=dimuon_3.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon_3.ig</subfield>
       <subfield code="n">dimuon_3</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11583&amp;filename=dimuon_4.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon_4.ig</subfield>
       <subfield code="n">dimuon_4</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11583&amp;filename=dimuon_5.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon_5.ig</subfield>
       <subfield code="n">dimuon_5</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11583&amp;filename=dimuon_6.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dimuon_6.ig</subfield>
       <subfield code="n">dimuon_6</subfield>
     </datafield>
   </record>
@@ -362,51 +362,51 @@
       <subfield code="a">CMS-Derived-Datasets</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12037&amp;filename=dielectron_0.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron_0.ig</subfield>
       <subfield code="n">dielectron_0</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12037&amp;filename=dielectron100k.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron100k.csv</subfield>
       <subfield code="n">dielectron</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12037&amp;filename=dielectron100k.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron100k.json</subfield>
       <subfield code="n">dielectron</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12037&amp;filename=dielectron_1.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron_1.ig</subfield>
       <subfield code="n">dielectron_1</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12037&amp;filename=dielectron_2.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron_2.ig</subfield>
       <subfield code="n">dielectron_2</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12037&amp;filename=dielectron_3.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron_3.ig</subfield>
       <subfield code="n">dielectron_3</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12037&amp;filename=dielectron_4.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron_4.ig</subfield>
       <subfield code="n">dielectron_4</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12037&amp;filename=dielectron_5.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron_5.ig</subfield>
       <subfield code="n">dielectron_5</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12037&amp;filename=dielectron_6.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron_6.ig</subfield>
       <subfield code="n">dielectron_6</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12037&amp;filename=dielectron_7.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron_7.ig</subfield>
       <subfield code="n">dielectron_7</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12037&amp;filename=dielectron_8.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron_8.ig</subfield>
       <subfield code="n">dielectron_8</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12037&amp;filename=dielectron_9.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron_9.ig</subfield>
       <subfield code="n">dielectron_9</subfield>
     </datafield>
   </record>
@@ -433,91 +433,91 @@
       <subfield code="a">CMS-Derived-Datasets</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_0.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_0.ig</subfield>
       <subfield code="n">dielectron-Upsilon_0</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_17.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_17.ig</subfield>
       <subfield code="n">dielectron-Upsilon_17</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_18.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_18.ig</subfield>
       <subfield code="n">dielectron-Upsilon_18</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_19.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_19.ig</subfield>
       <subfield code="n">dielectron-Upsilon_19</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_2.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_2.ig</subfield>
       <subfield code="n">dielectron-Upsilon_2</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_3.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_3.ig</subfield>
       <subfield code="n">dielectron-Upsilon_3</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_4.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_4.ig</subfield>
       <subfield code="n">dielectron-Upsilon_4</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_5.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_5.ig</subfield>
       <subfield code="n">dielectron-Upsilon_5</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_6.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_6.ig</subfield>
       <subfield code="n">dielectron-Upsilon_6</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_7.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_7.ig</subfield>
       <subfield code="n">dielectron-Upsilon_7</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_8.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_8.ig</subfield>
       <subfield code="n">dielectron-Upsilon_8</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_1.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_1.ig</subfield>
       <subfield code="n">dielectron-Upsilon_1</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_9.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_9.ig</subfield>
       <subfield code="n">dielectron-Upsilon_9</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_10.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_10.ig</subfield>
       <subfield code="n">dielectron-Upsilon_10</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_11.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_11.ig</subfield>
       <subfield code="n">dielectron-Upsilon_11</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_12.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_12.ig</subfield>
       <subfield code="n">dielectron-Upsilon_12</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_13.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_13.ig</subfield>
       <subfield code="n">dielectron-Upsilon_13</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_14.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_14.ig</subfield>
       <subfield code="n">dielectron-Upsilon_14</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_15.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_15.ig</subfield>
       <subfield code="n">dielectron-Upsilon_15</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon_16.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon_16.ig</subfield>
       <subfield code="n">dielectron-Upsilon_16</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon.csv</subfield>
       <subfield code="n">dielectron-Upsilon</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=12065&amp;filename=dielectron-Upsilon.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/dielectron-Upsilon.json</subfield>
       <subfield code="n">dielectron-Upsilon</subfield>
     </datafield>
   </record>
@@ -544,31 +544,31 @@
       <subfield code="a">CMS-Derived-Datasets</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11581&amp;filename=Zee.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zee.csv</subfield>
       <subfield code="n">Zee</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11581&amp;filename=Zee.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zee.json</subfield>
       <subfield code="n">Zee</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11581&amp;filename=Zee_0.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zee_0.ig</subfield>
       <subfield code="n">Zee_0</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11581&amp;filename=Zee_1.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zee_1.ig</subfield>
       <subfield code="n">Zee_1</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11581&amp;filename=Zee_2.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zee_2.ig</subfield>
       <subfield code="n">Zee_2</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11581&amp;filename=Zee_3.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zee_3.ig</subfield>
       <subfield code="n">Zee_3</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11581&amp;filename=Zee_4.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zee_4.ig</subfield>
       <subfield code="n">Zee_4</subfield>
     </datafield>
   </record>
@@ -595,31 +595,31 @@
       <subfield code="a">CMS-Derived-Datasets</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11582&amp;filename=Zmumu_0.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zmumu_0.ig</subfield>
       <subfield code="n">Zmumu_0</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11582&amp;filename=Zmumu_1.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zmumu_1.ig</subfield>
       <subfield code="n">Zmumu_1</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11582&amp;filename=Zmumu_2.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zmumu_2.ig</subfield>
       <subfield code="n">Zmumu_2</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11582&amp;filename=Zmumu_3.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zmumu_3.ig</subfield>
       <subfield code="n">Zmumu_3</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11582&amp;filename=Zmumu_4.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zmumu_4.ig</subfield>
       <subfield code="n">Zmumu_4</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11582&amp;filename=Zmumu.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zmumu.csv</subfield>
       <subfield code="n">Zmumu</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=11582&amp;filename=Zmumu.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zmumu.json</subfield>
       <subfield code="n">Zmumu</subfield>
     </datafield>
   </record>
@@ -646,51 +646,51 @@
       <subfield code="a">CMS-Derived-Datasets</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4673&amp;filename=Wenu.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu.csv</subfield>
       <subfield code="n">Wenu</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4673&amp;filename=Wenu_7.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu_7.ig</subfield>
       <subfield code="n">Wenu_7</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4673&amp;filename=Wenu_8.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu_8.ig</subfield>
       <subfield code="n">Wenu_8</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4673&amp;filename=Wenu_9.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu_9.ig</subfield>
       <subfield code="n">Wenu_9</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4673&amp;filename=Wenu.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu.json</subfield>
       <subfield code="n">Wenu</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4673&amp;filename=Wenu_0.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu_0.ig</subfield>
       <subfield code="n">Wenu_0</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4673&amp;filename=Wenu_1.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu_1.ig</subfield>
       <subfield code="n">Wenu_1</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4673&amp;filename=Wenu_2.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu_2.ig</subfield>
       <subfield code="n">Wenu_2</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4673&amp;filename=Wenu_3.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu_3.ig</subfield>
       <subfield code="n">Wenu_3</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4673&amp;filename=Wenu_4.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu_4.ig</subfield>
       <subfield code="n">Wenu_4</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4673&amp;filename=Wenu_5.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu_5.ig</subfield>
       <subfield code="n">Wenu_5</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4673&amp;filename=Wenu_6.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu_6.ig</subfield>
       <subfield code="n">Wenu_6</subfield>
     </datafield>
   </record>
@@ -717,51 +717,51 @@
       <subfield code="a">CMS-Derived-Datasets</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4655&amp;filename=Wmunu.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu.csv</subfield>
       <subfield code="n">Wmunu</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4655&amp;filename=Wmunu_7.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu_7.ig</subfield>
       <subfield code="n">Wmunu_7</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4655&amp;filename=Wmunu_8.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu_8.ig</subfield>
       <subfield code="n">Wmunu_8</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4655&amp;filename=Wmunu_9.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu_9.ig</subfield>
       <subfield code="n">Wmunu_9</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4655&amp;filename=Wmunu.json</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu.json</subfield>
       <subfield code="n">Wmunu</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4655&amp;filename=Wmunu_0.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu_0.ig</subfield>
       <subfield code="n">Wmunu_0</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4655&amp;filename=Wmunu_1.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu_1.ig</subfield>
       <subfield code="n">Wmunu_1</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4655&amp;filename=Wmunu_2.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu_2.ig</subfield>
       <subfield code="n">Wmunu_2</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4655&amp;filename=Wmunu_3.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu_3.ig</subfield>
       <subfield code="n">Wmunu_3</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4655&amp;filename=Wmunu_4.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu_4.ig</subfield>
       <subfield code="n">Wmunu_4</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4655&amp;filename=Wmunu_5.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu_5.ig</subfield>
       <subfield code="n">Wmunu_5</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile?docid=4655&amp;filename=Wmunu_6.ig</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu_6.ig</subfield>
       <subfield code="n">Wmunu_6</subfield>
     </datafield>
   </record>

--- a/invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml
@@ -77,27 +77,27 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">BTau AOD dataset file index (1 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
       <subfield code="z">BTau AOD dataset file index (2 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">BTau AOD dataset file index (3 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
       <subfield code="z">BTau AOD dataset file index (4 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
       <subfield code="z">BTau AOD dataset file index (5 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
       <subfield code="z">BTau AOD dataset file index (6 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -179,23 +179,23 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">ZeroBias AOD dataset file index (1 of 5) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
       <subfield code="z">ZeroBias AOD dataset file index (2 of 5) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">ZeroBias AOD dataset file index (3 of 5) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0006_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0006_file_index.txt</subfield>
       <subfield code="z">ZeroBias AOD dataset file index (4 of 5) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0008_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0008_file_index.txt</subfield>
       <subfield code="z">ZeroBias AOD dataset file index (5 of 5) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -277,19 +277,19 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">Commissioning AOD dataset file index (1 of 4) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">Commissioning AOD dataset file index (2 of 4) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
       <subfield code="z">Commissioning AOD dataset file index (3 of 4) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
       <subfield code="z">Commissioning AOD dataset file index (4 of 4) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -371,27 +371,27 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">EGMonitor AOD dataset file index (1 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
       <subfield code="z">EGMonitor AOD dataset file index (2 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">EGMonitor AOD dataset file index (3 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
       <subfield code="z">EGMonitor AOD dataset file index (4 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
       <subfield code="z">EGMonitor AOD dataset file index (5 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
       <subfield code="z">EGMonitor AOD dataset file index (6 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -473,27 +473,27 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">Electron AOD dataset file index (1 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
       <subfield code="z">Electron AOD dataset file index (2 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">Electron AOD dataset file index (3 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
       <subfield code="z">Electron AOD dataset file index (4 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
       <subfield code="z">Electron AOD dataset file index (5 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
       <subfield code="z">Electron AOD dataset file index (6 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -575,27 +575,27 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">Jet AOD dataset file index (1 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
       <subfield code="z">Jet AOD dataset file index (2 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">Jet AOD dataset file index (3 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
       <subfield code="z">Jet AOD dataset file index (4 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
       <subfield code="z">Jet AOD dataset file index (5 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
       <subfield code="z">Jet AOD dataset file index (6 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -677,27 +677,27 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">Photon AOD dataset file index (1 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
       <subfield code="z">Photon AOD dataset file index (2 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">Photon AOD dataset file index (3 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
       <subfield code="z">Photon AOD dataset file index (4 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
       <subfield code="z">Photon AOD dataset file index (5 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
       <subfield code="z">Photon AOD dataset file index (6 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -779,19 +779,19 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">MultiJet AOD dataset file index (1 of 4) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
       <subfield code="z">MultiJet AOD dataset file index (2 of 4) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">MultiJet AOD dataset file index (3 of 4) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
       <subfield code="z">MultiJet AOD dataset file index (4 of 4) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -873,7 +873,7 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MuMonitor_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MuMonitor_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">MuMonitor AOD dataset file index (1 of 1) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -955,31 +955,31 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">MinimumBias AOD dataset file index (1 of 7) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
       <subfield code="z">MinimumBias AOD dataset file index (2 of 7) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">MinimumBias AOD dataset file index (3 of 7) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
       <subfield code="z">MinimumBias AOD dataset file index (4 of 7) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
       <subfield code="z">MinimumBias AOD dataset file index (5 of 7) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
       <subfield code="z">MinimumBias AOD dataset file index (6 of 7) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0006_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0006_file_index.txt</subfield>
       <subfield code="z">MinimumBias AOD dataset file index (7 of 7) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -1061,27 +1061,27 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">JetMETTauMonitor AOD dataset file index (1 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
       <subfield code="z">JetMETTauMonitor AOD dataset file index (2 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">JetMETTauMonitor AOD dataset file index (3 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
       <subfield code="z">JetMETTauMonitor AOD dataset file index (4 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
       <subfield code="z">JetMETTauMonitor AOD dataset file index (5 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
       <subfield code="z">JetMETTauMonitor AOD dataset file index (6 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -1163,27 +1163,27 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">METFwd AOD dataset file index (1 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
       <subfield code="z">METFwd AOD dataset file index (2 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">METFwd AOD dataset file index (3 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
       <subfield code="z">METFwd AOD dataset file index (4 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
       <subfield code="z">METFwd AOD dataset file index (5 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
       <subfield code="z">METFwd AOD dataset file index (6 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -1265,27 +1265,27 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">MuOnia AOD dataset file index (1 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
       <subfield code="z">MuOnia AOD dataset file index (2 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">MuOnia AOD dataset file index (3 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
       <subfield code="z">MuOnia AOD dataset file index (4 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
       <subfield code="z">MuOnia AOD dataset file index (5 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
       <subfield code="z">MuOnia AOD dataset file index (6 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>
@@ -1367,27 +1367,27 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0000_file_index.txt</subfield>
       <subfield code="z">Mu AOD dataset file index (1 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0001_file_index.txt</subfield>
       <subfield code="z">Mu AOD dataset file index (2 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0002_file_index.txt</subfield>
       <subfield code="z">Mu AOD dataset file index (3 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0003_file_index.txt</subfield>
       <subfield code="z">Mu AOD dataset file index (4 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0004_file_index.txt</subfield>
       <subfield code="z">Mu AOD dataset file index (5 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/eos-file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-eos-file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0005_file_index.txt</subfield>
       <subfield code="z">Mu AOD dataset file index (6 of 6) for access to data via CMS virtual machine</subfield>
     </datafield>
   </record>

--- a/invenio_opendata/testsuite/data/cms/cms-tools-vm-image.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-vm-image.xml
@@ -18,7 +18,7 @@
       <subfield code="a">CMS-Tools</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">http://cernvm.cern.ch/releases/CMS-OpenData-1.0.0-rc4.ova</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cernvm-files/CMS-OpenData-1.0.0-rc4.ova</subfield>
     </datafield>
   </record>
 </collection>

--- a/invenio_opendata/testsuite/data/cms/cms-validated-runs.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-validated-runs.xml
@@ -22,7 +22,7 @@
       <subfield code="a">CMS-Validated-Runs</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">https://raw.githubusercontent.com/ayrodrig/pattuples2010/master/Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cernvm-files/Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt</subfield>
     </datafield>
   </record>
 </collection>

--- a/populate-fft-file-cache.sh
+++ b/populate-fft-file-cache.sh
@@ -1,0 +1,213 @@
+#!/bin/sh
+#
+# A helper script to download (mostly from CMS DocDB) files that are
+# used for FFT uploads when building opendata.cern.ch site.
+#
+# NOTE: the FFT file cache directory is by default located in
+# "$HOME/opendata.cern.ch-fft-file-cache".  The script also makes
+# symlink to this place from "/tmp" so that files can be uploaded
+# regardless of $HOME.
+#
+# NOTE: if the files are already present in the destinated directory,
+# does not download anything, even without checking whether remote
+# files have changed.
+#
+# NOTE: not using remote CMS DocDB URLs directly, because the total
+# amount of files to transfer is about 6.6 GB.  It is better to run
+# this script once in your development environment to store the files
+# locally on your laptop, in which case further rebuilds of
+# opendata.cern.ch site can be run fully locally, hence being
+# significantly faster.
+
+# config section:
+WGET="wget -nc -nv --no-check-certificate"
+DOCDB="https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/RetrieveFile"
+OUTDIR="$HOME/opendata.cern.ch-fft-file-cache"
+
+# quit on errors and potentially unbound symbols:
+#set -o errexit # because of wget
+set -o nounset
+
+# make sur output directory exists:
+mkdir -p $OUTDIR
+mkdir -p $OUTDIR/cms-eos-file-indexes
+mkdir -p $OUTDIR/alice-eos-file-indexes
+mkdir -p $OUTDIR/cms-docdb-files
+mkdir -p $OUTDIR/cernvm-files
+mkdir -p $OUTDIR/github-files
+
+# firstly, mirror EOS files existing in the repository:
+rsync -a invenio_opendata/testsuite/data/cms/eos-file-indexes/ $OUTDIR/cms-eos-file-indexes/
+rsync -a invenio_opendata/testsuite/data/alice/eos-file-indexes/ $OUTDIR/alice-eos-file-indexes/
+
+# secondly, download CMS DocDB files: (if not already existing)
+$WGET -O $OUTDIR/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_0.csv "$DOCDB?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_0.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon.csv "$DOCDB?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_1.csv "$DOCDB?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_1.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_2.csv "$DOCDB?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_2.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_3.csv "$DOCDB?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_3.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_4.csv "$DOCDB?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_4.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_5.csv "$DOCDB?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_5.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_6.csv "$DOCDB?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_6.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_7.csv "$DOCDB?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_7.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_8.csv "$DOCDB?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_8.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_9.csv "$DOCDB?docid=12450&amp;filename=Run2010B_Mu_AOD_Apr21ReReco-v1-dimuon_9.csv"
+$WGET -O $OUTDIR/cms-docdb-files/BTau.ig "$DOCDB?docid=12376&amp;filename=BTau.ig"
+$WGET -O $OUTDIR/cms-docdb-files/EGMonitor.ig "$DOCDB?docid=12376&amp;filename=EGMonitor.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Electron.ig "$DOCDB?docid=12376&amp;filename=Electron.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Jet.ig "$DOCDB?docid=12376&amp;filename=Jet.ig"
+$WGET -O $OUTDIR/cms-docdb-files/JetMETTauMonitor.ig "$DOCDB?docid=12376&amp;filename=JetMETTauMonitor.ig"
+$WGET -O $OUTDIR/cms-docdb-files/METFwd.ig "$DOCDB?docid=12376&amp;filename=METFwd.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Mu.ig "$DOCDB?docid=12376&amp;filename=Mu.ig"
+$WGET -O $OUTDIR/cms-docdb-files/MuMonitor.ig "$DOCDB?docid=12376&amp;filename=MuMonitor.ig"
+$WGET -O $OUTDIR/cms-docdb-files/MuOnia.ig "$DOCDB?docid=12376&amp;filename=MuOnia.ig"
+$WGET -O $OUTDIR/cms-docdb-files/MultiJet.ig "$DOCDB?docid=12376&amp;filename=MultiJet.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Photon.ig "$DOCDB?docid=12376&amp;filename=Photon.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Commissioning.ig "$DOCDB?docid=12376&amp;filename=Commissioning.ig"
+$WGET -O $OUTDIR/cms-docdb-files/MinimumBias.ig "$DOCDB?docid=12376&amp;filename=MinimumBias.ig"
+$WGET -O $OUTDIR/cms-docdb-files/ZeroBias.ig "$DOCDB?docid=12376&amp;filename=ZeroBias.ig"
+$WGET -O $OUTDIR/cms-docdb-files/4lepton.csv "$DOCDB?docid=11976&amp;filename=4lepton.csv"
+$WGET -O $OUTDIR/cms-docdb-files/4lepton.ig "$DOCDB?docid=11976&amp;filename=4lepton.ig"
+$WGET -O $OUTDIR/cms-docdb-files/4lepton.json "$DOCDB?docid=11976&amp;filename=4lepton.json"
+$WGET -O $OUTDIR/cms-docdb-files/diphoton.csv "$DOCDB?docid=11976&amp;filename=diphoton.csv"
+$WGET -O $OUTDIR/cms-docdb-files/diphoton.ig "$DOCDB?docid=11976&amp;filename=diphoton.ig"
+$WGET -O $OUTDIR/cms-docdb-files/diphoton.json "$DOCDB?docid=11976&amp;filename=diphoton.json"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi.csv "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi.csv"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_7.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_7.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_8.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_8.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_9.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_9.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_10.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_10.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_11.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_11.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_12.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_12.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_13.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_13.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_14.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_14.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_15.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_15.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_16.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_16.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi.json "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi.json"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_17.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_17.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_18.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_18.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_19.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_19.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_0.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_0.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_1.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_1.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_2.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_2.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_3.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_3.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_4.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_4.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_5.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_5.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon-Jpsi_6.ig "$DOCDB?docid=11580&amp;filename=dimuon-Jpsi_6.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_0.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_0.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_17.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_17.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_18.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_18.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_19.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_19.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_2.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_2.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_3.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_3.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_4.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_4.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_5.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_5.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_6.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_6.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_7.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_7.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_8.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_8.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_1.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_1.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_9.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_9.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_10.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_10.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_11.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_11.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_12.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_12.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_13.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_13.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_14.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_14.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_15.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_15.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi_16.ig "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi_16.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi.csv "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi.csv"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Jpsi.json "$DOCDB?docid=12064&amp;filename=dielectron-Jpsi.json"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon100k.json "$DOCDB?docid=11583&amp;filename=dimuon100k.json"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon_7.ig "$DOCDB?docid=11583&amp;filename=dimuon_7.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon_8.ig "$DOCDB?docid=11583&amp;filename=dimuon_8.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon_9.ig "$DOCDB?docid=11583&amp;filename=dimuon_9.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon100k.csv "$DOCDB?docid=11583&amp;filename=dimuon100k.csv"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon_0.ig "$DOCDB?docid=11583&amp;filename=dimuon_0.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon_1.ig "$DOCDB?docid=11583&amp;filename=dimuon_1.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon_2.ig "$DOCDB?docid=11583&amp;filename=dimuon_2.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon_3.ig "$DOCDB?docid=11583&amp;filename=dimuon_3.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon_4.ig "$DOCDB?docid=11583&amp;filename=dimuon_4.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon_5.ig "$DOCDB?docid=11583&amp;filename=dimuon_5.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dimuon_6.ig "$DOCDB?docid=11583&amp;filename=dimuon_6.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron_0.ig "$DOCDB?docid=12037&amp;filename=dielectron_0.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron100k.csv "$DOCDB?docid=12037&amp;filename=dielectron100k.csv"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron100k.json "$DOCDB?docid=12037&amp;filename=dielectron100k.json"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron_1.ig "$DOCDB?docid=12037&amp;filename=dielectron_1.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron_2.ig "$DOCDB?docid=12037&amp;filename=dielectron_2.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron_3.ig "$DOCDB?docid=12037&amp;filename=dielectron_3.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron_4.ig "$DOCDB?docid=12037&amp;filename=dielectron_4.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron_5.ig "$DOCDB?docid=12037&amp;filename=dielectron_5.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron_6.ig "$DOCDB?docid=12037&amp;filename=dielectron_6.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron_7.ig "$DOCDB?docid=12037&amp;filename=dielectron_7.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron_8.ig "$DOCDB?docid=12037&amp;filename=dielectron_8.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron_9.ig "$DOCDB?docid=12037&amp;filename=dielectron_9.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_0.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_0.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_17.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_17.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_18.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_18.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_19.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_19.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_2.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_2.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_3.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_3.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_4.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_4.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_5.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_5.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_6.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_6.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_7.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_7.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_8.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_8.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_1.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_1.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_9.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_9.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_10.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_10.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_11.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_11.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_12.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_12.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_13.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_13.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_14.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_14.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_15.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_15.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon_16.ig "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon_16.ig"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon.csv "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon.csv"
+$WGET -O $OUTDIR/cms-docdb-files/dielectron-Upsilon.json "$DOCDB?docid=12065&amp;filename=dielectron-Upsilon.json"
+$WGET -O $OUTDIR/cms-docdb-files/Zee.csv "$DOCDB?docid=11581&amp;filename=Zee.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Zee.json "$DOCDB?docid=11581&amp;filename=Zee.json"
+$WGET -O $OUTDIR/cms-docdb-files/Zee_0.ig "$DOCDB?docid=11581&amp;filename=Zee_0.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Zee_1.ig "$DOCDB?docid=11581&amp;filename=Zee_1.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Zee_2.ig "$DOCDB?docid=11581&amp;filename=Zee_2.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Zee_3.ig "$DOCDB?docid=11581&amp;filename=Zee_3.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Zee_4.ig "$DOCDB?docid=11581&amp;filename=Zee_4.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Zmumu_0.ig "$DOCDB?docid=11582&amp;filename=Zmumu_0.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Zmumu_1.ig "$DOCDB?docid=11582&amp;filename=Zmumu_1.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Zmumu_2.ig "$DOCDB?docid=11582&amp;filename=Zmumu_2.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Zmumu_3.ig "$DOCDB?docid=11582&amp;filename=Zmumu_3.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Zmumu_4.ig "$DOCDB?docid=11582&amp;filename=Zmumu_4.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Zmumu.csv "$DOCDB?docid=11582&amp;filename=Zmumu.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Zmumu.json "$DOCDB?docid=11582&amp;filename=Zmumu.json"
+$WGET -O $OUTDIR/cms-docdb-files/Wenu.csv "$DOCDB?docid=4673&amp;filename=Wenu.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Wenu_7.ig "$DOCDB?docid=4673&amp;filename=Wenu_7.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wenu_8.ig "$DOCDB?docid=4673&amp;filename=Wenu_8.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wenu_9.ig "$DOCDB?docid=4673&amp;filename=Wenu_9.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wenu.json "$DOCDB?docid=4673&amp;filename=Wenu.json"
+$WGET -O $OUTDIR/cms-docdb-files/Wenu_0.ig "$DOCDB?docid=4673&amp;filename=Wenu_0.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wenu_1.ig "$DOCDB?docid=4673&amp;filename=Wenu_1.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wenu_2.ig "$DOCDB?docid=4673&amp;filename=Wenu_2.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wenu_3.ig "$DOCDB?docid=4673&amp;filename=Wenu_3.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wenu_4.ig "$DOCDB?docid=4673&amp;filename=Wenu_4.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wenu_5.ig "$DOCDB?docid=4673&amp;filename=Wenu_5.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wenu_6.ig "$DOCDB?docid=4673&amp;filename=Wenu_6.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu.csv "$DOCDB?docid=4655&amp;filename=Wmunu.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu_7.ig "$DOCDB?docid=4655&amp;filename=Wmunu_7.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu_8.ig "$DOCDB?docid=4655&amp;filename=Wmunu_8.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu_9.ig "$DOCDB?docid=4655&amp;filename=Wmunu_9.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu.json "$DOCDB?docid=4655&amp;filename=Wmunu.json"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu_0.ig "$DOCDB?docid=4655&amp;filename=Wmunu_0.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu_1.ig "$DOCDB?docid=4655&amp;filename=Wmunu_1.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu_2.ig "$DOCDB?docid=4655&amp;filename=Wmunu_2.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu_3.ig "$DOCDB?docid=4655&amp;filename=Wmunu_3.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu_4.ig "$DOCDB?docid=4655&amp;filename=Wmunu_4.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu_5.ig "$DOCDB?docid=4655&amp;filename=Wmunu_5.ig"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu_6.ig "$DOCDB?docid=4655&amp;filename=Wmunu_6.ig"
+
+# thirdly, download more dependent files:
+$WGET -O $OUTDIR/cernvm-files/CMS-OpenData-1.0.0-rc4.ova "http://cernvm.cern.ch/releases/CMS-OpenData-1.0.0-rc4.ova"
+$WGET -O $OUTDIR/github-files/Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt "https://raw.githubusercontent.com/ayrodrig/pattuples2010/master/Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt"
+
+# finally, make symlink to FFT cache from tmp:
+if [ ! -L "/tmp/$(basename $OUTDIR)" ]; then
+    ln -s $OUTDIR /tmp
+fi
+
+# end of file


### PR DESCRIPTION
- Adds `populate-fft-file-cache.sh` helper build script useful to
  pre-download all files used in FFTs.  (closes #350)
- Amends installation instructions on how to use local FFT file cache.
- Amends all XML input files accordingly.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
