### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,12 +30,12 @@ We follow typical `GitHub flow
    say ``fix-event-display-icons``.
 3. Test your branch on a local site.  If everything works as expected,
    please `sign your commits
-   <http://invenio-software.org/wiki/Tools/Git/Workflow#R2.Remarksoncommitlogmessages>`_
+   <http://inveniosoftware.org/wiki/Tools/Git/Workflow#R2.Remarksoncommitlogmessages>`_
    to indicate its quality.
 4. Create `logically separate commits for logically separate things
-   <http://invenio-software.org/wiki/Tools/Git/Workflow#R1.Remarksoncommithistory>`_.
+   <http://inveniosoftware.org/wiki/Tools/Git/Workflow#R1.Remarksoncommithistory>`_.
    Check out our usual `development practices
-   <http://invenio-software.org/wiki/Development/Contributing>`_.
+   <http://inveniosoftware.org/wiki/Development/Contributing>`_.
 5. Please add any ``(closes #123)`` directives in your commit log
    message if your pull request closes an open issue.
 6. Issue a pull request.  If the branch is not quite ready yet, please

--- a/invenio_opendata/base/templates/about.html
+++ b/invenio_opendata/base/templates/about.html
@@ -88,7 +88,7 @@
           <div class="col-md-12">
             <div class="gen-box">
               <h2 id="invenio">Invenio</h2>
-              <p class="col-md-12 no-padding"><a href="http://invenio-software.org"><img class="aboutimg" src="{{ url_for('static', filename='/img/opendata/invenio.png') }}" alt=""></a>Invenio is a free software suite enabling you to run your own digital library or document repository on the web. The technology offered by the software covers all aspects of digital library management, from document ingestion through classification, indexing, and curation up to document dissemination. Invenio complies with standards such as the Open Archives Initiative and uses MARC 21 as its underlying bibliographic format. The flexibility and performance of Invenio make it a comprehensive solution for management of document repositories of moderate to large sizes.</p>
+              <p class="col-md-12 no-padding"><a href="http://inveniosoftware.org"><img class="aboutimg" src="{{ url_for('static', filename='/img/opendata/invenio.png') }}" alt=""></a>Invenio is a free software suite enabling you to run your own digital library or document repository on the web. The technology offered by the software covers all aspects of digital library management, from document ingestion through classification, indexing, and curation up to document dissemination. Invenio complies with standards such as the Open Archives Initiative and uses MARC 21 as its underlying bibliographic format. The flexibility and performance of Invenio make it a comprehensive solution for management of document repositories of moderate to large sizes.</p>
             </div>
           </div>
 

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     url='https://github.com/cernopendata/opendata.cern.ch',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     description=__doc__,
     long_description=open('README.rst', 'rt').read(),
     packages=find_packages(),


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>