### PR TITLE
ATLAS: Higgs Challenge 2014 software record update

### DIFF
--- a/invenio_opendata/testsuite/data/atlas/atlas-higgs-challenge-2014.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-higgs-challenge-2014.xml
@@ -314,7 +314,7 @@
     </datafield>
   </record>
   <record>
-  <controlfield tag="001">331</controlfield>
+    <controlfield tag="001">331</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="2">DOI</subfield>
       <subfield code="a">10.7483/OPENDATA.ATLAS.DFGK.DB9U</subfield>
@@ -331,7 +331,7 @@
       <subfield code="t">file</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
-      <subfield code="b">FIXME</subfield>
+      <subfield code="b">4090</subfield>
       <subfield code="t">bytes</subfield>
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
@@ -343,14 +343,14 @@
       <subfield code="w">328</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
-      <subfield code="a">Software to FIXME description</subfield>
+      <subfield code="a">FIXME Software description</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">GNU General Public License (GPL) version 3</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">See the instructions in</subfield>
-      <subfield code="u">FIXME GitHub link</subfield>
+      <subfield code="u">https://github.com/ATLAS-outreach/HiggsML</subfield>
       <subfield code="y">GitHub</subfield>
     </datafield>
     <datafield tag="693" ind1=" " ind2=" ">
@@ -358,67 +358,16 @@
       <subfield code="e">ATLAS</subfield>
     </datafield>
     <datafield tag="856" ind1="4" ind2=" ">
-      <subfield code="u">FIXME GITHUB link</subfield>
+      <subfield code="u">https://github.com/ATLAS-outreach/HiggsML</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Tools</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Higgs-Challenge-2014</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/github-files/HiggsML-0.0.tar.gz</subfield>
     </datafield>
   </record>
-  <record>
-  <controlfield tag="001">332</controlfield>
-    <datafield tag="024" ind1="7" ind2=" ">
-      <subfield code="2">DOI</subfield>
-      <subfield code="a">10.7483/OPENDATA.ATLAS.PJ6H.ZA9X</subfield>
-    </datafield>
-    <datafield tag="100" ind1=" " ind2=" ">
-      <subfield code="a">Rousseau, David</subfield>
-    </datafield>
-    <datafield tag="245" ind1=" " ind2=" ">
-      <subfield code="a">Another software example for the ATLAS Higgs Learning Challenge 2014</subfield>
-    </datafield>
-    <datafield tag="256" ind1=" " ind2=" ">
-      <subfield code="a">Software</subfield>
-      <subfield code="f">1</subfield>
-      <subfield code="t">file</subfield>
-    </datafield>
-    <datafield tag="256" ind1=" " ind2=" ">
-      <subfield code="b">FIXME</subfield>
-      <subfield code="t">bytes</subfield>
-    </datafield>
-    <datafield tag="260" ind1=" " ind2=" ">
-      <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2014</subfield>
-    </datafield>
-    <datafield tag="516" ind1=" " ind2=" ">
-      <subfield code="a">Use this with the following dataset:</subfield>
-      <subfield code="w">328</subfield>
-    </datafield>
-    <datafield tag="520" ind1=" " ind2=" ">
-      <subfield code="a">Software to FIXME description</subfield>
-    </datafield>
-    <datafield tag="540" ind1=" " ind2=" ">
-      <subfield code="a">GNU General Public License (GPL) version 3</subfield>
-    </datafield>
-    <datafield tag="581" ind1=" " ind2=" ">
-      <subfield code="a">See the instructions in</subfield>
-      <subfield code="u">FIXME GitHub link</subfield>
-      <subfield code="y">GitHub</subfield>
-    </datafield>
-    <datafield tag="693" ind1=" " ind2=" ">
-      <subfield code="a">CERN-LHC</subfield>
-      <subfield code="e">ATLAS</subfield>
-    </datafield>
-    <datafield tag="856" ind1="4" ind2=" ">
-      <subfield code="u">FIXME GITHUB link</subfield>
-    </datafield>
-    <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS-Tools</subfield>
-    </datafield>
-    <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS-Higgs-Challenge-2014</subfield>
-    </datafield>
-</record>
 </collection>

--- a/populate-fft-file-cache.sh
+++ b/populate-fft-file-cache.sh
@@ -289,6 +289,7 @@ $WGET -O $OUTDIR/github-files/pattuples2012-1.0.0.tar.gz https://github.com/ayro
 $WGET -O $OUTDIR/github-files/pattuples2012-1.0.2.tar.gz https://github.com/ayrodrig/pattuples2010/archive/v1.0.2.tar.gz
 $WGET -O $OUTDIR/github-files/OutreachExercise2010-1.0.0.tar.gz https://github.com/ayrodrig/OutreachExercise2010/archive/v1.0.0.tar.gz
 $WGET -O $OUTDIR/github-files/dimuon-filter-1.0.0.tar.gz https://github.com/tpmccauley/dimuon-filter/archive/1.0.0.tar.gz
+$WGET -O $OUTDIR/github-files/HiggsML-0.0.tar.gz https://github.com/ATLAS-outreach/HiggsML/archive/v0.0.tar.gz
 
 # fifthly, CMS Hamburg files:
 mkdir -p $OUTDIR/cms-hamburg-files


### PR DESCRIPTION
- Updates ATLAS Higgs Challenge 2014 software record with link to GitHub
  repository.  Archives latest "v0.0" version.  (addresses #660)
- Removes second software record, since there will be only one software
  repository for now.
- Improves indentation of the MARCXML file.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
