### PR TITLE
ATLAS: EOS files for Run2012D MC records

### DIFF
--- a/invenio_opendata/testsuite/data/atlas/atlas-simulated-datasets.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-simulated-datasets.xml
@@ -65,6 +65,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_105985.WW.root</subfield>
+      <subfield code="s">64727099</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -76,6 +81,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_105985.WW_file_index.txt</subfield>
+      <subfield code="z">mc_105985.WW file index</subfield>
     </datafield>
   </record>
   <record>
@@ -144,6 +153,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_105986.ZZ.root</subfield>
+      <subfield code="s">19849729</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -155,6 +169,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_105986.ZZ_file_index.txt</subfield>
+      <subfield code="z">mc_105986.ZZ file index</subfield>
     </datafield>
   </record>
   <record>
@@ -223,6 +241,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_105987.WZ.root</subfield>
+      <subfield code="s">69459481</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -234,6 +257,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_105987.WZ_file_index.txt</subfield>
+      <subfield code="z">mc_105987.WZ file index</subfield>
     </datafield>
   </record>
   <record>
@@ -302,6 +329,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110090.stop_tchan_top.root</subfield>
+      <subfield code="s">21637659</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -313,6 +345,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110090.stop_tchan_top_file_index.txt</subfield>
+      <subfield code="z">mc_110090.stop_tchan_top file index</subfield>
     </datafield>
   </record>
   <record>
@@ -381,6 +417,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110091.stop_tchan_antitop.root</subfield>
+      <subfield code="s">14509120</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -392,6 +433,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110091.stop_tchan_antitop_file_index.txt</subfield>
+      <subfield code="z">mc_110091.stop_tchan_antitop file index</subfield>
     </datafield>
   </record>
   <record>
@@ -460,6 +505,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110119.stop_schan.root</subfield>
+      <subfield code="s">15148662</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -471,6 +521,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110119.stop_schan_file_index.txt</subfield>
+      <subfield code="z">mc_110119.stop_schan file index</subfield>
     </datafield>
   </record>
   <record>
@@ -539,6 +593,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110140.stop_wtchan.root</subfield>
+      <subfield code="s">26422422</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -550,6 +609,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110140.stop_wtchan_file_index.txt</subfield>
+      <subfield code="z">mc_110140.stop_wtchan file index</subfield>
     </datafield>
   </record>
   <record>
@@ -618,6 +681,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110899.ZPrime400.root</subfield>
+      <subfield code="s">4389879</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -629,6 +697,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110899.ZPrime400_file_index.txt</subfield>
+      <subfield code="z">mc_110899.ZPrime400 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -697,6 +769,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110901.ZPrime500.root</subfield>
+      <subfield code="s">4765016</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -708,6 +785,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110901.ZPrime500_file_index.txt</subfield>
+      <subfield code="z">mc_110901.ZPrime500 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -776,6 +857,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110902.ZPrime750.root</subfield>
+      <subfield code="s">5400815</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -787,6 +873,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110902.ZPrime750_file_index.txt</subfield>
+      <subfield code="z">mc_110902.ZPrime750 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -855,6 +945,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110903.ZPrime1000.root</subfield>
+      <subfield code="s">5678500</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -866,6 +961,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110903.ZPrime1000_file_index.txt</subfield>
+      <subfield code="z">mc_110903.ZPrime1000 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -934,6 +1033,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110904.ZPrime1250.root</subfield>
+      <subfield code="s">5635939</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -945,6 +1049,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110904.ZPrime1250_file_index.txt</subfield>
+      <subfield code="z">mc_110904.ZPrime1250 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1013,6 +1121,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110905.ZPrime1500.root</subfield>
+      <subfield code="s">5474660</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -1024,6 +1137,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110905.ZPrime1500_file_index.txt</subfield>
+      <subfield code="z">mc_110905.ZPrime1500 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1092,6 +1209,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110906.ZPrime1750.root</subfield>
+      <subfield code="s">5241751</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -1103,6 +1225,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110906.ZPrime1750_file_index.txt</subfield>
+      <subfield code="z">mc_110906.ZPrime1750 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1171,6 +1297,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110907.ZPrime2000.root</subfield>
+      <subfield code="s">5000024</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -1182,6 +1313,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110907.ZPrime2000_file_index.txt</subfield>
+      <subfield code="z">mc_110907.ZPrime2000 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1250,6 +1385,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110908.ZPrime2250.root</subfield>
+      <subfield code="s">4798092</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -1261,6 +1401,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110908.ZPrime2250_file_index.txt</subfield>
+      <subfield code="z">mc_110908.ZPrime2250 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1329,6 +1473,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110909.ZPrime2500.root</subfield>
+      <subfield code="s">4610759</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -1340,6 +1489,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110909.ZPrime2500_file_index.txt</subfield>
+      <subfield code="z">mc_110909.ZPrime2500 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1408,6 +1561,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110910.ZPrime3000.root</subfield>
+      <subfield code="s">4408997</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -1419,6 +1577,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_110910.ZPrime3000_file_index.txt</subfield>
+      <subfield code="z">mc_110910.ZPrime3000 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1487,6 +1649,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_117049.ttbar_had.root</subfield>
+      <subfield code="s">5825184</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -1498,6 +1665,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_117049.ttbar_had_file_index.txt</subfield>
+      <subfield code="z">mc_117049.ttbar_had file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1566,6 +1737,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_117050.ttbar_lep.root</subfield>
+      <subfield code="s">300090186</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -1577,6 +1753,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_117050.ttbar_lep_file_index.txt</subfield>
+      <subfield code="z">mc_117050.ttbar_lep file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1645,6 +1825,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_147770.Zee.root</subfield>
+      <subfield code="s">966133549</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy:8TeV</subfield>
     </datafield>
@@ -1656,6 +1841,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_147770.Zee_file_index.txt</subfield>
+      <subfield code="z">mc_147770.Zee file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1724,6 +1913,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_147771.Zmumu.root</subfield>
+      <subfield code="s">946361551</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -1735,6 +1929,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_147771.Zmumu_file_index.txt</subfield>
+      <subfield code="z">mc_147771.Zmumu file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1803,6 +2001,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_147772.Ztautau.root</subfield>
+      <subfield code="s">95788974</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -1814,6 +2017,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_147772.Ztautau_file_index.txt</subfield>
+      <subfield code="z">mc_147772.Ztautau file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1882,6 +2089,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_160155.ggH125_ZZ4lep.root</subfield>
+      <subfield code="s">17580529</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -1893,6 +2105,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_160155.ggH125_ZZ4lep_file_index.txt</subfield>
+      <subfield code="z">mc_160155.ggH125_ZZ4lep file index</subfield>
     </datafield>
   </record>
   <record>
@@ -1961,6 +2177,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_160205.VBFH125_ZZ4lep.root</subfield>
+      <subfield code="s">19380185</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -1972,6 +2193,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_160205.VBFH125_ZZ4lep_file_index.txt</subfield>
+      <subfield code="z">mc_160205.VBFH125_ZZ4lep file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2040,6 +2265,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_161005.ggH125_WW2lep.root</subfield>
+      <subfield code="s">13607410</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2051,6 +2281,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_161005.ggH125_WW2lep_file_index.txt</subfield>
+      <subfield code="z">mc_161005.ggH125_WW2lep file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2119,6 +2353,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_161055.VBFH125_WW2lep.root</subfield>
+      <subfield code="s">15389694</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2130,6 +2369,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_161055.VBFH125_WW2lep_file_index.txt</subfield>
+      <subfield code="z">mc_161055.VBFH125_WW2lep file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2198,6 +2441,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167740.WenuWithB.root</subfield>
+      <subfield code="s">88002379</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2209,6 +2457,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_167740.WenuWithB_file_index.txt</subfield>
+      <subfield code="z">mc_167740.WenuWithB file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2277,6 +2529,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167741.WenuJetsBVeto.root</subfield>
+      <subfield code="s">305358713</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2288,6 +2545,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_167741.WenuJetsBVeto_file_index.txt</subfield>
+      <subfield code="z">mc_167741.WenuJetsBVeto file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2356,6 +2617,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167742.WenuNoJetsBVeto.root</subfield>
+      <subfield code="s">747210223</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2367,6 +2633,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_167742.WenuNoJetsBVeto_file_index.txt</subfield>
+      <subfield code="z">mc_167742.WenuNoJetsBVeto file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2435,6 +2705,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167743.WmunuWithB.root</subfield>
+      <subfield code="s">86686414</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2446,6 +2721,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_167743.WmunuWithB_file_index.txt</subfield>
+      <subfield code="z">mc_167743.WmunuWithB file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2514,6 +2793,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167744.WmunuJetsBVeto.root</subfield>
+      <subfield code="s">296131195</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2525,6 +2809,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_167744.WmunuJetsBVeto_file_index.txt</subfield>
+      <subfield code="z">mc_167744.WmunuJetsBVeto file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2593,6 +2881,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167745.WmunuNoJetsBVeto.root</subfield>
+      <subfield code="s">689245060</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2604,6 +2897,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_167745.WmunuNoJetsBVeto_file_index.txt</subfield>
+      <subfield code="z">mc_167745.WmunuNoJetsBVeto file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2672,6 +2969,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167746.WtaunuWithB.root</subfield>
+      <subfield code="s">12840353</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2683,6 +2985,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_167746.WtaunuWithB_file_index.txt</subfield>
+      <subfield code="z">mc_167746.WtaunuWithB file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2751,6 +3057,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167747.WtaunuJetsBVeto.root</subfield>
+      <subfield code="s">31642922</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2762,6 +3073,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_167747.WtaunuJetsBVeto_file_index.txt</subfield>
+      <subfield code="z">mc_167747.WtaunuJetsBVeto file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2830,6 +3145,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167748.WtaunuNoJetsBVeto.root</subfield>
+      <subfield code="s">56349987</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2841,6 +3161,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_167748.WtaunuNoJetsBVeto_file_index.txt</subfield>
+      <subfield code="z">mc_167748.WtaunuNoJetsBVeto file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2909,6 +3233,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173041.DYeeM08to15.root</subfield>
+      <subfield code="s">58248307</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2920,6 +3249,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_173041.DYeeM08to15_file_index.txt</subfield>
+      <subfield code="z">mc_173041.DYeeM08to15 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -2988,6 +3321,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173042.DYeeM15to40.root</subfield>
+      <subfield code="s">102182246</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -2999,6 +3337,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_173042.DYeeM15to40_file_index.txt</subfield>
+      <subfield code="z">mc_173042.DYeeM15to40 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -3067,6 +3409,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173043.DYmumuM08to15.root</subfield>
+      <subfield code="s">76091119</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -3078,6 +3425,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_173043.DYmumuM08to15_file_index.txt</subfield>
+      <subfield code="z">mc_173043.DYmumuM08to15 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -3146,6 +3497,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173044.DYmumuM15to40.root</subfield>
+      <subfield code="s">105863682</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -3157,6 +3513,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_173044.DYmumuM15to40_file_index.txt</subfield>
+      <subfield code="z">mc_173044.DYmumuM15to40 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -3225,6 +3585,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173045.DYtautauM08to15.root</subfield>
+      <subfield code="s">1463082</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -3236,6 +3601,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_173045.DYtautauM08to15_file_index.txt</subfield>
+      <subfield code="z">mc_173045.DYtautauM08to15 file index</subfield>
     </datafield>
   </record>
   <record>
@@ -3304,6 +3673,11 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
+    <datafield tag="856" ind1="7" ind2=" ">
+      <subfield code="2">xrootd</subfield>
+      <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173046.DYtautauM15to40.root</subfield>
+      <subfield code="s">4629749</subfield>
+    </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
     </datafield>
@@ -3315,6 +3689,10 @@
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">Education</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1=" " ind2=" ">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/mc_173046.DYtautauM15to40_file_index.txt</subfield>
+      <subfield code="z">mc_173046.DYtautauM15to40 file index</subfield>
     </datafield>
   </record>
 </collection>

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_105985.WW_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_105985.WW_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_105985.WW.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_105986.ZZ_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_105986.ZZ_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_105986.ZZ.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_105987.WZ_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_105987.WZ_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_105987.WZ.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110090.stop_tchan_top_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110090.stop_tchan_top_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110090.stop_tchan_top.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110091.stop_tchan_antitop_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110091.stop_tchan_antitop_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110091.stop_tchan_antitop.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110119.stop_schan_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110119.stop_schan_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110119.stop_schan.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110140.stop_wtchan_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110140.stop_wtchan_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110140.stop_wtchan.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110899.ZPrime400_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110899.ZPrime400_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110899.ZPrime400.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110901.ZPrime500_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110901.ZPrime500_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110901.ZPrime500.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110902.ZPrime750_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110902.ZPrime750_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110902.ZPrime750.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110903.ZPrime1000_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110903.ZPrime1000_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110903.ZPrime1000.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110904.ZPrime1250_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110904.ZPrime1250_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110904.ZPrime1250.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110905.ZPrime1500_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110905.ZPrime1500_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110905.ZPrime1500.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110906.ZPrime1750_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110906.ZPrime1750_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110906.ZPrime1750.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110907.ZPrime2000_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110907.ZPrime2000_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110907.ZPrime2000.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110908.ZPrime2250_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110908.ZPrime2250_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110908.ZPrime2250.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110909.ZPrime2500_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110909.ZPrime2500_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110909.ZPrime2500.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110910.ZPrime3000_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_110910.ZPrime3000_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110910.ZPrime3000.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_117049.ttbar_had_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_117049.ttbar_had_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_117049.ttbar_had.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_117050.ttbar_lep_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_117050.ttbar_lep_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_117050.ttbar_lep.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_147770.Zee_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_147770.Zee_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_147770.Zee.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_147771.Zmumu_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_147771.Zmumu_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_147771.Zmumu.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_147772.Ztautau_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_147772.Ztautau_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_147772.Ztautau.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_160155.ggH125_ZZ4lep_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_160155.ggH125_ZZ4lep_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_160155.ggH125_ZZ4lep.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_160205.VBFH125_ZZ4lep_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_160205.VBFH125_ZZ4lep_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_160205.VBFH125_ZZ4lep.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_161005.ggH125_WW2lep_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_161005.ggH125_WW2lep_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_161005.ggH125_WW2lep.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_161055.VBFH125_WW2lep_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_161055.VBFH125_WW2lep_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_161055.VBFH125_WW2lep.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167740.WenuWithB_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167740.WenuWithB_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167740.WenuWithB.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167741.WenuJetsBVeto_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167741.WenuJetsBVeto_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167741.WenuJetsBVeto.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167742.WenuNoJetsBVeto_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167742.WenuNoJetsBVeto_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167742.WenuNoJetsBVeto.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167743.WmunuWithB_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167743.WmunuWithB_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167743.WmunuWithB.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167744.WmunuJetsBVeto_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167744.WmunuJetsBVeto_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167744.WmunuJetsBVeto.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167745.WmunuNoJetsBVeto_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167745.WmunuNoJetsBVeto_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167745.WmunuNoJetsBVeto.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167746.WtaunuWithB_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167746.WtaunuWithB_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167746.WtaunuWithB.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167747.WtaunuJetsBVeto_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167747.WtaunuJetsBVeto_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167747.WtaunuJetsBVeto.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167748.WtaunuNoJetsBVeto_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_167748.WtaunuNoJetsBVeto_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167748.WtaunuNoJetsBVeto.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_173041.DYeeM08to15_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_173041.DYeeM08to15_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173041.DYeeM08to15.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_173042.DYeeM15to40_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_173042.DYeeM15to40_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173042.DYeeM15to40.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_173043.DYmumuM08to15_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_173043.DYmumuM08to15_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173043.DYmumuM08to15.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_173044.DYmumuM15to40_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_173044.DYmumuM15to40_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173044.DYmumuM15to40.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_173045.DYtautauM08to15_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_173045.DYtautauM08to15_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173045.DYtautauM08to15.root

--- a/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_173046.DYtautauM15to40_file_index.txt
+++ b/invenio_opendata/testsuite/data/atlas/eos-file-indexes/mc_173046.DYtautauM15to40_file_index.txt
@@ -1,0 +1,1 @@
+root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173046.DYtautauM15to40.root


### PR DESCRIPTION
* Adds EOS files for Run2012D MC records. (closes #1142)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>