### PR TITLE
ATLAS: new all samples record for 2016

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -100,6 +100,7 @@ populate *all* collections, you can use::
     -f invenio_opendata/testsuite/data/alice/alice-reconstructed-data.xml \
     -f invenio_opendata/testsuite/data/alice/alice-vm-image.xml \
     -f invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml \
+    -f invenio_opendata/testsuite/data/atlas/atlas-all-samples.xml \
     -f invenio_opendata/testsuite/data/atlas/atlas-simulated-datasets.xml \
     -f invenio_opendata/testsuite/data/atlas/atlas-higgs-challenge-2014.xml \
     -f invenio_opendata/testsuite/data/atlas/atlas-learning-resources.xml \

--- a/invenio_opendata/testsuite/data/atlas/atlas-all-samples.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-all-samples.xml
@@ -1,0 +1,65 @@
+<collection>
+  <record>
+    <controlfield tag="001">3860</controlfield>
+    <datafield tag="024" ind1="7" ind2=" ">
+      <subfield code="2">DOI</subfield>
+      <subfield code="a">10.7483/OPENDATA.ATLAS.AR1U.PNDA</subfield>
+    </datafield>
+    <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">ATLAS Collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">ATLAS samples for 2016 open data release</subfield>
+    </datafield>
+    <datafield tag="256" ind1=" " ind2=" ">
+      <subfield code="a">Dataset</subfield>
+      <subfield code="f">1</subfield>
+      <subfield code="t">files</subfield>
+    </datafield>
+    <datafield tag="256" ind1=" " ind2=" ">
+      <subfield code="b">5982176723</subfield>
+      <subfield code="t">bytes in total</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">The ATLAS collaboration is releasing 1fb^-1 of collision data at a centre-of-mass energy of 8 TeV from the 2012 data taking period for educational purposes to the general public.
+      This set of real data is accompanied by matching simulated data of Standard Model processes and a selection of Beyond the Standard Model signals.</subfield>
+    </datafield>
+    <datafield tag="540" ind1=" " ind2=" ">
+      <subfield code="a">CC0</subfield>
+    </datafield>
+    <datafield tag="567" ind1=" " ind2=" ">
+      <subfield code="a">Both real and simulated data is subjected to a loose event preselection to reduce processing time by reducing the overall number of events that have to be analysed.
+      The preselection consists of a set of object selection criteria and a subsequent event selection acting on these preselected objects.</subfield>
+    </datafield>
+    <datafield tag="581" ind1=" " ind2=" ">
+      <subfield code="a">You can access these data through the ATLAS Virtual Machines and Software. More documentation is available at:</subfield>
+      <subfield code="u">http://atlas-opendata.web.cern.ch/atlas-opendata/extendedanalysis/documentation.php</subfield>
+    </datafield>
+    <datafield tag="653" ind1="1" ind2=" ">
+      <subfield code="a">ATLAS</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">ATLAS</subfield>
+    </datafield>
+    <datafield tag="942" ind1=" " ind2=" ">
+      <subfield code="e">Collision energy: 8TeV</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012D</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Education</subfield>
+    </datafield>
+  </record>
+</collection>


### PR DESCRIPTION
* Creates new all samples record for 2016 open data release.
  (addresses #1148) (closes #1149)

Signed-off-by: Anxhela Dani anxhela.dani@cern.ch