### PR TITLE
ATLAS: addition of record IDs in 538__w

### DIFF
--- a/invenio_opendata/testsuite/data/atlas/atlas-simulated-datasets.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-simulated-datasets.xml
@@ -40,7 +40,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -119,7 +119,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -198,7 +198,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -277,7 +277,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -356,7 +356,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -435,7 +435,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -514,7 +514,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -593,7 +593,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -672,7 +672,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -751,7 +751,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -830,7 +830,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -909,7 +909,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -988,7 +988,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -1067,7 +1067,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -1146,7 +1146,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -1225,7 +1225,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -1304,7 +1304,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -1383,7 +1383,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -1462,7 +1462,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -1541,7 +1541,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -1620,7 +1620,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -1699,7 +1699,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -1778,7 +1778,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -1857,7 +1857,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -1936,7 +1936,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2015,7 +2015,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2094,7 +2094,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2173,7 +2173,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2252,7 +2252,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2331,7 +2331,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2410,7 +2410,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2489,7 +2489,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2568,7 +2568,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2647,7 +2647,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2726,7 +2726,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2805,7 +2805,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2884,7 +2884,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -2963,7 +2963,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -3042,7 +3042,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -3121,7 +3121,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -3200,7 +3200,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>
@@ -3279,7 +3279,7 @@
     </datafield>
     <datafield tag="538" ind1=" " ind2=" ">
       <subfield code="a">Recommended Software Release: ATLAS Software for 2016 open data release - V1.0 </subfield>
-      <subfield code="w"></subfield>
+      <subfield code="w">3850</subfield>
     </datafield>
     <datafield tag="540" ind1=" " ind2=" ">
       <subfield code="a">CC0</subfield>


### PR DESCRIPTION
* Adds record IDs in `538__w` in ATLAS Simulated Datasets.
  (closes #1160)

Signed-off-by: Anxhela Dani <anxhela.dani@cern.ch>