### PR TITLE
CMS: IFCA Run2011A PAT tuple event counts

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana-Run2011A.xml
@@ -13,7 +13,7 @@
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
       <subfield code="a">Dataset</subfield>
-      <subfield code="e">0</subfield>
+      <subfield code="e">35346886</subfield>
       <subfield code="t">events</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
@@ -365,7 +365,7 @@
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">
       <subfield code="a">Dataset</subfield>
-      <subfield code="e">0</subfield>
+      <subfield code="e">44210359</subfield>
       <subfield code="t">events</subfield>
     </datafield>
     <datafield tag="256" ind1=" " ind2=" ">


### PR DESCRIPTION
* Updates IFCA Run2011A PAT tuple file information with event
  counts. (addresses #1023)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>