### PR TITLE
CMS: fix for dimuon spectrum demo analyzer

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-tools-dimuon-spectrum-2010/demoanalyzer_cfg.py
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-dimuon-spectrum-2010/demoanalyzer_cfg.py
@@ -69,5 +69,6 @@ process.demo = cms.EDAnalyzer('DemoAnalyzer'
 # ***********************************************************
 process.TFileService = cms.Service("TFileService",
        fileName = cms.string('Mu.root')
+                                   )                                   
 
 process.p = cms.Path(process.demo)


### PR DESCRIPTION
* Fixes `demoanalyzer_cfg.py` by a new version from
  `/afs/desy.de/user/g/geiser/public/CMS/opendata/MUO-10-004demo/`.
  (closes #1116)