### PR TITLE
testsuite: record ID 450 for CMS author lists

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-author-list.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-author-list.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <collection>
 <record>
+  <controlfield tag="001">450</controlfield>
   <datafield tag="100" ind1=" " ind2=" ">
     <subfield code="a">Chatrchyan, Serguei</subfield>
     <subfield code="u">Yerevan Phys. Inst.</subfield>


### PR DESCRIPTION
- Fixes CMS author list record that did not have any record ID.  Uses
  record ID 450 now, which is close to "Data Policy" records.
  (see #607) (see PR #536)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
