### PR TITLE
global: fix identical record IDs

### DIFF
--- a/invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml
+++ b/invenio_opendata/testsuite/data/alice/alice-derived-datasets.xml
@@ -1,6 +1,6 @@
 <collection>
   <record>
-    <controlfield tag="001">1102</controlfield>
+    <controlfield tag="001">1120</controlfield>
     <datafield tag="024" ind1="7" ind2=" ">
       <subfield code="a">10.7483/OPENDATA.ALICE.Y62S.E7UR</subfield>
       <subfield code="2">DOI</subfield>

--- a/invenio_opendata/testsuite/data/alice/alice-learning-resources.xml
+++ b/invenio_opendata/testsuite/data/alice/alice-learning-resources.xml
@@ -1,6 +1,6 @@
 <collection>
 <record>
-  <controlfield tag="001">55</controlfield>
+  <controlfield tag="001">40</controlfield>
   <datafield tag="041" ind1=" " ind2=" ">
     <subfield code="a">English</subfield>
   </datafield>

--- a/invenio_opendata/testsuite/data/lhcb/lhcb-learning-resources.xml
+++ b/invenio_opendata/testsuite/data/lhcb/lhcb-learning-resources.xml
@@ -1,6 +1,6 @@
 <collection>
 <record>
-  <controlfield tag="001">56</controlfield>
+  <controlfield tag="001">41</controlfield>
   <datafield tag="110" ind1=" " ind2=" ">
     <subfield code="a">LHCb collaboration</subfield>
   </datafield>


### PR DESCRIPTION
* Fixes identical record IDs appearing in ALICE and LHCb
  collections. (closes #946) (closes #947)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>