### PR TITLE
CMS: trigger information overview table

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-trigger-information-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-trigger-information-Run2011A.xml
@@ -15,7 +15,71 @@
       <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
-      <subfield code="a">FIXME-Description</subfield>
+      <subfield code="a"><![CDATA[
+      Here is the list of trigger configuration files for the CMS Run2011A collision data:
+      <table class="table">
+      <thead>
+      <tr><th>run number</th><th>software version</th><th>trigger configuration</th></tr>
+      </thead>
+      <tbody>
+      <tr><td>160404 - 160406</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v4.2_HLT_V2.py">/cdaq/physics/Run2011/5e32/v4.2/HLT/V2</a></td></tr>
+      <tr><td>160410 - 160413</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v4.2_HLT_V5.py">/cdaq/physics/Run2011/5e32/v4.2/HLT/V5</a></td></tr>
+      <tr><td>160431 - 160463</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v4.2_HLT_V6.py">/cdaq/physics/Run2011/5e32/v4.2/HLT/V6</a></td></tr>
+      <tr><td>160497 - 160579</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v4.2_HLT_V7.py">/cdaq/physics/Run2011/5e32/v4.2/HLT/V7</a></td></tr>
+      <tr><td>160808 - 160815</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v4.2_HLT_V8.py">/cdaq/physics/Run2011/5e32/v4.2/HLT/V8</a></td></tr>
+      <tr><td>160819</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v4.3_HLT_V3.py">/cdaq/physics/Run2011/5e32/v4.3/HLT/V3</a></td></tr>
+      <tr><td>160827 - 160835</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v4.3_HLT_V4.py">/cdaq/physics/Run2011/5e32/v4.3/HLT/V4</a></td></tr>
+      <tr><td>160853 - 160877</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v5.1_HLT_V3.py">/cdaq/physics/Run2011/5e32/v5.1/HLT/V3</a></td></tr>
+      <tr><td>160888</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v5.2_HLT_V2.py">/cdaq/physics/Run2011/5e32/v5.2/HLT/V2</a></td></tr>
+      <tr><td>160890</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v5.2_HLT_V5.py">/cdaq/physics/Run2011/5e32/v5.2/HLT/V5</a></td></tr>
+      <tr><td>160894 - 160898</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v5.2_HLT_V6.py">/cdaq/physics/Run2011/5e32/v5.2/HLT/V6</a></td></tr>
+      <tr><td>160907 - 160943</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v5.2_HLT_V7.py">/cdaq/physics/Run2011/5e32/v5.2/HLT/V7</a></td></tr>
+      <tr><td>160955 - 161020</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v5.3_HLT_V1.py">/cdaq/physics/Run2011/5e32/v5.3/HLT/V1</a></td></tr>
+      <tr><td>161103 - 161176</td><td>CMSSW_4_1_1_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v5.3_HLT_V2.py">/cdaq/physics/Run2011/5e32/v5.3/HLT/V2</a></td></tr>
+      <tr><td>161216</td><td>CMSSW_4_1_2_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v6.1_HLT_V1.py">/cdaq/physics/Run2011/5e32/v6.1/HLT/V1</a></td></tr>
+      <tr><td>161217</td><td>CMSSW_4_1_2_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v6.1_HLT_V3.py">/cdaq/physics/Run2011/5e32/v6.1/HLT/V3</a></td></tr>
+      <tr><td>161222 - 161233</td><td>CMSSW_4_1_2_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v6.1_HLT_V5.py">/cdaq/physics/Run2011/5e32/v6.1/HLT/V5</a></td></tr>
+      <tr><td>161310 - 161312</td><td>CMSSW_4_1_2_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v6.1_HLT_V6.py">/cdaq/physics/Run2011/5e32/v6.1/HLT/V6</a></td></tr>
+      <tr><td>162718 - 162765</td><td>CMSSW_4_1_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v6.2_HLT_V2.py">/cdaq/physics/Run2011/5e32/v6.2/HLT/V2</a></td></tr>
+      <tr><td>162803 - 162926</td><td>CMSSW_4_1_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v6.2_HLT_V3.py">/cdaq/physics/Run2011/5e32/v6.2/HLT/V3</a></td></tr>
+      <tr><td>162929 - 163261</td><td>CMSSW_4_1_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v6.2_HLT_V4.py">/cdaq/physics/Run2011/5e32/v6.2/HLT/V4</a></td></tr>
+      <tr><td>163269 - 163270</td><td>CMSSW_4_1_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v8.1_HLT_V5.py">/cdaq/physics/Run2011/5e32/v8.1/HLT/V5</a></td></tr>
+      <tr><td>163286 - 163289</td><td>CMSSW_4_1_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v8.1_HLT_V6.py">/cdaq/physics/Run2011/5e32/v8.1/HLT/V6</a></td></tr>
+      <tr><td>163296 - 163334</td><td>CMSSW_4_1_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v8.1_HLT_V8.py">/cdaq/physics/Run2011/5e32/v8.1/HLT/V8</a></td></tr>
+      <tr><td>163337 - 163668</td><td>CMSSW_4_1_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v8.2_HLT_V3.py">/cdaq/physics/Run2011/5e32/v8.2/HLT/V3</a></td></tr>
+      <tr><td>163738 - 163753</td><td>CMSSW_4_1_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v8.3_HLT_V2.py">/cdaq/physics/Run2011/5e32/v8.3/HLT/V2</a></td></tr>
+      <tr><td>163754</td><td>CMSSW_4_1_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v8.3_HLT_V3.py">/cdaq/physics/Run2011/5e32/v8.3/HLT/V3</a></td></tr>
+      <tr><td>163757 - 163869</td><td>CMSSW_4_1_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_5e32_v8.3_HLT_V4.py">/cdaq/physics/Run2011/5e32/v8.3/HLT/V4</a></td></tr>
+      <tr><td>165088 - 165121</td><td>CMSSW_4_2_3_onlpatch3_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v1.3_HLT_V2.py">/cdaq/physics/Run2011/1e33/v1.3/HLT/V2</a></td></tr>
+      <tr><td>165205</td><td>CMSSW_4_2_3_onlpatch3_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v1.3_HLT_V6.py">/cdaq/physics/Run2011/1e33/v1.3/HLT/V6</a></td></tr>
+      <tr><td>165208</td><td>CMSSW_4_2_3_onlpatch3_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v1.3_HLT_V7.py">/cdaq/physics/Run2011/1e33/v1.3/HLT/V7</a></td></tr>
+      <tr><td>165364</td><td>CMSSW_4_2_3_onlpatch3_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v1.3_HLT_V12.py">/cdaq/physics/Run2011/1e33/v1.3/HLT/V12</a></td></tr>
+      <tr><td>165400 - 165633</td><td>CMSSW_4_2_3_onlpatch3_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v1.3_HLT_V13.py">/cdaq/physics/Run2011/1e33/v1.3/HLT/V13</a></td></tr>
+      <tr><td>165970 - 165993</td><td>CMSSW_4_2_3_onlpatch4_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v2.3_HLT_V1.py">/cdaq/physics/Run2011/1e33/v2.3/HLT/V1</a></td></tr>
+      <tr><td>166010 - 166150</td><td>CMSSW_4_2_3_onlpatch4_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v2.3_HLT_V3.py">/cdaq/physics/Run2011/1e33/v2.3/HLT/V3</a></td></tr>
+      <tr><td>166161 - 166164</td><td>CMSSW_4_2_3_onlpatch4_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v2.4_HLT_V2.py">/cdaq/physics/Run2011/1e33/v2.4/HLT/V2</a></td></tr>
+      <tr><td>166346</td><td>CMSSW_4_2_3_onlpatch4_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v2.5_HLT_V1.py">/cdaq/physics/Run2011/1e33/v2.5/HLT/V1</a></td></tr>
+      <tr><td>166374 - 166512</td><td>CMSSW_4_2_3_onlpatch4_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v2.4_HLT_V4.py">/cdaq/physics/Run2011/1e33/v2.4/HLT/V4</a></td></tr>
+      <tr><td>166514 - 166782</td><td>CMSSW_4_2_3_onlpatch4_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v2.4_HLT_V5.py">/cdaq/physics/Run2011/1e33/v2.4/HLT/V5</a></td></tr>
+      <tr><td>166784 - 166787</td><td>CMSSW_4_2_3_onlpatch4_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v2.4_HLT_V6.py">/cdaq/physics/Run2011/1e33/v2.4/HLT/V6</a></td></tr>
+      <tr><td>166839 - 166967</td><td>CMSSW_4_2_3_onlpatch4_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1e33_v2.4_HLT_V8.py">/cdaq/physics/Run2011/1e33/v2.4/HLT/V8</a></td></tr>
+      <tr><td>167039 - 167043</td><td>CMSSW_4_2_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1.4e33_v1.1_HLT_V1.py">/cdaq/physics/Run2011/1.4e33/v1.1/HLT/V1</a></td></tr>
+      <tr><td>167078 - 167284</td><td>CMSSW_4_2_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1.4e33_v1.2_HLT_V1.py">/cdaq/physics/Run2011/1.4e33/v1.2/HLT/V1</a></td></tr>
+      <tr><td>167551 - 167913</td><td>CMSSW_4_2_4_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_1.4e33_v1.2_HLT_V3.py">/cdaq/physics/Run2011/1.4e33/v1.2/HLT/V3</a></td></tr>
+      <tr><td>170249 - 170406</td><td>CMSSW_4_2_7_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_2e33_v1.1_HLT_V1.py">/cdaq/physics/Run2011/2e33/v1.1/HLT/V1</a></td></tr>
+      <tr><td>170452 - 170759</td><td>CMSSW_4_2_7_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_2e33_v1.1_HLT_V2.py">/cdaq/physics/Run2011/2e33/v1.1/HLT/V2</a></td></tr>
+      <tr><td>170826 - 171178</td><td>CMSSW_4_2_7_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_2e33_v1.2_HLT_V1.py">/cdaq/physics/Run2011/2e33/v1.2/HLT/V1</a></td></tr>
+      <tr><td>171219 - 172033</td><td>CMSSW_4_2_7_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_2e33_v1.2_HLT_V4.py">/cdaq/physics/Run2011/2e33/v1.2/HLT/V4</a></td></tr>
+      <tr><td>172163 - 172286</td><td>CMSSW_4_2_7_onlpatch1_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_2e33_v1.2_HLT_V5.py">/cdaq/physics/Run2011/2e33/v1.2/HLT/V5</a></td></tr>
+      <tr><td>172389 - 172411</td><td>CMSSW_4_2_7_onlpatch2_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_2e33_v1.2_HLT_V5.py">/cdaq/physics/Run2011/2e33/v1.2/HLT/V5</a></td></tr>
+      <tr><td>172478 - 173198</td><td>CMSSW_4_2_7_onlpatch2_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_2e33_v1.2_HLT_V7.py">/cdaq/physics/Run2011/2e33/v1.2/HLT/V7</a></td></tr>
+      <tr><td>173236 - 173241</td><td>CMSSW_4_2_7_onlpatch3_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_3e33_v1.1_HLT_V1.py">/cdaq/physics/Run2011/3e33/v1.1/HLT/V1</a></td></tr>
+      <tr><td>173243 - 173244</td><td>CMSSW_4_2_7_onlpatch3_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_3e33_v1.1_HLT_V3.py">/cdaq/physics/Run2011/3e33/v1.1/HLT/V3</a></td></tr>
+      <tr><td>173380 - 173439</td><td>CMSSW_4_2_7_onlpatch3_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_3e33_v1.1_HLT_V4.py">/cdaq/physics/Run2011/3e33/v1.1/HLT/V4</a></td></tr>
+      <tr><td>173657 - 173692</td><td>CMSSW_4_2_7_onlpatch3_ONLINE</td><td><a href="1700/files/cdaq_physics_Run2011_3e33_v1.2_HLT_V1.py">/cdaq/physics/Run2011/3e33/v1.2/HLT/V1</a></td></tr>
+      </tbody>
+      </table>
+      ]]></subfield>
     </datafield>
     <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
@@ -32,219 +96,165 @@
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v4.2_HLT_V2.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v4.2/HLT/V2 (runs 160404 - 160406)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v4.2_HLT_V5.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v4.2/HLT/V5 (runs 160410 - 160413)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v4.2_HLT_V6.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v4.2/HLT/V6 (runs 160431 - 160463)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v4.2_HLT_V7.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v4.2/HLT/V7 (runs 160497 - 160579)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v4.2_HLT_V8.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v4.2/HLT/V8 (runs 160808 - 160815)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v4.3_HLT_V3.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v4.3/HLT/V3 (run 160819)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v4.3_HLT_V4.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v4.3/HLT/V4 (runs 160827 - 160835)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v5.1_HLT_V3.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v5.1/HLT/V3 (runs 160853 - 160877)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v5.2_HLT_V2.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v5.2/HLT/V2 (run 160888)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v5.2_HLT_V5.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v5.2/HLT/V5 (run 160890)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v5.2_HLT_V6.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v5.2/HLT/V6 (runs 160894 - 160898)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v5.2_HLT_V7.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v5.2/HLT/V7 (runs 160907 - 160943)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v5.3_HLT_V1.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v5.3/HLT/V1 (runs 160955 - 161020)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v5.3_HLT_V2.py</subfield>
-      <subfield code="z">CMSSW_4_1_1_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v5.3/HLT/V2 (runs 161103 - 161176)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v6.1_HLT_V1.py</subfield>
-      <subfield code="z">CMSSW_4_1_2_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v6.1/HLT/V1 (run 161216)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v6.1_HLT_V3.py</subfield>
-      <subfield code="z">CMSSW_4_1_2_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v6.1/HLT/V3 (run 161217)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v6.1_HLT_V5.py</subfield>
-      <subfield code="z">CMSSW_4_1_2_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v6.1/HLT/V5 (runs 161222 - 161233)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v6.1_HLT_V6.py</subfield>
-      <subfield code="z">CMSSW_4_1_2_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v6.1/HLT/V6 (runs 161310 - 161312)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v6.2_HLT_V2.py</subfield>
-      <subfield code="z">CMSSW_4_1_4_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v6.2/HLT/V2 (runs 162718 - 162765)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v6.2_HLT_V3.py</subfield>
-      <subfield code="z">CMSSW_4_1_4_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v6.2/HLT/V3 (runs 162803 - 162926)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v6.2_HLT_V4.py</subfield>
-      <subfield code="z">CMSSW_4_1_4_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v6.2/HLT/V4 (runs 162929 - 163261)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v8.1_HLT_V5.py</subfield>
-      <subfield code="z">CMSSW_4_1_4_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v8.1/HLT/V5 (runs 163269 - 163270)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v8.1_HLT_V6.py</subfield>
-      <subfield code="z">CMSSW_4_1_4_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v8.1/HLT/V6 (runs 163286 - 163289)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v8.1_HLT_V8.py</subfield>
-      <subfield code="z">CMSSW_4_1_4_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v8.1/HLT/V8 (runs 163296 - 163334)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v8.2_HLT_V3.py</subfield>
-      <subfield code="z">CMSSW_4_1_4_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v8.2/HLT/V3 (runs 163337 - 163668)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v8.3_HLT_V2.py</subfield>
-      <subfield code="z">CMSSW_4_1_4_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v8.3/HLT/V2 (runs 163738 - 163753)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v8.3_HLT_V3.py</subfield>
-      <subfield code="z">CMSSW_4_1_4_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v8.3/HLT/V3 (run 163754)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_5e32_v8.3_HLT_V4.py</subfield>
-      <subfield code="z">CMSSW_4_1_4_onlpatch1_ONLINE /cdaq/physics/Run2011/5e32/v8.3/HLT/V4 (runs 163757 - 163869)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v1.3_HLT_V2.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch3_ONLINE /cdaq/physics/Run2011/1e33/v1.3/HLT/V2 (runs 165088 - 165121)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v1.3_HLT_V6.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch3_ONLINE /cdaq/physics/Run2011/1e33/v1.3/HLT/V6 (run 165205)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v1.3_HLT_V7.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch3_ONLINE /cdaq/physics/Run2011/1e33/v1.3/HLT/V7 (run 165208)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v1.3_HLT_V12.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch3_ONLINE /cdaq/physics/Run2011/1e33/v1.3/HLT/V12 (run 165364)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v1.3_HLT_V13.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch3_ONLINE /cdaq/physics/Run2011/1e33/v1.3/HLT/V13 (runs 165400 - 165633)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v2.3_HLT_V1.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch4_ONLINE /cdaq/physics/Run2011/1e33/v2.3/HLT/V1 (runs 165970 - 165993)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v2.3_HLT_V3.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch4_ONLINE /cdaq/physics/Run2011/1e33/v2.3/HLT/V3 (runs 166010 - 166150)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v2.4_HLT_V2.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch4_ONLINE /cdaq/physics/Run2011/1e33/v2.4/HLT/V2 (runs 166161 - 166164)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v2.5_HLT_V1.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch4_ONLINE /cdaq/physics/Run2011/1e33/v2.5/HLT/V1 (run 166346)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v2.4_HLT_V4.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch4_ONLINE /cdaq/physics/Run2011/1e33/v2.4/HLT/V4 (runs 166374 - 166512)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v2.4_HLT_V5.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch4_ONLINE /cdaq/physics/Run2011/1e33/v2.4/HLT/V5 (runs 166514 - 166782)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v2.4_HLT_V6.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch4_ONLINE /cdaq/physics/Run2011/1e33/v2.4/HLT/V6 (runs 166784 - 166787)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1e33_v2.4_HLT_V8.py</subfield>
-      <subfield code="z">CMSSW_4_2_3_onlpatch4_ONLINE /cdaq/physics/Run2011/1e33/v2.4/HLT/V8 (runs 166839 - 166967)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1.4e33_v1.1_HLT_V1.py</subfield>
-      <subfield code="z">CMSSW_4_2_4_onlpatch1_ONLINE /cdaq/physics/Run2011/1.4e33/v1.1/HLT/V1 (runs 167039 - 167043)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1.4e33_v1.2_HLT_V1.py</subfield>
-      <subfield code="z">CMSSW_4_2_4_onlpatch1_ONLINE /cdaq/physics/Run2011/1.4e33/v1.2/HLT/V1 (runs 167078 - 167284)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_1.4e33_v1.2_HLT_V3.py</subfield>
-      <subfield code="z">CMSSW_4_2_4_onlpatch1_ONLINE /cdaq/physics/Run2011/1.4e33/v1.2/HLT/V3 (runs 167551 - 167913)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_2e33_v1.1_HLT_V1.py</subfield>
-      <subfield code="z">CMSSW_4_2_7_onlpatch1_ONLINE /cdaq/physics/Run2011/2e33/v1.1/HLT/V1 (runs 170249 - 170406)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_2e33_v1.1_HLT_V2.py</subfield>
-      <subfield code="z">CMSSW_4_2_7_onlpatch1_ONLINE /cdaq/physics/Run2011/2e33/v1.1/HLT/V2 (runs 170452 - 170759)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_2e33_v1.2_HLT_V1.py</subfield>
-      <subfield code="z">CMSSW_4_2_7_onlpatch1_ONLINE /cdaq/physics/Run2011/2e33/v1.2/HLT/V1 (runs 170826 - 171178)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_2e33_v1.2_HLT_V4.py</subfield>
-      <subfield code="z">CMSSW_4_2_7_onlpatch1_ONLINE /cdaq/physics/Run2011/2e33/v1.2/HLT/V4 (runs 171219 - 172033)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_2e33_v1.2_HLT_V5.py</subfield>
-      <subfield code="z">CMSSW_4_2_7_onlpatch1_ONLINE /cdaq/physics/Run2011/2e33/v1.2/HLT/V5 (runs 172163 - 172286)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_2e33_v1.2_HLT_V7.py</subfield>
-      <subfield code="z">CMSSW_4_2_7_onlpatch2_ONLINE /cdaq/physics/Run2011/2e33/v1.2/HLT/V7 (runs 172478 - 173198)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_3e33_v1.1_HLT_V1.py</subfield>
-      <subfield code="z">CMSSW_4_2_7_onlpatch3_ONLINE /cdaq/physics/Run2011/3e33/v1.1/HLT/V1 (runs 173236 - 173241)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_3e33_v1.1_HLT_V3.py</subfield>
-      <subfield code="z">CMSSW_4_2_7_onlpatch3_ONLINE /cdaq/physics/Run2011/3e33/v1.1/HLT/V3 (runs 173243 - 173244)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_3e33_v1.1_HLT_V4.py</subfield>
-      <subfield code="z">CMSSW_4_2_7_onlpatch3_ONLINE /cdaq/physics/Run2011/3e33/v1.1/HLT/V4 (runs 173380 - 173439)</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-trigger-information/cdaq_physics_Run2011_3e33_v1.2_HLT_V1.py</subfield>
-      <subfield code="z">CMSSW_4_2_7_onlpatch3_ONLINE /cdaq/physics/Run2011/3e33/v1.2/HLT/V1 (runs 173657 - 173692)</subfield>
     </datafield>
   </record>
 </collection>


### PR DESCRIPTION
* Adds overview table to the CMS Trigger Information record for
  Run2011A. (addresses #832)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>