### PR TITLE
records: update of opendata.cfg

### DIFF
--- a/invenio_opendata/base/recordext/fields/opendata.cfg
+++ b/invenio_opendata/base/recordext/fields/opendata.cfg
@@ -183,13 +183,13 @@ computer_file_type:
     producer:
         json_for_marc(), {"516__a": "note", "516__u": "url", "516__w": "recid", "516__y": "description"}
 
-# 520__a
+# 520__a 520__u 520__w
 
 abstract:
     creator:
-        marc, "520__", {'summary':value['a'], 'expansion':value['b'], 'number':value['9']}
+        marc, "520__", {'summary':value['a'], 'expansion':value['b'], 'url': value['u'], 'recid': value['w'], 'number':value['9']}
     producer:
-        json_for_marc(), {"520__a": "summary", "520__b": "expansion", "520__9": "number"}
+        json_for_marc(), {"520__a": "summary", "520__b": "expansion", "520__u": "url", "520__w": "recid", "520__9": "number"}
         json_for_dc(), {"dc:description": "summary"}
 
 # 538__a 538__b 538__i 538__u 538__w
@@ -251,14 +251,6 @@ local_note:
         marc, "593__", {'type_generator': value['a'], 'global_tag': value['b']}
     producer:
         json_for_marc(), {"593__a": "type_generator", "593__b": "global_tag"}
-
-#653__a
-
-index_term:
-    creator:
-        marc, "653__", {'term': value['a']}
-    producer:
-        json_for_marc(), {"653__a": "term"}
 
 #6531_a
 
@@ -389,6 +381,8 @@ reprocessing_date:
 # 964_0c
 
 run_period:
+    schema:
+        {'run_period': {'type': 'list', 'force': True}}
     creator:
         marc, "964_0", value['c']
     producer:


### PR DESCRIPTION
Addition of `520__u` and `520__w`
Deletion of `653__a` and use only 6531_a (I'll update the 4 records, where the field was included)
Addition of schema with forcing true for `964_0c`

[see also https://github.com/cernopendata/opendata.cern.ch/issues/779#issuecomment-207396704 ]
