### PR TITLE
ATLAS: addition of all EOS URIs

### DIFF
--- a/invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml
@@ -27,15 +27,115 @@
     <datafield tag="520" ind1="" ind2="">
       <subfield code="a">A dataset of 1000 events taken in 2011 by the ATLAS Detector, used in the Physics Masterclasses W Path</subfield>
     </datafield>
+    <datafield tag="581" ind1="" ind2="">
+      <subfield code="a">The dataset can be analysed by using MINERVA which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorize events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
+      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+    </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="581" ind1="" ind2="">
-      <subfield code="a">The dataset can be analysed by using MINERVA which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorize events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
-      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1A.zip</subfield>
+      <subfield code="s">9056420</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1B.zip</subfield>
+      <subfield code="s">8315774</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1C.zip</subfield>
+      <subfield code="s">8248112</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1D.zip</subfield>
+      <subfield code="s">8100827</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1E.zip</subfield>
+      <subfield code="s">8772260</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1F.zip</subfield>
+      <subfield code="s">8659304</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1G.zip</subfield>
+      <subfield code="s">9691015</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1H.zip</subfield>
+      <subfield code="s">8789941</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1I.zip</subfield>
+      <subfield code="s">8594653</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1J.zip</subfield>
+      <subfield code="s">8954967</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1K.zip</subfield>
+      <subfield code="s">8492818</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1L.zip</subfield>
+      <subfield code="s">8713526</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1M.zip</subfield>
+      <subfield code="s">8513112</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1N.zip</subfield>
+      <subfield code="s">8637884</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1O.zip</subfield>
+      <subfield code="s">8780793</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1P.zip</subfield>
+      <subfield code="s">8222216</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1Q.zip</subfield>
+      <subfield code="s">9202088</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1R.zip</subfield>
+      <subfield code="s">8708754</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1S.zip</subfield>
+      <subfield code="s">8437830</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1T.zip</subfield>
+      <subfield code="s">8297961</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
@@ -73,15 +173,115 @@
     <datafield tag="520" ind1="" ind2="">
       <subfield code="a">A dataset of 1000 events taken in 2011 by the ATLAS Detector, used in the Physics Masterclasses W Path</subfield>
     </datafield>
+    <datafield tag="581" ind1="" ind2="">
+      <subfield code="a">The dataset can be analysed by using MINERVA which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorize events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
+      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+    </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="581" ind1="" ind2="">
-      <subfield code="a">The dataset can be analysed by using MINERVA which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorize events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
-      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2A.zip</subfield>
+      <subfield code="s">9500821</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2B.zip</subfield>
+      <subfield code="s">8409874</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2C.zip</subfield>
+      <subfield code="s">9046999</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2D.zip</subfield>
+      <subfield code="s">8531583</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2E.zip</subfield>
+      <subfield code="s">8359971</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2F.zip</subfield>
+      <subfield code="s">8365154</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2G.zip</subfield>
+      <subfield code="s">9216142</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2H.zip</subfield>
+      <subfield code="s">8818383</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2I.zip</subfield>
+      <subfield code="s">8851808</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2J.zip</subfield>
+      <subfield code="s">8901275</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2K.zip</subfield>
+      <subfield code="s">8737761</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2L.zip</subfield>
+      <subfield code="s">9120625</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2M.zip</subfield>
+      <subfield code="s">8968323</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2N.zip</subfield>
+      <subfield code="s">9129604</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2O.zip</subfield>
+      <subfield code="s">8909060</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2P.zip</subfield>
+      <subfield code="s">9565932</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2Q.zip</subfield>
+      <subfield code="s">8587197</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2R.zip</subfield>
+      <subfield code="s">8807101</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2S.zip</subfield>
+      <subfield code="s">9294270</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2T.zip</subfield>
+      <subfield code="s">8765904</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
@@ -119,15 +319,115 @@
     <datafield tag="520" ind1="" ind2="">
       <subfield code="a">A dataset of 1000 events taken in 2011 by the ATLAS Detector, used in the Physics Masterclasses W Path</subfield>
     </datafield>
+    <datafield tag="581" ind1="" ind2="">
+      <subfield code="a">The dataset can be analysed by using MINERVA which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorize events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
+      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+    </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="581" ind1="" ind2="">
-      <subfield code="a">The dataset can be analysed by using MINERVA which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorize events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
-      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3A.zip</subfield>
+      <subfield code="s">8566739</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3B.zip</subfield>
+      <subfield code="s">8139585</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3C.zip</subfield>
+      <subfield code="s">8930952</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3D.zip</subfield>
+      <subfield code="s">8993619</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3E.zip</subfield>
+      <subfield code="s">9078548</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3F.zip</subfield>
+      <subfield code="s">8924912</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3G.zip</subfield>
+      <subfield code="s">9243672</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3H.zip</subfield>
+      <subfield code="s">9046473</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3I.zip</subfield>
+      <subfield code="s">9337272</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3J.zip</subfield>
+      <subfield code="s">8867283</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3K.zip</subfield>
+      <subfield code="s">8171998</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3L.zip</subfield>
+      <subfield code="s">8600529</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3M.zip</subfield>
+      <subfield code="s">9026120</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3N.zip</subfield>
+      <subfield code="s">9416872</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3O.zip</subfield>
+      <subfield code="s">9185137</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3P.zip</subfield>
+      <subfield code="s">8937956</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3Q.zip</subfield>
+      <subfield code="s">8423767</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3R.zip</subfield>
+      <subfield code="s">9657868</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3S.zip</subfield>
+      <subfield code="s">9416560</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3T.zip</subfield>
+      <subfield code="s">8032391</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
@@ -165,15 +465,115 @@
     <datafield tag="520" ind1="" ind2="">
       <subfield code="a">A dataset of 1000 events taken in 2011 by the ATLAS Detector, used in the Physics Masterclasses W Path</subfield>
     </datafield>
+    <datafield tag="581" ind1="" ind2="">
+      <subfield code="a">The dataset can be analysed by using MINERVA which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorize events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
+      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+    </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="581" ind1="" ind2="">
-      <subfield code="a">The dataset can be analysed by using MINERVA which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorize events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
-      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4A.zip</subfield>
+      <subfield code="s">7916767</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4B.zip</subfield>
+      <subfield code="s">8485396</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4C.zip</subfield>
+      <subfield code="s">8799482</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4D.zip</subfield>
+      <subfield code="s">8859058</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4E.zip</subfield>
+      <subfield code="s">8399867</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4F.zip</subfield>
+      <subfield code="s">8360521</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4G.zip</subfield>
+      <subfield code="s">8176153</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4H.zip</subfield>
+      <subfield code="s">8370810</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4I.zip</subfield>
+      <subfield code="s">7931902</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4J.zip</subfield>
+      <subfield code="s">7918859</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4K.zip</subfield>
+      <subfield code="s">8449295</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4L.zip</subfield>
+      <subfield code="s">8507779</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4M.zip</subfield>
+      <subfield code="s">8749142</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4N.zip</subfield>
+      <subfield code="s">8615619</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4O.zip</subfield>
+      <subfield code="s">7897939</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4P.zip</subfield>
+      <subfield code="s">7969204</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4Q.zip</subfield>
+      <subfield code="s">7995581</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4R.zip</subfield>
+      <subfield code="s">7581294</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4S.zip</subfield>
+      <subfield code="s">8543351</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4T.zip</subfield>
+      <subfield code="s">8305498</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
@@ -211,15 +611,115 @@
     <datafield tag="520" ind1="" ind2="">
       <subfield code="a">A dataset of 1000 events taken in 2011 by the ATLAS Detector, used in the Physics Masterclasses W Path</subfield>
     </datafield>
+    <datafield tag="581" ind1="" ind2="">
+      <subfield code="a">The dataset can be analysed by using MINERVA which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorize events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
+      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+    </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="581" ind1="" ind2="">
-      <subfield code="a">The dataset can be analysed by using MINERVA which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorize events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
-      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5A.zip</subfield>
+      <subfield code="s">7973515</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5B.zip</subfield>
+      <subfield code="s">8079257</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5C.zip</subfield>
+      <subfield code="s">8211932</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5D.zip</subfield>
+      <subfield code="s">8488071</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5E.zip</subfield>
+      <subfield code="s">8815744</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5F.zip</subfield>
+      <subfield code="s">8186308</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5G.zip</subfield>
+      <subfield code="s">8364274</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5H.zip</subfield>
+      <subfield code="s">8287266</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5I.zip</subfield>
+      <subfield code="s">7808219</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5J.zip</subfield>
+      <subfield code="s">8252637</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5K.zip</subfield>
+      <subfield code="s">8669833</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5L.zip</subfield>
+      <subfield code="s">8202569</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5M.zip</subfield>
+      <subfield code="s">8969141</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5N.zip</subfield>
+      <subfield code="s">8562605</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5O.zip</subfield>
+      <subfield code="s">8360823</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5P.zip</subfield>
+      <subfield code="s">7945465</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5Q.zip</subfield>
+      <subfield code="s">8298524</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5R.zip</subfield>
+      <subfield code="s">8229453</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5S.zip</subfield>
+      <subfield code="s">9063763</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5T.zip</subfield>
+      <subfield code="s">8198176</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
@@ -257,15 +757,115 @@
     <datafield tag="520" ind1="" ind2="">
       <subfield code="a">A dataset of 1000 events taken in 2011 by the ATLAS Detector, used in the Physics Masterclasses W Path</subfield>
     </datafield>
+    <datafield tag="581" ind1="" ind2="">
+      <subfield code="a">The dataset can be analysed by using MINERVA which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorize events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
+      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+    </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="581" ind1="" ind2="">
-      <subfield code="a">The dataset can be analysed by using MINERVA which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorize events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
-      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6A.zip</subfield>
+      <subfield code="s">8314172</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6B.zip</subfield>
+      <subfield code="s">8430270</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6C.zip</subfield>
+      <subfield code="s">8372738</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6D.zip</subfield>
+      <subfield code="s">7837058</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6E.zip</subfield>
+      <subfield code="s">8168037</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6F.zip</subfield>
+      <subfield code="s">8251696</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6G.zip</subfield>
+      <subfield code="s">8422022</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6H.zip</subfield>
+      <subfield code="s">8429415</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6I.zip</subfield>
+      <subfield code="s">7796461</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6J.zip</subfield>
+      <subfield code="s">8165085</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6K.zip</subfield>
+      <subfield code="s">8729638</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6L.zip</subfield>
+      <subfield code="s">8051855</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6M.zip</subfield>
+      <subfield code="s">8075916</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6N.zip</subfield>
+      <subfield code="s">8835846</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6O.zip</subfield>
+      <subfield code="s">8271104</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6P.zip</subfield>
+      <subfield code="s">8608128</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6Q.zip</subfield>
+      <subfield code="s">7997176</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6R.zip</subfield>
+      <subfield code="s">8259946</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6S.zip</subfield>
+      <subfield code="s">8091207</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6T.zip</subfield>
+      <subfield code="s">8637499</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>


### PR DESCRIPTION
- Adds EOS URIs to all ATLAS records, so that e.g. dataset files can be
  downloaded via HTTP.  (addresses #377)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
