### PR TITLE
templates: copyright years in page footer

### DIFF
--- a/invenio_opendata/base/templates/footer.html
+++ b/invenio_opendata/base/templates/footer.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2015 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -53,7 +53,7 @@
         <div class="row">
           <div class="center-block legal">
             <ul class="">
-              <li>© 2014 CERN Open Data</li>
+              <li>© 2014, 2015 CERN</li>
               <li><a href="{{ url_for('terms-of-use') }}">Terms of Use</a></li>
               <li><a href="{{ url_for('privacy-policy') }}">Privacy Policy</a></li>
               <li><a href="mailto:opendata-support@cern.ch">Contact</a></li>


### PR DESCRIPTION
* Adds copyright year 2015 to the page footer, keeping CERN instead of
  CERN Open Data there.  (closes #784)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>