### PR TITLE
fixtures: visibility of ATLAS Higgs Challenge

### DIFF
--- a/invenio_opendata/base/fixtures/websearch.py
+++ b/invenio_opendata/base/fixtures/websearch.py
@@ -350,6 +350,12 @@ class CollectionCollectionData(DataSet):
         score = 2
         type = 'r'
 
+    class ATLAS_ATLASHiggsChallenge2014:
+        dad = CollectionData.ATLAS
+        son = CollectionData.ATLASHiggsChallenge2014
+        score = 3
+        type = 'r'
+
     class siteCollection_LHCb:
         dad = CollectionData.siteCollection
         son = CollectionData.LHCb
@@ -426,6 +432,12 @@ class CollectionCollectionData(DataSet):
         dad = CollectionData.siteCollection
         son = CollectionData.DataPolicies
         score = 16
+        type = 'r'
+
+    class siteCollection_ATLASHiggsChallenge2014:
+        dad = CollectionData.siteCollection
+        son = CollectionData.ATLASHiggsChallenge2014
+        score = 17
         type = 'r'
 
 


### PR DESCRIPTION
* Plugs collection "ATLAS Higgs Challenge 2014" into the visible
  collection tree, now that it is ready for production.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>