### PR TITLE
ATLAS: software record for 2016 open data release

### DIFF
--- a/invenio_opendata/testsuite/data/atlas/atlas-tools.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-tools.xml
@@ -63,4 +63,76 @@ code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_Maste
 index</subfield>
     </datafield>
   </record>
+  <record>
+    <controlfield tag="001">3850</controlfield>
+    <datafield tag="024" ind1="7" ind2=" ">
+      <subfield code="2">DOI</subfield>
+      <subfield code="a">10.7483/OPENDATA.ATLAS.WS1A.RLES</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">ATLAS Collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">ATLAS Software for 2016 open data release</subfield>
+    </datafield>
+    <datafield tag="256" ind1=" " ind2=" ">
+      <subfield code="a">Software</subfield>
+      <subfield code="f">1</subfield>
+      <subfield code="t">file</subfield>
+    </datafield>
+    <datafield tag="256" ind1=" " ind2=" ">
+      <subfield code="b">45098</subfield>
+      <subfield code="t">bytes</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="516" ind1=" " ind2=" ">
+      <subfield code="a">Use this with ATLAS Data and MC Data for 2016 open data release</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a"><![CDATA[<p>This is an Analysis Framework that is composed of a set of python macros with the objective to manage the reading and analysis of the samples of the 2016 open data release.</p>
+       <p>The Framework is divided into two main functionalities, with examples:
+       <ul>
+        <li>In the first part, a set of seven analysis examples, (W, Z, H and beyond SM analysis) has been included.</li>
+        <li>Those analysis are macros in python with defined cuts that produce a set of histograms.</li>
+        <li>The code is fully customisable by the user, like: samples to use, histograms to produce, the cuts to apply.</li>
+       </ul></p>
+       <p>The second part of the framework, always in python, is responsable to take those histograms and produce plots in a final publication-style, with the correct normalisations, colours, legends and style in general.
+       <ul>
+        <li>The code is fully customisable too, leaving the opportunity to the user to select the samples to use, histograms to produce, style to apply.</li></ul> </p>]]></subfield>
+    </datafield>
+    <datafield tag="538" ind1=" " ind2=" ">
+      <subfield code="a">Software release: V1.0 </subfield>
+      <subfield code="i">Use this code with ATLAS Virtual Machines for 2016 open data release</subfield>
+    </datafield>
+    <datafield tag="540" ind1=" " ind2=" ">
+      <subfield code="a">GNU General Public License (GPL) version 3</subfield>
+    </datafield>
+    <datafield tag="581" ind1=" " ind2=" ">
+      <subfield code="a">More documentation is available at ATLAS GitHub repository:</subfield>
+      <subfield code="u">https://github.com/atlas-outreach-data-tools/atlas-outreach-data-tools-framework/tree/b1b0984f650fa720a66b3f0cbb10fdb1f50ce147</subfield>
+      <subfield code="y">GitHub</subfield>
+    </datafield>
+    <datafield tag="653" ind1="1" ind2=" ">
+      <subfield code="a">ATLAS</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">ATLAS</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012D</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">ATLAS-Tools</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Education</subfield>
+    </datafield>
+  </record>
 </collection>


### PR DESCRIPTION
* Creates ATLAS Software record for 2016 open data release.
  (addresses #1144) (closes #1145)

Signed-off-by: Anxhela Dani anxhela.dani@cern.ch