### PR TITLE
change description of ATLAS

### DIFF
--- a/invenio_opendata/base/fixtures/websearch.py
+++ b/invenio_opendata/base/fixtures/websearch.py
@@ -526,7 +526,7 @@ class PortalboxData(DataSet):
         title = u'image'
 
     class Portalbox_20:
-        body = u'The ATLAS (A Toroidal LHC ApparatuS) experiment is the other general-purpose particle physics detector at the LHC. It covers a wide range of physics exploring topics like the properties of the Higgs-like particle whose discovery was announced in July 2012.'
+        body = u'The ATLAS (A Toroidal LHC ApparatuS) experiment is one of the two general purpose detectors at the LHC. It covers a wide range of physics exploring topics like the properties of the Higgs-like particle whose discovery was announced in July 2012.'
         id = 20
         title = u'description'
 


### PR DESCRIPTION
Suggest changing:
"The ATLAS experiment is the other general-purpose particle physics detector at the LHC." 
to 
"The ATLAS experiment is one of the two general purpose detectors at the LHC."

as seen here:
http://opendata.cern.ch/research/ATLAS
