### PR TITLE
global: s/OpenData/Open Data/g in visible texts

### DIFF
--- a/invenio_opendata/base/templates/data/news_db.html
+++ b/invenio_opendata/base/templates/data/news_db.html
@@ -1,9 +1,9 @@
 {% set news = [
-    ('CMS OpenData release: call for feedback','<p>
+    ('CMS Open Data release: call for feedback','<p>
                                           We are close to the first public release of CMS reconstructed data and the appropriate working environments, and would like to call for feedback from the CMS Collaboration.
                                       </p>
                                       <p>
-                                          The release is being made under the CMS Data Preservation and Open Access initiative and the expected date for the release is mid-October. In this effort, we have the support of CERN\'s IT and GIS services who have built an OpenData Portal at CERN. Please <strong>do not share</strong> this beta version of the portal outside the collaboration. A press release from CERN and a news item from CMS will accompany the official unveiling of the portal.
+                                          The release is being made under the CMS Data Preservation and Open Access initiative and the expected date for the release is mid-October. In this effort, we have the support of CERN\'s IT and GIS services who have built an Open Data Portal at CERN. Please <strong>do not share</strong> this beta version of the portal outside the collaboration. A press release from CERN and a news item from CMS will accompany the official unveiling of the portal.
                                       </p>
                                       <p>
                                           This release itself consists of primary dataset files in AOD format from 2010 RunB. We know that a considerable amount of additional knowledge is required in order to obtain meaningful results with these, and we have provided a minimal set of background information and some examples for external users to get started with our data. We also provide examples of how to further use these data in teaching and education.
@@ -16,7 +16,7 @@
                                       <p>
                                           <ul class="with-circles col-md-12">
                                               <li>
-                                                  BASIC: Take the OpenData portal for a spin and let us know if you have any comments, by writing to <a href="mailto:opendata-support@cern.ch">opendata-support@cern.ch</a>.
+                                                  BASIC: Take the Open Data portal for a spin and let us know if you have any comments, by writing to <a href="mailto:opendata-support@cern.ch">opendata-support@cern.ch</a>.
                                               </li>
                                               <li>
                                                   INTERMEDIATE: Go through the tasks on <a href="https://docs.google.com/forms/d/1i_vtQ_8nR4YXqZCNnXzN9zjbYp5YqLQM4HuGzCL243A/viewform">this Google form</a> to test the usability of the portal for different audiences.
@@ -27,7 +27,7 @@
                                           </ul>
                                       </p>','CMS Collaboration',('NULL', ('CMS',),()), '01/10/2014', '1'),
 
-     ('ALICE OpenData','<p>ALICE is making a public release of a number of datasets customised for
+     ('ALICE Open Data','<p>ALICE is making a public release of a number of datasets customised for
                 demonstration and educational purpose. A number of reconstructed data
                 files which are not statistically representative are included to allow
                 plotting transverse momentum and pseudorapidity distributions. More

--- a/invenio_opendata/base/templates/footer.html
+++ b/invenio_opendata/base/templates/footer.html
@@ -53,13 +53,13 @@
         <div class="row">
           <div class="center-block legal">
             <ul class="">
-              <li>© 2014 CERN OpenData</li>
+              <li>© 2014 CERN Open Data</li>
               <li><a href="{{ url_for('terms-of-use') }}">Terms of Use</a></li>
               <li><a href="{{ url_for('privacy-policy') }}">Privacy Policy</a></li>
               <li><a href="mailto:opendata-support@cern.ch">Contact</a></li>
             </ul>
           </div>
-        </div>        
+        </div>
       </div>
     </div>
 {%- endblock footer %}

--- a/invenio_opendata/base/templates/helpers/text/vms_page.html
+++ b/invenio_opendata/base/templates/helpers/text/vms_page.html
@@ -26,7 +26,7 @@
     <strong>Important</strong>: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see <a href="#issues">Issues and Limitations</a> if you encounter any problems with booting the VM.
   </p>
   <p>
-    Next download the CMS-specific CernVM image as OVA file from: <a href="{{url}}">CMS OpenData (latest)</a>.
+    Next download the CMS-specific CernVM image as OVA file from: <a href="{{url}}">CMS Open Data (latest)</a>.
   </p>
   <p>
     By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings: in case of any problems with booting with these default settings, see <a href="#issues">Issues and Limitations</a>. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment.

--- a/invenio_opendata/base/templates/privacy.html
+++ b/invenio_opendata/base/templates/privacy.html
@@ -43,11 +43,11 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-12">
-				<div class="header">CERN OpenData Privacy Policy</div>
+				<div class="header">CERN Open Data Privacy Policy</div>
 				<div class="body">
-					<p>CERN does not track, collect or retain personal information from users of CERN OpenData Portal, except as otherwise provided herein. In order to enhance CERN OpenData Portal and monitor traffic, non-personal information such as IP addresses and cookies may be tracked and retained, as well as log files shared in aggregation with other community services. User provided information, like corrections of metadata or paper claims, will be integrated into the database without displaying its source and may shared with other services.</p>
-					<p>CERN OpenData Portal will take all reasonable measures to protect the privacy of its users and to resist service interruptions, intentional attacks, or other events that may compromise the security of the CERN OpenData Portal website.</p>
-					<p>If you have any questions about the CERN OpenData Portal privacy policy, please contact <a href="mailto:opendata-support@cern.ch">opendata-support@cern.ch</a></p>
+					<p>CERN does not track, collect or retain personal information from users of CERN Open Data Portal, except as otherwise provided herein. In order to enhance CERN Open Data Portal and monitor traffic, non-personal information such as IP addresses and cookies may be tracked and retained, as well as log files shared in aggregation with other community services. User provided information, like corrections of metadata or paper claims, will be integrated into the database without displaying its source and may shared with other services.</p>
+					<p>CERN Open Data Portal will take all reasonable measures to protect the privacy of its users and to resist service interruptions, intentional attacks, or other events that may compromise the security of the CERN Open Data Portal website.</p>
+					<p>If you have any questions about the CERN Open Data Portal privacy policy, please contact <a href="mailto:opendata-support@cern.ch">opendata-support@cern.ch</a></p>
 				</div>
 			</div>
 		</div>

--- a/invenio_opendata/base/templates/records/macros.html
+++ b/invenio_opendata/base/templates/records/macros.html
@@ -335,7 +335,7 @@
 		<div id="disclaimer" class="info">
 			<div class="row">
 				{% if body == None %}
-					<div class="body col-md-12">The open data are released under the <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 waiver</a>. Neither {{ 'OpenData Portal' if exp == Undefined else exp  }} nor CERN endorse any works, scientific or otherwise, produced using these data.<br/>All releases will have a unique DOI that you are requested to cite in any applications or publications.
+					<div class="body col-md-12">The open data are released under the <a href="http://creativecommons.org/publicdomain/zero/1.0/">Creative Commons CC0 waiver</a>. Neither {{ 'Open Data Portal' if exp == Undefined else exp  }} nor CERN endorse any works, scientific or otherwise, produced using these data.<br/>All releases will have a unique DOI that you are requested to cite in any applications or publications.
 					</div>
 					<div class="col-md-12">
 						<div class="ccommons">

--- a/invenio_opendata/base/templates/termsofuse.html
+++ b/invenio_opendata/base/templates/termsofuse.html
@@ -42,7 +42,7 @@
 	<div class="container">
 		<div class="breadcrumbs">
 			<a href="/"><span style="font-size:16px;padding-top:1px;float:left;" class="glyphicon glyphicon-home"></span><span class="fa fa-chevron-right"></span></a>
-			<h4 class="">Terms of use</h4> 
+			<h4 class="">Terms of use</h4>
 		</div>
 	</div>
 </section>
@@ -50,13 +50,13 @@
 	<div class="container">
 		<div class="row">
 			<div class="col-md-12">
-				<div class="header">CERN OpenData Terms of Use</div>
+				<div class="header">CERN Open Data Terms of Use</div>
 				<div class="body">
-					<h4>Use of the CERN OpenData Portal service (hereafter “CERN OpenData”) denotes agreement with the following terms:</h4>
+					<h4>Use of the CERN Open Data Portal service denotes agreement with the following terms:</h4>
 					<ol>
 						<li>The CERN Open Data Portal is provided free of charge.</li>
 						<li>All metadata and datasets in the CERN Open Data Portal are made available under the terms of the CC0 waiver.</li>
-						<li>All other content is made available under its applicable license conditions as specified on the relevant web pages. For example, software packages are usually licensed under GNU General Public License (GPL). Download and use of such other content from the CERN Open Data Portal does not, unless expressly stated in the applicable license conditions, transfer any intellectual property.</li> 
+						<li>All other content is made available under its applicable license conditions as specified on the relevant web pages. For example, software packages are usually licensed under GNU General Public License (GPL). Download and use of such other content from the CERN Open Data Portal does not, unless expressly stated in the applicable license conditions, transfer any intellectual property.</li>
 						<li>Content of the CERN Open Data Portal will be updated or otherwise modified on a regular basis. The CERN Open Data Portal reserves the right to alter or delete content without notice.</li>
 						<li>All content is provided “as is” and the user shall hold CERN and the content providers free and harmless in connection with its use of such content.</li>
 						<li>Any use of the CERN Open Data Portal that interferes with its normal operations or violates these terms of use or applicable laws shall, at the sole discretion of CERN, result in restriction or removal of user access.</li>
@@ -65,7 +65,7 @@
 				</div>
 			</div>
 		</div>
-	</div>	
+	</div>
 </section>
 
 {% endblock %}

--- a/invenio_opendata/base/views.py
+++ b/invenio_opendata/base/views.py
@@ -306,7 +306,7 @@ def about():
 @register_breadcrumb(blueprint, '.about_cms', 'CMS', \
                         dynamic_list_constructor = (lambda :\
                         [{"url":".about", "text":"About"},\
-                        {"url":".about_cms","text":"CMS OpenData"}]) )
+                        {"url":".about_cms","text":"CMS Open Data"}]) )
 def about_cms():
     try:
         return render_template('about_cms.html')
@@ -318,7 +318,7 @@ def about_cms():
 @register_breadcrumb(blueprint, '.about_alice', 'ALICE', \
                         dynamic_list_constructor = (lambda :\
                         [{"url":".about", "text":"About"},\
-                        {"url":".about_alice","text":"ALICE OpenData"}]) )
+                        {"url":".about_alice","text":"ALICE Open Data"}]) )
 def about_alice():
     try:
         return render_template('about_alice.html')
@@ -330,7 +330,7 @@ def about_alice():
 @register_breadcrumb(blueprint, '.about_atlas', 'ATLAS', \
                         dynamic_list_constructor = (lambda :\
                         [{"url":".about", "text":"About"},\
-                        {"url":".about_atlas","text":"ATLAS OpenData"}]) )
+                        {"url":".about_atlas","text":"ATLAS Open Data"}]) )
 def about_atlas():
     try:
         return render_template('about_atlas.html')
@@ -342,7 +342,7 @@ def about_atlas():
 @register_breadcrumb(blueprint, '.about_lhcb', 'LHCb', \
                         dynamic_list_constructor = (lambda :\
                         [{"url":".about", "text":"About"},\
-                        {"url":".about_lhcb","text":"LHCb OpenData"}]) )
+                        {"url":".about_lhcb","text":"LHCb Open Data"}]) )
 def about_lhcb():
     try:
         return render_template('about_lhcb.html')


### PR DESCRIPTION
- Standardises on "Open Data" output text everywhere "OpenData" was used
  without middle blank space.  (closes #731)

Signed-off-by: Tibor Simko tibor.simko@cern.ch
