### PR TITLE
Event display help tab

### DIFF
--- a/invenio_opendata/base/templates/visualise_events.html
+++ b/invenio_opendata/base/templates/visualise_events.html
@@ -350,14 +350,14 @@ body.black a:hover {
               </table>
               </div>
             </div>
-
-          <div class="tab-pane fade" id="howto">
-            {% include "visualise_events_help.html" %}
-          </div>
+        </div>
+        <div class="tab-pane fade" id="howto">
+          {% include "visualise_events_help.html" %}
         </div>
       </div>
     </div>
   </div>
+</div>
 </section>
 
 {% include "visualise_events_popups.html" %}


### PR DESCRIPTION
* Move #howto tab to its own div to fix switching to and from it and #ispy.

* Closes #892.