### PR TITLE
templates: fix for collision_energy display

### DIFF
--- a/invenio_opendata/base/templates/records/metadata_base.html
+++ b/invenio_opendata/base/templates/records/metadata_base.html
@@ -76,8 +76,8 @@
           </a>
         {% endif %}
       {% endif %}
-      {% if record.get('collision_information', '').get('collision_energy', '') %}
-        {% set rr = record.get('collision_information', '').get('collision_energy', '').replace('Collision energy: ', '') %}
+      {% if record.get('collision_information', {}).get('collision_energy', '') %}
+        {% set rr = record.get('collision_information', {}).get('collision_energy', '').replace('Collision energy: ', '') %}
         <a href="{{ url_for('search.search', p=rr) }}">
           <div class="rec_thumb rec_parentcol">
             <div class="n no-glossary"><div class="t">Collision Energy</div>{{ rr }}</div>


### PR DESCRIPTION
* Updates templates regarding the `collision_energy` treatment, fixing
  display of CMS trigger TOC record. (addresses PR #1024)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>