### PR TITLE
CMS: fix record 50 as learning resource

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-learning-resources.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-learning-resources.xml
@@ -38,7 +38,7 @@
       <subfield code="c">Run2011A</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
-      <subfield code="a">CMS-Open-Data-Instructions</subfield>
+      <subfield code="a">CMS-Learning-Resources</subfield>
     </datafield>
     <datafield tag="980" ind1=" " ind2=" ">
       <subfield code="b">Education</subfield>


### PR DESCRIPTION
* Fixes record 50 that was catalogued as CMS Open Data Instructions,
  not as CMS Learning Resources. (closes #1198)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>