### PR TITLE
records: data model field update (786)

### DIFF
--- a/invenio_opendata/base/recordext/fields/opendata.cfg
+++ b/invenio_opendata/base/recordext/fields/opendata.cfg
@@ -308,6 +308,14 @@ issued_with_entry:
     producer:
         json_for_marc(), {"777__a": "heading", "777__u": "url", "777__w": "recid", "777__y": "description" }
 
+# 786__a 786__w
+
+data_source_entry:
+    creator:
+        marc, "786__", {'heading': value['a'], 'recid': value['w']}
+    producer:
+        json_for_marc(), {"786__a": "heading", "786__w": "recid"}
+
 # 787__a 787__o 787__u 787__w 787__y
 
 other_relationship_entry:


### PR DESCRIPTION
* Adds `786__a` & `786__w` to the data model.
  (closes #1179) (PR #1180)

Signed-off-by: Anxhela Dani <anxhela.dani@cern.ch>