### PR TITLE
ATLAS: EOS files for Run2012D VM records

### DIFF
--- a/invenio_opendata/testsuite/data/atlas/atlas-tools.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-tools.xml
@@ -180,6 +180,11 @@ index</subfield>
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/VM/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_S.vdi.gz</subfield>
+      <subfield code="s">4817828998</subfield>
+    </datafield>
     <datafield tag="964" ind1=" " ind2="0">
       <subfield code="c">Run2012D</subfield>
     </datafield>
@@ -188,6 +193,10 @@ index</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_M_file_index.txt</subfield>
+      <subfield code="z">ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_S file index</subfield>
     </datafield>
   </record>
   <record>
@@ -235,6 +244,11 @@ index</subfield>
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/VM/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_M.vdi.gz</subfield>
+      <subfield code="s">10895737443</subfield>
+    </datafield>
     <datafield tag="964" ind1=" " ind2="0">
       <subfield code="c">Run2012D</subfield>
     </datafield>
@@ -243,6 +257,10 @@ index</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_M_file_index.txt</subfield>
+      <subfield code="z">ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_M file index</subfield>
     </datafield>
   </record>
   <record>
@@ -290,6 +308,11 @@ index</subfield>
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/VM/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_N.vdi.gz</subfield>
+      <subfield code="s">5491698769</subfield>
+    </datafield>
     <datafield tag="964" ind1=" " ind2="0">
       <subfield code="c">Run2012D</subfield>
     </datafield>
@@ -298,6 +321,10 @@ index</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_N_file_index.txt</subfield>
+      <subfield code="z">ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_N file index</subfield>
     </datafield>
   </record>
   <record>

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_M_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_M_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/VM/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_M.vdi.gz

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_N_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_N_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/VM/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_N.vdi.gz

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_S_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_S_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/VM/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_S.vdi.gz


### PR DESCRIPTION
* Adds EOS files for Run2012D VM records. (closes #1146)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>