### PR TITLE
ATLAS: Higgs Challenge github repository update

### DIFF
--- a/invenio_opendata/testsuite/data/atlas/atlas-higgs-challenge-2014.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-higgs-challenge-2014.xml
@@ -333,7 +333,7 @@
       <subfield code="t">file</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
-      <subfield code="b">4090</subfield>
+      <subfield code="b">21249</subfield>
       <subfield code="t">bytes</subfield>
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
@@ -352,7 +352,7 @@
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">See the instructions in</subfield>
-      <subfield code="u">https://github.com/ATLAS-outreach/HiggsML</subfield>
+      <subfield code="u">https://github.com/ATLAS-outreach/HiggsML2014</subfield>
       <subfield code="y">GitHub</subfield>
     </datafield>
     <datafield tag="693" ind1=" " ind2=" ">
@@ -360,7 +360,7 @@
       <subfield code="e">ATLAS</subfield>
     </datafield>
     <datafield tag="856" ind1="4" ind2=" ">
-      <subfield code="u">https://github.com/ATLAS-outreach/HiggsML</subfield>
+      <subfield code="u">https://github.com/ATLAS-outreach/HiggsML2014</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Tools</subfield>
@@ -369,7 +369,7 @@
       <subfield code="a">ATLAS-Higgs-Challenge-2014</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/github-files/HiggsML-0.0.tar.gz</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/github-files/HiggsML2014-0.0.tar.gz</subfield>
     </datafield>
   </record>
 </collection>

--- a/populate-fft-file-cache.sh
+++ b/populate-fft-file-cache.sh
@@ -289,7 +289,7 @@ $WGET -O $OUTDIR/github-files/pattuples2012-1.0.0.tar.gz https://github.com/ayro
 $WGET -O $OUTDIR/github-files/pattuples2012-1.0.2.tar.gz https://github.com/ayrodrig/pattuples2010/archive/v1.0.2.tar.gz
 $WGET -O $OUTDIR/github-files/OutreachExercise2010-1.0.0.tar.gz https://github.com/ayrodrig/OutreachExercise2010/archive/v1.0.0.tar.gz
 $WGET -O $OUTDIR/github-files/dimuon-filter-1.0.0.tar.gz https://github.com/tpmccauley/dimuon-filter/archive/1.0.0.tar.gz
-$WGET -O $OUTDIR/github-files/HiggsML-0.0.tar.gz https://github.com/ATLAS-outreach/HiggsML/archive/v0.0.tar.gz
+$WGET -O $OUTDIR/github-files/HiggsML2014-0.0.tar.gz https://github.com/ATLAS-outreach/HiggsML2014/archive/v0.0.tar.gz
 
 # fifthly, CMS Hamburg files:
 mkdir -p $OUTDIR/cms-hamburg-files


### PR DESCRIPTION
- Updates location of the ATLAS Higgs Challenge 2014 github
  repository.  (addresses #660)
- Updates record metadata and installation instructions accordingly.

Signed-off-by: Tibor Simko tibor.simko@cern.ch
