### PR TITLE
templates: Fix CC0 disclaimer

### DIFF
--- a/invenio_opendata/base/templates/about_cms.html
+++ b/invenio_opendata/base/templates/about_cms.html
@@ -80,7 +80,7 @@
             <div class="gen-box">
               <h2 id="disclaimer">Disclaimer</h2>
               <ul class="col-md-12 no-padding">
-                <li>The open data are released under <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons Zero (CC0)</a>. Neither CMS or nor CERN endorse any works, scientific or otherwise, produced using these data.</li>
+                <li>The open data are released under the <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 waiver</a>. Neither CMS or nor CERN endorse any works, scientific or otherwise, produced using these data.</li>
                 <li>All datasets will have a unique DOI that you are requested to cite in any applications or publications.</li>
                 <li>Despite being processed, the high-level primary datasets remain complex and selection criteria need to be applied in order to analyse them, requiring some understanding of particle physics and detector functioning. The data cannot be viewed in simple data tables for spreadsheet-based analyses.
                 </li>


### PR DESCRIPTION
Replaced "under Creative Commons Zero (CC0)" with "under the Creative Commons CC0 waiver" as in the press release.
