### PR TITLE
Update cms-eventdisplay-files-Run2011A.xml

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-eventdisplay-files-Run2011A.xml
@@ -53,7 +53,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -120,7 +122,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -187,7 +191,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -254,7 +260,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -321,7 +329,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -388,7 +398,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -455,7 +467,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -522,7 +536,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -589,7 +605,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -656,7 +674,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -723,7 +743,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -790,7 +812,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -857,7 +881,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -924,7 +950,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -991,7 +1019,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -1058,7 +1088,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -1125,7 +1157,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -1192,7 +1226,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>
@@ -1259,7 +1295,9 @@
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 7TeV</subfield>
-      <subfield code="r">Run2011A</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Derived-Datasets</subfield>


### PR DESCRIPTION
Deleting `942 $rRun2011A` - adding `964_0 $cRun2011A` for https://github.com/cernopendata/opendata.cern.ch/pull/925/files#r54900534 (according to https://github.com/cernopendata/opendata.cern.ch/pull/849#issuecomment-170926622)