### PR TITLE
CMS: new Run2011A configuration files

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files-Run2011A.xml
@@ -18127,4 +18127,884 @@
       <subfield code="f">py</subfield>
     </datafield>
   </record>
+  <record>
+    <controlfield tag="001">3601</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e958aa8</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_TauPlusX</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e958aa8.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3602</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e97b7c2</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_MET</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e97b7c2.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3603</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e972c4b</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_BTag</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e972c4b.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3604</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e9527d4</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_SingleElectron</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9527d4.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3605</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e936581</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_MuHad</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e936581.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3606</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e995804</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_SingleMu</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e995804.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3607</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e9675f4</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_ElectronHad</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9675f4.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3608</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e963393</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_Jet</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e963393.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3609</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e9c2b96</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_METBTag</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9c2b96.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3610</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e983f2e</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_MinimumBias</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e983f2e.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3611</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e927f5e</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_Photon</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e927f5e.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3612</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e9a2f16</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_PhotonHad</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9a2f16.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3613</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e992c09</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_HT</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e992c09.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3614</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e92401d</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_MuOnia</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e92401d.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3615</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e95b846</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_Tau</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e95b846.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3616</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e3db18c</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_MultiJet</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e3db18c.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3617</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e463912</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_DoubleElectron</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e463912.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3618</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e9b3301</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_DoubleMu</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9b3301.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3619</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e40a16f</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_ForwardTriggers</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e40a16f.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
+  <record>
+    <controlfield tag="001">3620</controlfield>
+    <datafield tag="035" ind1=" " ind2=" ">
+      <subfield code="a">b6ad4db04bcd6551c0d7907e7e91fbd4</subfield>
+      <subfield code="9">CMS-ConfDB</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">CMS collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">Configuration file for RECO step reco_2011A_MuEG</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The configuration file used in RECO data processing step.</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">7TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Configuration-Files</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Research</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e91fbd4.configFile</subfield>
+      <subfield code="n">configFile</subfield>
+      <subfield code="f">py</subfield>
+    </datafield>
+  </record>
 </collection>

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e3db18c.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e3db18c.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_MultiJet.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e40a16f.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e40a16f.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_ForwardTriggers.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e463912.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e463912.configFile
@@ -1,0 +1,150 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,ALCA:@DoubleElectron,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_DoubleElectron.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('Configuration.StandardSequences.AlCaRecoStreams_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+process.ALCARECOStreamEcalCalElectron = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOEcalCalZElectron', 
+            'pathALCARECOEcalCalWElectron')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_pfMet_*_*', 
+        'keep *_kt6PFJetsForRhoCorrection_rho_*', 
+        'keep *_kt6PFJets_rho_*', 
+        'keep *_offlinePrimaryVerticesWithBS_*_*', 
+        'keep *BeamSpot_offlineBeamSpot_*_*', 
+        'keep *_allConversions_*_*', 
+        'keep *_conversions_*_*', 
+        'keep *GsfTrack*_*_*_*', 
+        'keep *_generator_*_*', 
+        'keep *_addPileupInfo_*_*', 
+        'keep *_genParticles_*_*', 
+        'keep recoGsfElectron*_gsfElectron*_*_*', 
+        'keep recoCaloClusters_*_*_*', 
+        'keep recoSuperClusters_*_*_*', 
+        'keep recoPreshowerCluster*_*_*_*', 
+        'drop reco*Clusters_hfEMClusters_*_*', 
+        'drop reco*Clusters_pfPhotonTranslator_*_*', 
+        'drop *_*Unclean*_*_*', 
+        'drop *_*unclean*_*_*', 
+        'drop *_*_*Unclean*_*', 
+        'drop *_*_*unclean*_*', 
+        'keep *_*_*_HLT', 
+        'keep recoTracks_generalTracks_*_*', 
+        'drop *EcalRecHit*_ecalRecHit_*_*', 
+        'drop *EcalrecHit*_*ecalPreshowerRecHit*_*EcalRecHitsES*_*', 
+        'drop *EcalRecHit*_reducedEcalRecHitsE*_*_*', 
+        'keep *EcalRecHit*_alCaIsolatedElectrons_*_*', 
+        'keep *EcalRecHit*_reducedEcalRecHitsES_alCaRecHitsES_*'),
+    fileName = cms.untracked.string('EcalCalElectron.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('EcalCalElectron'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+process.ALCARECOStreamEcalCalElectronOutPath = cms.EndPath(process.ALCARECOStreamEcalCalElectron)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.pathALCARECOEcalCalZElectron,process.pathALCARECOEcalCalWElectron,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step,process.ALCARECOStreamEcalCalElectronOutPath)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e91fbd4.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e91fbd4.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_MuEG.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e92401d.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e92401d.configFile
@@ -1,0 +1,146 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,ALCA:@MuOnia,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_MuOnia.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('Configuration.StandardSequences.AlCaRecoStreams_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+process.ALCARECOStreamTkAlJpsiMuMu = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOTkAlJpsiMuMu')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_ALCARECOTkAlJpsiMuMu_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*', 
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*', 
+        'keep *_TriggerResults_*_*', 
+        'keep DcsStatuss_scalersRawToDigi_*_*', 
+        'keep *_offlinePrimaryVertices_*_*'),
+    fileName = cms.untracked.string('TkAlJpsiMuMu.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('TkAlJpsiMuMu'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+process.ALCARECOStreamTkAlUpsilonMuMu = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOTkAlUpsilonMuMu')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_ALCARECOTkAlUpsilonMuMu_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*', 
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*', 
+        'keep *_TriggerResults_*_*', 
+        'keep DcsStatuss_scalersRawToDigi_*_*', 
+        'keep *_offlinePrimaryVertices_*_*'),
+    fileName = cms.untracked.string('TkAlUpsilonMuMu.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('TkAlUpsilonMuMu'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+process.ALCARECOStreamTkAlJpsiMuMuOutPath = cms.EndPath(process.ALCARECOStreamTkAlJpsiMuMu)
+process.ALCARECOStreamTkAlUpsilonMuMuOutPath = cms.EndPath(process.ALCARECOStreamTkAlUpsilonMuMu)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.pathALCARECOTkAlJpsiMuMu,process.pathALCARECOTkAlUpsilonMuMu,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step,process.ALCARECOStreamTkAlJpsiMuMuOutPath,process.ALCARECOStreamTkAlUpsilonMuMuOutPath)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e927f5e.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e927f5e.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_Photon.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e936581.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e936581.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_MuHad.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9527d4.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9527d4.configFile
@@ -1,0 +1,150 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,ALCA:@SingleElectron,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_SingleElectron.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('Configuration.StandardSequences.AlCaRecoStreams_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+process.ALCARECOStreamEcalCalElectron = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOEcalCalZElectron', 
+            'pathALCARECOEcalCalWElectron')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_pfMet_*_*', 
+        'keep *_kt6PFJetsForRhoCorrection_rho_*', 
+        'keep *_kt6PFJets_rho_*', 
+        'keep *_offlinePrimaryVerticesWithBS_*_*', 
+        'keep *BeamSpot_offlineBeamSpot_*_*', 
+        'keep *_allConversions_*_*', 
+        'keep *_conversions_*_*', 
+        'keep *GsfTrack*_*_*_*', 
+        'keep *_generator_*_*', 
+        'keep *_addPileupInfo_*_*', 
+        'keep *_genParticles_*_*', 
+        'keep recoGsfElectron*_gsfElectron*_*_*', 
+        'keep recoCaloClusters_*_*_*', 
+        'keep recoSuperClusters_*_*_*', 
+        'keep recoPreshowerCluster*_*_*_*', 
+        'drop reco*Clusters_hfEMClusters_*_*', 
+        'drop reco*Clusters_pfPhotonTranslator_*_*', 
+        'drop *_*Unclean*_*_*', 
+        'drop *_*unclean*_*_*', 
+        'drop *_*_*Unclean*_*', 
+        'drop *_*_*unclean*_*', 
+        'keep *_*_*_HLT', 
+        'keep recoTracks_generalTracks_*_*', 
+        'drop *EcalRecHit*_ecalRecHit_*_*', 
+        'drop *EcalrecHit*_*ecalPreshowerRecHit*_*EcalRecHitsES*_*', 
+        'drop *EcalRecHit*_reducedEcalRecHitsE*_*_*', 
+        'keep *EcalRecHit*_alCaIsolatedElectrons_*_*', 
+        'keep *EcalRecHit*_reducedEcalRecHitsES_alCaRecHitsES_*'),
+    fileName = cms.untracked.string('EcalCalElectron.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('EcalCalElectron'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+process.ALCARECOStreamEcalCalElectronOutPath = cms.EndPath(process.ALCARECOStreamEcalCalElectron)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.pathALCARECOEcalCalZElectron,process.pathALCARECOEcalCalWElectron,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step,process.ALCARECOStreamEcalCalElectronOutPath)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e958aa8.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e958aa8.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_TauPlusX.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e95b846.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e95b846.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_Tau.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e963393.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e963393.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_Jet.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9675f4.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9675f4.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_ElectronHad.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e972c4b.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e972c4b.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_BTag.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e97b7c2.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e97b7c2.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_MET.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e983f2e.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e983f2e.configFile
@@ -1,0 +1,155 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,ALCA:@MinimumBias,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM:@MinimumBias --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_MinimumBias.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('Configuration.StandardSequences.AlCaRecoStreams_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+process.ALCARECOStreamSiStripCalMinBias = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOSiStripCalMinBias')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_ALCARECOSiStripCalMinBias_*_*', 
+        'keep *_siStripClusters_*_*', 
+        'keep *_siPixelClusters_*_*', 
+        'keep DetIdedmEDCollection_siStripDigis_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*', 
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*', 
+        'keep *_TriggerResults_*_*'),
+    fileName = cms.untracked.string('SiStripCalMinBias.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('SiStripCalMinBias'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+process.ALCARECOStreamTkAlMinBias = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOTkAlMinBias')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_ALCARECOTkAlMinBias_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*', 
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*', 
+        'keep *_TriggerResults_*_*', 
+        'keep DcsStatuss_scalersRawToDigi_*_*', 
+        'keep *_offlinePrimaryVertices_*_*', 
+        'keep *_offlineBeamSpot_*_*'),
+    fileName = cms.untracked.string('TkAlMinBias.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('TkAlMinBias'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.bTagPlots)
+process.dqmoffline_1_step = cms.Path(process.HcalDQMOfflineSequence)
+process.dqmoffline_2_step = cms.Path(process.egammaDQMOffline)
+process.dqmoffline_3_step = cms.Path(process.DQMOfflineCommonSiStripZeroBias)
+process.dqmoffline_4_step = cms.Path(process.DQMOfflineMuon)
+process.dqmoffline_5_step = cms.Path(process.DQMOfflineHcal)
+process.dqmoffline_6_step = cms.Path(process.DQMOfflineJetMET)
+process.dqmoffline_7_step = cms.Path(process.DQMOfflineEcal)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+process.ALCARECOStreamSiStripCalMinBiasOutPath = cms.EndPath(process.ALCARECOStreamSiStripCalMinBias)
+process.ALCARECOStreamTkAlMinBiasOutPath = cms.EndPath(process.ALCARECOStreamTkAlMinBias)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.pathALCARECOSiStripCalMinBias,process.pathALCARECOTkAlMinBias,process.user_step,process.dqmoffline_step,process.dqmoffline_1_step,process.dqmoffline_2_step,process.dqmoffline_3_step,process.dqmoffline_4_step,process.dqmoffline_5_step,process.dqmoffline_6_step,process.dqmoffline_7_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step,process.ALCARECOStreamSiStripCalMinBiasOutPath,process.ALCARECOStreamTkAlMinBiasOutPath)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e992c09.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e992c09.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_HT.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e995804.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e995804.configFile
@@ -1,0 +1,193 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,ALCA:@SingleMu,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_SingleMu.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('Configuration.StandardSequences.AlCaRecoStreams_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+process.ALCARECOStreamDtCalib = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECODtCalib')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_dt4DSegments_*_*', 
+        'keep *_dt4DSegmentsNoWire_*_*', 
+        'keep *_muonDTDigis_*_*', 
+        'keep *_dttfDigis_*_*', 
+        'keep *_gtDigis_*_*', 
+        'keep *_TriggerResults_*_*', 
+        'keep recoMuons_muons_*_*', 
+        'keep booledmValueMap_muid*_*_*'),
+    fileName = cms.untracked.string('DtCalib.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('DtCalib'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+process.ALCARECOStreamMuAlCalIsolatedMu = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOMuAlCalIsolatedMu')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_ALCARECOMuAlCalIsolatedMu_*_*', 
+        'keep *_muonCSCDigis_*_*', 
+        'keep *_muonDTDigis_*_*', 
+        'keep *_muonRPCDigis_*_*', 
+        'keep *_dt1DRecHits_*_*', 
+        'keep *_dt2DSegments_*_*', 
+        'keep *_dt4DSegments_*_*', 
+        'keep *_csc2DRecHits_*_*', 
+        'keep *_cscSegments_*_*', 
+        'keep *_rpcRecHits_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*', 
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*', 
+        'keep *_TriggerResults_*_*', 
+        'keep DcsStatuss_scalersRawToDigi_*_*'),
+    fileName = cms.untracked.string('MuAlCalIsolatedMu.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('MuAlCalIsolatedMu'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+process.ALCARECOStreamMuAlOverlaps = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOMuAlOverlaps')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_ALCARECOMuAlOverlaps_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*', 
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*', 
+        'keep *_TriggerResults_*_*', 
+        'keep DcsStatuss_scalersRawToDigi_*_*'),
+    fileName = cms.untracked.string('MuAlOverlaps.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('MuAlOverlaps'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+process.ALCARECOStreamTkAlMuonIsolated = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOTkAlMuonIsolated')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_ALCARECOTkAlMuonIsolated_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*', 
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*', 
+        'keep *_TriggerResults_*_*', 
+        'keep DcsStatuss_scalersRawToDigi_*_*', 
+        'keep *_offlinePrimaryVertices_*_*'),
+    fileName = cms.untracked.string('TkAlMuonIsolated.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('TkAlMuonIsolated'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+process.ALCARECOStreamDtCalibOutPath = cms.EndPath(process.ALCARECOStreamDtCalib)
+process.ALCARECOStreamMuAlCalIsolatedMuOutPath = cms.EndPath(process.ALCARECOStreamMuAlCalIsolatedMu)
+process.ALCARECOStreamMuAlOverlapsOutPath = cms.EndPath(process.ALCARECOStreamMuAlOverlaps)
+process.ALCARECOStreamTkAlMuonIsolatedOutPath = cms.EndPath(process.ALCARECOStreamTkAlMuonIsolated)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.pathALCARECOMuAlCalIsolatedMu,process.pathALCARECOTkAlMuonIsolated,process.pathALCARECODtCalib,process.pathALCARECOMuAlOverlaps,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step,process.ALCARECOStreamDtCalibOutPath,process.ALCARECOStreamMuAlCalIsolatedMuOutPath,process.ALCARECOStreamMuAlOverlapsOutPath,process.ALCARECOStreamTkAlMuonIsolatedOutPath)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9a2f16.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9a2f16.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_PhotonHad.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9b3301.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9b3301.configFile
@@ -1,0 +1,193 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,ALCA:@DoubleMu,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_DoubleMu.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('Configuration.StandardSequences.AlCaRecoStreams_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_ALCA_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+process.ALCARECOStreamDtCalib = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECODtCalib')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_dt4DSegments_*_*', 
+        'keep *_dt4DSegmentsNoWire_*_*', 
+        'keep *_muonDTDigis_*_*', 
+        'keep *_dttfDigis_*_*', 
+        'keep *_gtDigis_*_*', 
+        'keep *_TriggerResults_*_*', 
+        'keep recoMuons_muons_*_*', 
+        'keep booledmValueMap_muid*_*_*'),
+    fileName = cms.untracked.string('DtCalib.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('DtCalib'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+process.ALCARECOStreamMuAlCalIsolatedMu = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOMuAlCalIsolatedMu')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_ALCARECOMuAlCalIsolatedMu_*_*', 
+        'keep *_muonCSCDigis_*_*', 
+        'keep *_muonDTDigis_*_*', 
+        'keep *_muonRPCDigis_*_*', 
+        'keep *_dt1DRecHits_*_*', 
+        'keep *_dt2DSegments_*_*', 
+        'keep *_dt4DSegments_*_*', 
+        'keep *_csc2DRecHits_*_*', 
+        'keep *_cscSegments_*_*', 
+        'keep *_rpcRecHits_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*', 
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*', 
+        'keep *_TriggerResults_*_*', 
+        'keep DcsStatuss_scalersRawToDigi_*_*'),
+    fileName = cms.untracked.string('MuAlCalIsolatedMu.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('MuAlCalIsolatedMu'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+process.ALCARECOStreamMuAlOverlaps = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOMuAlOverlaps')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_ALCARECOMuAlOverlaps_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*', 
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*', 
+        'keep *_TriggerResults_*_*', 
+        'keep DcsStatuss_scalersRawToDigi_*_*'),
+    fileName = cms.untracked.string('MuAlOverlaps.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('MuAlOverlaps'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+process.ALCARECOStreamTkAlZMuMu = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOTkAlZMuMu')
+    ),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_ALCARECOTkAlZMuMu_*_*', 
+        'keep L1AcceptBunchCrossings_*_*_*', 
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*', 
+        'keep *_TriggerResults_*_*', 
+        'keep DcsStatuss_scalersRawToDigi_*_*', 
+        'keep *_offlinePrimaryVertices_*_*'),
+    fileName = cms.untracked.string('TkAlZMuMu.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string('TkAlZMuMu'),
+        dataTier = cms.untracked.string('ALCARECO')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880)
+)
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+process.ALCARECOStreamDtCalibOutPath = cms.EndPath(process.ALCARECOStreamDtCalib)
+process.ALCARECOStreamMuAlCalIsolatedMuOutPath = cms.EndPath(process.ALCARECOStreamMuAlCalIsolatedMu)
+process.ALCARECOStreamMuAlOverlapsOutPath = cms.EndPath(process.ALCARECOStreamMuAlOverlaps)
+process.ALCARECOStreamTkAlZMuMuOutPath = cms.EndPath(process.ALCARECOStreamTkAlZMuMu)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.pathALCARECOTkAlZMuMu,process.pathALCARECOMuAlCalIsolatedMu,process.pathALCARECODtCalib,process.pathALCARECOMuAlOverlaps,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step,process.ALCARECOStreamDtCalibOutPath,process.ALCARECOStreamMuAlCalIsolatedMuOutPath,process.ALCARECOStreamMuAlOverlapsOutPath,process.ALCARECOStreamTkAlZMuMuOutPath)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9c2b96.configFile
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files/b6ad4db04bcd6551c0d7907e7e9c2b96.configFile
@@ -1,0 +1,107 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: reco -s RAW2DIGI,L1Reco,RECO,USER:EventFilter/HcalRawToDigi/hcallaserhbhehffilter2012_cff.hcallLaser2012Filter,DQM --data --conditions FT_R_53_LV5::All --eventcontent RECO,AOD,DQM --datatier RECO,AOD,DQM --customise Configuration/DataProcessing/RecoTLR.customisePrompt --no_exec --python reco_2011A_METBTag.py
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('RECO')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.RawToDigi_Data_cff')
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.load('Configuration.StandardSequences.Reconstruction_Data_cff')
+process.load('EventFilter.HcalRawToDigi.hcallaserhbhehffilter2012_cff')
+process.load('DQMOffline.Configuration.DQMOffline_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    secondaryFileNames = cms.untracked.vstring(),
+    fileNames = cms.untracked.vstring('file:reco_DIGI2RAW.root')
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('reco nevts:1'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RECOoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RECOEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('RECO')
+    )
+)
+
+process.AODoutput = cms.OutputModule("PoolOutputModule",
+    eventAutoFlushCompressedSize = cms.untracked.int32(15728640),
+    outputCommands = process.AODEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inAOD.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('AOD')
+    )
+)
+
+process.DQMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('reco_RAW2DIGI_L1Reco_RECO_USER_DQM_inDQM.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQM')
+    )
+)
+
+# Additional output definition
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'FT_R_53_LV5::All', '')
+
+# Path and EndPath definitions
+process.raw2digi_step = cms.Path(process.RawToDigi)
+process.L1Reco_step = cms.Path(process.L1Reco)
+process.reconstruction_step = cms.Path(process.reconstruction)
+process.user_step = cms.Path(process.hcallLaser2012Filter)
+process.dqmoffline_step = cms.Path(process.DQMOffline)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RECOoutput_step = cms.EndPath(process.RECOoutput)
+process.AODoutput_step = cms.EndPath(process.AODoutput)
+process.DQMoutput_step = cms.EndPath(process.DQMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.raw2digi_step,process.L1Reco_step,process.reconstruction_step,process.user_step,process.dqmoffline_step,process.endjob_step,process.RECOoutput_step,process.AODoutput_step,process.DQMoutput_step)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from Configuration.DataProcessing.RecoTLR
+from Configuration.DataProcessing.RecoTLR import customisePrompt 
+
+#call to customisation function customisePrompt imported from Configuration.DataProcessing.RecoTLR
+process = customisePrompt(process)
+
+# End of customisation functions


### PR DESCRIPTION
* Adds new Run2011A configuration files extracted from primary datasets.
  The collection so far included only those for simulated datasets.
  (addresses #934)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>