### PR TITLE
CMS: two-lepton/four-lepton analysis example text

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-tools-ana.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-ana.xml
@@ -117,7 +117,7 @@
       <subfield code="w">201</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
-      <subfield code="a">Example code for a simple analysis on Z decays to two leptons and ZZ decays to four leptons.</subfield>
+      <subfield code="a">Example code for a simple analysis on Z decays to two leptons and ZZ decays to four leptons.  Please see below the details on data selection and the generated example plots.</subfield>
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Software release: CMSSW_4_2_8</subfield>
@@ -128,7 +128,7 @@
       <subfield code="a">GNU General Public License (GPL) version 3</subfield>
     </datafield>
     <datafield tag="556" ind1=" " ind2=" ">
-      <subfield code="a">Processing the preprocessed datasets takes several hours.</subfield>
+      <subfield code="a">Running the analysis code on the pre-processed datasets takes several hours.</subfield>
     </datafield>
     <datafield tag="567" ind1=" " ind2=" ">
       <subfield code="a"><![CDATA[ <p> An event selection is applied in the two analysis cases:
@@ -166,10 +166,6 @@
     <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">CMS</subfield>
-    </datafield>
-    <datafield tag="787" ind1=" " ind2=" ">
-      <subfield code="a">The expected output is a histogram file such as</subfield>
-      <subfield code="o">http://opendata.cern.ch/visualise/histograms/CMS</subfield>
     </datafield>
     <datafield tag="856" ind1="4" ind2=" ">
       <subfield code="u">https://github.com/ayrodrig/OutreachExercise2010</subfield>


### PR DESCRIPTION
* Amends text of the two-lepton/four-lepton analysis example record as
  per newly attached example plots.  (addresses #557) (closes #916)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>