### PR TITLE
CMS: create new records under Open Data Instructions

### DIFF
--- a/invenio_opendata/testsuite/data/cms/ODInstructions_record1.xml
+++ b/invenio_opendata/testsuite/data/cms/ODInstructions_record1.xml
@@ -1,6 +1,6 @@
 <collection>
 	<record>
-		<controlfield tag="001">FIXME</controlfield>
+		<controlfield tag="001">70</controlfield>
 		<datafield tag="110" ind1=" " ind2=" ">
 			<subfield code="a">CMS Collaboration</subfield>
 			<subfield code="w">451</subfield>

--- a/invenio_opendata/testsuite/data/cms/ODInstructions_record1.xml
+++ b/invenio_opendata/testsuite/data/cms/ODInstructions_record1.xml
@@ -1,0 +1,33 @@
+<collection>
+	<record>
+		<controlfield tag="001">FIXME</controlfield>
+		<datafield tag="110" ind1=" " ind2=" ">
+			<subfield code="a">CMS Collaboration</subfield>
+			<subfield code="w">451</subfield>
+		</datafield>
+		<datafield tag="245" ind1=" " ind2=" ">
+			<subfield code="a">CMS Pile-up Simulation</subfield>
+		</datafield>
+		<datafield tag="260" ind1=" " ind2=" ">
+			<subfield code="b">CERN Open Data Portal</subfield>
+			<subfield code="c">2016</subfield>
+		</datafield>
+		<datafield tag="264" ind1=" " ind2="0">
+			<subfield code="c">2016</subfield>
+		</datafield>
+		<datafield tag="520" ind1=" " ind2=" ">
+			<subfield code="a">Monte Carlo simulation of pile-up is controlled by the code and configuration files of the package  SimGeneral/MixingModule. An input distribution is specified for each set of production samples which is supposed to represent the distribution of the mean number of interactions seen during data-taking. Below you can find more information on how the simulation proceeds:</subfield>
+			<subfield code="u">/about/CMS-Pileup-Simulation</subfield>
+		</datafield>
+		<datafield tag="693" ind1=" " ind2=" ">
+			<subfield code="a">CERN-LHC</subfield>
+			<subfield code="e">CMS</subfield>
+		</datafield>
+		<datafield tag="964" ind1=" " ind2="0">
+			<subfield code="c">Run2011A</subfield>
+		</datafield>
+		<datafield tag="980" ind1=" " ind2=" ">
+			<subfield code="a">CMS-Open-Data-Instructions</subfield>
+		</datafield>
+	</record>
+</collection>

--- a/invenio_opendata/testsuite/data/cms/ODInstructions_record2.xml
+++ b/invenio_opendata/testsuite/data/cms/ODInstructions_record2.xml
@@ -1,0 +1,33 @@
+<collection>
+	<record>
+		<controlfield tag="001">FIXME</controlfield>
+		<datafield tag="110" ind1=" " ind2=" ">
+			<subfield code="a">CMS Collaboration</subfield>
+			<subfield code="w">451</subfield>
+		</datafield>
+		<datafield tag="245" ind1=" " ind2=" ">
+			<subfield code="a">CMS Simulated Dataset Names</subfield>
+		</datafield>
+		<datafield tag="260" ind1=" " ind2=" ">
+			<subfield code="b">CERN Open Data Portal</subfield>
+			<subfield code="c">2016</subfield>
+		</datafield>
+		<datafield tag="264" ind1=" " ind2="0">
+			<subfield code="c">2016</subfield>
+		</datafield>
+		<datafield tag="520" ind1=" " ind2=" ">
+			<subfield code="a">Below you can find information related to CMS Simulated Dataset Names:</subfield>
+			<subfield code="u">/about/CMS-Simulated-Dataset-Names</subfield>
+		</datafield>
+		<datafield tag="693" ind1=" " ind2=" ">
+			<subfield code="a">CERN-LHC</subfield>
+			<subfield code="e">CMS</subfield>
+		</datafield>
+		<datafield tag="964" ind1=" " ind2="0">
+			<subfield code="c">Run2011A</subfield>
+		</datafield>
+		<datafield tag="980" ind1=" " ind2=" ">
+			<subfield code="a">CMS-Open-Data-Instructions</subfield>
+		</datafield>
+	</record>
+</collection>

--- a/invenio_opendata/testsuite/data/cms/ODInstructions_record2.xml
+++ b/invenio_opendata/testsuite/data/cms/ODInstructions_record2.xml
@@ -1,6 +1,6 @@
 <collection>
 	<record>
-		<controlfield tag="001">FIXME</controlfield>
+		<controlfield tag="001">71</controlfield>
 		<datafield tag="110" ind1=" " ind2=" ">
 			<subfield code="a">CMS Collaboration</subfield>
 			<subfield code="w">451</subfield>


### PR DESCRIPTION
According to discussion with @katilp:
Two new records under collection: Open Data Instructions pointing to
"CMS Pile-up Simulation" and "CMS Simulated Dataset Names" pages,
respectively.