### PR TITLE
master-updates

### DIFF
--- a/invenio_opendata/base/static/css/collection.css
+++ b/invenio_opendata/base/static/css/collection.css
@@ -503,6 +503,8 @@
   padding: 10px;
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
+  font-size: 17px;
+  font-weight: 400;
 }
 #subcollection .coll-overview .coll-box .bottom > div {
   text-align: center;
@@ -834,12 +836,12 @@ li.disabled {
 
 .rec-single-box .desc .go {
   background-color: #acc6d4;
-  height: 39px;
+  height: 41px;
   margin: 0 -15px;
   padding: 10px 15px;
   color: #fff;
-  font-weight: 100;
-  font-size: 14px;
+  font-weight: 400;
+  font-size: 16px;
   display: block;
   overflow: hidden;
   border-bottom-left-radius: 3px;

--- a/invenio_opendata/base/static/css/records.css
+++ b/invenio_opendata/base/static/css/records.css
@@ -97,7 +97,8 @@
 .rec_doi a:hover,
 .rec_doi a:focus {
   color: inherit;
-  text-decoration: underline;
+  border-bottom: 1px dotted;
+  text-decoration: none;
 }
 
 .rec_files_info {

--- a/invenio_opendata/base/static/css/style.css
+++ b/invenio_opendata/base/static/css/style.css
@@ -33,9 +33,10 @@ html body {
   border: 0;
   background-color: #CFE1EB;
 }
+
 body #wrap {
-  margin: 0;
-  padding: 0;
+  margin: 0 auto -80px;
+  padding: 0 0 80px;
 }
 
 a, a:hover, a:focus {

--- a/invenio_opendata/base/static/css/style.css
+++ b/invenio_opendata/base/static/css/style.css
@@ -45,6 +45,13 @@ a, a:hover, a:focus {
   font-size: inherit;
 }
 
+a.clean, a.clean:hover, a.clean:focus {
+  color: inherit!important;
+  text-decoration: none!important;
+  font-size: inherit!important;
+  border: 0!important;
+}
+
 header a, header a:hover, header a:focus,
 footer a, footer a:hover, footer a:focus {
   color: #fff;
@@ -722,8 +729,8 @@ a.glossaryTerm:focus {
   color: inherit!important;
   font-size: inherit!important;
   font-weight: inherit!important;
-  background-color: rgba(51, 51, 51, 0.09);
-  /*border-bottom: 1px dotted!important;*/
+  /*background-color: rgba(51, 51, 51, 0.09);*/
+  border-bottom: 1px dashed!important;
   width: auto!important;
 }
 

--- a/invenio_opendata/base/static/js/zglossary/jquery.zglossary.js
+++ b/invenio_opendata/base/static/js/zglossary/jquery.zglossary.js
@@ -15,7 +15,7 @@
 
 (function($){
 	
-	$.fn.glossary = function(url, options) {
+	$.fn.glossary = function(url, options, exp) {
 
 		// Set plugin defaults
 		var defaults = {
@@ -141,9 +141,27 @@
 
 						var count = data.length;
 						for (var i=0; i<count; i++) {
+							move_on = false;
 
 							// Find term in text
 							var item = data[i];
+							if (item.category == 'specific') {
+								console.log('## '+' == '+exp+' : '+ item.term );
+								console.log(item.experiment);
+
+								item.experiment.forEach(function(e, i, a) {
+									console.log('-- '+e.name+' == '+exp+' : '+ item.term  +'////'+ e)
+									if( e.name == exp ){
+										move_on = true;
+									}
+								});
+							}
+							else {
+								move_on = true;
+							}
+							if (!move_on) {
+								continue;
+							}
 							if ( item.term instanceof Array) {
 								for (var o = 0 ; o < item.term.length ; o++) {
 									_addTerm(e, item.term[o], item.type, item.definition);

--- a/invenio_opendata/base/static/json/glossary.json
+++ b/invenio_opendata/base/static/json/glossary.json
@@ -3,36 +3,420 @@
 		"term": "AOD",
 		"anchor": "AOD",
 		"definition": "Stands for “Analysis Object Data”, a format that contains all information needed for a CMS analysis. It contains reconstructed “physics objects” such as electrons, photons and muons.",
-		"type": "0"
+		"type": "0",
+		"category": "specific",
+		"experiment": [
+			{
+				"name": "CMS"
+			}
+		],
+		"see_also": [
+			{
+				"term": "primary"
+			},
+			{
+				"term": "reconstruction"
+			}
+		],
+		"links": [
+			{
+				"text": "Read more in the CMS WorkBook",
+				"url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookDataFormats#AoD"
+			},
+			{
+				"text": "Read more on the “About CMS” page on this portal",
+				"url": "http://opendata.cern.ch/about/CMS"
+			}
+		]
 	},
 	{
 		"term": "CMSSW",
 		"anchor": "CMSSW",
+		"category": "specific",
+		"type": "0",
 		"definition": "Stands for CMS Software and refers to the so-called “Offline” software needed to analyse CMS data.",
-		"type": "0"
+		"experiment": [
+			{
+				"name": "CMS"
+			}
+		],
+		"links": [
+			{
+				"text": "See the CMSSW codebase on GitHub",
+				"url": "https://github.com/cms-sw/cmssw"
+			}
+		]
 	},
 	{
 		"term": ["Derived Datasets", "Derived Dataset"],
 		"anchor": "derived",
+		"category": "specific",
+		"type": "0",
 		"definition": "Contains data that have been derived from the primary datasets. The data may be reduced in the sense that (a) only part of the information is kept or (b) only part of the events are selected.",
-		"type": "0"
+		"experiment": [
+			{
+				"name": "CMS"
+			},
+			{
+				"name": "ATLAS"
+			},
+			{
+				"name": "ALICE"
+			},
+			{
+				"name": "LHCb"
+			}
+		],
+		"see_also": [
+			{
+				"term": "primary"
+			}
+		],
+		"links": [
+			{
+				"text": "See all the “Derived datasets” collections on this portal",
+				"url": "http://opendata.cern.ch/search?ln=en&p=+%28collection%3AALICE-Derived-Datasets+OR+collection%3ACMS-Derived-Datasets+OR+collection%3AATLAS-Derived-Datasets+OR+collection%3ALHCb-Derived-Datasets%29&action_search="
+			}
+		]
+	},
+	{
+		"term": ["Electron","Electrons"],
+		"anchor": "electron",
+		"category": "generic",
+		"type": "0",
+		"definition": "A stable elementary particle belonging to the first generation of the “lepton” family of particles. It has a &minus;1 electrical charge, while its anti-particle, the anti-electron or positron, has a +1 electrical charge. Atoms are made of electrons orbiting positively charged nuclei. An electron has a mass of ~0.5 MeV/c<sup>2</sup>, or about 1/1836 times the mass of a proton.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Electron"
+			}
+		],
+		"see_also": [
+			{
+				"term": "muon"
+			},
+			{
+				"term": "proton"
+			},
+			{
+				"term": "neutrino"
+			}
+		]
+	},
+	{
+		"term": "Gluon",
+		"anchor": "Gluon",
+		"category": "generic",
+		"type": "0",
+		"definition": "An elementary particle belonging to the “boson” family of particles. It is the carrier of the strong force that binds quarks together to form hadrons. It is massless and has no electrical charge but has a property known as “colour charge”.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Gluon"
+			}
+		],
+		"see_also": [
+			{
+				"term": "quark"
+			},
+			{
+				"term": "photon"
+			}
+		]
+	},
+	{
+		"term": "Hadron",
+		"anchor": "hadron",
+		"category": "generic",
+		"type": "0",
+		"definition": "A composite particle made of two or more quarks. There are two sub-categories of hadrons: “baryons” such as protons and neutrons are made of three quarks (or three anti-quarks), while “mesons” are made of a quark and an anti-quark. Atomic nuclei can also be considered hadrons, since they are also fundamentally made of quarks. The LHC collides two species of hadrons: protons and lead nuclei (also called lead ions). Hadrons produced in collisions typically cluster together to form particle jets in the detectors.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Hadron"
+			}
+		],
+		"see_also": [
+			{
+				"term": "proton"
+			},
+			{
+				"term": "quark"
+			},
+			{
+				"term": "jet"
+			},
+			{
+				"term": "ion"
+			}
+		]
+	},
+	{
+		"term": "Ion",
+		"anchor": "ion",
+		"category": "generic",
+		"type": "0",
+		"definition": "An ion is an atom or a molecule in which the number of electrons is not the same as the number of protons. In the context of the LHC, the term “heavy ion” refers to the nuclei of heavy atoms such as lead.",
+		"links": [
+			{
+				"text": "Read more about heavy-ion physics on the CERN website",
+				"url": "http://home.web.cern.ch/about/physics/heavy-ions-and-quark-gluon-plasma"
+			}
+		],
+		"see_also": [
+			{
+				"term": "proton"
+			},
+			{
+				"term": "quark"
+			},
+			{
+				"term": "jet"
+			},
+			{
+				"term": "ion"
+			}
+		]
+	},
+	{
+		"term": "Muon",
+		"anchor": "Muon",
+		"type": "0",
+		"category": "generic",
+		"definition": "An elementary particle belonging to the second generation of the “lepton” family of particles. It has a &minus;1 electrical charge, while its anti-particle, the anti-muon, has a +1 electrical charge. A muon’s properties are similar to those of an electron but it is around 200 times more massive. It is represented by the Greek letter “&mu;”.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Muon"
+			}
+		],
+		"see_also": [
+			{
+				"term": "electron"
+			},
+			{
+				"term": "neutrino"
+			}
+		]
+	},
+	{
+		"term": "Neutrino",
+		"anchor": "neutrino",
+		"category": "generic",
+		"type": "0",
+		"definition": "An elementary particle belonging to the “lepton” family of particles. Neutrinos and their anti-particles, anti-neutrinos, have no charge, although measurements show that they are not massless. Neutrinos rarely interact with matter: they can fly through lightyears of lead without coming to a stop. Therefore, they cannot be detected directly by the particle detectors at the LHC: their presence has to be inferred by detecting and measuring every other particle produced in the collisions and then applying conservation laws. Neutrinos are recorded as “missing transverse energy” or MET, although MET could also be a sign of previously undiscovered, non-interacting particles.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Neutrino"
+			}
+		],
+		"see_also": [
+			{
+				"term": "muon"
+			},
+			{
+				"term": "neutrino"
+			}
+		]
+	},
+	{
+		"term": "Particle jet",
+		"anchor": "jet",
+		"category": "generic",
+		"type": "0",
+		"definition": "A jet is a shower of hadrons clustered together after being produced in particle collisions.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Jet_%28particle_physics%29"
+			}
+		],
+		"see_also": [
+			{
+				"term": "proton"
+			},
+			{
+				"term": "quark"
+			},
+			{
+				"term": "hadron"
+			}
+		]
 	},
 	{
 		"term": "PAT",
 		"anchor": "PAT",
+		"category": "specific",
+		"type": "0",
 		"definition": "Stands for Physics Analysis Toolkit, and provides easy access to algorithms developed by the CMS Physics Object Groups (POGs) in the framework of CMS Software (CMSSW), suitable for most CMS analyses.",
-		"type": "0"
+		"experiment": [
+			{
+				"name": "CMS"
+			}
+		],
+		"links": [
+			{
+				"text": "Read more in the CMS Software guide",
+				"url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuidePAT"
+			}
+		]
+	},
+	{
+		"term": "Photon",
+		"anchor": "photon",
+		"category": "generic",
+		"type": "0",
+		"definition": "A stable elementary particle belonging to the “boson” family of particles. Called the “quantum” of light, the photon is the carrier of the electromagnetic force and is massless with no electrical charge. It is represented by the Greek letter “&gamma;”.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Photon"
+			}
+		],
+		"see_also": [
+			{
+				"term": "gluon"
+			}
+		]
 	},
 	{
 		"term": ["Primary Datasets", "Primary Dataset"],
 		"anchor": "primary",
-		"definition": "Datasets without any selection criteria applied. On this portal, primary datasets refer to “reconstructed data”.",
-		"type": "0"
+		"definition": "Datasets prepared after trigger selections, with no further selection criteria applied. On this portal, primary datasets refer to “reconstructed data”.",
+		"type": "0",
+		"category": "specific",
+		"experiment": [
+			{
+				"name": "CMS"
+			},
+			{
+				"name": "ATLAS"
+			},
+			{
+				"name": "ALICE"
+			},
+			{
+				"name": "LHCb"
+			}
+		],
+		"see_also": [
+			{
+				"term": "AOD"
+			},
+			{
+				"term": "reconstruction"
+			}
+		],
+		"links": [
+			{
+				"text": "Read more on the CMS website",
+				"url": "http://cern.ch/cms"
+			}
+		]
+	},
+	{
+		"term": "Proton",
+		"anchor": "proton",
+		"category": "generic",
+		"type": "0",
+		"definition": "A stable composite particle belonging to the “hadron” family of particles, made of two up quarks and a down quark. It has a +1 electrical charge and is found in the nuclei of atoms. A proton has a mass of ~938 MeV/c<sup>2</sup>, or about 1836 times the mass of an electron. Protons are one of the species of particles collided at the LHC.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Proton"
+			}
+		],
+		"see_also": [
+			{
+				"term": "hadron"
+			},
+			{
+				"term": "electron"
+			},
+			{
+				"term": "jet"
+			}
+		]
+	},
+	{
+		"term": "Quark",
+		"anchor": "quark",
+		"category": "generic",
+		"type": "0",
+		"definition": "An elementary particle that comes in six flavours: up, charm and top (all with +2/3 electrical charge) and down, strange and bottom (all with &minus;1/3 electrical charge). Quarks also have a property known as “colour charge” and cannot exist freely because of a phenomenon called “colour confinement”: they are held together by gluons to form hadrons.",
+		"links": [
+			{
+				"text": "Read more on Wikipedia",
+				"url": "https://en.wikipedia.org/wiki/Quark"
+			}
+		],
+		"see_also": [
+			{
+				"term": "hadron"
+			},
+			{
+				"term": "proton"
+			},
+			{
+				"term": "jet"
+			},
+			{
+				"term": "gluon"
+			}
+		]
 	},
 	{
 		"term": ["Reconstruction", "Reconstructions"],
 		"anchor": "reconstruction",
 		"definition": "Fragmented data from various sub-detectors are processed or “reconstructed” to provide coherent information about individual physics objects such as electrons or particle jets. Reconstruction involves putting together information from different sub-detectors into a coherent representation of every particle collision. However, the format for the first tier of reconstructed data is often too huge for meaningful analysis, and is converted into a lighter format, such as the AOD format for CMS.",
-		"type": "0"
+		"type": "0",
+		"category": "specific",
+		"experiment": [
+			{
+				"name": "CMS"
+			},
+			{
+				"name": "ATLAS"
+			},
+			{
+				"name": "ALICE"
+			},
+			{
+				"name": "LHCb"
+			}
+		],
+		"see_also": [
+			{
+				"term": "AOD"
+			},
+			{
+				"term": "primary"
+			}
+		],
+		"links": [
+			{
+				"text": "Read more in the CMS WorkBook",
+				"url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookDataFormats#RecO"
+			}
+		]
+	},
+	{
+		"term": "RunB",
+		"anchor": "RunB",
+		"type": "0",
+		"category": "specific",
+		"definition": "The data collected by CMS in 2010 were divided into two sets called “RunA” and “RunB”. The latter is from the second part of the year, corresponding to a volume of 27 TB.",
+		"experiment": [
+			{
+				"name": "CMS"
+			}
+		],
+		"links": [
+			{
+				"text": "Read more about CMS Luminosity records",
+				"url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/LumiPublicResults"
+			}
+		]
 	}
 ]

--- a/invenio_opendata/base/templates/helpers/general.html
+++ b/invenio_opendata/base/templates/helpers/general.html
@@ -6,10 +6,10 @@
         {% set url_href = url_for(b.url, exp = exp) %}
       {% elif b.param == 'name' %}
         {% set url_href = url_for(b.url, name = b.value) %}
-        <a href="{{url_href}}"><h4 class="{{ ' active' if (loop.index is divisibleby 2) }}">{{b.text}}</h4></a>{{ '<span class="fa fa-chevron-right"></span>'|safe if ((not loop.last) )}} 
+        <a href="{{url_href}}"><h4 class="no-glossary {{ ' active' if (loop.index is divisibleby 2) }}">{{b.text}}</h4></a>{{ '<span class="fa fa-chevron-right"></span>'|safe if ((not loop.last) )}} 
       {% else %}
         {% set url_href = url_for(b.url) %}
-        <a href="{{url_href}}"><h4 class="{{ ' active' if (loop.index is divisibleby 2) }}">{{b.text}}</h4></a>{{ '<span class="fa fa-chevron-right"></span>'|safe if ((not loop.last) )}} 
+        <a href="{{url_href}}"><h4 class="no-glossary {{ ' active' if (loop.index is divisibleby 2) }}">{{b.text}}</h4></a>{{ '<span class="fa fa-chevron-right"></span>'|safe if ((not loop.last) )}} 
       {% endif %}
       {% if loop.last and exp and  exp_names %}
         {{ experiments_dropdown(loop, b.url, exp, exp_names, exclude) }}

--- a/invenio_opendata/base/templates/page.html
+++ b/invenio_opendata/base/templates/page.html
@@ -78,7 +78,8 @@
             ignorecase: true,
             linktarget: '_blank',
             excludetags: ['a','h2','pre', 'kbd'],
-          });
+          },
+          exp = "{{ exp if exp else ''}}");
       });      
       {% endblock %}
       {% block js_search_for_external_links %}

--- a/invenio_opendata/base/templates/records/macros.html
+++ b/invenio_opendata/base/templates/records/macros.html
@@ -255,6 +255,7 @@
 					<li><a href="{{ url_for('record.metadata', recid=record.get('action_note.recid', '')) }}">{{ (record.get('action_note.recid', ''))|get_record_name }}</a></li>
 					{% endif %}
 					{% if record_data['url'] %}
+					<li><a href="{{ record_data['url'] }}">{{ record_data['description'] }}</a></li>
 					{% for u in record.get('action_note') %}
 					<li><a href="{{ u.url }}">{{ u.description }}</a></li>
 					{% endfor %}

--- a/invenio_opendata/base/templates/records/metadata_base.html
+++ b/invenio_opendata/base/templates/records/metadata_base.html
@@ -264,7 +264,12 @@
               {% if record.get('system_details', {}).get('displaytext', '') %}
                 {{record.get('system_details', {}).get('displaytext', '')}}<br>
               {% endif %}
-              {{record.get('system_details', {}).get('note', '')}}
+              {% if record.get('system_details', {}).get('notebis', '') %}
+                {{record.get('system_details', {}).get('notebis', '')}}<br>
+              {% endif %}
+              {% if record.get('system_details', {}).get('note', '') %}
+                {{record.get('system_details', {}).get('note', '')}}<br>
+              {% endif %}
               {% if record.get('system_details', {}).get('recid', '') %}
                 <a href="{{url_for('.metadata', recid = record.get('system_details', {}).get('recid', '') )}}">{{(record.get('system_details', {}).get('recid', ''))|get_record_name }}</a>
               {% endif %}

--- a/invenio_opendata/base/templates/records/metadata_base.html
+++ b/invenio_opendata/base/templates/records/metadata_base.html
@@ -52,7 +52,7 @@
             <span> <i>et al</i></span>
           {% endif %}
         {% endif %}
-        {{ record['_first_corporate_name']['name'] if record['_first_corporate_name']}} ({{ record.get('imprint', {}).get('date', '') }}). {% if record.get('title_additional', '') %}{{ record.get('title_additional',{}).get('title','') }}{% elif record.get('title',{}).get('title','') %}{{ record.get('title',{}).get('title','') }}{% endif %}. CERN Open Data Portal. DOI: <a href="http://doi.org/{{ record.get('doi','') }}">{{ record.get('doi','') }}</a></div>
+        {{ record['_first_corporate_name']['name'] if record['_first_corporate_name']}} ({{ record.get('imprint', {}).get('date', '') }}). {% if record.get('title_additional', '') %}{{ record.get('title_additional',{}).get('title','') }}{% elif record.get('title',{}).get('title','') %}{{ record.get('title',{}).get('title','') }}{% endif %}. CERN Open Data Portal. DOI: <a class="clean" href="http://doi.org/{{ record.get('doi','') }}">{{ record.get('doi','') }}</a></div>
         </div>
       {% endif %}
       <div class="rec_thumb rec_parentcol">

--- a/invenio_opendata/base/views.py
+++ b/invenio_opendata/base/views.py
@@ -426,6 +426,9 @@ def collection(name):
     breadcrumbs = [{}]
     if parent_collection:
         breadcrumbs.append({ "url":".collection", "text": parent_collection.name_ln, "param":"name", "value": parent_collection.name })
+        exp = parent_collection.name_ln
+    else:
+        exp = collection.name_ln
 
     breadcrumbs.append({ "url":".collection", "text": collection.name_ln, "param":"name", "value": collection.name })
 
@@ -433,7 +436,7 @@ def collection(name):
                             'search/collection_{0}.html'.format(slugify(name,
                                                                         '_')),
                             'search/collection.html'],
-                           collection=collection, coll_records=coll_records, breadcrumbs = breadcrumbs)
+                           collection=collection, coll_records=coll_records, breadcrumbs = breadcrumbs, exp = exp)
 
 
 # Routing for "record" module


### PR DESCRIPTION
* templates: fixes layout with sticky-footer
* records: updates styling in record header links
* glossary: removes glossary display in breadcrumbs
* records: fixes template for correct 583 field display
* UI: updates titles font-size in collection boxes
* records: displays missing global tag in 'System Details'
* glossary: generic/specific distinction