### PR TITLE
CMS: fix for L1 trigger information record links

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-l1-trigger-information-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-l1-trigger-information-Run2011A.xml
@@ -24,9 +24,9 @@
         <tbody>
         <tr><td>157942</td><td><a href="/record/3701">L1Menu_Collisions2011_v0_L1T_Scales_20101224_Imp0_0x101e</td></tr>
         <tr><td>161205</td><td><a href="/record/3702">L1Menu_Collisions2011_v1_L1T_Scales_20101224_Imp0_0x101f</td></tr>
-        <tr><td>161568</td><td><a href="/record/3702">L1Menu_Collisions2011_v2_L1T_Scales_20101224_Imp0_0x1020</td></tr>
+        <tr><td>161568</td><td><a href="/record/3703">L1Menu_Collisions2011_v2_L1T_Scales_20101224_Imp0_0x1020</td></tr>
         <tr><td>165897</td><td><a href="/record/3704">L1Menu_Collisions2011_v3_L1T_Scales_20101224_Imp0_0x1021</td></tr>
-        <tr><td>170065</td><td><a href="/record/3701">L1Menu_Collisions2011_v4_L1T_Scales_20101224_Imp0_0x1022</td></tr>
+        <tr><td>170065</td><td><a href="/record/3705">L1Menu_Collisions2011_v4_L1T_Scales_20101224_Imp0_0x1022</td></tr>
         <tr><td>173212</td><td><a href="/record/3706">L1Menu_Collisions2011_v5_L1T_Scales_20101224_Imp0_0x1023</td></tr>
         <tr><td>176725</td><td><a href="/record/3707">L1Menu_Collisions2011_v6_L1T_Scales_20101224_Imp0_0x1024</td></tr>
         </tbody>


### PR DESCRIPTION
* Fixes CMS L1 trigger information links in the table-of-contents
  record. (addresses #907)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>