### PR TITLE
CMS: fix XML compliance of `cms-tools-vm-image.xml`

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-tools-vm-image.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-vm-image.xml
@@ -17,7 +17,7 @@
     <datafield tag="556" ind1=" " ind2=" ">
       <subfield code="a">For known issues and limitations see</subfield>
       <subfield code="u">http://opendata.cern.ch/VM/CMS#limitation</subfield>
-      <subfield code="y">CMS Virtual Machines - Known Issues & Limitations</subfield>
+      <subfield code="y">CMS Virtual Machines - Known Issues and Limitations</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">Please follow the tutorial on how to use the CMS Virtual Machine</subfield>


### PR DESCRIPTION
- Fixes XML escaping problem that was introduced in
  2e720ab7735771555626828164f45e5fe289e396.
- Also, prefers to use "and" instead of "&". (see #357)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
