### PR TITLE
templates: fix CMS year-based search links

### DIFF
--- a/invenio_opendata/base/templates/helpers/collections_educate.html
+++ b/invenio_opendata/base/templates/helpers/collections_educate.html
@@ -26,7 +26,7 @@
                                         </div>
                                         <div class="years col-xs-12">
                                             {% if collection.name_ln in YEARLY_TABED_COLLECTIONS %}
-                                                Years: <div class="yr"><a href="#URL_FIXME">2010</a></div>, <div class="yr"><a href="#URL_FIXME">2011</a></div>
+                                                Years: <div class="yr"><a href="/search?p=Run2010B%20collection%3A{{ collection.name }}">2010</a></div>, <div class="yr"><a href="/search?p=Run2011A%20collection%3A{{ collection.name }}">2011</a></div>
                                             {% endif %}
                                         </div>
                                     </div>

--- a/invenio_opendata/base/templates/helpers/collections_research.html
+++ b/invenio_opendata/base/templates/helpers/collections_research.html
@@ -25,7 +25,7 @@
                       </div>
                       <div class="years col-xs-12">
                         {% if collection.name_ln in YEARLY_TABED_COLLECTIONS %}
-                          Years: <div class="yr"><a href="#URL_FIXME">2010</a></div>, <div class="yr"><a href="#URL_FIXME">2011</a></div>
+                          Years: <div class="yr"><a href="/search?p=Run2010B%20collection%3A{{ collection.name }}">2010</a></div>, <div class="yr"><a href="/search?p=Run2011A%20collection%3A{{ collection.name }}">2011</a></div>
                         {% endif %}
                       </div>
                     </div>
@@ -38,7 +38,7 @@
                           <div class="col-xs-12">
                             <b>Total records:</b>
                           </div>
-                          <div class="col-xs-12 coll-rec-num">{{collection.nbrecs}}</div>  
+                          <div class="col-xs-12 coll-rec-num">{{collection.nbrecs}}</div>
                         </div>
                         {% endif %}
                       </div>
@@ -48,7 +48,7 @@
               </a>
             </div>
           </li>
-        {% endfor %}  
+        {% endfor %}
       </ul>
     </div>
   </div>

--- a/invenio_opendata/base/templates/search/collection.html
+++ b/invenio_opendata/base/templates/search/collection.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2016 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -48,7 +48,7 @@
                 </div>
                 <div class="years col-xs-12">
                   {% if collection.name_ln in YEARLY_TABED_COLLECTIONS %}
-                    Years: <div class="yr"><a href="#URL_FIXME">2010</a></div>, <div class="yr"><a href="#URL_FIXME">2011</a></div>
+                    Years: <div class="yr"><a href="/search?p=Run2010B%20collection%3A{{ collection.name }}">2010</a></div>, <div class="yr"><a href="/search?p=Run2011A%20collection%3A{{ collection.name }}">2011</a></div>
                   {% endif %}
                 </div>
               </div>


### PR DESCRIPTION
* Fixes year-based search links in CMS collections. Searches for
  Run2010B and Run2011A in any field. (closes #904)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>