### PR TITLE
templates: CMS VM link fixes

### DIFF
--- a/invenio_opendata/base/templates/helpers/text/vms_cms_page_2011.html
+++ b/invenio_opendata/base/templates/helpers/text/vms_cms_page_2011.html
@@ -22,7 +22,7 @@
     <div class="gen-box">{{ text.cms_install_2011_s1() }}</div>
   </div>
   <div class="col-sm-12">
-    <div class="gen-box">{{ text.cms_install_2011_s2(url_for('.metadata', recid = 250)) }}</div>
+    <div class="gen-box">{{ text.cms_install_2011_s2(url_for('.metadata', recid = 252)) }}</div>
   </div>
 
   <h1 id="testvalidate2011" class="col-sm-12">How to Test & Validate?</h1>

--- a/invenio_opendata/base/templates/helpers/text/vms_page_2010.html
+++ b/invenio_opendata/base/templates/helpers/text/vms_page_2010.html
@@ -20,7 +20,7 @@
     <strong>Important</strong>: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see <a href="#issues">Issues and Limitations</a> if you encounter any problems with booting the VM.
   </p>
   <p>
-    Next download the CMS-specific CernVM image as OVA file from: <a href="{{url}}">CMS Open Data</a>.
+    Next download the CMS-specific CernVM image as OVA file from: <a href="{{url}}">CMS VM Image for 2010 CMS open data</a>.
   </p>
   <p>
     By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings: in case of any problems with booting with these default settings, see <a href="#issues">Issues and Limitations</a>. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment.

--- a/invenio_opendata/base/templates/helpers/text/vms_page_2011.html
+++ b/invenio_opendata/base/templates/helpers/text/vms_page_2011.html
@@ -20,7 +20,7 @@
     <strong>Important</strong>: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see <a href="#issues">Issues and Limitations</a> if you encounter any problems with booting the VM.
   </p>
   <p>
-    Next download the CMS-specific CernVM image as OVA file from: <a href="{{url}}">CMS Open Data (latest)</a>.
+    Next download the CMS-specific CernVM image as OVA file from: <a href="{{url}}">CMS VM Image for 2011 CMS open data</a>.
   </p>
   <p>
     By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings: in case of any problems with booting with these default settings, see <a href="#issues">Issues and Limitations</a>. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment.


### PR DESCRIPTION
* Fixes CMS VM link targets and labels. (closes #974)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>