### PR TITLE
ATLAS: EOS files for Run2012D Data records

### DIFF
--- a/invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml
@@ -8893,8 +8893,13 @@ index</subfield>
       <subfield code="a">ATLAS</subfield>
     </datafield>
     <datafield tag="693" ind1=" " ind2=" ">
-      <subfield code="a">CERN-LHC</subfield>  
+      <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
+    </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/Data/DataEgamma.root</subfield>
+      <subfield code="s">746284873</subfield>
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
@@ -8907,6 +8912,10 @@ index</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/DataEgamma_file_index.txt</subfield>
+      <subfield code="z">DataEgamma file index</subfield>
     </datafield>
   </record>
   <record>
@@ -8968,6 +8977,11 @@ index</subfield>
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/Data/DataMuons.root</subfield>
+      <subfield code="s">619800948</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -8979,6 +8993,10 @@ index</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/DataMuons_file_index.txt</subfield>
+      <subfield code="z">DataMuons file index</subfield>
     </datafield>
   </record>
 </collection>

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/DataEgamma_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/DataEgamma_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/Data/DataEgamma.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/DataMuons_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/DataMuons_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/Data/DataMuons.root


### PR DESCRIPTION
* Adds EOS files for Run2012D Data records. (closes #1140)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>