### PR TITLE
ATLAS: EOS files for Run2012D all samples record

### DIFF
--- a/invenio_opendata/testsuite/data/atlas/atlas-all-samples.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-all-samples.xml
@@ -49,6 +49,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/complete_set_of_ATLAS_open_data_samples_July_2016.zip</subfield>
+      <subfield code="s">5982176723</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -60,6 +65,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/complete_set_of_ATLAS_open_data_samples_July_2016_file_index.txt</subfield>
+      <subfield code="z">complete_set_of_ATLAS_open_data_samples_July_2016 file index</subfield>
     </datafield>
   </record>
 </collection>

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/complete_set_of_ATLAS_open_data_samples_July_2016_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/complete_set_of_ATLAS_open_data_samples_July_2016_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/complete_set_of_ATLAS_open_data_samples_July_2016.zip


### PR DESCRIPTION
* Adds EOS files for Run2012D all samples record. (closes #1148)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>