### PR TITLE
CMS: fix absolute links

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-tools-ana-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-ana-Run2011A.xml
@@ -128,7 +128,7 @@
       <subfield code="a">Running the job over all preprocessed datasets may take several hours.</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
-      <subfield code="a"><![CDATA[ <p> The event selection is the same as the one used in <a href="http://opendatadev.cern.ch/record/101">2010 example</a>:
+      <subfield code="a"><![CDATA[ <p> The event selection is the same as the one used in <a href="/record/101">2010 example</a>:
       <ol class="text"><li>In the Z analysis at least two leptons with opposite charge, with invariant mass ”mll” between 12 GeV and 120 GeV are required. The pair with the invariant mass closest to the Z boson mass is selected as the Z candidate.</li>
       <li>In the ZZ analysis two Z candidates are required, and for both candidates, two leptons with opposite charge are required. The first Z candidate is required to have higher lepton momentum: 20 GeV for the first lepton and 10 GeV for the second lepton. The invariant mass is required to be in the range 40 GeV to 120 GeV. The second candidate is required to have an invariant mass higher then 4 GeV. The first candidate is the one with the invariant mass closest to the Z boson mass.</li></ol></p>
       <p>Selection criteria for electron candidates:

--- a/invenio_opendata/testsuite/data/cms/cms-tools-cmssw-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-cmssw-Run2011A.xml
@@ -28,7 +28,7 @@
         <subfield code="a">Apache License, Version 2.0</subfield>
       </datafield>
       <datafield tag="581" ind1=" " ind2=" ">
-        <subfield code="a"><![CDATA[<p>To get started with CMSSW in the context of the CMS open data, follow the instructions in <a href="http://opendatadev.cern.ch/getting-started/CMS/2011">Getting started with CMS 2011 data</a>
+        <subfield code="a"><![CDATA[<p>To get started with CMSSW in the context of the CMS open data, follow the instructions in <a href="/getting-started/CMS/2011">Getting started with CMS 2011 data</a>
         You can learn more about CMSSW in <a href="https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBook">The CMS Offline WorkBook</a>. If you follow the instructions in the Workbook make sure, though, that you replace the release version (CMSSW_nnn) with the release that
         you are using, i.e. one that is compatible with the CMS open data.  Be aware that the instructions in the WorkBook
         are in use in CMS currently and have been updated for more recent CMSSW releases. With the 2011 data, you should

--- a/invenio_opendata/testsuite/data/cms/cms-tools-cmssw.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-cmssw.xml
@@ -28,7 +28,7 @@
       <subfield code="a">Apache License, Version 2.0</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
-      <subfield code="a"><![CDATA[<p>To get started with CMSSW in the context of the CMS open data, follow the instructions in <a href="http://opendatadev.cern.ch/getting-started/CMS/2010">Getting started with CMS 2010 data</a>
+      <subfield code="a"><![CDATA[<p>To get started with CMSSW in the context of the CMS open data, follow the instructions in <a href="/getting-started/CMS/2010">Getting started with CMS 2010 data</a>
       You can learn more about CMSSW in <a href="https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBook">The CMS Offline WorkBook</a>. If you follow the instructions in the Workbook make sure, though, that you replace the release version (CMSSW_nnn) with the release that
       you are using, i.e. one that is compatible with the CMS open data.  Be aware that the instructions in the WorkBook
       are in use in CMS currently and have been updated for more recent CMSSW releases. With the 2010 data, you should

--- a/invenio_opendata/testsuite/data/cms/cms-tools-dimuon-spectrum-2010.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-dimuon-spectrum-2010.xml
@@ -43,9 +43,9 @@
       <subfield code="e">CMS</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
-      <subfield code="a"><![CDATA[ <p>If you do not have the CMS 2010 Virtual Machine installed follow the instructions in step 1 at <a href="http://opendatadev.cern.ch/VM/CMS/2010">How to install a CERN Virtual Machine</a>.
-      Then install and run the Demo (demo analyzer) program following the instructions at <a href="http://opendatadev.cern.ch/VM/CMS/2010#testvalidate2010">How to Test & Validate</a> </p>.
-      <p>To run di-muon spectrum demo: <ol> <li>Create directory <code>datasets</code> under <code>Demo/DemoAnalyzer</code>.</li><li>Download the index files for the <a href="http://opendatadev.cern.ch/record/14">/Mu/Run2010B-Apr21ReReco-v1/AOD</a>
+      <subfield code="a"><![CDATA[ <p>If you do not have the CMS 2010 Virtual Machine installed follow the instructions in step 1 at <a href="/VM/CMS/2010">How to install a CERN Virtual Machine</a>.
+      Then install and run the Demo (demo analyzer) program following the instructions at <a href="/VM/CMS/2010#testvalidate2010">How to Test & Validate</a> </p>.
+      <p>To run di-muon spectrum demo: <ol> <li>Create directory <code>datasets</code> under <code>Demo/DemoAnalyzer</code>.</li><li>Download the index files for the <a href="/record/14">/Mu/Run2010B-Apr21ReReco-v1/AOD</a>
       primary data sets and store them in <code>Demo/DemoAnalyzer/datasets/</code>.</li>
       <li>Download the JSON file from <a href="http://opendata.cern.ch/record/1000">CMS Validated Runs</a>
       and save it to the <code>Demo/DemoAnalyzer/datasets</code> directory.</li>
@@ -54,7 +54,7 @@
       <code>demoanalyzer_cfg.py</code>,
       <code>src/Demoanalyzer.cc</code>
       by the ones from this record and read the comments in <code>Demoanalyzer.cc</code> if you want to understand what the program does.</li>
-      <li>Recompile ("scram b") and rerun ("cmsRun ...") exactly as before <a href="http://opendatadev.cern.ch/VM/CMS/2010#testvalidate2010">How to Test & Validate</a>.
+      <li>Recompile ("scram b") and rerun ("cmsRun ...") exactly as before <a href="/VM/CMS/2010#testvalidate2010">How to Test & Validate</a>.
       <li>You should get an output file Mu.root which contains histograms for 10000 input events (small subset of data).
       These can be looked at using a Root Browser (see above-Description). The most interesting histogram is GM_mass_log
       In order to compare with the invariant mass spectrum of dimuons in <a href="https://inspirehep.net/record/1118729/plots">MUO-10-004</a> it should be viewed with the 'logy' option. Of course with 10000 events


### PR DESCRIPTION
* Fixes absolute OPENDATADEV links that would be invalid on the QA and
  production sites.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>