### PR TITLE
CMS: FFT for Tom's github code release v1.0.0

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-tools-dimuon-filter.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-dimuon-filter.xml
@@ -1,53 +1,65 @@
 <collection>
-<record>
-<controlfield tag="001">552</controlfield>
-  <datafield tag="024" ind1="7" ind2=" ">
-    <subfield code="2">DOI</subfield>
-    <subfield code="a">10.7483/OPENDATA.CMS.RB4W.3ZK9</subfield>
-  </datafield>
-  <datafield tag="100" ind1=" " ind2=" ">
-    <subfield code="a">McCauley, Thomas</subfield>
-  </datafield>
-  <datafield tag="245" ind1=" " ind2=" ">
-    <subfield code="a">Software to extract data in csv format from a CMS primary dataset</subfield>
-  </datafield>
-  <datafield tag="260" ind1=" " ind2=" ">
-    <subfield code="b">CERN Open Data Portal</subfield>
-    <subfield code="c">2014</subfield>
-  </datafield>
-  <datafield tag="516" ind1=" " ind2=" ">
-    <subfield code="a">Use this with the Mu primary datasets /Mu/Run2010B-Apr21ReReco-v1/AOD</subfield>
-    <subfield code="w">14</subfield>
-  </datafield>
-  <datafield tag="520" ind1=" " ind2=" ">
-    <subfield code="a">This package is a filter that selects events from the Mu primary dataset from the CMS open data release. In particular, the event is selected if (for simplicity) there are precisely two muons in the event and at least one is a global muon. A csv file containing the four-vector information, charge, and invariant mass of the two muons is produced.</subfield>
-  </datafield>
-  <datafield tag="538" ind1=" " ind2=" ">
-    <subfield code="a">Software release: CMSSW_4_2_8</subfield>
-    <subfield code="i">Use this code with the CMS Open Data VM environment</subfield>
-    <subfield code="w">250</subfield>
-  </datafield>
-  <datafield tag="693" ind1=" " ind2=" ">
-    <subfield code="a">CERN-LHC</subfield>
-    <subfield code="e">CMS</subfield>
-  </datafield>
-  <datafield tag="581" ind1=" " ind2=" ">
-    <subfield code="a">See the run instructions in</subfield>
-    <subfield code="u">https://github.com/tpmccauley/dimuon-filter</subfield>
-    <subfield code="y">GitHub</subfield>
-  </datafield>
-  <datafield tag="787" ind1=" " ind2=" ">
-    <subfield code="a">The output are files in csv format such as</subfield>
-    <subfield code="w">700</subfield>
-  </datafield>
-  <datafield tag="856" ind1="4" ind2=" ">
-    <subfield code="u">https://github.com/tpmccauley/dimuon-filter</subfield>
-  </datafield>
-  <datafield tag="980" ind1=" " ind2=" ">
-    <subfield code="a">CMS-Tools</subfield>
-  </datafield>
-  <datafield tag="980" ind1=" " ind2=" ">
-    <subfield code="b">Research</subfield>
-  </datafield>
-</record>
+  <record>
+    <controlfield tag="001">552</controlfield>
+    <datafield tag="024" ind1="7" ind2=" ">
+      <subfield code="2">DOI</subfield>
+      <subfield code="a">10.7483/OPENDATA.CMS.RB4W.3ZK9</subfield>
+    </datafield>
+    <datafield tag="100" ind1=" " ind2=" ">
+      <subfield code="a">McCauley, Thomas</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Software to extract data in csv format from a CMS primary dataset</subfield>
+    </datafield>
+    <datafield tag="256" ind1=" " ind2=" ">
+      <subfield code="a">Software</subfield>
+      <subfield code="f">1</subfield>
+      <subfield code="t">file</subfield>
+    </datafield>
+    <datafield tag="256" ind1=" " ind2=" ">
+      <subfield code="b">52754</subfield>
+      <subfield code="t">bytes</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2014</subfield>
+    </datafield>
+    <datafield tag="516" ind1=" " ind2=" ">
+      <subfield code="a">Use this with the Mu primary datasets /Mu/Run2010B-Apr21ReReco-v1/AOD</subfield>
+      <subfield code="w">14</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">This package is a filter that selects events from the Mu primary dataset from the CMS open data release. In particular, the event is selected if (for simplicity) there are precisely two muons in the event and at least one is a global muon. A csv file containing the four-vector information, charge, and invariant mass of the two muons is produced.</subfield>
+    </datafield>
+    <datafield tag="538" ind1=" " ind2=" ">
+      <subfield code="a">Software release: CMSSW_4_2_8</subfield>
+      <subfield code="i">Use this code with the CMS Open Data VM environment</subfield>
+      <subfield code="w">250</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="581" ind1=" " ind2=" ">
+      <subfield code="a">See the run instructions in</subfield>
+      <subfield code="u">https://github.com/tpmccauley/dimuon-filter</subfield>
+      <subfield code="y">GitHub</subfield>
+    </datafield>
+    <datafield tag="787" ind1=" " ind2=" ">
+      <subfield code="a">The output are files in csv format such as</subfield>
+      <subfield code="w">700</subfield>
+    </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">https://github.com/tpmccauley/dimuon-filter</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Tools</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/github-files/dimuon-filter-1.0.0.tar.gz</subfield>
+    </datafield>
+  </record>
 </collection>

--- a/populate-fft-file-cache.sh
+++ b/populate-fft-file-cache.sh
@@ -286,6 +286,7 @@ mkdir -p $OUTDIR/github-files
 $WGET -O $OUTDIR/github-files/Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt "https://raw.githubusercontent.com/ayrodrig/pattuples2010/master/Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt"
 $WGET -O $OUTDIR/github-files/pattuples2012-1.0.0.tar.gz https://github.com/ayrodrig/pattuples2010/archive/v1.0.0.tar.gz
 $WGET -O $OUTDIR/github-files/OutreachExercise2010-1.0.0.tar.gz https://github.com/ayrodrig/OutreachExercise2010/archive/v1.0.0.tar.gz
+$WGET -O $OUTDIR/github-files/dimuon-filter-1.0.0.tar.gz https://github.com/tpmccauley/dimuon-filter/archive/1.0.0.tar.gz
 
 # fifthly, CMS Hamburg files:
 mkdir -p $OUTDIR/cms-hamburg-files


### PR DESCRIPTION
- Adds FFT for Tom's github code release v1.0.0.  Amends MARCXML files
  accordingly.  (addresses #71) (addresses #89)
- Improves indentation of `cms-tools-dimuon-filter.xml`.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
