### PR TITLE
ALICE: addition of all EOS URIs

### DIFF
--- a/invenio_opendata/testsuite/data/alice/alice-analysis-modules.xml
+++ b/invenio_opendata/testsuite/data/alice/alice-analysis-modules.xml
@@ -32,7 +32,8 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ALICE</subfield>
     </datafield>
-    <datafield tag="856" ind1="4" ind2=" ">
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/modules/PtAnalysis.tgz</subfield>
       <subfield code="s">2086046</subfield>
     </datafield>
@@ -76,7 +77,8 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ALICE</subfield>
     </datafield>
-    <datafield tag="856" ind1="4" ind2=" ">
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/modules/alice-mc.tgz</subfield>
       <subfield code="s">31139203</subfield>
     </datafield>
@@ -120,9 +122,10 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ALICE</subfield>
     </datafield>
-    <datafield tag="856" ind1="4" ind2=" ">
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/modules/alice-raa.tgz</subfield>
-      <subfield code="s">15470107</subfield>
+      <subfield code="s">15469921</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ALICE-Tools</subfield>
@@ -153,9 +156,10 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ALICE</subfield>
     </datafield>
-    <datafield tag="856" ind1="4" ind2=" ">
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/modules/bootstrap.tgz</subfield>
-      <subfield code="s">42415</subfield>
+      <subfield code="s">42540</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ALICE-Tools</subfield>

--- a/invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml
+++ b/invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml
@@ -43,6 +43,61 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ALICE</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/masterclass/AliVSD_Masterclass_1.root</subfield>
+      <subfield code="s">43359305</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/masterclass/AliVSD_Masterclass_10.root</subfield>
+      <subfield code="s">46920005</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/masterclass/AliVSD_Masterclass_2.root</subfield>
+      <subfield code="s">40473110</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/masterclass/AliVSD_Masterclass_3.root</subfield>
+      <subfield code="s">46666641</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/masterclass/AliVSD_Masterclass_4.root</subfield>
+      <subfield code="s">44175305</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/masterclass/AliVSD_Masterclass_5.root</subfield>
+      <subfield code="s">67736734</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/masterclass/AliVSD_Masterclass_6.root</subfield>
+      <subfield code="s">35379987</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/masterclass/AliVSD_Masterclass_7.root</subfield>
+      <subfield code="s">63455250</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/masterclass/AliVSD_Masterclass_8.root</subfield>
+      <subfield code="s">46325793</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/masterclass/AliVSD_Masterclass_9.root</subfield>
+      <subfield code="s">45248227</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/masterclass/MasterClassesTree_LHC10h_Run139036.root</subfield>
+      <subfield code="s">293121910</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ALICE-Derived-Datasets</subfield>
     </datafield>

--- a/invenio_opendata/testsuite/data/alice/alice-reconstructed-data.xml
+++ b/invenio_opendata/testsuite/data/alice/alice-reconstructed-data.xml
@@ -42,6 +42,16 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ALICE</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/2010/LHC10b/000117222/ESD/0000/AliESDs.root</subfield>
+      <subfield code="s">242166790</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/2010/LHC10b/000117222/ESD/0001/AliESDs.root</subfield>
+      <subfield code="s">242767485</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ALICE-Reconstructed-Data</subfield>
     </datafield>
@@ -91,6 +101,21 @@
     <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ALICE</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/2010/LHC10h/000138275/ESD/0000/AliESDs.root</subfield>
+      <subfield code="s">200762886</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/2010/LHC10h/000138275/ESD/0001/AliESDs.root</subfield>
+      <subfield code="s">225890865</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/alice/2010/LHC10h/000138275/ESD/0002/AliESDs.root</subfield>
+      <subfield code="s">222416778</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ALICE-Reconstructed-Data</subfield>


### PR DESCRIPTION
- Adds EOS URIs to all ALICE records, so that e.g. dataset files can be
  downloaded via HTTP.  (addresses #377)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
