### PR TITLE
docker: initial release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+*.gitignore
+
+*.mo
+*.pyc
+*.swp
+*.swo
+*.~
+
+.dockerignore
+Dockerfile
+docker-compose.yml
+docker-compose-dev.yml
+
+Procfile*

--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -8,216 +8,160 @@
 Installation
 ============
 
-If you'd like to install CERN Open Data portal demo site locally for
-your personal developments, you can use `invenio2-kickstart
-<https://raw.githubusercontent.com/tiborsimko/invenio-devscripts/master/invenio2-kickstart>`_
-helper script and proceed as follows:
+Here is how to install an instance of the CERN Open Data Portal on
+your laptop.
 
-Firstly, fire up new VM:
+Quick installation instructions
+-------------------------------
 
-.. code-block:: console
+Quick installation instructions for an impatient Invenio developer::
 
-    laptop> mkdir -p ~/private/vm/opendata2trusty64
-    laptop> cd ~/private/vm/opendata2trusty64
-    laptop> vim Vagrantfile # enter following content:
-    Vagrant.configure("2") do |config|
-      config.vm.box = "trusty64"
-      config.vm.box_url = "http://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
-      config.vm.hostname = 'localhost.localdomain'
-      config.vm.network :forwarded_port, host: 8080, guest: 8080
-      config.vm.network :forwarded_port, host: 8443, guest: 8443
-      config.vm.provider :virtualbox do |vb|
-        vb.customize ["modifyvm", :id, "--memory", "2048"]
-        vb.customize ["modifyvm", :id, "--cpus", "2"]
-      end
-    end
-    laptop> vagrant up
+   cd ~/private/src/invenio
+   git checkout maint-2.0
+   docker build -t invenio:2.0 .
+   cd ~/private/src/opendata.cern.ch
+   git checkout master
+   ./scripts/populate-fft-file-cache.sh
+   docker-compose -f docker-compose-dev.yml build
+   docker-compose -f docker-compose-dev.yml up
+   # now wait until all daemons are fully up and running
+   firefox http://127.0.0.1:28080/
+   # now populate demo site with some records
+   docker exec -i -t -u invenio opendatacernch_web_1 \
+     inveniomanage demosite populate --packages=invenio_opendata.base \
+       -f invenio_opendata/testsuite/data/lhcb/lhcb-derived-datasets.xml \
+       -e force-recids --yes-i-know
+   firefox http://127.0.0.1:28080/
 
-Secondly, if you have already a pre-populated local FFT file cache
-archive (``opendata.cern.ch-fft-file-cache``) somewhere, say under
-``/vagrant/``, then you can reuse it by creating a symbolic link on
-the VM:
+Detailed installation instructions
+----------------------------------
 
-.. code-block:: console
+Detailed installation instructions for a patient Invenio developer.
 
-    laptop> vagrant ssh
-    vm> ln -s /vagrant/opendata.cern.ch-fft-file-cache .
+Firstly, `install Docker <https://docs.docker.com/installation/>`_.
 
-If you don't have any such FFT file cache archive, then you can simply
-continue; the files will be downloaded during first installation.
+Secondly, clone Invenio and CERN Open Data Portal sources, following
+`Appendix: Setting up repostory
+<https://github.com/cernopendata/opendata.cern.ch/blob/master/DEVELOPING.rst#setting-up-repository>`_.
 
-Thirdly, connect to the VM and download Invenio kickstarter:
+You now have sources in the following directories::
 
-.. code-block:: console
+  ~/private/src/invenio
+  ~/private/src/opendata.cern.ch
 
-    laptop> vagrant ssh
-    vm> wget https://raw.githubusercontent.com/tiborsimko/invenio-devscripts/master/invenio2-kickstart
-    vm> chmod u+x ./invenio2-kickstart
+Thirdly, run helper script to pre-populate local fulltext file cache
+archive from which the demo records will be later loaded::
 
-Now you can actually launch the Invenio kickstarter with the
-opendata.cern.ch overlay.  There are two options:
+  cd ~/private/src/opendata.cern.ch
+  ./scripts/populate-fft-file-cache.sh
 
-- option 1, complete-but-slow-and-big installation, downloading 6 GB
-  of files from CMS DocDB; so please beware and please plan ahead your
-  free disk space and your free time accordingly:
+Note that this will download about 8 GB of files to the following
+directory::
 
-  .. code-block:: console
+  ~/Local/opendata.cern.ch-fft-file-cache
 
-      vm> CFG_INVENIO2_REPOSITORY_OVERLAY=git://github.com/tiborsimko/opendata.cern.ch \
-          CFG_INVENIO2_REPOSITORY_OVERLAY_BRANCH=master \
-          CFG_INVENIO2_VIRTUAL_ENV=opendata \
-          CFG_INVENIO2_DATABASE_USER=opendata \
-          CFG_INVENIO2_DATABASE_NAME=opendata \
-          CFG_INVENIO2_DEMOSITE_POPULATE_BEFORE="./populate-fft-file-cache.sh" \
-          CFG_INVENIO2_DEMOSITE_POPULATE="-f invenio_opendata/testsuite/data/alice/alice-analysis-modules.xml \
-                                          -f invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml \
-                                          -f invenio_opendata/testsuite/data/alice/alice-learning-resources.xml \
-                                          -f invenio_opendata/testsuite/data/alice/alice-reconstructed-data.xml \
-                                          -f invenio_opendata/testsuite/data/alice/alice-vm-image.xml \
-                                          -f invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml \
-                                          -f invenio_opendata/testsuite/data/atlas/atlas-higgs-challenge-2014.xml \
-                                          -f invenio_opendata/testsuite/data/atlas/atlas-learning-resources.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-author-list.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-csv-files.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-hamburg-files.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-learning-resources.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-masterclass-files.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-open-data-instructions.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-tools-ana.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-tools-dimuon-filter.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-tools-ispy.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-tools-vm-image.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-validated-runs.xml \
-                                          -f invenio_opendata/testsuite/data/lhcb/lhcb-derived-datasets.xml \
-                                          -f invenio_opendata/testsuite/data/lhcb/lhcb-learning-resources.xml \
-                                          -f invenio_opendata/testsuite/data/lhcb/lhcb-tools.xml \
-                                          -f invenio_opendata/testsuite/data/data-policies.xml \
-                                          -e force-recids" \
-          ./invenio2-kickstart --yes-i-know --yes-i-really-know
+Fourthly, build Invenio Docker image if you haven't built one yet::
 
-- option 2, incomplete-but-fast-and-tiny installation, downloading
-  some selected files only; i.e. no big download of CMS files at all;
-  however this will make the site largely desert; so this option is
-  useful notably for testing collection setup or testing templates
-  only:
+  cd ~/private/src/invenio
+  git checkout maint-2.0
+  docker build -t invenio:2.0 .
 
-  .. code-block:: console
+Fifthly, create CERN Open Data Portal docker image and bring up the
+containers::
 
-      vm> CFG_INVENIO2_REPOSITORY_OVERLAY=git://github.com/tiborsimko/opendata.cern.ch \
-          CFG_INVENIO2_REPOSITORY_OVERLAY_BRANCH=master \
-          CFG_INVENIO2_VIRTUAL_ENV=opendata \
-          CFG_INVENIO2_DATABASE_USER=opendata \
-          CFG_INVENIO2_DATABASE_NAME=opendata \
-          CFG_INVENIO2_DEMOSITE_POPULATE="-f invenio_opendata/testsuite/data/cms/cms-tools-ana.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-tools-ispy.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-tools-dimuon-filter.xml \
-                                          -f invenio_opendata/testsuite/data/cms/cms-learning-resources.xml \
-                                          -e force-recids" \
-          ./invenio2-kickstart --yes-i-know --yes-i-really-know
+  cd ~/private/src/opendata.cern.ch
+  docker-compose -f docker-compose-dev.yml build
+  docker-compose -f docker-compose-dev.yml up
 
-Finally, go brew some tee, come back in twenty minutes, enjoy!
+Wait until all daemons are fully up and running.  Now you should be
+able to see the empty site::
 
-.. code-block:: console
+  firefox http://127.0.0.1:28080/
 
-    laptop> firefox http://0.0.0.0:8080/
+Sixthly, if you would like to populate your CERN Open Data local
+installation with records, you can now do in another terminal::
+
+  cd ~/private/src/opendata.cern.ch
+  docker exec -i -t -u invenio opendatacernch_web_1 \
+    inveniomanage demosite populate --packages=invenio_opendata.base \
+    -f invenio_opendata/testsuite/data/lhcb/lhcb-derived-datasets.xml \
+    -e force-recids --yes-i-know
+
+for all the files you'd like to upload, depending on which collection
+you'd like to work with.  For example, the above command will populate
+only the LHCb Derived Datasets collection.  If you would like to
+populate *all* collections, you can use::
+
+  docker exec -i -t -u invenio opendatacernch_web_1 \
+    inveniomanage demosite populate --packages=invenio_opendata.base \
+    -f invenio_opendata/testsuite/data/alice/alice-analysis-modules.xml \
+    -f invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml \
+    -f invenio_opendata/testsuite/data/alice/alice-learning-resources.xml \
+    -f invenio_opendata/testsuite/data/alice/alice-reconstructed-data.xml \
+    -f invenio_opendata/testsuite/data/alice/alice-vm-image.xml \
+    -f invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml \
+    -f invenio_opendata/testsuite/data/atlas/atlas-higgs-challenge-2014.xml \
+    -f invenio_opendata/testsuite/data/atlas/atlas-learning-resources.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-author-list.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-csv-files.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-hamburg-files.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-learning-resources.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-masterclass-files.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-open-data-instructions.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-tools-ana.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-tools-dimuon-filter.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-tools-ispy.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-tools-vm-image.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-validated-runs.xml \
+    -f invenio_opendata/testsuite/data/lhcb/lhcb-derived-datasets.xml \
+    -f invenio_opendata/testsuite/data/lhcb/lhcb-learning-resources.xml \
+    -f invenio_opendata/testsuite/data/lhcb/lhcb-tools.xml \
+    -f invenio_opendata/testsuite/data/data-policies.xml \
+    -e force-recids --yes-i-know
+
+Now you should be able to see the populated site::
+
+  firefox http://127.0.0.1:28080/
 
 Running
 =======
 
-The above kickstarter will already start Invenio application for you.
-Should you shut down and reboot your VM, you need to restart Invenio
-as follows:
+The data in your newly built Docker containers are persistent.  You
+can stop the containers by e.g. interrupting the ``docker-compose up``
+process at any time, and bring your work back up by doing::
 
-.. code-block:: console
+  cd ~/private/src/opendata.cern.ch
+  docker-compose -f docker-compose-dev.yml up
 
-    laptop> cd ~/private/vm/opendata2trusty64
-    laptop> vagrant halt
-    laptop> vagrant up
-    laptop> vagrant ssh
-    vm> workon opendata
-    vm> cdvirtualenv src/invenio
-    vm> honcho start
-
-You can keep `honcho` running in a screen session for example.
-
-Upgrading
-=========
-
-To upgrade your installation, it is sufficient to pull latest versions
-of this overlay:
-
-.. code-block:: console
-
-    vm> workon opendata
-    vm> cdvirtualenv src/opendata.cern.ch
-    vm> git pull
-
-You can also update Invenio itself:
-
-.. code-block:: console
-
-    vm> cdvirtualenv src/invenio
-    vm> git pull
-
-Populating
+Developing
 ==========
 
-If you change incoming data files for example and if you'd like to
-re-populate your site anew to have your updated records, you can do:
-
-.. code-block:: console
-
-    vm> workon opendata
-    vm> inveniomanage database recreate --yes-i-know
-    vm> inveniomanage demosite populate --packages=invenio_opendata.base \
-         -f invenio_opendata/testsuite/data/alice/alice-analysis-modules.xml \
-         -f invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml \
-         -f invenio_opendata/testsuite/data/alice/alice-learning-resources.xml \
-         -f invenio_opendata/testsuite/data/alice/alice-reconstructed-data.xml \
-         -f invenio_opendata/testsuite/data/alice/alice-vm-image.xml \
-         -f invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml \
-         -f invenio_opendata/testsuite/data/atlas/atlas-higgs-challenge-2014.xml \
-         -f invenio_opendata/testsuite/data/atlas/atlas-learning-resources.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-author-list.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-csv-files.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-hamburg-files.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-learning-resources.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-masterclass-files.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-open-data-instructions.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-primary-datasets.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-tools-ana.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-tools-dimuon-filter.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-tools-ispy.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-tools-vm-image.xml \
-         -f invenio_opendata/testsuite/data/cms/cms-validated-runs.xml \
-         -f invenio_opendata/testsuite/data/lhcb/lhcb-derived-datasets.xml \
-         -f invenio_opendata/testsuite/data/lhcb/lhcb-learning-resources.xml \
-         -f invenio_opendata/testsuite/data/lhcb/lhcb-tools.xml \
-         -f invenio_opendata/testsuite/data/data-policies.xml \
-         -e force-recids --yes-i-know
+The sources in your local directories ``~/private/src/invenio`` and
+``~/private/src/opendata.cern.ch`` are mounted in your running Docker
+containers when ``docker-compose up`` starts them.  Hence you can
+simply edit the files directly on your laptop and observe the changes
+in the running application.
 
 JS/CSS Assets
 =============
 
-If you change JS or CSS requirements, you'd need to rebuild bundles:
+If you change JS or CSS requirements, you may need to rebuild
+bundles::
 
-.. code-block:: console
-
-    vm> workon opendata
-    vm> cdvirtualenv src/opendata.cern.ch
-    vm> inveniomanage bower -i bower-base.json > bower.json
-    vm> CI=true bower install
-    vm> inveniomanage collect
+  docker exec -i -t -u invenio opendatacernch_web_1 \
+    sh -c 'inveniomanage bower -i bower-base.json > bower.json'
+  docker exec -i -t -u invenio opendatacernch_web_1 \
+    sh -c 'CI=true bower install'
+  docker exec -i -t -u invenio opendatacernch_web_1 \
+    inveniomanage collect
 
 See also
 ========
 
-* http://invenio.readthedocs.org/en/latest/getting-started/overlay.html
+* http://invenio.readthedocs.org/en/latest/developers/docker.html
 
 
 Appendix: Git workflow

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# This file is part of CERN Open Data Portal.
+# Copyright (C) 2015 CERN.
+#
+# CERN Open Data Portal is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Open Data Portal is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+# based on the right Invenio base image
+FROM invenio:2.0
+
+# get root rights again
+USER root
+
+# add content
+ADD . /code-overlay
+WORKDIR /code-overlay
+
+# fix requirements.txt and install additional dependencies
+RUN sed -i '/inveniosoftware\/invenio[@#]/d' requirements.txt && \
+    pip install -r requirements.txt --exists-action i
+
+# step back
+# in general code should not be writeable, especially because we are using
+# `pip install -e`
+RUN mkdir -p /code-overlay/src && \
+    chown -R invenio:invenio /code-overlay && \
+    chown -R root:root /code-overlay/invenio_opendata && \
+    chown -R root:root /code-overlay/setup.* && \
+    chown -R root:root /code-overlay/src
+
+# finally step back again
+USER invenio

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,67 @@
+# This file is part of CERN Open Data Portal.
+# Copyright (C) 2015 CERN.
+#
+# CERN Open Data Portal is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Open Data Portal is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+web:
+  build: .
+  command: inveniomanage runserver -h 0.0.0.0 -p 28080 -d -r
+  ports:
+    - "127.0.0.1:28080:28080"
+  environment:
+    - CACHE_REDIS_HOST=cache
+    - CFG_DATABASE_HOST=db
+    - DEBUG=True
+    - DEBUG_TB_INTERCEPT_REDIRECTS=False
+    - INVENIO_APP_CONFIG_ENVS=CACHE_REDIS_HOST,CFG_DATABASE_HOST,DEBUG,DEBUG_TB_INTERCEPT_REDIRECTS
+  volumes:
+    - ../invenio/invenio:/code/invenio:ro
+    - ../invenio/docs:/code/docs:rw
+    - ../invenio/scripts:/code/scripts:ro
+    - ./invenio_opendata:/code-overlay/invenio_opendata:ro
+    - /code/invenio/base/translations
+    - ~/Local/opendata.cern.ch-fft-file-cache:/tmp/opendata.cern.ch-fft-file-cache:ro
+  links:
+    - mysql:db
+    - redis:cache
+worker:
+  build: .
+  command: celery worker --purge -E -A invenio.celery.celery --loglevel=DEBUG
+  environment:
+    - BROKER_URL=redis://cache:6379/1
+    - CACHE_REDIS_HOST=cache
+    - CELERY_RESULT_BACKEND=redis://cache:6379/1
+    - CFG_DATABASE_HOST=db
+    - DEBUG=True
+    - DEBUG_TB_INTERCEPT_REDIRECTS=False
+    - INVENIO_APP_CONFIG_ENVS=BROKER_URL,CELERY_RESULT_BACKEND,CACHE_REDIS_HOST,CFG_DATABASE_HOST,DEBUG,DEBUG_TB_INTERCEPT_REDIRECTS
+  volumes_from:
+    - web
+  links:
+    - mysql:db
+    - redis:cache
+redis:
+  image: redis
+  ports:
+    - "127.0.0.1:26379:6379"
+mysql:
+  image: mysql
+  ports:
+    - "127.0.0.1:23306:3306"
+  environment:
+    - MYSQL_DATABASE=invenio
+    - MYSQL_USER=invenio
+    - MYSQL_PASSWORD=my123p$ss
+    - MYSQL_ROOT_PASSWORD=mysecretpassword

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,54 @@
+# This file is part of CERN Open Data Portal.
+# Copyright (C) 2015 CERN.
+#
+# CERN Open Data Portal is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Open Data Portal is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+
+web:
+  build: .
+  command: inveniomanage runserver -h 0.0.0.0 -p 28080
+  ports:
+    - "28080:28080"
+  environment:
+    - CACHE_REDIS_HOST=cache
+    - CFG_DATABASE_HOST=db
+    - INVENIO_APP_CONFIG_ENVS=CACHE_REDIS_HOST,CFG_DATABASE_HOST
+  volumes:
+    - /tmp:/tmp
+  links:
+    - mysql:db
+    - redis:cache
+worker:
+  build: .
+  command: celery worker --purge -E -A invenio.celery.celery --loglevel=DEBUG
+  environment:
+    - BROKER_URL=redis://cache:6379/1
+    - CACHE_REDIS_HOST=cache
+    - CELERY_RESULT_BACKEND=redis://cache:6379/1
+    - CFG_DATABASE_HOST=db
+    - INVENIO_APP_CONFIG_ENVS=BROKER_URL,CELERY_RESULT_BACKEND,CACHE_REDIS_HOST,CFG_DATABASE_HOST
+  volumes_from:
+    - web
+  links:
+    - mysql:db
+    - redis:cache
+redis:
+  image: redis
+mysql:
+  image: mysql
+  environment:
+    - MYSQL_DATABASE=invenio
+    - MYSQL_USER=invenio
+    - MYSQL_PASSWORD=my123p$ss
+    - MYSQL_ROOT_PASSWORD=mysecretpassword


### PR DESCRIPTION
* Initial release of Docker and Docker-Compose configuration suitable
  for local CERN Open Data Portal developments.  The demo site can now
  be obtained via:

  $ cd ~/private/src/invenio
  $ git checkout maint-2.0
  $ docker build -t invenio:2.0 .
  $ cd ~/private/src/opendata.cern.ch
  $ git checkout master
  $ ./scripts/populate-fft-file-cache.sh
  $ docker-compose -f docker-compose-dev.yml build
  $ docker-compose -f docker-compose-dev.yml up
  $ # now wait until all daemons are fully up and running
  $ firefox http://127.0.0.1:28080/
  $ # now populate demo site with some records
  $ docker exec -i -t -u invenio opendatacernch_web_1 \
     inveniomanage demosite populate --packages=invenio_opendata.base \
     -f invenio_opendata/testsuite/data/lhcb/lhcb-derived-datasets.xml \
     -e force-recids --yes-i-know
  $ firefox http://127.0.0.1:28080/

* Switches documentation on how to develop CERN Open Data Portal locally
  from the old Vagrant-based approach to the new Docker-based approach.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>