### PR TITLE
CMS:link the author list to 2011 configuration files

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files-Run2011A.xml
@@ -11752,6 +11752,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00127_1_cfg.py</subfield>
@@ -11796,6 +11797,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00036_1_cfg.py</subfield>
@@ -11840,6 +11842,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00103_1_cfg.py</subfield>
@@ -11884,6 +11887,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step SUS-Summer11LegpLHE-00001_1_cfg.py</subfield>
@@ -11928,6 +11932,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00036_1_cfg.py</subfield>
@@ -11972,6 +11977,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00041_1_cfg.py</subfield>
@@ -12016,6 +12022,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00009_1_cfg.py</subfield>
@@ -12060,6 +12067,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00155_1_cfg.py</subfield>
@@ -12104,6 +12112,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00236_1_cfg.py</subfield>
@@ -12148,6 +12157,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00009_1_cfg.py</subfield>
@@ -12192,6 +12202,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00002_1_cfg.py</subfield>
@@ -12236,6 +12247,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00022_1_cfg.py</subfield>
@@ -12280,6 +12292,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00002_1_cfg.py</subfield>
@@ -12324,6 +12337,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00075_1_cfg.py</subfield>
@@ -12368,6 +12382,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00096_1_cfg.py</subfield>
@@ -12412,6 +12427,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00129_1_cfg.py</subfield>
@@ -12456,6 +12472,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00008_1_cfg.py</subfield>
@@ -12500,6 +12517,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00260_1_cfg.py</subfield>
@@ -12544,6 +12562,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00014_1_cfg.py</subfield>
@@ -12588,6 +12607,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00091_1_cfg.py</subfield>
@@ -12632,6 +12652,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00135_1_cfg.py</subfield>
@@ -12676,6 +12697,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00022_1_cfg.py</subfield>
@@ -12720,6 +12742,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00028_1_cfg.py</subfield>
@@ -12764,6 +12787,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00145_1_cfg.py</subfield>
@@ -12808,6 +12832,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00005_1_cfg.py</subfield>
@@ -12852,6 +12877,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00013_1_cfg.py</subfield>
@@ -12896,6 +12922,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00032_1_cfg.py</subfield>
@@ -12940,6 +12967,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00055_1_cfg.py</subfield>
@@ -12984,6 +13012,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00018_1_cfg.py</subfield>
@@ -13028,6 +13057,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00010_1_cfg.py</subfield>
@@ -13072,6 +13102,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00035_1_cfg.py</subfield>
@@ -13116,6 +13147,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00062_1_cfg.py</subfield>
@@ -13160,6 +13192,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00006_1_cfg.py</subfield>
@@ -13204,6 +13237,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step EWK-Summer11Leg-00006_1_cfg.py</subfield>
@@ -13248,6 +13282,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00172_1_cfg.py</subfield>
@@ -13292,6 +13327,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00053_1_cfg.py</subfield>
@@ -13336,6 +13372,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00143_1_cfg.py</subfield>
@@ -13380,6 +13417,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00018_1_cfg.py</subfield>
@@ -13424,6 +13462,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00021_1_cfg.py</subfield>
@@ -13468,6 +13507,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00039_1_cfg.py</subfield>
@@ -13512,6 +13552,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00017_1_cfg.py</subfield>
@@ -13556,6 +13597,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00033_1_cfg.py</subfield>
@@ -13600,6 +13642,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step BTV-Summer11LegDR-00013_2_cfg.py</subfield>
@@ -13644,6 +13687,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00039_1_cfg.py</subfield>
@@ -13688,6 +13732,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00099_1_cfg.py</subfield>
@@ -13732,6 +13777,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00049_1_cfg.py</subfield>
@@ -13776,6 +13822,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00112_1_cfg.py</subfield>
@@ -13820,6 +13867,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00149_1_cfg.py</subfield>
@@ -13864,6 +13912,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00234_1_cfg.py</subfield>
@@ -13908,6 +13957,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00113_1_cfg.py</subfield>
@@ -13952,6 +14002,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00207_1_cfg.py</subfield>
@@ -13996,6 +14047,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00147_1_cfg.py</subfield>
@@ -14040,6 +14092,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00063_1_cfg.py</subfield>
@@ -14084,6 +14137,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step BPH-Summer11LegDR-00001_2_cfg.py</subfield>
@@ -14128,6 +14182,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step SUS-Summer11Leg-00005_1_cfg.py</subfield>
@@ -14172,6 +14227,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00001_1_cfg.py</subfield>
@@ -14216,6 +14272,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00013_1_cfg.py</subfield>
@@ -14260,6 +14317,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00026_1_cfg.py</subfield>
@@ -14304,6 +14362,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00013_1_cfg.py</subfield>
@@ -14348,6 +14407,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00241_1_cfg.py</subfield>
@@ -14392,6 +14452,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00252_1_cfg.py</subfield>
@@ -14436,6 +14497,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00004_1_cfg.py</subfield>
@@ -14480,6 +14542,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00154_1_cfg.py</subfield>
@@ -14524,6 +14587,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00041_1_cfg.py</subfield>
@@ -14568,6 +14632,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00218_1_cfg.py</subfield>
@@ -14612,6 +14677,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00117_1_cfg.py</subfield>
@@ -14656,6 +14722,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00100_1_cfg.py</subfield>
@@ -14700,6 +14767,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step EWK-Summer11Leg-00011_1_cfg.py</subfield>
@@ -14744,6 +14812,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00008_1_cfg.py</subfield>
@@ -14788,6 +14857,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00038_1_cfg.py</subfield>
@@ -14832,6 +14902,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00002_1_cfg.py</subfield>
@@ -14876,6 +14947,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00096_1_cfg.py</subfield>
@@ -14920,6 +14992,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00007_1_cfg.py</subfield>
@@ -14964,6 +15037,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00027_1_cfg.py</subfield>
@@ -15008,6 +15082,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00123_1_cfg.py</subfield>
@@ -15052,6 +15127,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00082_1_cfg.py</subfield>
@@ -15096,6 +15172,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00006_1_cfg.py</subfield>
@@ -15140,6 +15217,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00084_1_cfg.py</subfield>
@@ -15184,6 +15262,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00082_1_cfg.py</subfield>
@@ -15228,6 +15307,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00037_1_cfg.py</subfield>
@@ -15272,6 +15352,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00092_1_cfg.py</subfield>
@@ -15316,6 +15397,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step SUS-Summer11LegpLHE-00004_1_cfg.py</subfield>
@@ -15360,6 +15442,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00112_1_cfg.py</subfield>
@@ -15404,6 +15487,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00142_1_cfg.py</subfield>
@@ -15448,6 +15532,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00010_1_cfg.py</subfield>
@@ -15492,6 +15577,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00153_1_cfg.py</subfield>
@@ -15536,6 +15622,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00061_1_cfg.py</subfield>
@@ -15580,6 +15667,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00012_1_cfg.py</subfield>
@@ -15624,6 +15712,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00128_1_cfg.py</subfield>
@@ -15668,6 +15757,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00002_1_cfg.py</subfield>
@@ -15712,6 +15802,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00216_1_cfg.py</subfield>
@@ -15756,6 +15847,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00019_1_cfg.py</subfield>
@@ -15800,6 +15892,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00156_1_cfg.py</subfield>
@@ -15844,6 +15937,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00021_1_cfg.py</subfield>
@@ -15888,6 +15982,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00221_1_cfg.py</subfield>

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files-Run2011A.xml
@@ -7,6 +7,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00261_1_cfg.py</subfield>
@@ -51,6 +52,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00043_1_cfg.py</subfield>
@@ -95,6 +97,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00015_1_cfg.py</subfield>
@@ -139,6 +142,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00205_1_cfg.py</subfield>
@@ -183,6 +187,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00253_1_cfg.py</subfield>
@@ -227,6 +232,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00114_1_cfg.py</subfield>
@@ -271,6 +277,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00014_1_cfg.py</subfield>
@@ -315,6 +322,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00208_1_cfg.py</subfield>
@@ -359,6 +367,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00152_1_cfg.py</subfield>
@@ -403,6 +412,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00248_1_cfg.py</subfield>
@@ -447,6 +457,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00119_1_cfg.py</subfield>
@@ -491,6 +502,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00109_1_cfg.py</subfield>
@@ -535,6 +547,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00126_1_cfg.py</subfield>
@@ -579,6 +592,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00122_1_cfg.py</subfield>
@@ -623,6 +637,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00037_1_cfg.py</subfield>
@@ -667,6 +682,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00011_1_cfg.py</subfield>
@@ -711,6 +727,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00006_1_cfg.py</subfield>
@@ -755,6 +772,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00014_1_cfg.py</subfield>
@@ -799,6 +817,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00262_1_cfg.py</subfield>
@@ -843,6 +862,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00012_1_cfg.py</subfield>
@@ -887,6 +907,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00010_1_cfg.py</subfield>
@@ -931,6 +952,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00113_1_cfg.py</subfield>
@@ -975,6 +997,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step EWK-Summer11Leg-00008_1_cfg.py</subfield>
@@ -1019,6 +1042,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00045_1_cfg.py</subfield>
@@ -1063,6 +1087,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00107_1_cfg.py</subfield>
@@ -1107,6 +1132,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00108_1_cfg.py</subfield>
@@ -1151,6 +1177,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00013_1_cfg.py</subfield>
@@ -1195,6 +1222,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00068_1_cfg.py</subfield>
@@ -1239,6 +1267,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00033_1_cfg.py</subfield>
@@ -1283,6 +1312,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00007_1_cfg.py</subfield>
@@ -1327,6 +1357,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00082_1_cfg.py</subfield>
@@ -1371,6 +1402,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00119_1_cfg.py</subfield>
@@ -1415,6 +1447,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00215_1_cfg.py</subfield>
@@ -1459,6 +1492,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00237_1_cfg.py</subfield>
@@ -1503,6 +1537,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00012_1_cfg.py</subfield>
@@ -1547,6 +1582,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00254_1_cfg.py</subfield>
@@ -1591,6 +1627,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00119_1_cfg.py</subfield>
@@ -1635,6 +1672,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00150_1_cfg.py</subfield>
@@ -1679,6 +1717,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step SUS-Summer11Leg-00001_1_cfg.py</subfield>
@@ -1723,6 +1762,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00017_1_cfg.py</subfield>
@@ -1767,6 +1807,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00148_1_cfg.py</subfield>
@@ -1811,6 +1852,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00317_1_cfg.py</subfield>
@@ -1855,6 +1897,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for HLT step HIG-Summer11LegDR-00204_1_cfg.py</subfield>
@@ -1899,6 +1942,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00116_1_cfg.py</subfield>
@@ -1943,6 +1987,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00104_1_cfg.py</subfield>
@@ -1987,6 +2032,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00217_1_cfg.py</subfield>
@@ -2031,6 +2077,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00003_1_cfg.py</subfield>
@@ -2075,6 +2122,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00041_1_cfg.py</subfield>
@@ -2119,6 +2167,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00056_1_cfg.py</subfield>
@@ -2163,6 +2212,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00001_1_cfg.py</subfield>
@@ -2207,6 +2257,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00057_1_cfg.py</subfield>
@@ -2251,6 +2302,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00197_1_cfg.py</subfield>
@@ -2295,6 +2347,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00244_1_cfg.py</subfield>
@@ -2339,6 +2392,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00060_1_cfg.py</subfield>
@@ -2383,6 +2437,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00003_1_cfg.py</subfield>
@@ -2427,6 +2482,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step EWK-Summer11Leg-00004_1_cfg.py</subfield>
@@ -2471,6 +2527,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00125_1_cfg.py</subfield>
@@ -2515,6 +2572,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00011_1_cfg.py</subfield>
@@ -2559,6 +2617,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00145_1_cfg.py</subfield>
@@ -2603,6 +2662,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00021_1_cfg.py</subfield>
@@ -2647,6 +2707,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00250_1_cfg.py</subfield>
@@ -2691,6 +2752,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00099_1_cfg.py</subfield>
@@ -2735,6 +2797,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00019_1_cfg.py</subfield>
@@ -2779,6 +2842,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00010_1_cfg.py</subfield>
@@ -2823,6 +2887,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00222_1_cfg.py</subfield>
@@ -2867,6 +2932,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for HLT step BPH-Summer11LegDR-00001_1_cfg.py</subfield>
@@ -2911,6 +2977,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00002_1_cfg.py</subfield>
@@ -2955,6 +3022,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00144_1_cfg.py</subfield>
@@ -2999,6 +3067,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00233_1_cfg.py</subfield>
@@ -3043,6 +3112,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00014_1_cfg.py</subfield>
@@ -3087,6 +3157,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00031_1_cfg.py</subfield>
@@ -3131,6 +3202,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00097_1_cfg.py</subfield>
@@ -3175,6 +3247,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00126_1_cfg.py</subfield>
@@ -3219,6 +3292,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00007_1_cfg.py</subfield>
@@ -3263,6 +3337,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00081_1_cfg.py</subfield>
@@ -3307,6 +3382,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00020_1_cfg.py</subfield>
@@ -3351,6 +3427,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00022_1_cfg.py</subfield>
@@ -3395,6 +3472,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00058_1_cfg.py</subfield>
@@ -3439,6 +3517,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00111_1_cfg.py</subfield>
@@ -3483,6 +3562,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step SMP-Summer11LegDR-00003_2_cfg.py</subfield>
@@ -3527,6 +3607,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00151_1_cfg.py</subfield>
@@ -3571,6 +3652,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00003_1_cfg.py</subfield>
@@ -3615,6 +3697,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00001_1_cfg.py</subfield>
@@ -3659,6 +3742,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step EWK-Summer11Leg-00003_1_cfg.py</subfield>
@@ -3703,6 +3787,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00140_1_cfg.py</subfield>
@@ -3747,6 +3832,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step HIG-Summer11LegDR-00204_2_cfg.py</subfield>
@@ -3791,6 +3877,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for HLT step TOP-Summer11LegDR-00024_1_cfg.py</subfield>
@@ -3835,6 +3922,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00111_1_cfg.py</subfield>
@@ -3879,6 +3967,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00016_1_cfg.py</subfield>
@@ -3923,6 +4012,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00005_1_cfg.py</subfield>
@@ -3967,6 +4057,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00256_1_cfg.py</subfield>
@@ -4011,6 +4102,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00129_1_cfg.py</subfield>
@@ -4055,6 +4147,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step EWK-Summer11Leg-00010_1_cfg.py</subfield>
@@ -4099,6 +4192,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00004_1_cfg.py</subfield>
@@ -4143,6 +4237,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00002_1_cfg.py</subfield>
@@ -4187,6 +4282,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00214_1_cfg.py</subfield>
@@ -4231,6 +4327,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00246_1_cfg.py</subfield>
@@ -4275,6 +4372,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00133_1_cfg.py</subfield>
@@ -4319,6 +4417,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00051_1_cfg.py</subfield>
@@ -4363,6 +4462,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00123_1_cfg.py</subfield>
@@ -4407,6 +4507,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00040_1_cfg.py</subfield>
@@ -4451,6 +4552,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00156_1_cfg.py</subfield>
@@ -4495,6 +4597,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00013_1_cfg.py</subfield>
@@ -4539,6 +4642,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00015_1_cfg.py</subfield>
@@ -4583,6 +4687,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00002_1_cfg.py</subfield>
@@ -4627,6 +4732,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00095_1_cfg.py</subfield>
@@ -4671,6 +4777,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00128_1_cfg.py</subfield>
@@ -4715,6 +4822,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00003_1_cfg.py</subfield>
@@ -4759,6 +4867,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for HLT step TOP-Summer11LegDR-00030_1_cfg.py</subfield>
@@ -4803,6 +4912,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00010_1_cfg.py</subfield>
@@ -4847,6 +4957,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00052_1_cfg.py</subfield>
@@ -4891,6 +5002,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00005_1_cfg.py</subfield>
@@ -4935,6 +5047,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00105_1_cfg.py</subfield>
@@ -4979,6 +5092,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00247_1_cfg.py</subfield>
@@ -5023,6 +5137,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00232_1_cfg.py</subfield>
@@ -5067,6 +5182,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00054_1_cfg.py</subfield>
@@ -5111,6 +5227,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for HLT step HIG-Summer11LegDR-00101_1_cfg.py</subfield>
@@ -5155,6 +5272,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00025_1_cfg.py</subfield>
@@ -5199,6 +5317,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00057_1_cfg.py</subfield>
@@ -5243,6 +5362,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for HLT step HIG-Summer11LegDR-00284_1_cfg.py</subfield>
@@ -5287,6 +5407,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00005_1_cfg.py</subfield>
@@ -5331,6 +5452,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00131_1_cfg.py</subfield>
@@ -5375,6 +5497,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00157_1_cfg.py</subfield>
@@ -5419,6 +5542,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00003_1_cfg.py</subfield>
@@ -5463,6 +5587,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00122_1_cfg.py</subfield>
@@ -5507,6 +5632,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step BPH-Summer11LegDR-00019_2_cfg.py</subfield>
@@ -5551,6 +5677,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00124_1_cfg.py</subfield>
@@ -5595,6 +5722,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00020_1_cfg.py</subfield>
@@ -5639,6 +5767,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00031_1_cfg.py</subfield>
@@ -5683,6 +5812,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00139_1_cfg.py</subfield>
@@ -5727,6 +5857,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00086_1_cfg.py</subfield>
@@ -5771,6 +5902,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00027_1_cfg.py</subfield>
@@ -5815,6 +5947,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00151_1_cfg.py</subfield>
@@ -5859,6 +5992,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00109_1_cfg.py</subfield>
@@ -5903,6 +6037,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00258_1_cfg.py</subfield>
@@ -5947,6 +6082,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00063_1_cfg.py</subfield>
@@ -5991,6 +6127,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00009_1_cfg.py</subfield>
@@ -6035,6 +6172,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00011_1_cfg.py</subfield>
@@ -6079,6 +6217,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00003_1_cfg.py</subfield>
@@ -6123,6 +6262,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00210_1_cfg.py</subfield>
@@ -6167,6 +6307,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for HLT step HIG-Summer11LegDR-00066_1_cfg.py</subfield>
@@ -6211,6 +6352,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00009_1_cfg.py</subfield>
@@ -6255,6 +6397,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00097_1_cfg.py</subfield>
@@ -6299,6 +6442,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00231_1_cfg.py</subfield>
@@ -6343,6 +6487,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00101_1_cfg.py</subfield>
@@ -6387,6 +6532,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00120_1_cfg.py</subfield>
@@ -6431,6 +6577,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00014_1_cfg.py</subfield>
@@ -6475,6 +6622,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00136_1_cfg.py</subfield>
@@ -6519,6 +6667,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00017_1_cfg.py</subfield>
@@ -6563,6 +6712,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00011_1_cfg.py</subfield>
@@ -6607,6 +6757,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step EWK-Summer11Leg-00001_1_cfg.py</subfield>
@@ -6651,6 +6802,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00134_1_cfg.py</subfield>
@@ -6695,6 +6847,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00025_1_cfg.py</subfield>
@@ -6739,6 +6892,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00146_1_cfg.py</subfield>
@@ -6783,6 +6937,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00243_1_cfg.py</subfield>
@@ -6827,6 +6982,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00005_1_cfg.py</subfield>
@@ -6871,6 +7027,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00121_1_cfg.py</subfield>
@@ -6915,6 +7072,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00013_1_cfg.py</subfield>
@@ -6959,6 +7117,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00127_1_cfg.py</subfield>
@@ -7003,6 +7162,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00095_1_cfg.py</subfield>
@@ -7047,6 +7207,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00030_1_cfg.py</subfield>
@@ -7091,6 +7252,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step SUS-Summer11LegpLHE-00002_1_cfg.py</subfield>
@@ -7135,6 +7297,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00131_1_cfg.py</subfield>
@@ -7179,6 +7342,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00242_1_cfg.py</subfield>
@@ -7223,6 +7387,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00011_1_cfg.py</subfield>
@@ -7267,6 +7432,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00238_1_cfg.py</subfield>
@@ -7311,6 +7477,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00024_1_cfg.py</subfield>
@@ -7355,6 +7522,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00016_1_cfg.py</subfield>
@@ -7399,6 +7567,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for HLT step BPH-Summer11LegDR-00019_1_cfg.py</subfield>
@@ -7443,6 +7612,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00016_1_cfg.py</subfield>
@@ -7487,6 +7657,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00001_1_cfg.py</subfield>
@@ -7531,6 +7702,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00117_1_cfg.py</subfield>
@@ -7575,6 +7747,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00098_1_cfg.py</subfield>
@@ -7619,6 +7792,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00114_1_cfg.py</subfield>
@@ -7663,6 +7837,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00116_1_cfg.py</subfield>
@@ -7707,6 +7882,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00113_1_cfg.py</subfield>
@@ -7751,6 +7927,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00107_1_cfg.py</subfield>
@@ -7795,6 +7972,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00081_1_cfg.py</subfield>
@@ -7839,6 +8017,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00143_1_cfg.py</subfield>
@@ -7883,6 +8062,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00044_1_cfg.py</subfield>
@@ -7927,6 +8107,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00015_1_cfg.py</subfield>
@@ -7971,6 +8152,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step TOP-Summer11LegDR-00024_2_cfg.py</subfield>
@@ -8015,6 +8197,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00006_1_cfg.py</subfield>
@@ -8059,6 +8242,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step BPH-Summer11LegDR-00017_2_cfg.py</subfield>
@@ -8103,6 +8287,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00130_1_cfg.py</subfield>
@@ -8147,6 +8332,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00115_1_cfg.py</subfield>
@@ -8191,6 +8377,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00102_1_cfg.py</subfield>
@@ -8235,6 +8422,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00013_1_cfg.py</subfield>
@@ -8279,6 +8467,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00015_1_cfg.py</subfield>
@@ -8323,6 +8512,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step TOP-Summer11LegDR-00035_2_cfg.py</subfield>
@@ -8367,6 +8557,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00028_1_cfg.py</subfield>
@@ -8411,6 +8602,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step HIG-Summer11LegDR-00284_2_cfg.py</subfield>
@@ -8455,6 +8647,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00012_1_cfg.py</subfield>
@@ -8499,6 +8692,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00011_1_cfg.py</subfield>
@@ -8543,6 +8737,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00008_1_cfg.py</subfield>
@@ -8587,6 +8782,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00096_1_cfg.py</subfield>
@@ -8631,6 +8827,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00017_1_cfg.py</subfield>
@@ -8675,6 +8872,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for HLT step SMP-Summer11LegDR-00003_1_cfg.py</subfield>
@@ -8719,6 +8917,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00001_1_cfg.py</subfield>
@@ -8763,6 +8962,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00027_1_cfg.py</subfield>
@@ -8807,6 +9007,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step SMP-Summer11Leg-00001_1_cfg.py</subfield>
@@ -8851,6 +9052,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00110_1_cfg.py</subfield>
@@ -8895,6 +9097,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00223_1_cfg.py</subfield>
@@ -8939,6 +9142,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00019_1_cfg.py</subfield>
@@ -8983,6 +9187,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for HLT step BPH-Summer11LegDR-00017_1_cfg.py</subfield>
@@ -9027,6 +9232,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00004_1_cfg.py</subfield>
@@ -9071,6 +9277,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00211_1_cfg.py</subfield>
@@ -9115,6 +9322,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00259_1_cfg.py</subfield>
@@ -9159,6 +9367,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00009_1_cfg.py</subfield>
@@ -9203,6 +9412,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00029_1_cfg.py</subfield>
@@ -9247,6 +9457,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00010_1_cfg.py</subfield>
@@ -9291,6 +9502,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00006_1_cfg.py</subfield>
@@ -9335,6 +9547,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00007_1_cfg.py</subfield>
@@ -9379,6 +9592,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00110_1_cfg.py</subfield>
@@ -9423,6 +9637,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00018_1_cfg.py</subfield>
@@ -9467,6 +9682,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00125_1_cfg.py</subfield>
@@ -9511,6 +9727,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00132_1_cfg.py</subfield>
@@ -9555,6 +9772,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00015_1_cfg.py</subfield>
@@ -9599,6 +9817,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00008_1_cfg.py</subfield>
@@ -9643,6 +9862,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00038_1_cfg.py</subfield>
@@ -9687,6 +9907,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00107_1_cfg.py</subfield>
@@ -9731,6 +9952,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00004_1_cfg.py</subfield>
@@ -9775,6 +9997,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00052_1_cfg.py</subfield>
@@ -9819,6 +10042,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00255_1_cfg.py</subfield>
@@ -9863,6 +10087,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00064_1_cfg.py</subfield>
@@ -9907,6 +10132,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00219_1_cfg.py</subfield>
@@ -9951,6 +10177,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step SUS-Summer11Leg-00002_1_cfg.py</subfield>
@@ -9995,6 +10222,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00030_1_cfg.py</subfield>
@@ -10039,6 +10267,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00251_1_cfg.py</subfield>
@@ -10083,6 +10312,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00328_1_cfg.py</subfield>
@@ -10127,6 +10357,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step SMP-Summer11LegwmLHE-00001_1_cfg.py</subfield>
@@ -10171,6 +10402,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00004_1_cfg.py</subfield>
@@ -10215,6 +10447,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00007_1_cfg.py</subfield>
@@ -10259,6 +10492,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00015_1_cfg.py</subfield>
@@ -10303,6 +10537,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00023_1_cfg.py</subfield>
@@ -10347,6 +10582,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00008_1_cfg.py</subfield>
@@ -10391,6 +10627,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00124_1_cfg.py</subfield>
@@ -10435,6 +10672,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00006_1_cfg.py</subfield>
@@ -10479,6 +10717,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00213_1_cfg.py</subfield>
@@ -10523,6 +10762,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step EWK-Summer11Leg-00009_1_cfg.py</subfield>
@@ -10567,6 +10807,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00085_1_cfg.py</subfield>
@@ -10611,6 +10852,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00130_1_cfg.py</subfield>
@@ -10655,6 +10897,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00144_1_cfg.py</subfield>
@@ -10699,6 +10942,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00206_1_cfg.py</subfield>
@@ -10743,6 +10987,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00118_1_cfg.py</subfield>
@@ -10787,6 +11032,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00270_1_cfg.py</subfield>
@@ -10831,6 +11077,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00102_1_cfg.py</subfield>
@@ -10875,6 +11122,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00059_1_cfg.py</subfield>
@@ -10919,6 +11167,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00142_1_cfg.py</subfield>
@@ -10963,6 +11212,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00018_1_cfg.py</subfield>
@@ -11007,6 +11257,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step TOP-Summer11LegDR-00030_2_cfg.py</subfield>
@@ -11051,6 +11302,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00014_1_cfg.py</subfield>
@@ -11095,6 +11347,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00106_1_cfg.py</subfield>
@@ -11139,6 +11392,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00023_1_cfg.py</subfield>
@@ -11183,6 +11437,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00016_1_cfg.py</subfield>
@@ -11227,6 +11482,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00008_1_cfg.py</subfield>
@@ -11271,6 +11527,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00046_1_cfg.py</subfield>
@@ -11315,6 +11572,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00209_1_cfg.py</subfield>
@@ -11359,6 +11617,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for HLT step BTV-Summer11LegDR-00013_1_cfg.py</subfield>
@@ -11403,6 +11662,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00245_1_cfg.py</subfield>
@@ -11447,6 +11707,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00034_1_cfg.py</subfield>

--- a/invenio_opendata/testsuite/data/cms/cms-configuration-files-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-configuration-files-Run2011A.xml
@@ -16027,6 +16027,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00212_1_cfg.py</subfield>
@@ -16071,6 +16072,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step SUS-Summer11LegpLHE-00005_1_cfg.py</subfield>
@@ -16115,6 +16117,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00040_1_cfg.py</subfield>
@@ -16159,6 +16162,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00090_1_cfg.py</subfield>
@@ -16203,6 +16207,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step SUS-Summer11Leg-00004_1_cfg.py</subfield>
@@ -16247,6 +16252,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step SUS-Summer11LegpLHE-00003_1_cfg.py</subfield>
@@ -16291,6 +16297,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step EWK-Summer11Leg-00005_1_cfg.py</subfield>
@@ -16335,6 +16342,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00115_1_cfg.py</subfield>
@@ -16379,6 +16387,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00017_1_cfg.py</subfield>
@@ -16423,6 +16432,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00137_1_cfg.py</subfield>
@@ -16467,6 +16477,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00098_1_cfg.py</subfield>
@@ -16511,6 +16522,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegpLHE-00003_1_cfg.py</subfield>
@@ -16555,6 +16567,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00239_1_cfg.py</subfield>
@@ -16599,6 +16612,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00070_1_cfg.py</subfield>
@@ -16643,6 +16657,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00087_1_cfg.py</subfield>
@@ -16687,6 +16702,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for HLT step TOP-Summer11LegDR-00035_1_cfg.py</subfield>
@@ -16731,6 +16747,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00065_1_cfg.py</subfield>
@@ -16775,6 +16792,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00003_1_cfg.py</subfield>
@@ -16819,6 +16837,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00001_1_cfg.py</subfield>
@@ -16863,6 +16882,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00009_1_cfg.py</subfield>
@@ -16907,6 +16927,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step EWK-Summer11Leg-00002_1_cfg.py</subfield>
@@ -16951,6 +16972,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00240_1_cfg.py</subfield>
@@ -16995,6 +17017,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00249_1_cfg.py</subfield>
@@ -17039,6 +17062,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00138_1_cfg.py</subfield>
@@ -17083,6 +17107,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00121_1_cfg.py</subfield>
@@ -17127,6 +17152,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00103_1_cfg.py</subfield>
@@ -17171,6 +17197,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step HIG-Summer11LegDR-00101_2_cfg.py</subfield>
@@ -17215,6 +17242,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00118_1_cfg.py</subfield>
@@ -17259,6 +17287,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00035_1_cfg.py</subfield>
@@ -17303,6 +17332,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00010_1_cfg.py</subfield>
@@ -17347,6 +17377,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00016_1_cfg.py</subfield>
@@ -17391,6 +17422,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00047_1_cfg.py</subfield>
@@ -17435,6 +17467,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00001_1_cfg.py</subfield>
@@ -17479,6 +17512,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00100_1_cfg.py</subfield>
@@ -17523,6 +17557,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step SMP-Summer11Leg-00015_1_cfg.py</subfield>
@@ -17567,6 +17602,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00141_1_cfg.py</subfield>
@@ -17611,6 +17647,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00089_1_cfg.py</subfield>
@@ -17655,6 +17692,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00108_1_cfg.py</subfield>
@@ -17699,6 +17737,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00088_1_cfg.py</subfield>
@@ -17743,6 +17782,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BPH-Summer11Leg-00009_1_cfg.py</subfield>
@@ -17787,6 +17827,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00019_1_cfg.py</subfield>
@@ -17831,6 +17872,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00120_1_cfg.py</subfield>
@@ -17875,6 +17917,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00044_1_cfg.py</subfield>
@@ -17919,6 +17962,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step EWK-Summer11Leg-00007_1_cfg.py</subfield>
@@ -17963,6 +18007,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00257_1_cfg.py</subfield>
@@ -18007,6 +18052,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00093_1_cfg.py</subfield>
@@ -18051,6 +18097,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step JME-Summer11Leg-00007_1_cfg.py</subfield>
@@ -18095,6 +18142,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11pLHE-00069_1_cfg.py</subfield>
@@ -18139,6 +18187,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step TOP-Summer11Leg-00004_1_cfg.py</subfield>
@@ -18183,6 +18232,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00042_1_cfg.py</subfield>
@@ -18227,6 +18277,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step BTV-Summer11Leg-00001_1_cfg.py</subfield>
@@ -18271,6 +18322,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step HIG-Summer11LegDR-00066_2_cfg.py</subfield>
@@ -18315,6 +18367,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step TOP-Summer11LegwmLHE-00008_1_cfg.py</subfield>
@@ -18359,6 +18412,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for SIM step HIG-Summer11Leg-00235_1_cfg.py</subfield>
@@ -18403,6 +18457,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00083_1_cfg.py</subfield>
@@ -18447,6 +18502,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for LHE step HIG-Summer11LegpLHE-00013_1_cfg.py</subfield>
@@ -18491,6 +18547,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_TauPlusX</subfield>
@@ -18535,6 +18592,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_MET</subfield>
@@ -18579,6 +18637,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_BTag</subfield>
@@ -18623,6 +18682,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_SingleElectron</subfield>
@@ -18667,6 +18727,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_MuHad</subfield>
@@ -18711,6 +18772,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_SingleMu</subfield>
@@ -18755,6 +18817,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_ElectronHad</subfield>
@@ -18799,6 +18862,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_Jet</subfield>
@@ -18843,6 +18907,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_METBTag</subfield>
@@ -18887,6 +18952,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_MinimumBias</subfield>
@@ -18931,6 +18997,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_Photon</subfield>
@@ -18975,6 +19042,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_PhotonHad</subfield>
@@ -19019,6 +19087,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_HT</subfield>
@@ -19063,6 +19132,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_MuOnia</subfield>
@@ -19107,6 +19177,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_Tau</subfield>
@@ -19151,6 +19222,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_MultiJet</subfield>
@@ -19195,6 +19267,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_DoubleElectron</subfield>
@@ -19239,6 +19312,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_DoubleMu</subfield>
@@ -19283,6 +19357,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_ForwardTriggers</subfield>
@@ -19327,6 +19402,7 @@
     </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS collaboration</subfield>
+      <subfield code="w">451</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">Configuration file for RECO step reco_2011A_MuEG</subfield>


### PR DESCRIPTION
Addition of `110__$w` according to https://github.com/cernopendata/opendata.cern.ch/issues/954#issuecomment-207347572