### PR TITLE
CMS: new release of pattuples2012 code v1.0.2

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-tools-ana.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-ana.xml
@@ -74,7 +74,7 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/github-files/pattuples2012-1.0.0.tar.gz</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/github-files/pattuples2012-1.0.2.tar.gz</subfield>
     </datafield>
   </record>
   <record>
@@ -170,7 +170,7 @@
       <subfield code="b">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/github-files/pattuples2012-1.0.0.tar.gz</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/github-files/OutreachExercise2010-1.0.0.tar.gz</subfield>
     </datafield>
   </record>
 </collection>

--- a/populate-fft-file-cache.sh
+++ b/populate-fft-file-cache.sh
@@ -285,6 +285,7 @@ $WGET -O $OUTDIR/cernvm-files/CMS-OpenData-1.0.0-rc6.ova "http://cernvm.cern.ch/
 mkdir -p $OUTDIR/github-files
 $WGET -O $OUTDIR/github-files/Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt "https://raw.githubusercontent.com/ayrodrig/pattuples2010/master/Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt"
 $WGET -O $OUTDIR/github-files/pattuples2012-1.0.0.tar.gz https://github.com/ayrodrig/pattuples2010/archive/v1.0.0.tar.gz
+$WGET -O $OUTDIR/github-files/pattuples2012-1.0.2.tar.gz https://github.com/ayrodrig/pattuples2010/archive/v1.0.2.tar.gz
 $WGET -O $OUTDIR/github-files/OutreachExercise2010-1.0.0.tar.gz https://github.com/ayrodrig/OutreachExercise2010/archive/v1.0.0.tar.gz
 $WGET -O $OUTDIR/github-files/dimuon-filter-1.0.0.tar.gz https://github.com/tpmccauley/dimuon-filter/archive/1.0.0.tar.gz
 


### PR DESCRIPTION
- New version of pattuples2012 code v1.0.2.  (addresses #666)
- Corrects FFT software package for OutreachExercise2010.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
