### PR TITLE
CMS: new VM 2011 image

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-tools-vm-image-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-vm-image-Run2011A.xml
@@ -52,7 +52,7 @@
       <subfield code="b">Research</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
-      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-vm-images/CMS-Open-Data-1.2.0-rc3.ova</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-vm-images/CMS-Open-Data-1.2.0.ova</subfield>
     </datafield>
   </record>
   <record>

--- a/invenio_opendata/testsuite/data/cms/cms-vm-contextualisation-scripts-Run2011A/cernvm-script
+++ b/invenio_opendata/testsuite/data/cms/cms-vm-contextualisation-scripts-Run2011A/cernvm-script
@@ -1,5 +1,5 @@
-cvm2ova -n "CMS-Open-Data-1.2.0-rc3" -d 20000 -m 2048 \
--i ucernvm-prod.2.5-2.cernvm.x86_64.hdd \
+cvm2ova -n "CMS-Open-Data-1.2.0" -d 20000 -m 2048 \
+-i ucernvm-prod.2.6-0.cernvm.x86_64.hdd \
 -u cms-user-data.txt
 
 https://github.com/cernvm/cernvm-config/blob/master/usr/bin/cvm2ova


### PR DESCRIPTION
* Updates CMS VM 2011 image to the latest `CMS-Open-Data-1.2.0.ova`
  version sent by Adam. It uses the latest CernVM release that includes
  the fix for a reported logwatch issue. (closes #1113)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>