### PR TITLE
CMS: pileup configuration file

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -124,6 +124,7 @@ populate *all* collections, you can use::
     -f invenio_opendata/testsuite/data/cms/cms-condition-data-Run2011A.xml \
     -f invenio_opendata/testsuite/data/cms/cms-configuration-files-Run2011A.xml \
     -f invenio_opendata/testsuite/data/cms/cms-hlt-2011-configuration-files.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-pileup-configuration-files.xml \
     -f invenio_opendata/testsuite/data/lhcb/lhcb-derived-datasets.xml \
     -f invenio_opendata/testsuite/data/lhcb/lhcb-learning-resources.xml \
     -f invenio_opendata/testsuite/data/lhcb/lhcb-tools.xml \

--- a/invenio_opendata/testsuite/data/cms/cms-pileup-configuration-files.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-pileup-configuration-files.xml
@@ -1,0 +1,34 @@
+<collection>
+  <record>
+    <controlfield tag="001">3600</controlfield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">CMS pileup configuration file mix_2011_FinalDist_OOTPU_cfi</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The pileup configuration file.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-pileup-configuration-files/mix_2011_FinalDist_OOTPU_cfi.py</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/invenio_opendata/testsuite/data/cms/cms-pileup-configuration-files/mix_2011_FinalDist_OOTPU_cfi.py
+++ b/invenio_opendata/testsuite/data/cms/cms-pileup-configuration-files/mix_2011_FinalDist_OOTPU_cfi.py
@@ -1,0 +1,88 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup based on full 2011 dataset
+from SimGeneral.MixingModule.mixObjects_cfi import *
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12),  ## in terms of 25 nsec
+
+    bunchspace = cms.int32(50), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("PoolSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34),
+          probValue = cms.vdouble(
+                               1.30976e-05,
+                               0.000148266,
+                               0.00226073,
+                               0.030543,
+                               0.0868303,
+                               0.120295,
+                               0.124687,
+                               0.110419,
+                               0.0945742,
+                               0.0837875,
+                               0.0774277,
+                               0.0740595,
+                               0.0676844,
+                               0.0551203,
+                               0.0378357,
+                               0.0210203,
+                               0.00918262,
+                               0.00309786,
+                               0.000808509,
+                               0.000168568,
+                               3.02344e-05,
+                               5.16455e-06,
+                               8.83185e-07,
+                               1.43975e-07,
+                               2.07228e-08,
+                               2.51393e-09,
+                               2.52072e-10,
+                               2.07328e-11,
+                               1.39369e-12,
+                               7.63843e-14,
+                               3.4069e-15,
+                               1.23492e-16,
+                               3.63059e-18,
+                               8.53277e-20,
+                               1.33668e-22 ),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+    sequential = cms.untracked.bool(False),
+        manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+        ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(
+        mixCH = cms.PSet(
+            mixCaloHits
+        ),
+        mixTracks = cms.PSet(
+            mixSimTracks
+        ),
+        mixVertices = cms.PSet(
+            mixSimVertices
+        ),
+        mixSH = cms.PSet(
+            mixSimHits
+        ),
+        mixHepMC = cms.PSet(
+            mixHepMCProducts
+        )
+    )
+)

--- a/scripts/populate-fft-file-cache.sh
+++ b/scripts/populate-fft-file-cache.sh
@@ -347,6 +347,9 @@ rsync -a invenio_opendata/testsuite/data/cms/cms-configuration-files/ $OUTDIR/cm
 # fourteenthly, CMS HLT 2011 configuration files:
 rsync -a invenio_opendata/testsuite/data/cms/cms-hlt-2011-configuration-files/ $OUTDIR/cms-hlt-2011-configuration-files/
 
+# fifteenthly, CMS pileup configuration files:
+rsync -a invenio_opendata/testsuite/data/cms/cms-pileup-configuration-files/ $OUTDIR/cms-pileup-configuration-files/
+
 # finally, make symlink to FFT cache from tmp:
 if [ ! -L "/tmp/$(basename $OUTDIR)" ]; then
     ln -s $OUTDIR /tmp


### PR DESCRIPTION
* Adds CMS pileup configuration file for the 2011 data. (closes #935)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>