### PR TITLE
LHCb: addition of all EOS URIs

### DIFF
--- a/invenio_opendata/testsuite/data/lhcb/lhcb-derived-datasets.xml
+++ b/invenio_opendata/testsuite/data/lhcb/lhcb-derived-datasets.xml
@@ -31,6 +31,11 @@
     <datafield tag="520" ind1="" ind2="">
       <subfield code="a">Each file contains 30 events recorded with LHCb detector. The events have been pre-selected using loose criteria to contain D0 meson candidates decaying into a Kaon and a Pion.</subfield>
     </datafield>
+    <datafield tag="581" ind1="" ind2="">
+      <subfield code="a">It can be visualized with the LHCb event display using LHCb VM image</subfield>
+      <subfield code="w">402</subfield>
+      <subfield code="y">LHCb VM image</subfield>
+    </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
     </datafield>
@@ -41,10 +46,880 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">LHCb</subfield>
     </datafield>
-    <datafield tag="581" ind1="" ind2="">
-      <subfield code="a">It can be visualized with the LHCb event display using LHCb VM image</subfield>
-      <subfield code="w">402</subfield>
-      <subfield code="y">LHCb VM image</subfield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_1.root</subfield>
+      <subfield code="s">553275</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_10.root</subfield>
+      <subfield code="s">491569</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_100.root</subfield>
+      <subfield code="s">559434</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_101.root</subfield>
+      <subfield code="s">614174</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_102.root</subfield>
+      <subfield code="s">478253</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_103.root</subfield>
+      <subfield code="s">548798</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_104.root</subfield>
+      <subfield code="s">608320</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_105.root</subfield>
+      <subfield code="s">577972</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_106.root</subfield>
+      <subfield code="s">591225</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_107.root</subfield>
+      <subfield code="s">540740</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_108.root</subfield>
+      <subfield code="s">632520</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_109.root</subfield>
+      <subfield code="s">564024</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_11.root</subfield>
+      <subfield code="s">588479</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_110.root</subfield>
+      <subfield code="s">665802</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_111.root</subfield>
+      <subfield code="s">603210</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_112.root</subfield>
+      <subfield code="s">623009</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_113.root</subfield>
+      <subfield code="s">569832</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_114.root</subfield>
+      <subfield code="s">558142</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_115.root</subfield>
+      <subfield code="s">626669</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_116.root</subfield>
+      <subfield code="s">685192</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_117.root</subfield>
+      <subfield code="s">617612</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_118.root</subfield>
+      <subfield code="s">618438</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_119.root</subfield>
+      <subfield code="s">562310</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_12.root</subfield>
+      <subfield code="s">438622</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_120.root</subfield>
+      <subfield code="s">599337</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_121.root</subfield>
+      <subfield code="s">564208</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_122.root</subfield>
+      <subfield code="s">529423</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_123.root</subfield>
+      <subfield code="s">604452</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_124.root</subfield>
+      <subfield code="s">593614</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_125.root</subfield>
+      <subfield code="s">511393</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_126.root</subfield>
+      <subfield code="s">601308</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_127.root</subfield>
+      <subfield code="s">607658</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_128.root</subfield>
+      <subfield code="s">535046</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_129.root</subfield>
+      <subfield code="s">627587</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_13.root</subfield>
+      <subfield code="s">571230</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_130.root</subfield>
+      <subfield code="s">480426</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_131.root</subfield>
+      <subfield code="s">613214</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_132.root</subfield>
+      <subfield code="s">585320</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_133.root</subfield>
+      <subfield code="s">531121</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_134.root</subfield>
+      <subfield code="s">491759</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_135.root</subfield>
+      <subfield code="s">701117</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_136.root</subfield>
+      <subfield code="s">611973</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_137.root</subfield>
+      <subfield code="s">619374</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_138.root</subfield>
+      <subfield code="s">523920</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_139.root</subfield>
+      <subfield code="s">587350</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_14.root</subfield>
+      <subfield code="s">570482</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_140.root</subfield>
+      <subfield code="s">609076</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_141.root</subfield>
+      <subfield code="s">578403</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_142.root</subfield>
+      <subfield code="s">556523</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_143.root</subfield>
+      <subfield code="s">532463</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_144.root</subfield>
+      <subfield code="s">485025</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_145.root</subfield>
+      <subfield code="s">551534</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_146.root</subfield>
+      <subfield code="s">580751</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_147.root</subfield>
+      <subfield code="s">588348</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_148.root</subfield>
+      <subfield code="s">574374</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_149.root</subfield>
+      <subfield code="s">520806</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_15.root</subfield>
+      <subfield code="s">558753</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_150.root</subfield>
+      <subfield code="s">731331</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_151.root</subfield>
+      <subfield code="s">569023</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_152.root</subfield>
+      <subfield code="s">539481</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_153.root</subfield>
+      <subfield code="s">526879</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_154.root</subfield>
+      <subfield code="s">675784</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_155.root</subfield>
+      <subfield code="s">628221</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_156.root</subfield>
+      <subfield code="s">518776</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_157.root</subfield>
+      <subfield code="s">586418</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_158.root</subfield>
+      <subfield code="s">633591</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_159.root</subfield>
+      <subfield code="s">581017</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_16.root</subfield>
+      <subfield code="s">509119</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_160.root</subfield>
+      <subfield code="s">575387</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_161.root</subfield>
+      <subfield code="s">525971</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_162.root</subfield>
+      <subfield code="s">551060</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_163.root</subfield>
+      <subfield code="s">628505</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_164.root</subfield>
+      <subfield code="s">548977</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_165.root</subfield>
+      <subfield code="s">559591</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_166.root</subfield>
+      <subfield code="s">574903</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_167.root</subfield>
+      <subfield code="s">549987</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_168.root</subfield>
+      <subfield code="s">586905</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_169.root</subfield>
+      <subfield code="s">574848</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_17.root</subfield>
+      <subfield code="s">609131</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_170.root</subfield>
+      <subfield code="s">599413</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_171.root</subfield>
+      <subfield code="s">591474</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_172.root</subfield>
+      <subfield code="s">591252</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_173.root</subfield>
+      <subfield code="s">453265</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_174.root</subfield>
+      <subfield code="s">552974</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_175.root</subfield>
+      <subfield code="s">572137</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_18.root</subfield>
+      <subfield code="s">531189</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_19.root</subfield>
+      <subfield code="s">582803</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_2.root</subfield>
+      <subfield code="s">555932</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_20.root</subfield>
+      <subfield code="s">552996</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_21.root</subfield>
+      <subfield code="s">544609</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_22.root</subfield>
+      <subfield code="s">672150</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_23.root</subfield>
+      <subfield code="s">571930</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_24.root</subfield>
+      <subfield code="s">557505</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_25.root</subfield>
+      <subfield code="s">652575</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_26.root</subfield>
+      <subfield code="s">611263</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_27.root</subfield>
+      <subfield code="s">638512</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_28.root</subfield>
+      <subfield code="s">608943</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_29.root</subfield>
+      <subfield code="s">641526</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_3.root</subfield>
+      <subfield code="s">470622</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_30.root</subfield>
+      <subfield code="s">591248</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_31.root</subfield>
+      <subfield code="s">610586</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_32.root</subfield>
+      <subfield code="s">579287</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_33.root</subfield>
+      <subfield code="s">618816</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_34.root</subfield>
+      <subfield code="s">540252</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_35.root</subfield>
+      <subfield code="s">583056</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_36.root</subfield>
+      <subfield code="s">536611</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_37.root</subfield>
+      <subfield code="s">515206</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_38.root</subfield>
+      <subfield code="s">537294</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_39.root</subfield>
+      <subfield code="s">597096</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_4.root</subfield>
+      <subfield code="s">553631</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_40.root</subfield>
+      <subfield code="s">580408</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_41.root</subfield>
+      <subfield code="s">556069</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_42.root</subfield>
+      <subfield code="s">553198</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_43.root</subfield>
+      <subfield code="s">558181</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_44.root</subfield>
+      <subfield code="s">580865</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_45.root</subfield>
+      <subfield code="s">538580</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_46.root</subfield>
+      <subfield code="s">502055</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_47.root</subfield>
+      <subfield code="s">554206</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_48.root</subfield>
+      <subfield code="s">524715</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_49.root</subfield>
+      <subfield code="s">542090</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_5.root</subfield>
+      <subfield code="s">449088</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_50.root</subfield>
+      <subfield code="s">533660</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_51.root</subfield>
+      <subfield code="s">571718</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_52.root</subfield>
+      <subfield code="s">582657</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_53.root</subfield>
+      <subfield code="s">650958</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_54.root</subfield>
+      <subfield code="s">521529</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_55.root</subfield>
+      <subfield code="s">497876</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_56.root</subfield>
+      <subfield code="s">563034</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_57.root</subfield>
+      <subfield code="s">553089</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_58.root</subfield>
+      <subfield code="s">549247</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_59.root</subfield>
+      <subfield code="s">583278</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_6.root</subfield>
+      <subfield code="s">598279</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_60.root</subfield>
+      <subfield code="s">547366</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_61.root</subfield>
+      <subfield code="s">582539</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_62.root</subfield>
+      <subfield code="s">567443</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_63.root</subfield>
+      <subfield code="s">516317</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_64.root</subfield>
+      <subfield code="s">556144</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_65.root</subfield>
+      <subfield code="s">578104</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_66.root</subfield>
+      <subfield code="s">523158</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_67.root</subfield>
+      <subfield code="s">579535</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_68.root</subfield>
+      <subfield code="s">656622</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_69.root</subfield>
+      <subfield code="s">574804</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_7.root</subfield>
+      <subfield code="s">610895</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_70.root</subfield>
+      <subfield code="s">562798</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_71.root</subfield>
+      <subfield code="s">522052</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_72.root</subfield>
+      <subfield code="s">546844</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_73.root</subfield>
+      <subfield code="s">560661</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_74.root</subfield>
+      <subfield code="s">570020</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_75.root</subfield>
+      <subfield code="s">629136</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_76.root</subfield>
+      <subfield code="s">605013</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_77.root</subfield>
+      <subfield code="s">476158</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_78.root</subfield>
+      <subfield code="s">570710</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_79.root</subfield>
+      <subfield code="s">611646</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_8.root</subfield>
+      <subfield code="s">573825</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_80.root</subfield>
+      <subfield code="s">471950</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_81.root</subfield>
+      <subfield code="s">638873</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_82.root</subfield>
+      <subfield code="s">543416</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_83.root</subfield>
+      <subfield code="s">573873</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_84.root</subfield>
+      <subfield code="s">576530</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_85.root</subfield>
+      <subfield code="s">511442</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_86.root</subfield>
+      <subfield code="s">511607</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_87.root</subfield>
+      <subfield code="s">531422</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_88.root</subfield>
+      <subfield code="s">479890</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_89.root</subfield>
+      <subfield code="s">507100</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_9.root</subfield>
+      <subfield code="s">630671</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_90.root</subfield>
+      <subfield code="s">528572</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_91.root</subfield>
+      <subfield code="s">512238</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_92.root</subfield>
+      <subfield code="s">562598</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_93.root</subfield>
+      <subfield code="s">553116</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_94.root</subfield>
+      <subfield code="s">461304</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_95.root</subfield>
+      <subfield code="s">468772</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_96.root</subfield>
+      <subfield code="s">514657</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_97.root</subfield>
+      <subfield code="s">535802</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_98.root</subfield>
+      <subfield code="s">472459</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_99.root</subfield>
+      <subfield code="s">584063</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">LHCb-Derived-Datasets</subfield>
@@ -86,6 +961,11 @@
     <datafield tag="520" ind1="" ind2="">
       <subfield code="a">This file contains about 60k events pre-selected using loose criteria to contain D0 meson candidates decaying into a Kaon and a Pion.</subfield>
     </datafield>
+    <datafield tag="581" ind1="" ind2="">
+      <subfield code="a">The file can be accessed and analyzed using LHCb D0 lifetime measurement code using LHCb VM image</subfield>
+      <subfield code="w">402</subfield>
+      <subfield code="y">LHCb VM image</subfield>
+    </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
     </datafield>
@@ -96,10 +976,10 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">LHCb</subfield>
     </datafield>
-    <datafield tag="581" ind1="" ind2="">
-      <subfield code="a">The file can be accessed and analyzed using LHCb D0 lifetime measurement code using LHCb VM image</subfield>
-      <subfield code="w">402</subfield>
-      <subfield code="y">LHCb VM image</subfield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/MasterclassData.root</subfield>
+      <subfield code="s">1289541</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">LHCb-Derived-Datasets</subfield>


### PR DESCRIPTION
- Adds EOS URIs to all LHCb records, so that e.g. dataset files can be
  downloaded via HTTP.  (addresses #377)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
