### PR TITLE
templates: data generated" heading for AODSIM

### DIFF
--- a/invenio_opendata/base/templates/records/CMS-Simulated-Datasets_dedicated.html
+++ b/invenio_opendata/base/templates/records/CMS-Simulated-Datasets_dedicated.html
@@ -1,0 +1,5 @@
+{% extends 'records/dedicated_base.html' %}
+
+{% block methodology_note %}
+  {{ record_methodology_note(record.get('methodology_note', ''), 'How were these data generated?') }}
+{% endblock %}


### PR DESCRIPTION
* Changes heading from "data selected" to "data generated" for CMS
  Simulated Datasets.  (closes #862)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>