### PR TITLE
templates: page header DEMO stamp

### DIFF
--- a/invenio_opendata/base/templates/header.html
+++ b/invenio_opendata/base/templates/header.html
@@ -38,8 +38,8 @@
               </button>
             </div>
           </div>
+          <img src="{{ url_for('static', filename='img/demo.png') }}" alt="" style="position:absolute;left:40%;top:0;width:200px;">
           <div  class="innernav col-md-7">
-
             <!-- Collection of nav links and other content for toggling -->
             <div id="navbarCollapse" class="collapse navbar-collapse">
               <ul class="nav navbar-nav pull-right">


### PR DESCRIPTION
* Re-enables the DEMO stamp in the page header for the `master`
  branch. (closes #884)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>