### PR TITLE
CMS: fix definition of Validated Runs

### DIFF
--- a/invenio_opendata/base/fixtures/websearch.py
+++ b/invenio_opendata/base/fixtures/websearch.py
@@ -209,7 +209,7 @@ class CollectionData(DataSet):
     class CMSValidationUtilities(siteCollection):
         id = 26
         name = 'CMS-Validation-Utilities'
-        dbquery = '980__a:"CMS-Vallidation-Utilities"'
+        dbquery = '980__a:"CMS-Validation-Utilities"'
         names = {
             ('en', 'ln'): u'CMS Validation Utilities',
         }

--- a/invenio_opendata/base/templates/about_cms.html
+++ b/invenio_opendata/base/templates/about_cms.html
@@ -65,7 +65,7 @@
                 </div>
               </li>
               <li>AOD files can be read in <a href="http://root.cern.ch/">ROOT</a>, but they cannot be opened (and understood) as simple data tables.</li>
-              <li>Only the runs that are validated by data quality monitoring should be used in any analysis. The <a href="{{ url_for('.collection', name= 'CMS-Validated-Runs') }}">list of the validated runs</a> is provided.</li>
+              <li>Only the runs that are validated by data quality monitoring should be used in any analysis. The <a href="{{ url_for('.collection', name= 'CMS-Validation-Utilities') }}">list of the validated runs</a> is provided.</li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
* Amends the definitions of CMS Validation Utilities and CMS Validated
  Runs so that the two collections can co-exist. (closes #951)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>