### PR TITLE
ATLAS:update of ATLAS Derived Datasets records

### DIFF
--- a/invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml
@@ -2,7 +2,7 @@
   <record>
     <controlfield tag="001">320</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2014 Masterclass dataset 1</subfield>
@@ -24,6 +24,9 @@
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2014</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 events taken in 2011 by the ATLAS Detector, used in the Physics Masterclasses W Path</subfield>
     </datafield>
@@ -37,7 +40,7 @@
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -141,8 +144,23 @@
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1T.zip</subfield>
       <subfield code="s">8297961</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2014</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011I</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011J</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_1_file_index.txt</subfield>
@@ -152,7 +170,7 @@
   <record>
     <controlfield tag="001">321</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2014 Masterclass dataset 2</subfield>
@@ -174,6 +192,9 @@
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2014</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 events taken in 2011 by the ATLAS Detector, used in the Physics Masterclasses W Path</subfield>
     </datafield>
@@ -187,7 +208,7 @@
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -291,8 +312,23 @@
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2T.zip</subfield>
       <subfield code="s">8765904</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2014</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011I</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011J</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_2_file_index.txt</subfield>
@@ -302,7 +338,7 @@
   <record>
     <controlfield tag="001">322</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2014 Masterclass dataset 3</subfield>
@@ -324,6 +360,9 @@
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2014</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 events taken in 2011 by the ATLAS Detector, used in the Physics Masterclasses W Path</subfield>
     </datafield>
@@ -337,7 +376,7 @@
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -441,8 +480,23 @@
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3T.zip</subfield>
       <subfield code="s">8032391</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2014</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011I</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011J</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_3_file_index.txt</subfield>
@@ -452,7 +506,7 @@
   <record>
     <controlfield tag="001">323</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2014 Masterclass dataset 4</subfield>
@@ -474,6 +528,9 @@
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2014</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 events taken in 2011 by the ATLAS Detector, used in the Physics Masterclasses W Path</subfield>
     </datafield>
@@ -487,7 +544,7 @@
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -591,8 +648,23 @@
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4T.zip</subfield>
       <subfield code="s">8305498</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2014</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011I</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011J</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_4_file_index.txt</subfield>
@@ -602,7 +674,7 @@
   <record>
     <controlfield tag="001">324</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2014 Masterclass dataset 5</subfield>
@@ -624,6 +696,9 @@
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2014</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 events taken in 2011 by the ATLAS Detector, used in the Physics Masterclasses W Path</subfield>
     </datafield>
@@ -637,7 +712,7 @@
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -741,8 +816,23 @@
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5T.zip</subfield>
       <subfield code="s">8198176</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2014</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011I</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011J</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_5_file_index.txt</subfield>
@@ -752,7 +842,7 @@
   <record>
     <controlfield tag="001">325</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2014 Masterclass dataset 6</subfield>
@@ -774,6 +864,9 @@
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2014</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 events taken in 2011 by the ATLAS Detector, used in the Physics Masterclasses W Path</subfield>
     </datafield>
@@ -787,7 +880,7 @@
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -891,8 +984,23 @@
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6T.zip</subfield>
       <subfield code="s">8637499</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2014</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011I</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011J</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_6_file_index.txt</subfield>
@@ -902,7 +1010,7 @@
   <record>
     <controlfield tag="001">340</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2015 Masterclass dataset 1</subfield>
@@ -923,6 +1031,9 @@
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
@@ -947,7 +1058,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -1051,8 +1162,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1T.zip</subfield>
       <subfield code="s">12512876</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011L</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -1064,7 +1187,7 @@ index</subfield>
   <record>
     <controlfield tag="001">341</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2015 Masterclass dataset 2</subfield>
@@ -1085,6 +1208,9 @@ index</subfield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
@@ -1109,7 +1235,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -1213,8 +1339,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2T.zip</subfield>
       <subfield code="s">11821966</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011L</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -1226,7 +1364,7 @@ index</subfield>
   <record>
     <controlfield tag="001">342</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2015 Masterclass dataset 3</subfield>
@@ -1247,6 +1385,9 @@ index</subfield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
@@ -1271,7 +1412,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -1375,8 +1516,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3T.zip</subfield>
       <subfield code="s">10964115</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011L</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -1388,7 +1541,7 @@ index</subfield>
   <record>
     <controlfield tag="001">343</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2015 Masterclass dataset 4</subfield>
@@ -1409,6 +1562,9 @@ index</subfield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
@@ -1433,7 +1589,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -1537,8 +1693,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4T.zip</subfield>
       <subfield code="s">12003126</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011L</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -1550,7 +1718,7 @@ index</subfield>
   <record>
     <controlfield tag="001">344</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2015 Masterclass dataset 5</subfield>
@@ -1571,6 +1739,9 @@ index</subfield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
@@ -1595,7 +1766,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -1699,8 +1870,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5T.zip</subfield>
       <subfield code="s">12183104</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011L</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -1712,7 +1895,7 @@ index</subfield>
   <record>
     <controlfield tag="001">345</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2015 Masterclass dataset 6</subfield>
@@ -1733,6 +1916,9 @@ index</subfield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
@@ -1757,7 +1943,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -1861,8 +2047,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6T.zip</subfield>
       <subfield code="s">10245624</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011L</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -1874,7 +2072,7 @@ index</subfield>
   <record>
     <controlfield tag="001">346</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2015 Masterclass dataset 7</subfield>
@@ -1895,6 +2093,9 @@ index</subfield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
@@ -1919,7 +2120,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -2023,8 +2224,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7T.zip</subfield>
       <subfield code="s">11538696</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011L</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -2036,7 +2249,7 @@ index</subfield>
   <record>
     <controlfield tag="001">347</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2015 Masterclass dataset 8</subfield>
@@ -2057,6 +2270,9 @@ index</subfield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
@@ -2081,7 +2297,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -2185,8 +2401,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8T.zip</subfield>
       <subfield code="s">11125793</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011L</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -2198,7 +2426,7 @@ index</subfield>
   <record>
     <controlfield tag="001">348</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2015 Masterclass dataset 9</subfield>
@@ -2219,6 +2447,9 @@ index</subfield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
@@ -2243,7 +2474,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -2347,8 +2578,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9T.zip</subfield>
       <subfield code="s">10890972</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011L</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -2360,7 +2603,7 @@ index</subfield>
   <record>
     <controlfield tag="001">349</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2015 Masterclass dataset 10</subfield>
@@ -2381,6 +2624,9 @@ index</subfield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
@@ -2405,7 +2651,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -2509,8 +2755,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10T.zip</subfield>
       <subfield code="s">11837451</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011L</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -2522,7 +2780,7 @@ index</subfield>
   <record>
     <controlfield tag="001">350</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2015 Masterclass dataset 11</subfield>
@@ -2543,6 +2801,9 @@ index</subfield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
@@ -2567,7 +2828,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -2671,8 +2932,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11T.zip</subfield>
       <subfield code="s">11492346</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011L</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -2684,7 +2957,7 @@ index</subfield>
   <record>
     <controlfield tag="001">351</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS WPath 2015 Masterclass dataset 12</subfield>
@@ -2705,6 +2978,9 @@ index</subfield>
     <datafield tag="260" ind1=" " ind2=" ">
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
+    </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2011</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
@@ -2729,7 +3005,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -2833,8 +3109,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12T.zip</subfield>
       <subfield code="s">12511530</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011K</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011L</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -2846,7 +3134,7 @@ index</subfield>
   <record>
     <controlfield tag="001">353</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 1</subfield>
@@ -2868,9 +3156,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -2891,7 +3182,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -2995,8 +3286,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupT.zip</subfield>
       <subfield code="s">32018492</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -3008,7 +3311,7 @@ index</subfield>
   <record>
     <controlfield tag="001">354</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 2</subfield>
@@ -3030,9 +3333,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -3053,7 +3359,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -3157,8 +3463,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupT.zip</subfield>
       <subfield code="s">30479301</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -3170,7 +3488,7 @@ index</subfield>
   <record>
     <controlfield tag="001">355</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 3</subfield>
@@ -3192,9 +3510,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -3215,7 +3536,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -3319,8 +3640,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupT.zip</subfield>
       <subfield code="s">32996991</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -3332,7 +3665,7 @@ index</subfield>
   <record>
     <controlfield tag="001">356</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 4</subfield>
@@ -3354,9 +3687,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -3377,7 +3713,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -3481,8 +3817,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupT.zip</subfield>
       <subfield code="s">32558053</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -3494,7 +3842,7 @@ index</subfield>
   <record>
     <controlfield tag="001">357</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 5</subfield>
@@ -3516,9 +3864,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -3539,7 +3890,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -3643,8 +3994,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupT.zip</subfield>
       <subfield code="s">31863887</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -3678,9 +4041,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -3701,7 +4067,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -3805,8 +4171,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupT.zip</subfield>
       <subfield code="s">31816713</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -3818,7 +4196,7 @@ index</subfield>
   <record>
     <controlfield tag="001">359</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 7</subfield>
@@ -3840,9 +4218,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -3863,7 +4244,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -3967,8 +4348,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupT.zip</subfield>
       <subfield code="s">30776350</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -3980,7 +4373,7 @@ index</subfield>
   <record>
     <controlfield tag="001">360</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 8</subfield>
@@ -4002,9 +4395,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -4025,7 +4421,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -4129,8 +4525,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupT.zip</subfield>
       <subfield code="s">31219842</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -4142,7 +4550,7 @@ index</subfield>
   <record>
     <controlfield tag="001">361</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 9</subfield>
@@ -4164,9 +4572,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -4187,7 +4598,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -4291,8 +4702,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupT.zip</subfield>
       <subfield code="s">27945436</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -4304,7 +4727,7 @@ index</subfield>
   <record>
     <controlfield tag="001">362</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 10</subfield>
@@ -4326,9 +4749,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -4349,7 +4775,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -4453,8 +4879,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupT.zip</subfield>
       <subfield code="s">27932106</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -4466,7 +4904,7 @@ index</subfield>
   <record>
     <controlfield tag="001">363</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 11</subfield>
@@ -4488,9 +4926,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -4511,7 +4952,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -4615,8 +5056,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupT.zip</subfield>
       <subfield code="s">28346170</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -4628,7 +5081,7 @@ index</subfield>
   <record>
     <controlfield tag="001">364</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 12</subfield>
@@ -4650,9 +5103,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -4673,7 +5129,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -4777,8 +5233,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupT.zip</subfield>
       <subfield code="s">31341595</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -4790,7 +5258,7 @@ index</subfield>
   <record>
     <controlfield tag="001">365</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 13</subfield>
@@ -4812,9 +5280,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -4835,7 +5306,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -4939,8 +5410,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupT.zip</subfield>
       <subfield code="s">29136102</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -4952,7 +5435,7 @@ index</subfield>
   <record>
     <controlfield tag="001">366</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 14</subfield>
@@ -4974,9 +5457,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -4997,7 +5483,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -5101,8 +5587,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupT.zip</subfield>
       <subfield code="s">30380370</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -5114,7 +5612,7 @@ index</subfield>
   <record>
     <controlfield tag="001">367</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 15</subfield>
@@ -5136,9 +5634,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -5159,7 +5660,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -5263,8 +5764,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupT.zip</subfield>
       <subfield code="s">31778090</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -5276,7 +5789,7 @@ index</subfield>
   <record>
     <controlfield tag="001">368</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 16</subfield>
@@ -5298,9 +5811,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -5321,7 +5837,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -5425,8 +5941,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupT.zip</subfield>
       <subfield code="s">30181136</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -5438,7 +5966,7 @@ index</subfield>
   <record>
     <controlfield tag="001">369</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 17</subfield>
@@ -5460,9 +5988,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -5483,7 +6014,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -5587,8 +6118,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupT.zip</subfield>
       <subfield code="s">29888671</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -5600,7 +6143,7 @@ index</subfield>
   <record>
     <controlfield tag="001">370</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 18</subfield>
@@ -5622,9 +6165,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -5645,7 +6191,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -5749,8 +6295,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupT.zip</subfield>
       <subfield code="s">29937114</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -5762,7 +6320,7 @@ index</subfield>
   <record>
     <controlfield tag="001">371</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 19</subfield>
@@ -5784,9 +6342,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -5807,7 +6368,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -5911,8 +6472,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupT.zip</subfield>
       <subfield code="s">32411975</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -5924,7 +6497,7 @@ index</subfield>
   <record>
     <controlfield tag="001">372</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 20</subfield>
@@ -5946,9 +6519,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -5969,7 +6545,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -6073,8 +6649,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupT.zip</subfield>
       <subfield code="s">27218509</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -6086,7 +6674,7 @@ index</subfield>
   <record>
     <controlfield tag="001">373</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 21</subfield>
@@ -6108,9 +6696,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -6131,7 +6722,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -6235,8 +6826,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupT.zip</subfield>
       <subfield code="s">31552890</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -6248,7 +6851,7 @@ index</subfield>
   <record>
     <controlfield tag="001">374</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 22</subfield>
@@ -6270,9 +6873,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -6293,7 +6899,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -6397,8 +7003,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupT.zip</subfield>
       <subfield code="s">31287173</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -6410,7 +7028,7 @@ index</subfield>
   <record>
     <controlfield tag="001">375</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 23</subfield>
@@ -6432,9 +7050,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -6455,7 +7076,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -6559,8 +7180,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupT.zip</subfield>
       <subfield code="s">29817809</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -6572,7 +7205,7 @@ index</subfield>
   <record>
     <controlfield tag="001">376</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 24</subfield>
@@ -6594,9 +7227,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -6617,7 +7253,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -6721,8 +7357,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupT.zip</subfield>
       <subfield code="s">28988152</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -6734,7 +7382,7 @@ index</subfield>
   <record>
     <controlfield tag="001">377</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 25</subfield>
@@ -6756,9 +7404,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -6779,7 +7430,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -6883,8 +7534,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupT.zip</subfield>
       <subfield code="s">29630008</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -6896,7 +7559,7 @@ index</subfield>
   <record>
     <controlfield tag="001">378</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 26</subfield>
@@ -6918,9 +7581,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -6941,7 +7607,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -7045,8 +7711,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupT.zip</subfield>
       <subfield code="s">28124831</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -7058,7 +7736,7 @@ index</subfield>
   <record>
     <controlfield tag="001">379</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 27</subfield>
@@ -7080,9 +7758,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -7103,7 +7784,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -7207,8 +7888,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupT.zip</subfield>
       <subfield code="s">31373657</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -7220,7 +7913,7 @@ index</subfield>
   <record>
     <controlfield tag="001">380</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 28</subfield>
@@ -7242,9 +7935,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -7265,7 +7961,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -7369,8 +8065,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupT.zip</subfield>
       <subfield code="s">31950559</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -7382,7 +8090,7 @@ index</subfield>
   <record>
     <controlfield tag="001">381</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 29</subfield>
@@ -7404,9 +8112,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -7427,7 +8138,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -7531,8 +8242,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupT.zip</subfield>
       <subfield code="s">27229939</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -7544,7 +8267,7 @@ index</subfield>
   <record>
     <controlfield tag="001">382</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 30</subfield>
@@ -7566,9 +8289,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -7589,7 +8315,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -7693,8 +8419,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupT.zip</subfield>
       <subfield code="s">25871115</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -7706,7 +8444,7 @@ index</subfield>
   <record>
     <controlfield tag="001">383</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 31</subfield>
@@ -7728,9 +8466,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -7751,7 +8492,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -7855,8 +8596,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupT.zip</subfield>
       <subfield code="s">27963600</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -7868,7 +8621,7 @@ index</subfield>
   <record>
     <controlfield tag="001">384</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 32</subfield>
@@ -7890,9 +8643,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -7913,7 +8669,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -8017,8 +8773,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupT.zip</subfield>
       <subfield code="s">29442718</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -8030,7 +8798,7 @@ index</subfield>
   <record>
     <controlfield tag="001">385</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 33</subfield>
@@ -8052,9 +8820,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -8075,7 +8846,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -8179,8 +8950,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupT.zip</subfield>
       <subfield code="s">29297063</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -8192,7 +8975,7 @@ index</subfield>
   <record>
     <controlfield tag="001">386</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 34</subfield>
@@ -8214,9 +8997,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -8237,7 +9023,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -8341,8 +9127,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupT.zip</subfield>
       <subfield code="s">29278041</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -8354,7 +9152,7 @@ index</subfield>
   <record>
     <controlfield tag="001">387</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 35</subfield>
@@ -8376,9 +9174,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -8399,7 +9200,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -8503,8 +9304,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupT.zip</subfield>
       <subfield code="s">30879302</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -8516,7 +9329,7 @@ index</subfield>
   <record>
     <controlfield tag="001">388</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 36</subfield>
@@ -8538,9 +9351,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -8561,7 +9377,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -8665,8 +9481,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupT.zip</subfield>
       <subfield code="s">28614813</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -8678,7 +9506,7 @@ index</subfield>
   <record>
     <controlfield tag="001">389</controlfield>
     <datafield tag="110" ind1=" " ind2=" ">
-      <subfield code="a">ATLAS collaboration</subfield>
+      <subfield code="a">ATLAS Collaboration</subfield>
     </datafield>
     <datafield tag="245" ind1=" " ind2=" ">
       <subfield code="a">ATLAS ZPath 2015 Masterclass dataset 37</subfield>
@@ -8700,9 +9528,12 @@ index</subfield>
       <subfield code="b">CERN Open Data Portal</subfield>
       <subfield code="c">2016</subfield>
     </datafield>
+    <datafield tag="264" ind1=" " ind2="0">
+      <subfield code="c">2012</subfield>
+    </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2011
+HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
 by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
@@ -8723,7 +9554,7 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">ATLAS</subfield>
     </datafield>
-    <datafield tag="693" ind1="1" ind2=" ">
+    <datafield tag="693" ind1=" " ind2=" ">
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">ATLAS</subfield>
     </datafield>
@@ -8827,8 +9658,20 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupT.zip</subfield>
       <subfield code="s">26066893</subfield>
     </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2015</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012B</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2012C</subfield>
+    </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">ATLAS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">Education</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
@@ -8907,6 +9750,9 @@ index</subfield>
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
+    </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="964" ind1=" " ind2="0">
       <subfield code="c">Run2012D</subfield>
@@ -8992,6 +9838,9 @@ index</subfield>
     </datafield>
     <datafield tag="942" ind1=" " ind2=" ">
       <subfield code="e">Collision energy: 8TeV</subfield>
+    </datafield>
+    <datafield tag="960" ind1=" " ind2=" ">
+      <subfield code="c">2016</subfield>
     </datafield>
     <datafield tag="964" ind1=" " ind2="0">
       <subfield code="c">Run2012D</subfield>


### PR DESCRIPTION
- Correction of text in `110__ $a` and `520__ $a`
- Correction of `6931_` field to `693__`
- Addition of `264_0 $c`, `960__ $c` , `964_0 $c` and `980__ $a`

(addresses #1181 )

Signed-off-by: Anxhela Dani anxhela.dani@cern.ch