### PR TITLE
CMS: release year 2016 for 2011 data

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files-Run2011A.xml
@@ -18,7 +18,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -85,7 +85,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -152,7 +152,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -219,7 +219,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -286,7 +286,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -353,7 +353,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -420,7 +420,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -487,7 +487,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -554,7 +554,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -621,7 +621,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -688,7 +688,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -755,7 +755,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -822,7 +822,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -889,7 +889,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -956,7 +956,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -1023,7 +1023,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -1090,7 +1090,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -1157,7 +1157,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>
@@ -1224,7 +1224,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>

--- a/invenio_opendata/testsuite/data/cms/cms-validated-runs.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-validated-runs.xml
@@ -71,7 +71,7 @@
     </datafield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
-      <subfield code="c">2015</subfield>
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
       <subfield code="c">2011</subfield>


### PR DESCRIPTION
* Postpones release year to 2016 for CMS 2011 data. (closes #868)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>