### PR TITLE
CMS: fix for visualisation tool records

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-open-data-instructions.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-open-data-instructions.xml
@@ -86,7 +86,7 @@
       <subfield code="e">CMS</subfield>
     </datafield>
     <datafield tag="856" ind1="4" ind2=" ">
-      <subfield code="a">http://opendata.cern.ch/visualise/histograms/CMS</subfield>
+      <subfield code="u">http://opendata.cern.ch/visualise/histograms/CMS</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Open-Data-Instructions</subfield>
@@ -115,7 +115,7 @@
       <subfield code="e">CMS</subfield>
     </datafield>
     <datafield tag="856" ind1="4" ind2=" ">
-      <subfield code="a">http://opendata.cern.ch/visualise/events/CMS</subfield>
+      <subfield code="u">http://opendata.cern.ch/visualise/events/CMS</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="a">CMS-Open-Data-Instructions</subfield>


### PR DESCRIPTION
* Fixes metadata of CMS visualisation tool records 57 and 58, resolving Internal
  Server Error issues at the same time. (closes #1199)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>