### PR TITLE
docker: $HOME/Local volume mounting fix

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,5 +1,5 @@
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -32,7 +32,7 @@ web:
     - ../invenio/scripts:/code/scripts:ro
     - ./invenio_opendata:/code-overlay/invenio_opendata:ro
     - /code/invenio/base/translations
-    - ~/Local/opendata.cern.ch-fft-file-cache:/tmp/opendata.cern.ch-fft-file-cache:ro
+    - $HOME/Local/opendata.cern.ch-fft-file-cache:/tmp/opendata.cern.ch-fft-file-cache:ro
   links:
     - mysql:db
     - redis:cache


### PR DESCRIPTION
* Fixes $HOME/Local volume mounting that stopped working after upgrade
  to Docker 1.11.0.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>