### PR TITLE
iSpy event information handling

### DIFF
--- a/invenio_opendata/base/templates/visualise_events.html
+++ b/invenio_opendata/base/templates/visualise_events.html
@@ -341,7 +341,14 @@ body.black a:hover {
                 </div>
               </div>
 
-
+              <div id="event-info" class="black">
+              <table>
+                <tr>
+                  <td id="cms-logo"></td>
+                  <td id="event-text"></td>
+                </tr>
+              </table>
+              </div>
             </div>
 
           <div class="tab-pane fade" id="howto">

--- a/invenio_opendata/base/templates/visualise_events.html
+++ b/invenio_opendata/base/templates/visualise_events.html
@@ -344,7 +344,7 @@ body.black a:hover {
               <div id="event-info" class="black">
               <table>
                 <tr>
-                  <td id="cms-logo"></td>
+                  <td id="cms-logo"><img src="{{url_for('base.static', filename='vendors/ispy-webgl/graphics/cms-color-medium.png')}}"/></td>
                   <td id="event-text"></td>
                 </tr>
               </table>


### PR DESCRIPTION
In the stand-alone display the event information (e.g. "CMS Experiment at the LHC...") was missing. In the previewer for an event display file record the event information was there but the CMS logo was missing. Along with an update to the previewer in a separate pull request this closes #874 and closes #875. Now the CMS logo appear by default on a page load and the text gets added as needed when an event is loaded.