### PR TITLE
ATLAS: new canonical URL for masterclasses

### DIFF
--- a/invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml
@@ -29,7 +29,7 @@
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorise events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
-      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+      <subfield code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -179,7 +179,7 @@
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorise events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
-      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+      <subfield code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -329,7 +329,7 @@
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorise events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
-      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+      <subfield code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -479,7 +479,7 @@
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorise events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
-      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+      <subfield code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -629,7 +629,7 @@
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorise events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
-      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+      <subfield code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -779,7 +779,7 @@
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which can be found on the linked site in the section "Measurement". There you will also find a tally sheet and links to instructions on how to analyse the data found in the dataset. The section "Identifying Pariticles" will show how to find out which detector signature hints at which particle. "Identifying Events" details how to categorise events. Using the knowledge of these two sections, one can use the prescriptions in "Measurement" to find out how the proton is structured and to hunt for the Higgs particle.</subfield>
-      <subfield code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+      <subfield code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -939,7 +939,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -1101,7 +1101,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -1263,7 +1263,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -1425,7 +1425,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -1587,7 +1587,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -1749,7 +1749,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -1911,7 +1911,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -2073,7 +2073,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -2235,7 +2235,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -2397,7 +2397,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -2559,7 +2559,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -2721,7 +2721,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -2883,7 +2883,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -3045,7 +3045,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -3207,7 +3207,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -3369,7 +3369,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -3531,7 +3531,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -3693,7 +3693,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -3855,7 +3855,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4017,7 +4017,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4179,7 +4179,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4341,7 +4341,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4503,7 +4503,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4665,7 +4665,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4827,7 +4827,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4989,7 +4989,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -5151,7 +5151,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -5313,7 +5313,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -5475,7 +5475,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -5637,7 +5637,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -5799,7 +5799,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -5961,7 +5961,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -6123,7 +6123,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -6285,7 +6285,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -6447,7 +6447,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -6609,7 +6609,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -6771,7 +6771,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -6933,7 +6933,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -7095,7 +7095,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -7257,7 +7257,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -7419,7 +7419,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -7581,7 +7581,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -7743,7 +7743,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -7905,7 +7905,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -8067,7 +8067,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -8229,7 +8229,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -8391,7 +8391,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -8553,7 +8553,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -8715,7 +8715,7 @@ details how to categorise events. Using the knowledge of these two sections,
 one can use the prescriptions in "Measurement" to find out how the proton is
 structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://kjende.web.cern.ch/kjende/en/wpath_ziele.htm</subfield>
+code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>


### PR DESCRIPTION
* Switches to the new canonical URL for
  masterclasses (atlas.physicsmasterclasses.org). (addresses #790)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>