### PR TITLE
ATLAS: updated EOS file listings for ZPath 2015

### DIFF
--- a/invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml
+++ b/invenio_opendata/testsuite/data/atlas/atlas-derived-datasets.xml
@@ -1037,20 +1037,20 @@
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
-by the ATLAS detector.</subfield>
+      MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which
-can be found on the linked site in the section "Measurement". There you will
-also find a tally sheet and links to instructions on how to analyse the data
-found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Measurement" to find out how the proton is
-structured and to hunt for the Higgs particle.</subfield>
+      can be found on the linked site in the section "Measurement". There you will
+      also find a tally sheet and links to instructions on how to analyse the data
+      found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Measurement" to find out how the proton is
+      structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -1179,9 +1179,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_1_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_1_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass WPath 2015 dataset 1 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -1214,20 +1214,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
-by the ATLAS detector.</subfield>
+      MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which
-can be found on the linked site in the section "Measurement". There you will
-also find a tally sheet and links to instructions on how to analyse the data
-found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Measurement" to find out how the proton is
-structured and to hunt for the Higgs particle.</subfield>
+      can be found on the linked site in the section "Measurement". There you will
+      also find a tally sheet and links to instructions on how to analyse the data
+      found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Measurement" to find out how the proton is
+      structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -1356,9 +1356,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_2_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_2_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass WPath 2015 dataset 2 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -1391,20 +1391,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
-by the ATLAS detector.</subfield>
+      MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which
-can be found on the linked site in the section "Measurement". There you will
-also find a tally sheet and links to instructions on how to analyse the data
-found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Measurement" to find out how the proton is
-structured and to hunt for the Higgs particle.</subfield>
+      can be found on the linked site in the section "Measurement". There you will
+      also find a tally sheet and links to instructions on how to analyse the data
+      found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Measurement" to find out how the proton is
+      structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -1533,9 +1533,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_3_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_3_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass WPath 2015 dataset 3 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -1568,20 +1568,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
-by the ATLAS detector.</subfield>
+      MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which
-can be found on the linked site in the section "Measurement". There you will
-also find a tally sheet and links to instructions on how to analyse the data
-found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Measurement" to find out how the proton is
-structured and to hunt for the Higgs particle.</subfield>
+      can be found on the linked site in the section "Measurement". There you will
+      also find a tally sheet and links to instructions on how to analyse the data
+      found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Measurement" to find out how the proton is
+      structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -1710,9 +1710,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_4_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_4_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass WPath 2015 dataset 4 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -1745,20 +1745,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
-by the ATLAS detector.</subfield>
+      MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which
-can be found on the linked site in the section "Measurement". There you will
-also find a tally sheet and links to instructions on how to analyse the data
-found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Measurement" to find out how the proton is
-structured and to hunt for the Higgs particle.</subfield>
+      can be found on the linked site in the section "Measurement". There you will
+      also find a tally sheet and links to instructions on how to analyse the data
+      found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Measurement" to find out how the proton is
+      structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -1887,9 +1887,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_5_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_5_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass WPath 2015 dataset 5 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -1922,20 +1922,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
-by the ATLAS detector.</subfield>
+      MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which
-can be found on the linked site in the section "Measurement". There you will
-also find a tally sheet and links to instructions on how to analyse the data
-found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Measurement" to find out how the proton is
-structured and to hunt for the Higgs particle.</subfield>
+      can be found on the linked site in the section "Measurement". There you will
+      also find a tally sheet and links to instructions on how to analyse the data
+      found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Measurement" to find out how the proton is
+      structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -2064,9 +2064,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_6_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_6_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass WPath 2015 dataset 6 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -2099,20 +2099,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
-by the ATLAS detector.</subfield>
+      MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which
-can be found on the linked site in the section "Measurement". There you will
-also find a tally sheet and links to instructions on how to analyse the data
-found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Measurement" to find out how the proton is
-structured and to hunt for the Higgs particle.</subfield>
+      can be found on the linked site in the section "Measurement". There you will
+      also find a tally sheet and links to instructions on how to analyse the data
+      found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Measurement" to find out how the proton is
+      structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -2241,9 +2241,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_7_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_7_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass WPath 2015 dataset 7 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -2276,20 +2276,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
-by the ATLAS detector.</subfield>
+      MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which
-can be found on the linked site in the section "Measurement". There you will
-also find a tally sheet and links to instructions on how to analyse the data
-found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Measurement" to find out how the proton is
-structured and to hunt for the Higgs particle.</subfield>
+      can be found on the linked site in the section "Measurement". There you will
+      also find a tally sheet and links to instructions on how to analyse the data
+      found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Measurement" to find out how the proton is
+      structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -2418,9 +2418,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_8_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_8_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass WPath 2015 dataset 8 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -2453,20 +2453,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
-by the ATLAS detector.</subfield>
+      MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which
-can be found on the linked site in the section "Measurement". There you will
-also find a tally sheet and links to instructions on how to analyse the data
-found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Measurement" to find out how the proton is
-structured and to hunt for the Higgs particle.</subfield>
+      can be found on the linked site in the section "Measurement". There you will
+      also find a tally sheet and links to instructions on how to analyse the data
+      found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Measurement" to find out how the proton is
+      structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -2595,9 +2595,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_9_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_9_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass WPath 2015 dataset 9 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -2630,20 +2630,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
-by the ATLAS detector.</subfield>
+      MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which
-can be found on the linked site in the section "Measurement". There you will
-also find a tally sheet and links to instructions on how to analyse the data
-found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Measurement" to find out how the proton is
-structured and to hunt for the Higgs particle.</subfield>
+      can be found on the linked site in the section "Measurement". There you will
+      also find a tally sheet and links to instructions on how to analyse the data
+      found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Measurement" to find out how the proton is
+      structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -2772,9 +2772,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_10_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_10_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass WPath 2015 dataset 10 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -2807,20 +2807,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
-by the ATLAS detector.</subfield>
+      MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which
-can be found on the linked site in the section "Measurement". There you will
-also find a tally sheet and links to instructions on how to analyse the data
-found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Measurement" to find out how the proton is
-structured and to hunt for the Higgs particle.</subfield>
+      can be found on the linked site in the section "Measurement". There you will
+      also find a tally sheet and links to instructions on how to analyse the data
+      found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Measurement" to find out how the proton is
+      structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -2949,9 +2949,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_11_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_11_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass WPath 2015 dataset 11 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -2984,20 +2984,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
-by the ATLAS detector.</subfield>
+      MINERVA as part of the Masterclasses W-Path. The events were recorded in 2011
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using MINERVA, which
-can be found on the linked site in the section "Measurement". There you will
-also find a tally sheet and links to instructions on how to analyse the data
-found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Measurement" to find out how the proton is
-structured and to hunt for the Higgs particle.</subfield>
+      can be found on the linked site in the section "Measurement". There you will
+      also find a tally sheet and links to instructions on how to analyse the data
+      found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Measurement" to find out how the proton is
+      structured and to hunt for the Higgs particle.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -3126,9 +3126,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/wpath_ziele.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_12_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_12_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass WPath 2015 dataset 12 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -3161,20 +3161,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -3189,102 +3189,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupA.zip</subfield>
-      <subfield code="s">31431166</subfield>
+      <subfield code="s">29376316</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupB.zip</subfield>
-      <subfield code="s">32695324</subfield>
+      <subfield code="s">30435287</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupC.zip</subfield>
-      <subfield code="s">35324519</subfield>
+      <subfield code="s">31450999</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupD.zip</subfield>
-      <subfield code="s">33381459</subfield>
+      <subfield code="s">35044973</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupE.zip</subfield>
-      <subfield code="s">31350762</subfield>
+      <subfield code="s">29518337</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupF.zip</subfield>
-      <subfield code="s">33263366</subfield>
+      <subfield code="s">32410285</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupG.zip</subfield>
-      <subfield code="s">32054238</subfield>
+      <subfield code="s">30115899</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupH.zip</subfield>
-      <subfield code="s">31486376</subfield>
+      <subfield code="s">30214418</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupI.zip</subfield>
-      <subfield code="s">31867319</subfield>
+      <subfield code="s">29081133</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupJ.zip</subfield>
-      <subfield code="s">31419536</subfield>
+      <subfield code="s">29623640</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupK.zip</subfield>
-      <subfield code="s">31463391</subfield>
+      <subfield code="s">32886287</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupL.zip</subfield>
-      <subfield code="s">34940625</subfield>
+      <subfield code="s">34076633</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupM.zip</subfield>
-      <subfield code="s">33408995</subfield>
+      <subfield code="s">32467184</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupN.zip</subfield>
-      <subfield code="s">31711757</subfield>
+      <subfield code="s">31894195</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupO.zip</subfield>
-      <subfield code="s">31114980</subfield>
+      <subfield code="s">32874933</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupP.zip</subfield>
-      <subfield code="s">30204329</subfield>
+      <subfield code="s">31185893</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupQ.zip</subfield>
-      <subfield code="s">30304045</subfield>
+      <subfield code="s">32186308</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupR.zip</subfield>
-      <subfield code="s">32909093</subfield>
+      <subfield code="s">29625851</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupS.zip</subfield>
-      <subfield code="s">30385121</subfield>
+      <subfield code="s">26950890</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupT.zip</subfield>
-      <subfield code="s">32018492</subfield>
+      <subfield code="s">30257271</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -3303,9 +3303,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_1_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_1_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 1 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -3338,20 +3338,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -3366,102 +3366,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupA.zip</subfield>
-      <subfield code="s">30674168</subfield>
+      <subfield code="s">31701967</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupB.zip</subfield>
-      <subfield code="s">31903428</subfield>
+      <subfield code="s">28857005</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupC.zip</subfield>
-      <subfield code="s">28942900</subfield>
+      <subfield code="s">31367400</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupD.zip</subfield>
-      <subfield code="s">32028310</subfield>
+      <subfield code="s">29687023</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupE.zip</subfield>
-      <subfield code="s">28746282</subfield>
+      <subfield code="s">31622164</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupF.zip</subfield>
-      <subfield code="s">33979028</subfield>
+      <subfield code="s">29731961</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupG.zip</subfield>
-      <subfield code="s">31266910</subfield>
+      <subfield code="s">30678574</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupH.zip</subfield>
-      <subfield code="s">30181406</subfield>
+      <subfield code="s">29716266</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupI.zip</subfield>
-      <subfield code="s">30438376</subfield>
+      <subfield code="s">29707400</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupJ.zip</subfield>
-      <subfield code="s">31341315</subfield>
+      <subfield code="s">30398322</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupK.zip</subfield>
-      <subfield code="s">32507981</subfield>
+      <subfield code="s">31434951</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupL.zip</subfield>
-      <subfield code="s">33305679</subfield>
+      <subfield code="s">30474412</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupM.zip</subfield>
-      <subfield code="s">34278144</subfield>
+      <subfield code="s">30373024</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupN.zip</subfield>
-      <subfield code="s">32706893</subfield>
+      <subfield code="s">31677043</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupO.zip</subfield>
-      <subfield code="s">31858765</subfield>
+      <subfield code="s">31291257</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupP.zip</subfield>
-      <subfield code="s">31150058</subfield>
+      <subfield code="s">31389325</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupQ.zip</subfield>
-      <subfield code="s">33274136</subfield>
+      <subfield code="s">32341424</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupR.zip</subfield>
-      <subfield code="s">31166602</subfield>
+      <subfield code="s">31213183</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupS.zip</subfield>
-      <subfield code="s">31173951</subfield>
+      <subfield code="s">30643323</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupT.zip</subfield>
-      <subfield code="s">30479301</subfield>
+      <subfield code="s">32936560</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -3480,9 +3480,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_2_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_2_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 2 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -3515,20 +3515,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -3543,102 +3543,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupA.zip</subfield>
-      <subfield code="s">33390021</subfield>
+      <subfield code="s">33685260</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupB.zip</subfield>
-      <subfield code="s">32869077</subfield>
+      <subfield code="s">33173825</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupC.zip</subfield>
-      <subfield code="s">34608084</subfield>
+      <subfield code="s">30631562</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupD.zip</subfield>
-      <subfield code="s">33368180</subfield>
+      <subfield code="s">32435612</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupE.zip</subfield>
-      <subfield code="s">30576808</subfield>
+      <subfield code="s">29404717</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupF.zip</subfield>
-      <subfield code="s">32459381</subfield>
+      <subfield code="s">33274728</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupG.zip</subfield>
-      <subfield code="s">32178290</subfield>
+      <subfield code="s">34154753</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupH.zip</subfield>
-      <subfield code="s">31929507</subfield>
+      <subfield code="s">29159338</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupI.zip</subfield>
-      <subfield code="s">31155340</subfield>
+      <subfield code="s">30661296</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupJ.zip</subfield>
-      <subfield code="s">31217859</subfield>
+      <subfield code="s">31086793</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupK.zip</subfield>
-      <subfield code="s">30865231</subfield>
+      <subfield code="s">30153311</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupL.zip</subfield>
-      <subfield code="s">32399854</subfield>
+      <subfield code="s">30320490</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupM.zip</subfield>
-      <subfield code="s">31963203</subfield>
+      <subfield code="s">31013379</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupN.zip</subfield>
-      <subfield code="s">32484844</subfield>
+      <subfield code="s">28698108</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupO.zip</subfield>
-      <subfield code="s">30449749</subfield>
+      <subfield code="s">27818616</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupP.zip</subfield>
-      <subfield code="s">30334714</subfield>
+      <subfield code="s">33053744</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupQ.zip</subfield>
-      <subfield code="s">33036146</subfield>
+      <subfield code="s">31567082</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupR.zip</subfield>
-      <subfield code="s">30208381</subfield>
+      <subfield code="s">30087579</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupS.zip</subfield>
-      <subfield code="s">29317685</subfield>
+      <subfield code="s">31698877</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupT.zip</subfield>
-      <subfield code="s">32996991</subfield>
+      <subfield code="s">34328077</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -3657,9 +3657,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_3_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_3_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 3 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -3692,20 +3692,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -3720,102 +3720,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupA.zip</subfield>
-      <subfield code="s">28558781</subfield>
+      <subfield code="s">31925663</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupB.zip</subfield>
-      <subfield code="s">31599414</subfield>
+      <subfield code="s">31746716</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupC.zip</subfield>
-      <subfield code="s">30682076</subfield>
+      <subfield code="s">29147467</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupD.zip</subfield>
-      <subfield code="s">30719562</subfield>
+      <subfield code="s">28641611</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupE.zip</subfield>
-      <subfield code="s">31873302</subfield>
+      <subfield code="s">29248430</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupF.zip</subfield>
-      <subfield code="s">30969792</subfield>
+      <subfield code="s">31692714</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupG.zip</subfield>
-      <subfield code="s">30823362</subfield>
+      <subfield code="s">29397961</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupH.zip</subfield>
-      <subfield code="s">30873996</subfield>
+      <subfield code="s">31614578</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupI.zip</subfield>
-      <subfield code="s">30691114</subfield>
+      <subfield code="s">33361948</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupJ.zip</subfield>
-      <subfield code="s">35644564</subfield>
+      <subfield code="s">30954238</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupK.zip</subfield>
-      <subfield code="s">30754228</subfield>
+      <subfield code="s">30492688</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupL.zip</subfield>
-      <subfield code="s">31028377</subfield>
+      <subfield code="s">28183900</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupM.zip</subfield>
-      <subfield code="s">31198108</subfield>
+      <subfield code="s">30706292</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupN.zip</subfield>
-      <subfield code="s">32898065</subfield>
+      <subfield code="s">30198860</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupO.zip</subfield>
-      <subfield code="s">33309759</subfield>
+      <subfield code="s">30468522</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupP.zip</subfield>
-      <subfield code="s">29135053</subfield>
+      <subfield code="s">31241882</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupQ.zip</subfield>
-      <subfield code="s">31279724</subfield>
+      <subfield code="s">30625334</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupR.zip</subfield>
-      <subfield code="s">31925419</subfield>
+      <subfield code="s">30138969</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupS.zip</subfield>
-      <subfield code="s">30954569</subfield>
+      <subfield code="s">32455201</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupT.zip</subfield>
-      <subfield code="s">32558053</subfield>
+      <subfield code="s">28889206</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -3834,9 +3834,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_4_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_4_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 4 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -3869,20 +3869,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -3897,102 +3897,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupA.zip</subfield>
-      <subfield code="s">29921798</subfield>
+      <subfield code="s">32274393</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupB.zip</subfield>
-      <subfield code="s">31219522</subfield>
+      <subfield code="s">30703203</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupC.zip</subfield>
-      <subfield code="s">35127196</subfield>
+      <subfield code="s">29176362</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupD.zip</subfield>
-      <subfield code="s">32342276</subfield>
+      <subfield code="s">29249094</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupE.zip</subfield>
-      <subfield code="s">32301401</subfield>
+      <subfield code="s">30300337</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupF.zip</subfield>
-      <subfield code="s">32521219</subfield>
+      <subfield code="s">27062694</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupG.zip</subfield>
-      <subfield code="s">30518415</subfield>
+      <subfield code="s">31292443</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupH.zip</subfield>
-      <subfield code="s">31981959</subfield>
+      <subfield code="s">30855842</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupI.zip</subfield>
-      <subfield code="s">33007600</subfield>
+      <subfield code="s">32153069</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupJ.zip</subfield>
-      <subfield code="s">29900807</subfield>
+      <subfield code="s">31695769</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupK.zip</subfield>
-      <subfield code="s">29699124</subfield>
+      <subfield code="s">30426028</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupL.zip</subfield>
-      <subfield code="s">33073378</subfield>
+      <subfield code="s">30417528</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupM.zip</subfield>
-      <subfield code="s">30785322</subfield>
+      <subfield code="s">30640676</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupN.zip</subfield>
-      <subfield code="s">29370209</subfield>
+      <subfield code="s">31062814</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupO.zip</subfield>
-      <subfield code="s">31420225</subfield>
+      <subfield code="s">30618521</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupP.zip</subfield>
-      <subfield code="s">30996866</subfield>
+      <subfield code="s">31515467</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupQ.zip</subfield>
-      <subfield code="s">30633974</subfield>
+      <subfield code="s">28503344</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupR.zip</subfield>
-      <subfield code="s">29230480</subfield>
+      <subfield code="s">31292548</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupS.zip</subfield>
-      <subfield code="s">31313731</subfield>
+      <subfield code="s">30608842</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupT.zip</subfield>
-      <subfield code="s">31863887</subfield>
+      <subfield code="s">29727784</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -4011,9 +4011,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_5_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_5_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 5 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -4046,20 +4046,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4074,102 +4074,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupA.zip</subfield>
-      <subfield code="s">31818479</subfield>
+      <subfield code="s">31744117</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupB.zip</subfield>
-      <subfield code="s">32345397</subfield>
+      <subfield code="s">27652908</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupC.zip</subfield>
-      <subfield code="s">30894390</subfield>
+      <subfield code="s">30228292</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupD.zip</subfield>
-      <subfield code="s">32533941</subfield>
+      <subfield code="s">32531967</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupE.zip</subfield>
-      <subfield code="s">31143347</subfield>
+      <subfield code="s">32188629</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupF.zip</subfield>
-      <subfield code="s">33612394</subfield>
+      <subfield code="s">30274661</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupG.zip</subfield>
-      <subfield code="s">31703792</subfield>
+      <subfield code="s">32253233</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupH.zip</subfield>
-      <subfield code="s">33604844</subfield>
+      <subfield code="s">31039900</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupI.zip</subfield>
-      <subfield code="s">34323503</subfield>
+      <subfield code="s">30405795</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupJ.zip</subfield>
-      <subfield code="s">33761041</subfield>
+      <subfield code="s">31671502</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupK.zip</subfield>
-      <subfield code="s">31982134</subfield>
+      <subfield code="s">31472872</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupL.zip</subfield>
-      <subfield code="s">33797750</subfield>
+      <subfield code="s">33602279</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupM.zip</subfield>
-      <subfield code="s">32105247</subfield>
+      <subfield code="s">32623371</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupN.zip</subfield>
-      <subfield code="s">32332012</subfield>
+      <subfield code="s">31729304</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupO.zip</subfield>
-      <subfield code="s">32455981</subfield>
+      <subfield code="s">33137194</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupP.zip</subfield>
-      <subfield code="s">32461464</subfield>
+      <subfield code="s">35045624</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupQ.zip</subfield>
-      <subfield code="s">36107043</subfield>
+      <subfield code="s">30432030</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupR.zip</subfield>
-      <subfield code="s">33702870</subfield>
+      <subfield code="s">31537982</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupS.zip</subfield>
-      <subfield code="s">32224024</subfield>
+      <subfield code="s">32337412</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupT.zip</subfield>
-      <subfield code="s">31816713</subfield>
+      <subfield code="s">31905174</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -4188,9 +4188,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_6_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_6_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 6 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -4223,20 +4223,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4251,102 +4251,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupA.zip</subfield>
-      <subfield code="s">31541014</subfield>
+      <subfield code="s">31823239</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupB.zip</subfield>
-      <subfield code="s">30439402</subfield>
+      <subfield code="s">32636337</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupC.zip</subfield>
-      <subfield code="s">32759342</subfield>
+      <subfield code="s">30558198</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupD.zip</subfield>
-      <subfield code="s">33154647</subfield>
+      <subfield code="s">30170637</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupE.zip</subfield>
-      <subfield code="s">32417302</subfield>
+      <subfield code="s">34542386</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupF.zip</subfield>
-      <subfield code="s">34080726</subfield>
+      <subfield code="s">30815554</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupG.zip</subfield>
-      <subfield code="s">33630546</subfield>
+      <subfield code="s">30261171</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupH.zip</subfield>
-      <subfield code="s">30920855</subfield>
+      <subfield code="s">32580076</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupI.zip</subfield>
-      <subfield code="s">34589196</subfield>
+      <subfield code="s">29477717</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupJ.zip</subfield>
-      <subfield code="s">33986829</subfield>
+      <subfield code="s">32623142</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupK.zip</subfield>
-      <subfield code="s">34334924</subfield>
+      <subfield code="s">31801746</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupL.zip</subfield>
-      <subfield code="s">33289395</subfield>
+      <subfield code="s">33108617</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupM.zip</subfield>
-      <subfield code="s">30981576</subfield>
+      <subfield code="s">33338702</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupN.zip</subfield>
-      <subfield code="s">32457345</subfield>
+      <subfield code="s">30374691</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupO.zip</subfield>
-      <subfield code="s">31743326</subfield>
+      <subfield code="s">30283491</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupP.zip</subfield>
-      <subfield code="s">32828553</subfield>
+      <subfield code="s">30946274</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupQ.zip</subfield>
-      <subfield code="s">32496247</subfield>
+      <subfield code="s">31079461</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupR.zip</subfield>
-      <subfield code="s">30795063</subfield>
+      <subfield code="s">33650867</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupS.zip</subfield>
-      <subfield code="s">30374795</subfield>
+      <subfield code="s">30714484</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupT.zip</subfield>
-      <subfield code="s">30776350</subfield>
+      <subfield code="s">33864284</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -4365,9 +4365,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_7_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_7_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 7 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -4400,20 +4400,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4428,102 +4428,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupA.zip</subfield>
-      <subfield code="s">34189004</subfield>
+      <subfield code="s">32095569</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupB.zip</subfield>
-      <subfield code="s">32170122</subfield>
+      <subfield code="s">30279210</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupC.zip</subfield>
-      <subfield code="s">31236723</subfield>
+      <subfield code="s">31956025</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupD.zip</subfield>
-      <subfield code="s">32174802</subfield>
+      <subfield code="s">29821676</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupE.zip</subfield>
-      <subfield code="s">31284594</subfield>
+      <subfield code="s">29288542</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupF.zip</subfield>
-      <subfield code="s">29563809</subfield>
+      <subfield code="s">30946909</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupG.zip</subfield>
-      <subfield code="s">30761530</subfield>
+      <subfield code="s">32935203</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupH.zip</subfield>
-      <subfield code="s">28732980</subfield>
+      <subfield code="s">29189238</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupI.zip</subfield>
-      <subfield code="s">29865789</subfield>
+      <subfield code="s">32151014</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupJ.zip</subfield>
-      <subfield code="s">30242101</subfield>
+      <subfield code="s">32930724</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupK.zip</subfield>
-      <subfield code="s">30587619</subfield>
+      <subfield code="s">32624865</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupL.zip</subfield>
-      <subfield code="s">31827987</subfield>
+      <subfield code="s">29834424</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupM.zip</subfield>
-      <subfield code="s">31487006</subfield>
+      <subfield code="s">29564064</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupN.zip</subfield>
-      <subfield code="s">33652297</subfield>
+      <subfield code="s">30510393</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupO.zip</subfield>
-      <subfield code="s">28756081</subfield>
+      <subfield code="s">31587180</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupP.zip</subfield>
-      <subfield code="s">32483425</subfield>
+      <subfield code="s">30496904</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupQ.zip</subfield>
-      <subfield code="s">31562148</subfield>
+      <subfield code="s">26805044</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupR.zip</subfield>
-      <subfield code="s">30601476</subfield>
+      <subfield code="s">29417025</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupS.zip</subfield>
-      <subfield code="s">31291345</subfield>
+      <subfield code="s">28865791</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupT.zip</subfield>
-      <subfield code="s">31219842</subfield>
+      <subfield code="s">31765379</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -4542,9 +4542,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_8_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_8_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 8 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -4577,20 +4577,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4605,102 +4605,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupA.zip</subfield>
-      <subfield code="s">28767572</subfield>
+      <subfield code="s">29116283</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupB.zip</subfield>
-      <subfield code="s">26629679</subfield>
+      <subfield code="s">29314242</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupC.zip</subfield>
-      <subfield code="s">28236830</subfield>
+      <subfield code="s">32134518</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupD.zip</subfield>
-      <subfield code="s">25498974</subfield>
+      <subfield code="s">31800243</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupE.zip</subfield>
-      <subfield code="s">27668291</subfield>
+      <subfield code="s">29992741</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupF.zip</subfield>
-      <subfield code="s">24931491</subfield>
+      <subfield code="s">28940878</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupG.zip</subfield>
-      <subfield code="s">28408138</subfield>
+      <subfield code="s">27517714</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupH.zip</subfield>
-      <subfield code="s">29092780</subfield>
+      <subfield code="s">28398321</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupI.zip</subfield>
-      <subfield code="s">28198683</subfield>
+      <subfield code="s">29192753</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupJ.zip</subfield>
-      <subfield code="s">26935663</subfield>
+      <subfield code="s">26418297</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupK.zip</subfield>
-      <subfield code="s">29948330</subfield>
+      <subfield code="s">27307942</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupL.zip</subfield>
-      <subfield code="s">29207137</subfield>
+      <subfield code="s">27397604</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupM.zip</subfield>
-      <subfield code="s">30998624</subfield>
+      <subfield code="s">26806059</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupN.zip</subfield>
-      <subfield code="s">28908938</subfield>
+      <subfield code="s">26717972</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupO.zip</subfield>
-      <subfield code="s">28469944</subfield>
+      <subfield code="s">27157142</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupP.zip</subfield>
-      <subfield code="s">29929679</subfield>
+      <subfield code="s">26998132</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupQ.zip</subfield>
-      <subfield code="s">32202215</subfield>
+      <subfield code="s">27369339</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupR.zip</subfield>
-      <subfield code="s">30051398</subfield>
+      <subfield code="s">28379949</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupS.zip</subfield>
-      <subfield code="s">29620059</subfield>
+      <subfield code="s">28746794</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupT.zip</subfield>
-      <subfield code="s">27945436</subfield>
+      <subfield code="s">29130389</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -4719,9 +4719,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_9_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_9_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 9 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -4754,20 +4754,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4782,102 +4782,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupA.zip</subfield>
-      <subfield code="s">32307774</subfield>
+      <subfield code="s">29466047</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupB.zip</subfield>
-      <subfield code="s">28606134</subfield>
+      <subfield code="s">27769468</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupC.zip</subfield>
-      <subfield code="s">29708845</subfield>
+      <subfield code="s">29161258</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupD.zip</subfield>
-      <subfield code="s">28851508</subfield>
+      <subfield code="s">29929226</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupE.zip</subfield>
-      <subfield code="s">29134504</subfield>
+      <subfield code="s">29558291</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupF.zip</subfield>
-      <subfield code="s">27280344</subfield>
+      <subfield code="s">29594866</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupG.zip</subfield>
-      <subfield code="s">27371984</subfield>
+      <subfield code="s">28090713</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupH.zip</subfield>
-      <subfield code="s">30724092</subfield>
+      <subfield code="s">26322227</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupI.zip</subfield>
-      <subfield code="s">29426883</subfield>
+      <subfield code="s">28646367</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupJ.zip</subfield>
-      <subfield code="s">30176777</subfield>
+      <subfield code="s">30653292</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupK.zip</subfield>
-      <subfield code="s">30551874</subfield>
+      <subfield code="s">29960799</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupL.zip</subfield>
-      <subfield code="s">30251543</subfield>
+      <subfield code="s">27674621</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupM.zip</subfield>
-      <subfield code="s">30061492</subfield>
+      <subfield code="s">29368377</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupN.zip</subfield>
-      <subfield code="s">27319005</subfield>
+      <subfield code="s">28265088</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupO.zip</subfield>
-      <subfield code="s">30311941</subfield>
+      <subfield code="s">28107525</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupP.zip</subfield>
-      <subfield code="s">27673612</subfield>
+      <subfield code="s">27371098</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupQ.zip</subfield>
-      <subfield code="s">28556823</subfield>
+      <subfield code="s">26991180</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupR.zip</subfield>
-      <subfield code="s">30250405</subfield>
+      <subfield code="s">32209294</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupS.zip</subfield>
-      <subfield code="s">26942667</subfield>
+      <subfield code="s">27415300</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupT.zip</subfield>
-      <subfield code="s">27932106</subfield>
+      <subfield code="s">29231827</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -4896,9 +4896,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_10_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_10_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 10 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -4931,20 +4931,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -4959,102 +4959,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupA.zip</subfield>
-      <subfield code="s">27162625</subfield>
+      <subfield code="s">29046447</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupB.zip</subfield>
-      <subfield code="s">28541475</subfield>
+      <subfield code="s">27021400</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupC.zip</subfield>
-      <subfield code="s">29200554</subfield>
+      <subfield code="s">28226672</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupD.zip</subfield>
-      <subfield code="s">24641087</subfield>
+      <subfield code="s">26546945</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupE.zip</subfield>
-      <subfield code="s">28369025</subfield>
+      <subfield code="s">29210651</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupF.zip</subfield>
-      <subfield code="s">29349996</subfield>
+      <subfield code="s">28782931</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupG.zip</subfield>
-      <subfield code="s">27139295</subfield>
+      <subfield code="s">27365682</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupH.zip</subfield>
-      <subfield code="s">28523730</subfield>
+      <subfield code="s">28400891</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupI.zip</subfield>
-      <subfield code="s">29792592</subfield>
+      <subfield code="s">27750753</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupJ.zip</subfield>
-      <subfield code="s">30713064</subfield>
+      <subfield code="s">28177750</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupK.zip</subfield>
-      <subfield code="s">27274404</subfield>
+      <subfield code="s">29231047</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupL.zip</subfield>
-      <subfield code="s">27311903</subfield>
+      <subfield code="s">28764582</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupM.zip</subfield>
-      <subfield code="s">27738230</subfield>
+      <subfield code="s">27882744</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupN.zip</subfield>
-      <subfield code="s">29918032</subfield>
+      <subfield code="s">28801836</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupO.zip</subfield>
-      <subfield code="s">26358708</subfield>
+      <subfield code="s">28012240</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupP.zip</subfield>
-      <subfield code="s">28855214</subfield>
+      <subfield code="s">26584246</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupQ.zip</subfield>
-      <subfield code="s">28042685</subfield>
+      <subfield code="s">28540632</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupR.zip</subfield>
-      <subfield code="s">28847810</subfield>
+      <subfield code="s">28094149</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupS.zip</subfield>
-      <subfield code="s">31833584</subfield>
+      <subfield code="s">28038879</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupT.zip</subfield>
-      <subfield code="s">28346170</subfield>
+      <subfield code="s">28214087</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -5073,9 +5073,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_11_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_11_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 11 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -5108,20 +5108,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -5136,102 +5136,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupA.zip</subfield>
-      <subfield code="s">30785364</subfield>
+      <subfield code="s">27429390</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupB.zip</subfield>
-      <subfield code="s">31067151</subfield>
+      <subfield code="s">27025432</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupC.zip</subfield>
-      <subfield code="s">30762520</subfield>
+      <subfield code="s">28179852</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupD.zip</subfield>
-      <subfield code="s">28070605</subfield>
+      <subfield code="s">29419624</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupE.zip</subfield>
-      <subfield code="s">30827299</subfield>
+      <subfield code="s">26775995</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupF.zip</subfield>
-      <subfield code="s">29970941</subfield>
+      <subfield code="s">29519971</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupG.zip</subfield>
-      <subfield code="s">30165839</subfield>
+      <subfield code="s">27647187</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupH.zip</subfield>
-      <subfield code="s">28194708</subfield>
+      <subfield code="s">24921676</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupI.zip</subfield>
-      <subfield code="s">31429323</subfield>
+      <subfield code="s">28566101</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupJ.zip</subfield>
-      <subfield code="s">32094088</subfield>
+      <subfield code="s">27443014</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupK.zip</subfield>
-      <subfield code="s">31620808</subfield>
+      <subfield code="s">27205939</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupL.zip</subfield>
-      <subfield code="s">32657528</subfield>
+      <subfield code="s">31835075</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupM.zip</subfield>
-      <subfield code="s">31561476</subfield>
+      <subfield code="s">29500576</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupN.zip</subfield>
-      <subfield code="s">30766920</subfield>
+      <subfield code="s">30845501</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupO.zip</subfield>
-      <subfield code="s">31633501</subfield>
+      <subfield code="s">30168529</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupP.zip</subfield>
-      <subfield code="s">27964207</subfield>
+      <subfield code="s">30405236</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupQ.zip</subfield>
-      <subfield code="s">28442073</subfield>
+      <subfield code="s">31100706</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupR.zip</subfield>
-      <subfield code="s">29856948</subfield>
+      <subfield code="s">30377142</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupS.zip</subfield>
-      <subfield code="s">30804944</subfield>
+      <subfield code="s">29326992</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupT.zip</subfield>
-      <subfield code="s">31341595</subfield>
+      <subfield code="s">30559845</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -5250,9 +5250,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_12_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_12_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 12 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -5285,20 +5285,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -5313,102 +5313,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupA.zip</subfield>
-      <subfield code="s">28964392</subfield>
+      <subfield code="s">32203300</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupB.zip</subfield>
-      <subfield code="s">32974893</subfield>
+      <subfield code="s">29747943</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupC.zip</subfield>
-      <subfield code="s">29595790</subfield>
+      <subfield code="s">30056287</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupD.zip</subfield>
-      <subfield code="s">31646611</subfield>
+      <subfield code="s">30619678</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupE.zip</subfield>
-      <subfield code="s">29158880</subfield>
+      <subfield code="s">28848223</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupF.zip</subfield>
-      <subfield code="s">30605576</subfield>
+      <subfield code="s">28211871</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupG.zip</subfield>
-      <subfield code="s">29821532</subfield>
+      <subfield code="s">31917785</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupH.zip</subfield>
-      <subfield code="s">28776271</subfield>
+      <subfield code="s">27797923</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupI.zip</subfield>
-      <subfield code="s">28309581</subfield>
+      <subfield code="s">28078741</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupJ.zip</subfield>
-      <subfield code="s">29558758</subfield>
+      <subfield code="s">30999226</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupK.zip</subfield>
-      <subfield code="s">27510492</subfield>
+      <subfield code="s">30884444</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupL.zip</subfield>
-      <subfield code="s">30272573</subfield>
+      <subfield code="s">31783623</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupM.zip</subfield>
-      <subfield code="s">30326002</subfield>
+      <subfield code="s">28444257</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupN.zip</subfield>
-      <subfield code="s">29597498</subfield>
+      <subfield code="s">29966571</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupO.zip</subfield>
-      <subfield code="s">29744541</subfield>
+      <subfield code="s">28226634</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupP.zip</subfield>
-      <subfield code="s">31221347</subfield>
+      <subfield code="s">29191308</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupQ.zip</subfield>
-      <subfield code="s">27087499</subfield>
+      <subfield code="s">28676439</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupR.zip</subfield>
-      <subfield code="s">29020301</subfield>
+      <subfield code="s">27215445</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupS.zip</subfield>
-      <subfield code="s">29251163</subfield>
+      <subfield code="s">30667356</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupT.zip</subfield>
-      <subfield code="s">29136102</subfield>
+      <subfield code="s">31319897</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -5427,9 +5427,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_13_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_13_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 13 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -5462,20 +5462,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -5490,102 +5490,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupA.zip</subfield>
-      <subfield code="s">32417153</subfield>
+      <subfield code="s">33162023</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupB.zip</subfield>
-      <subfield code="s">29661912</subfield>
+      <subfield code="s">29070293</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupC.zip</subfield>
-      <subfield code="s">29105227</subfield>
+      <subfield code="s">30400761</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupD.zip</subfield>
-      <subfield code="s">30475740</subfield>
+      <subfield code="s">30403285</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupE.zip</subfield>
-      <subfield code="s">29723273</subfield>
+      <subfield code="s">31089836</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupF.zip</subfield>
-      <subfield code="s">28459989</subfield>
+      <subfield code="s">27577881</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupG.zip</subfield>
-      <subfield code="s">31031346</subfield>
+      <subfield code="s">29356443</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupH.zip</subfield>
-      <subfield code="s">29623252</subfield>
+      <subfield code="s">26317945</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupI.zip</subfield>
-      <subfield code="s">27695645</subfield>
+      <subfield code="s">26286539</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupJ.zip</subfield>
-      <subfield code="s">28369277</subfield>
+      <subfield code="s">28224931</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupK.zip</subfield>
-      <subfield code="s">31091635</subfield>
+      <subfield code="s">28904478</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupL.zip</subfield>
-      <subfield code="s">31792256</subfield>
+      <subfield code="s">30550585</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupM.zip</subfield>
-      <subfield code="s">28104248</subfield>
+      <subfield code="s">31819986</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupN.zip</subfield>
-      <subfield code="s">28318592</subfield>
+      <subfield code="s">26282703</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupO.zip</subfield>
-      <subfield code="s">28543393</subfield>
+      <subfield code="s">25755892</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupP.zip</subfield>
-      <subfield code="s">30924809</subfield>
+      <subfield code="s">29334982</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupQ.zip</subfield>
-      <subfield code="s">31715146</subfield>
+      <subfield code="s">29512105</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupR.zip</subfield>
-      <subfield code="s">30166077</subfield>
+      <subfield code="s">28157609</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupS.zip</subfield>
-      <subfield code="s">28124697</subfield>
+      <subfield code="s">29843877</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupT.zip</subfield>
-      <subfield code="s">30380370</subfield>
+      <subfield code="s">29687975</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -5604,9 +5604,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_14_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_14_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 14 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -5639,20 +5639,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -5667,102 +5667,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupA.zip</subfield>
-      <subfield code="s">28667843</subfield>
+      <subfield code="s">28332919</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupB.zip</subfield>
-      <subfield code="s">30662478</subfield>
+      <subfield code="s">27852269</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupC.zip</subfield>
-      <subfield code="s">31243284</subfield>
+      <subfield code="s">27320687</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupD.zip</subfield>
-      <subfield code="s">29001089</subfield>
+      <subfield code="s">29533574</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupE.zip</subfield>
-      <subfield code="s">29663184</subfield>
+      <subfield code="s">29058266</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupF.zip</subfield>
-      <subfield code="s">35020296</subfield>
+      <subfield code="s">30863508</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupG.zip</subfield>
-      <subfield code="s">32032711</subfield>
+      <subfield code="s">28654013</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupH.zip</subfield>
-      <subfield code="s">28688468</subfield>
+      <subfield code="s">30268404</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupI.zip</subfield>
-      <subfield code="s">32388264</subfield>
+      <subfield code="s">28736798</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupJ.zip</subfield>
-      <subfield code="s">29224699</subfield>
+      <subfield code="s">26920503</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupK.zip</subfield>
-      <subfield code="s">29116945</subfield>
+      <subfield code="s">31028276</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupL.zip</subfield>
-      <subfield code="s">28213904</subfield>
+      <subfield code="s">31806795</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupM.zip</subfield>
-      <subfield code="s">30654383</subfield>
+      <subfield code="s">31718939</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupN.zip</subfield>
-      <subfield code="s">31370305</subfield>
+      <subfield code="s">26523696</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupO.zip</subfield>
-      <subfield code="s">30376413</subfield>
+      <subfield code="s">28508668</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupP.zip</subfield>
-      <subfield code="s">30475030</subfield>
+      <subfield code="s">29879540</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupQ.zip</subfield>
-      <subfield code="s">28474096</subfield>
+      <subfield code="s">27264121</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupR.zip</subfield>
-      <subfield code="s">30333726</subfield>
+      <subfield code="s">28446974</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupS.zip</subfield>
-      <subfield code="s">28161966</subfield>
+      <subfield code="s">27434206</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupT.zip</subfield>
-      <subfield code="s">31778090</subfield>
+      <subfield code="s">28278485</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -5781,9 +5781,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_15_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_15_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 15 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -5816,20 +5816,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -5844,102 +5844,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupA.zip</subfield>
-      <subfield code="s">26195344</subfield>
+      <subfield code="s">29104481</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupB.zip</subfield>
-      <subfield code="s">27332903</subfield>
+      <subfield code="s">28922057</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupC.zip</subfield>
-      <subfield code="s">29265013</subfield>
+      <subfield code="s">31196622</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupD.zip</subfield>
-      <subfield code="s">29972936</subfield>
+      <subfield code="s">30271888</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupE.zip</subfield>
-      <subfield code="s">26734192</subfield>
+      <subfield code="s">27369096</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupF.zip</subfield>
-      <subfield code="s">29972346</subfield>
+      <subfield code="s">28349425</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupG.zip</subfield>
-      <subfield code="s">30388651</subfield>
+      <subfield code="s">29289194</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupH.zip</subfield>
-      <subfield code="s">29224040</subfield>
+      <subfield code="s">25971987</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupI.zip</subfield>
-      <subfield code="s">30942522</subfield>
+      <subfield code="s">32663877</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupJ.zip</subfield>
-      <subfield code="s">29721557</subfield>
+      <subfield code="s">27993976</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupK.zip</subfield>
-      <subfield code="s">27898520</subfield>
+      <subfield code="s">30312009</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupL.zip</subfield>
-      <subfield code="s">29906087</subfield>
+      <subfield code="s">29075581</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupM.zip</subfield>
-      <subfield code="s">29865356</subfield>
+      <subfield code="s">27266783</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupN.zip</subfield>
-      <subfield code="s">30133602</subfield>
+      <subfield code="s">27840753</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupO.zip</subfield>
-      <subfield code="s">31659636</subfield>
+      <subfield code="s">27012470</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupP.zip</subfield>
-      <subfield code="s">32993447</subfield>
+      <subfield code="s">26671221</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupQ.zip</subfield>
-      <subfield code="s">27449324</subfield>
+      <subfield code="s">25200326</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupR.zip</subfield>
-      <subfield code="s">29897205</subfield>
+      <subfield code="s">30953627</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupS.zip</subfield>
-      <subfield code="s">29283992</subfield>
+      <subfield code="s">29658503</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupT.zip</subfield>
-      <subfield code="s">30181136</subfield>
+      <subfield code="s">28463904</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -5958,9 +5958,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_16_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_16_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 16 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -5993,20 +5993,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -6021,102 +6021,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupA.zip</subfield>
-      <subfield code="s">27852212</subfield>
+      <subfield code="s">32043151</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupB.zip</subfield>
-      <subfield code="s">25300023</subfield>
+      <subfield code="s">26346850</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupC.zip</subfield>
-      <subfield code="s">28117950</subfield>
+      <subfield code="s">30555526</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupD.zip</subfield>
-      <subfield code="s">31014115</subfield>
+      <subfield code="s">29684052</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupE.zip</subfield>
-      <subfield code="s">31252568</subfield>
+      <subfield code="s">29953135</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupF.zip</subfield>
-      <subfield code="s">26341868</subfield>
+      <subfield code="s">27499917</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupG.zip</subfield>
-      <subfield code="s">30823437</subfield>
+      <subfield code="s">27782599</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupH.zip</subfield>
-      <subfield code="s">27818211</subfield>
+      <subfield code="s">29897470</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupI.zip</subfield>
-      <subfield code="s">31857113</subfield>
+      <subfield code="s">29800533</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupJ.zip</subfield>
-      <subfield code="s">34427097</subfield>
+      <subfield code="s">32007110</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupK.zip</subfield>
-      <subfield code="s">30095670</subfield>
+      <subfield code="s">27775545</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupL.zip</subfield>
-      <subfield code="s">31711812</subfield>
+      <subfield code="s">30038916</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupM.zip</subfield>
-      <subfield code="s">31188213</subfield>
+      <subfield code="s">24413246</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupN.zip</subfield>
-      <subfield code="s">28881495</subfield>
+      <subfield code="s">30540421</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupO.zip</subfield>
-      <subfield code="s">28905776</subfield>
+      <subfield code="s">31426106</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupP.zip</subfield>
-      <subfield code="s">30147856</subfield>
+      <subfield code="s">29287910</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupQ.zip</subfield>
-      <subfield code="s">29055378</subfield>
+      <subfield code="s">31547522</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupR.zip</subfield>
-      <subfield code="s">29574169</subfield>
+      <subfield code="s">28749800</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupS.zip</subfield>
-      <subfield code="s">29717168</subfield>
+      <subfield code="s">30543500</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupT.zip</subfield>
-      <subfield code="s">29888671</subfield>
+      <subfield code="s">27936425</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -6135,9 +6135,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_17_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_17_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 17 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -6170,20 +6170,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -6198,102 +6198,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupA.zip</subfield>
-      <subfield code="s">28293914</subfield>
+      <subfield code="s">29360765</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupB.zip</subfield>
-      <subfield code="s">30150082</subfield>
+      <subfield code="s">29392335</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupC.zip</subfield>
-      <subfield code="s">29240159</subfield>
+      <subfield code="s">28998161</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupD.zip</subfield>
-      <subfield code="s">31269662</subfield>
+      <subfield code="s">24465805</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupE.zip</subfield>
-      <subfield code="s">31497697</subfield>
+      <subfield code="s">29091502</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupF.zip</subfield>
-      <subfield code="s">29647239</subfield>
+      <subfield code="s">27031030</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupG.zip</subfield>
-      <subfield code="s">28194976</subfield>
+      <subfield code="s">28315068</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupH.zip</subfield>
-      <subfield code="s">29515895</subfield>
+      <subfield code="s">28937173</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupI.zip</subfield>
-      <subfield code="s">28397954</subfield>
+      <subfield code="s">27114060</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupJ.zip</subfield>
-      <subfield code="s">29297584</subfield>
+      <subfield code="s">27209069</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupK.zip</subfield>
-      <subfield code="s">30257388</subfield>
+      <subfield code="s">29791326</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupL.zip</subfield>
-      <subfield code="s">29546866</subfield>
+      <subfield code="s">32523321</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupM.zip</subfield>
-      <subfield code="s">29703155</subfield>
+      <subfield code="s">30747833</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupN.zip</subfield>
-      <subfield code="s">29680871</subfield>
+      <subfield code="s">30397701</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupO.zip</subfield>
-      <subfield code="s">29447811</subfield>
+      <subfield code="s">29353286</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupP.zip</subfield>
-      <subfield code="s">28270653</subfield>
+      <subfield code="s">27791054</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupQ.zip</subfield>
-      <subfield code="s">27127841</subfield>
+      <subfield code="s">28567622</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupR.zip</subfield>
-      <subfield code="s">30238047</subfield>
+      <subfield code="s">29495546</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupS.zip</subfield>
-      <subfield code="s">30858788</subfield>
+      <subfield code="s">26736232</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupT.zip</subfield>
-      <subfield code="s">29937114</subfield>
+      <subfield code="s">28885465</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -6312,9 +6312,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_18_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_18_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 18 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -6347,20 +6347,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -6375,102 +6375,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupA.zip</subfield>
-      <subfield code="s">28219870</subfield>
+      <subfield code="s">28468874</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupB.zip</subfield>
-      <subfield code="s">27382461</subfield>
+      <subfield code="s">25643260</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupC.zip</subfield>
-      <subfield code="s">28711433</subfield>
+      <subfield code="s">25968498</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupD.zip</subfield>
-      <subfield code="s">30995584</subfield>
+      <subfield code="s">27414846</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupE.zip</subfield>
-      <subfield code="s">28584440</subfield>
+      <subfield code="s">27182709</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupF.zip</subfield>
-      <subfield code="s">29547652</subfield>
+      <subfield code="s">28107919</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupG.zip</subfield>
-      <subfield code="s">30651365</subfield>
+      <subfield code="s">30412999</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupH.zip</subfield>
-      <subfield code="s">28601333</subfield>
+      <subfield code="s">29105102</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupI.zip</subfield>
-      <subfield code="s">26973441</subfield>
+      <subfield code="s">32109108</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupJ.zip</subfield>
-      <subfield code="s">29167402</subfield>
+      <subfield code="s">28311711</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupK.zip</subfield>
-      <subfield code="s">29095642</subfield>
+      <subfield code="s">27778455</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupL.zip</subfield>
-      <subfield code="s">27570739</subfield>
+      <subfield code="s">30609782</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupM.zip</subfield>
-      <subfield code="s">28231256</subfield>
+      <subfield code="s">29110615</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupN.zip</subfield>
-      <subfield code="s">28302395</subfield>
+      <subfield code="s">32249664</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupO.zip</subfield>
-      <subfield code="s">29328269</subfield>
+      <subfield code="s">30456054</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupP.zip</subfield>
-      <subfield code="s">29188748</subfield>
+      <subfield code="s">27594363</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupQ.zip</subfield>
-      <subfield code="s">30675468</subfield>
+      <subfield code="s">29561324</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupR.zip</subfield>
-      <subfield code="s">29226324</subfield>
+      <subfield code="s">29294352</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupS.zip</subfield>
-      <subfield code="s">29032574</subfield>
+      <subfield code="s">29011260</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupT.zip</subfield>
-      <subfield code="s">32411975</subfield>
+      <subfield code="s">27873043</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -6489,9 +6489,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_19_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_19_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 19 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -6524,20 +6524,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -6552,102 +6552,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupA.zip</subfield>
-      <subfield code="s">30186181</subfield>
+      <subfield code="s">27773731</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupB.zip</subfield>
-      <subfield code="s">28564039</subfield>
+      <subfield code="s">28094651</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupC.zip</subfield>
-      <subfield code="s">28721896</subfield>
+      <subfield code="s">28514584</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupD.zip</subfield>
-      <subfield code="s">28272333</subfield>
+      <subfield code="s">27437053</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupE.zip</subfield>
-      <subfield code="s">30003258</subfield>
+      <subfield code="s">29178664</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupF.zip</subfield>
-      <subfield code="s">30269438</subfield>
+      <subfield code="s">29498146</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupG.zip</subfield>
-      <subfield code="s">28819887</subfield>
+      <subfield code="s">27442254</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupH.zip</subfield>
-      <subfield code="s">27445188</subfield>
+      <subfield code="s">28043763</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupI.zip</subfield>
-      <subfield code="s">30565432</subfield>
+      <subfield code="s">29005793</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupJ.zip</subfield>
-      <subfield code="s">31170488</subfield>
+      <subfield code="s">29763488</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupK.zip</subfield>
-      <subfield code="s">30270893</subfield>
+      <subfield code="s">30817326</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupL.zip</subfield>
-      <subfield code="s">29595788</subfield>
+      <subfield code="s">30782744</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupM.zip</subfield>
-      <subfield code="s">28080463</subfield>
+      <subfield code="s">29213017</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupN.zip</subfield>
-      <subfield code="s">28827831</subfield>
+      <subfield code="s">27797430</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupO.zip</subfield>
-      <subfield code="s">29750252</subfield>
+      <subfield code="s">29781200</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupP.zip</subfield>
-      <subfield code="s">26363186</subfield>
+      <subfield code="s">30156926</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupQ.zip</subfield>
-      <subfield code="s">29409243</subfield>
+      <subfield code="s">27277903</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupR.zip</subfield>
-      <subfield code="s">28966532</subfield>
+      <subfield code="s">28629431</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupS.zip</subfield>
-      <subfield code="s">29124647</subfield>
+      <subfield code="s">28169116</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupT.zip</subfield>
-      <subfield code="s">27218509</subfield>
+      <subfield code="s">28799653</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -6666,9 +6666,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_20_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_20_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 20 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -6701,20 +6701,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -6729,102 +6729,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupA.zip</subfield>
-      <subfield code="s">27673345</subfield>
+      <subfield code="s">28674446</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupB.zip</subfield>
-      <subfield code="s">30579670</subfield>
+      <subfield code="s">29282185</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupC.zip</subfield>
-      <subfield code="s">29845333</subfield>
+      <subfield code="s">28628098</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupD.zip</subfield>
-      <subfield code="s">28294424</subfield>
+      <subfield code="s">28830215</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupE.zip</subfield>
-      <subfield code="s">29089927</subfield>
+      <subfield code="s">30459439</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupF.zip</subfield>
-      <subfield code="s">32725049</subfield>
+      <subfield code="s">27282065</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupG.zip</subfield>
-      <subfield code="s">33249803</subfield>
+      <subfield code="s">30287470</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupH.zip</subfield>
-      <subfield code="s">34636840</subfield>
+      <subfield code="s">30318807</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupI.zip</subfield>
-      <subfield code="s">30928971</subfield>
+      <subfield code="s">28981935</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupJ.zip</subfield>
-      <subfield code="s">29659055</subfield>
+      <subfield code="s">27531316</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupK.zip</subfield>
-      <subfield code="s">30106883</subfield>
+      <subfield code="s">30733059</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupL.zip</subfield>
-      <subfield code="s">29344730</subfield>
+      <subfield code="s">28935776</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupM.zip</subfield>
-      <subfield code="s">30319637</subfield>
+      <subfield code="s">28534750</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupN.zip</subfield>
-      <subfield code="s">31114054</subfield>
+      <subfield code="s">27064425</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupO.zip</subfield>
-      <subfield code="s">30797614</subfield>
+      <subfield code="s">26530290</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupP.zip</subfield>
-      <subfield code="s">28562113</subfield>
+      <subfield code="s">27804196</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupQ.zip</subfield>
-      <subfield code="s">31307981</subfield>
+      <subfield code="s">31697776</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupR.zip</subfield>
-      <subfield code="s">29883404</subfield>
+      <subfield code="s">27129277</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupS.zip</subfield>
-      <subfield code="s">31919545</subfield>
+      <subfield code="s">28182561</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupT.zip</subfield>
-      <subfield code="s">31552890</subfield>
+      <subfield code="s">30556033</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -6843,9 +6843,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_21_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_21_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 21 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -6878,20 +6878,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -6906,102 +6906,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupA.zip</subfield>
-      <subfield code="s">31980548</subfield>
+      <subfield code="s">30077316</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupB.zip</subfield>
-      <subfield code="s">31579180</subfield>
+      <subfield code="s">30406718</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupC.zip</subfield>
-      <subfield code="s">31032052</subfield>
+      <subfield code="s">26808427</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupD.zip</subfield>
-      <subfield code="s">32933769</subfield>
+      <subfield code="s">27201057</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupE.zip</subfield>
-      <subfield code="s">30356356</subfield>
+      <subfield code="s">29106734</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupF.zip</subfield>
-      <subfield code="s">30855940</subfield>
+      <subfield code="s">26649617</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupG.zip</subfield>
-      <subfield code="s">34985364</subfield>
+      <subfield code="s">28585223</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupH.zip</subfield>
-      <subfield code="s">33461890</subfield>
+      <subfield code="s">28573126</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupI.zip</subfield>
-      <subfield code="s">32827670</subfield>
+      <subfield code="s">28962261</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupJ.zip</subfield>
-      <subfield code="s">31887420</subfield>
+      <subfield code="s">28746970</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupK.zip</subfield>
-      <subfield code="s">33108318</subfield>
+      <subfield code="s">29002818</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupL.zip</subfield>
-      <subfield code="s">31538827</subfield>
+      <subfield code="s">28562273</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupM.zip</subfield>
-      <subfield code="s">29822382</subfield>
+      <subfield code="s">31560222</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupN.zip</subfield>
-      <subfield code="s">31941035</subfield>
+      <subfield code="s">28758400</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupO.zip</subfield>
-      <subfield code="s">29692024</subfield>
+      <subfield code="s">27119363</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupP.zip</subfield>
-      <subfield code="s">33639557</subfield>
+      <subfield code="s">31943294</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupQ.zip</subfield>
-      <subfield code="s">29867676</subfield>
+      <subfield code="s">30837001</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupR.zip</subfield>
-      <subfield code="s">29407448</subfield>
+      <subfield code="s">29196925</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupS.zip</subfield>
-      <subfield code="s">31378077</subfield>
+      <subfield code="s">28411803</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupT.zip</subfield>
-      <subfield code="s">31287173</subfield>
+      <subfield code="s">29150470</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -7020,9 +7020,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_22_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_22_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 22 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -7055,20 +7055,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -7083,102 +7083,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupA.zip</subfield>
-      <subfield code="s">30163727</subfield>
+      <subfield code="s">29630225</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupB.zip</subfield>
-      <subfield code="s">29092526</subfield>
+      <subfield code="s">30982722</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupC.zip</subfield>
-      <subfield code="s">31189764</subfield>
+      <subfield code="s">30001730</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupD.zip</subfield>
-      <subfield code="s">30830727</subfield>
+      <subfield code="s">31251815</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupE.zip</subfield>
-      <subfield code="s">31253450</subfield>
+      <subfield code="s">30373265</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupF.zip</subfield>
-      <subfield code="s">32861474</subfield>
+      <subfield code="s">31111701</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupG.zip</subfield>
-      <subfield code="s">31026981</subfield>
+      <subfield code="s">29630244</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupH.zip</subfield>
-      <subfield code="s">29386122</subfield>
+      <subfield code="s">29230648</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupI.zip</subfield>
-      <subfield code="s">31035203</subfield>
+      <subfield code="s">27979169</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupJ.zip</subfield>
-      <subfield code="s">28437415</subfield>
+      <subfield code="s">30820474</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupK.zip</subfield>
-      <subfield code="s">27496097</subfield>
+      <subfield code="s">30363731</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupL.zip</subfield>
-      <subfield code="s">31586406</subfield>
+      <subfield code="s">31668147</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupM.zip</subfield>
-      <subfield code="s">30466750</subfield>
+      <subfield code="s">29845592</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupN.zip</subfield>
-      <subfield code="s">30450264</subfield>
+      <subfield code="s">31642498</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupO.zip</subfield>
-      <subfield code="s">25687706</subfield>
+      <subfield code="s">29561473</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupP.zip</subfield>
-      <subfield code="s">28439639</subfield>
+      <subfield code="s">29219967</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupQ.zip</subfield>
-      <subfield code="s">28012412</subfield>
+      <subfield code="s">31837151</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupR.zip</subfield>
-      <subfield code="s">29628613</subfield>
+      <subfield code="s">29414155</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupS.zip</subfield>
-      <subfield code="s">27913680</subfield>
+      <subfield code="s">32949527</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupT.zip</subfield>
-      <subfield code="s">29817809</subfield>
+      <subfield code="s">30512962</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -7197,9 +7197,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_23_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_23_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 23 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -7232,20 +7232,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -7260,102 +7260,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupA.zip</subfield>
-      <subfield code="s">28345652</subfield>
+      <subfield code="s">29909250</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupB.zip</subfield>
-      <subfield code="s">29473635</subfield>
+      <subfield code="s">29283433</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupC.zip</subfield>
-      <subfield code="s">27339428</subfield>
+      <subfield code="s">30973113</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupD.zip</subfield>
-      <subfield code="s">28008158</subfield>
+      <subfield code="s">31032455</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupE.zip</subfield>
-      <subfield code="s">26889568</subfield>
+      <subfield code="s">28901530</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupF.zip</subfield>
-      <subfield code="s">24992586</subfield>
+      <subfield code="s">29281637</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupG.zip</subfield>
-      <subfield code="s">27438521</subfield>
+      <subfield code="s">30298459</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupH.zip</subfield>
-      <subfield code="s">27327221</subfield>
+      <subfield code="s">31395358</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupI.zip</subfield>
-      <subfield code="s">27300904</subfield>
+      <subfield code="s">29368692</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupJ.zip</subfield>
-      <subfield code="s">28632138</subfield>
+      <subfield code="s">30463007</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupK.zip</subfield>
-      <subfield code="s">28271798</subfield>
+      <subfield code="s">30554022</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupL.zip</subfield>
-      <subfield code="s">29495363</subfield>
+      <subfield code="s">29671619</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupM.zip</subfield>
-      <subfield code="s">28389472</subfield>
+      <subfield code="s">30605288</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupN.zip</subfield>
-      <subfield code="s">29584474</subfield>
+      <subfield code="s">29821478</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupO.zip</subfield>
-      <subfield code="s">26824713</subfield>
+      <subfield code="s">29281943</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupP.zip</subfield>
-      <subfield code="s">27584502</subfield>
+      <subfield code="s">28661050</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupQ.zip</subfield>
-      <subfield code="s">27464010</subfield>
+      <subfield code="s">31881830</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupR.zip</subfield>
-      <subfield code="s">27627146</subfield>
+      <subfield code="s">28651678</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupS.zip</subfield>
-      <subfield code="s">31903562</subfield>
+      <subfield code="s">27673978</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupT.zip</subfield>
-      <subfield code="s">28988152</subfield>
+      <subfield code="s">27402723</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -7374,9 +7374,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_24_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_24_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 24 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -7409,20 +7409,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -7437,102 +7437,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupA.zip</subfield>
-      <subfield code="s">30488674</subfield>
+      <subfield code="s">27250963</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupB.zip</subfield>
-      <subfield code="s">31656203</subfield>
+      <subfield code="s">26255790</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupC.zip</subfield>
-      <subfield code="s">29507548</subfield>
+      <subfield code="s">28165451</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupD.zip</subfield>
-      <subfield code="s">30077962</subfield>
+      <subfield code="s">31940778</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupE.zip</subfield>
-      <subfield code="s">30079668</subfield>
+      <subfield code="s">29267965</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupF.zip</subfield>
-      <subfield code="s">30104594</subfield>
+      <subfield code="s">28081214</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupG.zip</subfield>
-      <subfield code="s">30075892</subfield>
+      <subfield code="s">30076956</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupH.zip</subfield>
-      <subfield code="s">30356638</subfield>
+      <subfield code="s">28538518</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupI.zip</subfield>
-      <subfield code="s">30791034</subfield>
+      <subfield code="s">27552634</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupJ.zip</subfield>
-      <subfield code="s">29480675</subfield>
+      <subfield code="s">27067609</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupK.zip</subfield>
-      <subfield code="s">30179695</subfield>
+      <subfield code="s">29146659</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupL.zip</subfield>
-      <subfield code="s">30796001</subfield>
+      <subfield code="s">29567919</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupM.zip</subfield>
-      <subfield code="s">31132936</subfield>
+      <subfield code="s">28092177</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupN.zip</subfield>
-      <subfield code="s">31511171</subfield>
+      <subfield code="s">27984237</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupO.zip</subfield>
-      <subfield code="s">28439525</subfield>
+      <subfield code="s">30078874</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupP.zip</subfield>
-      <subfield code="s">28452759</subfield>
+      <subfield code="s">28487302</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupQ.zip</subfield>
-      <subfield code="s">30836890</subfield>
+      <subfield code="s">26305485</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupR.zip</subfield>
-      <subfield code="s">30155235</subfield>
+      <subfield code="s">25471851</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupS.zip</subfield>
-      <subfield code="s">27542511</subfield>
+      <subfield code="s">27262799</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupT.zip</subfield>
-      <subfield code="s">29630008</subfield>
+      <subfield code="s">25819134</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -7551,9 +7551,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_25_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_25_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 25 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -7586,20 +7586,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -7614,102 +7614,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupA.zip</subfield>
-      <subfield code="s">26650010</subfield>
+      <subfield code="s">29342961</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupB.zip</subfield>
-      <subfield code="s">26859904</subfield>
+      <subfield code="s">25755034</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupC.zip</subfield>
-      <subfield code="s">32539689</subfield>
+      <subfield code="s">27645484</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupD.zip</subfield>
-      <subfield code="s">27814674</subfield>
+      <subfield code="s">29018825</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupE.zip</subfield>
-      <subfield code="s">32217942</subfield>
+      <subfield code="s">26943291</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupF.zip</subfield>
-      <subfield code="s">29815391</subfield>
+      <subfield code="s">28210279</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupG.zip</subfield>
-      <subfield code="s">32230520</subfield>
+      <subfield code="s">29279563</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupH.zip</subfield>
-      <subfield code="s">29717464</subfield>
+      <subfield code="s">29495042</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupI.zip</subfield>
-      <subfield code="s">28392383</subfield>
+      <subfield code="s">26808561</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupJ.zip</subfield>
-      <subfield code="s">28630995</subfield>
+      <subfield code="s">27118251</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupK.zip</subfield>
-      <subfield code="s">27181415</subfield>
+      <subfield code="s">29794519</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupL.zip</subfield>
-      <subfield code="s">29468736</subfield>
+      <subfield code="s">29810312</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupM.zip</subfield>
-      <subfield code="s">26539548</subfield>
+      <subfield code="s">27792737</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupN.zip</subfield>
-      <subfield code="s">28135284</subfield>
+      <subfield code="s">27999805</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupO.zip</subfield>
-      <subfield code="s">26487227</subfield>
+      <subfield code="s">27153764</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupP.zip</subfield>
-      <subfield code="s">25691607</subfield>
+      <subfield code="s">26961940</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupQ.zip</subfield>
-      <subfield code="s">26689656</subfield>
+      <subfield code="s">27618371</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupR.zip</subfield>
-      <subfield code="s">29989269</subfield>
+      <subfield code="s">26936582</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupS.zip</subfield>
-      <subfield code="s">27718889</subfield>
+      <subfield code="s">29907302</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupT.zip</subfield>
-      <subfield code="s">28124831</subfield>
+      <subfield code="s">28281691</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -7728,9 +7728,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_26_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_26_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 26 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -7763,20 +7763,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -7791,102 +7791,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupA.zip</subfield>
-      <subfield code="s">25923674</subfield>
+      <subfield code="s">30293028</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupB.zip</subfield>
-      <subfield code="s">26644461</subfield>
+      <subfield code="s">30462839</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupC.zip</subfield>
-      <subfield code="s">29026472</subfield>
+      <subfield code="s">27171512</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupD.zip</subfield>
-      <subfield code="s">25946372</subfield>
+      <subfield code="s">26427457</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupE.zip</subfield>
-      <subfield code="s">27317639</subfield>
+      <subfield code="s">28418333</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupF.zip</subfield>
-      <subfield code="s">28844037</subfield>
+      <subfield code="s">28631798</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupG.zip</subfield>
-      <subfield code="s">27556313</subfield>
+      <subfield code="s">26582096</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupH.zip</subfield>
-      <subfield code="s">27625295</subfield>
+      <subfield code="s">28883814</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupI.zip</subfield>
-      <subfield code="s">26900413</subfield>
+      <subfield code="s">29036671</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupJ.zip</subfield>
-      <subfield code="s">28300586</subfield>
+      <subfield code="s">28395556</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupK.zip</subfield>
-      <subfield code="s">28292784</subfield>
+      <subfield code="s">28787116</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupL.zip</subfield>
-      <subfield code="s">25775786</subfield>
+      <subfield code="s">31193369</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupM.zip</subfield>
-      <subfield code="s">29652064</subfield>
+      <subfield code="s">27737989</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupN.zip</subfield>
-      <subfield code="s">29068569</subfield>
+      <subfield code="s">27124937</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupO.zip</subfield>
-      <subfield code="s">26071141</subfield>
+      <subfield code="s">28335042</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupP.zip</subfield>
-      <subfield code="s">25137394</subfield>
+      <subfield code="s">27793286</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupQ.zip</subfield>
-      <subfield code="s">27420038</subfield>
+      <subfield code="s">25738158</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupR.zip</subfield>
-      <subfield code="s">30281713</subfield>
+      <subfield code="s">26055390</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupS.zip</subfield>
-      <subfield code="s">33448767</subfield>
+      <subfield code="s">25223534</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupT.zip</subfield>
-      <subfield code="s">31373657</subfield>
+      <subfield code="s">27491162</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -7905,9 +7905,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_27_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_27_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 27 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -7940,20 +7940,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -7968,102 +7968,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupA.zip</subfield>
-      <subfield code="s">28634144</subfield>
+      <subfield code="s">31193150</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupB.zip</subfield>
-      <subfield code="s">30435371</subfield>
+      <subfield code="s">29443266</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupC.zip</subfield>
-      <subfield code="s">30238183</subfield>
+      <subfield code="s">27859385</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupD.zip</subfield>
-      <subfield code="s">28628841</subfield>
+      <subfield code="s">27241665</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupE.zip</subfield>
-      <subfield code="s">30894844</subfield>
+      <subfield code="s">28975610</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupF.zip</subfield>
-      <subfield code="s">30594139</subfield>
+      <subfield code="s">26439393</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupG.zip</subfield>
-      <subfield code="s">27879731</subfield>
+      <subfield code="s">26237301</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupH.zip</subfield>
-      <subfield code="s">28924664</subfield>
+      <subfield code="s">25463814</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupI.zip</subfield>
-      <subfield code="s">31690525</subfield>
+      <subfield code="s">27747307</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupJ.zip</subfield>
-      <subfield code="s">32414527</subfield>
+      <subfield code="s">26353676</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupK.zip</subfield>
-      <subfield code="s">31985436</subfield>
+      <subfield code="s">28750865</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupL.zip</subfield>
-      <subfield code="s">30472371</subfield>
+      <subfield code="s">27229648</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupM.zip</subfield>
-      <subfield code="s">30471000</subfield>
+      <subfield code="s">26422811</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupN.zip</subfield>
-      <subfield code="s">30509926</subfield>
+      <subfield code="s">27335766</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupO.zip</subfield>
-      <subfield code="s">29883764</subfield>
+      <subfield code="s">27743575</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupP.zip</subfield>
-      <subfield code="s">32438470</subfield>
+      <subfield code="s">27314100</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupQ.zip</subfield>
-      <subfield code="s">30833849</subfield>
+      <subfield code="s">28492221</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupR.zip</subfield>
-      <subfield code="s">30672261</subfield>
+      <subfield code="s">31700521</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupS.zip</subfield>
-      <subfield code="s">31096413</subfield>
+      <subfield code="s">26692652</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupT.zip</subfield>
-      <subfield code="s">31950559</subfield>
+      <subfield code="s">26618226</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -8082,9 +8082,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_28_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_28_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 28 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -8117,20 +8117,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -8145,102 +8145,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupA.zip</subfield>
-      <subfield code="s">30094949</subfield>
+      <subfield code="s">28259910</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupB.zip</subfield>
-      <subfield code="s">29353161</subfield>
+      <subfield code="s">30360132</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupC.zip</subfield>
-      <subfield code="s">29184084</subfield>
+      <subfield code="s">27887967</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupD.zip</subfield>
-      <subfield code="s">29727469</subfield>
+      <subfield code="s">27587825</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupE.zip</subfield>
-      <subfield code="s">28124337</subfield>
+      <subfield code="s">27483338</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupF.zip</subfield>
-      <subfield code="s">31113677</subfield>
+      <subfield code="s">27596724</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupG.zip</subfield>
-      <subfield code="s">32228107</subfield>
+      <subfield code="s">29194912</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupH.zip</subfield>
-      <subfield code="s">31069953</subfield>
+      <subfield code="s">24474448</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupI.zip</subfield>
-      <subfield code="s">28264793</subfield>
+      <subfield code="s">27443114</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupJ.zip</subfield>
-      <subfield code="s">33542442</subfield>
+      <subfield code="s">30969588</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupK.zip</subfield>
-      <subfield code="s">33110894</subfield>
+      <subfield code="s">30688521</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupL.zip</subfield>
-      <subfield code="s">31413101</subfield>
+      <subfield code="s">30232153</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupM.zip</subfield>
-      <subfield code="s">28921490</subfield>
+      <subfield code="s">28928839</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupN.zip</subfield>
-      <subfield code="s">30926124</subfield>
+      <subfield code="s">29362032</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupO.zip</subfield>
-      <subfield code="s">31395924</subfield>
+      <subfield code="s">28449140</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupP.zip</subfield>
-      <subfield code="s">29807106</subfield>
+      <subfield code="s">28231018</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupQ.zip</subfield>
-      <subfield code="s">28944913</subfield>
+      <subfield code="s">27083919</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupR.zip</subfield>
-      <subfield code="s">29931825</subfield>
+      <subfield code="s">27519892</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupS.zip</subfield>
-      <subfield code="s">28751156</subfield>
+      <subfield code="s">29062917</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupT.zip</subfield>
-      <subfield code="s">27229939</subfield>
+      <subfield code="s">32668838</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -8259,9 +8259,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_29_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_29_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 29 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -8294,20 +8294,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -8322,102 +8322,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupA.zip</subfield>
-      <subfield code="s">30445405</subfield>
+      <subfield code="s">32481653</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupB.zip</subfield>
-      <subfield code="s">28699073</subfield>
+      <subfield code="s">30643486</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupC.zip</subfield>
-      <subfield code="s">28604269</subfield>
+      <subfield code="s">28558164</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupD.zip</subfield>
-      <subfield code="s">28080030</subfield>
+      <subfield code="s">28857245</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupE.zip</subfield>
-      <subfield code="s">29134194</subfield>
+      <subfield code="s">28930260</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupF.zip</subfield>
-      <subfield code="s">27529353</subfield>
+      <subfield code="s">30404310</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupG.zip</subfield>
-      <subfield code="s">28865913</subfield>
+      <subfield code="s">30094407</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupH.zip</subfield>
-      <subfield code="s">32151516</subfield>
+      <subfield code="s">32525001</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupI.zip</subfield>
-      <subfield code="s">26905681</subfield>
+      <subfield code="s">29813848</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupJ.zip</subfield>
-      <subfield code="s">30008801</subfield>
+      <subfield code="s">29357350</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupK.zip</subfield>
-      <subfield code="s">28281907</subfield>
+      <subfield code="s">28010937</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupL.zip</subfield>
-      <subfield code="s">28450864</subfield>
+      <subfield code="s">28757323</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupM.zip</subfield>
-      <subfield code="s">31270080</subfield>
+      <subfield code="s">31612233</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupN.zip</subfield>
-      <subfield code="s">28594372</subfield>
+      <subfield code="s">30681159</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupO.zip</subfield>
-      <subfield code="s">30276963</subfield>
+      <subfield code="s">30858111</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupP.zip</subfield>
-      <subfield code="s">26736609</subfield>
+      <subfield code="s">30533229</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupQ.zip</subfield>
-      <subfield code="s">26153908</subfield>
+      <subfield code="s">29625764</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupR.zip</subfield>
-      <subfield code="s">29052607</subfield>
+      <subfield code="s">31503594</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupS.zip</subfield>
-      <subfield code="s">30649762</subfield>
+      <subfield code="s">31184051</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupT.zip</subfield>
-      <subfield code="s">25871115</subfield>
+      <subfield code="s">29107705</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -8436,9 +8436,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_30_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_30_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 30 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -8471,20 +8471,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -8499,102 +8499,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupA.zip</subfield>
-      <subfield code="s">28559318</subfield>
+      <subfield code="s">33448624</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupB.zip</subfield>
-      <subfield code="s">28196005</subfield>
+      <subfield code="s">28936239</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupC.zip</subfield>
-      <subfield code="s">29105998</subfield>
+      <subfield code="s">30131550</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupD.zip</subfield>
-      <subfield code="s">27257341</subfield>
+      <subfield code="s">32184718</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupE.zip</subfield>
-      <subfield code="s">27681716</subfield>
+      <subfield code="s">28669680</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupF.zip</subfield>
-      <subfield code="s">28621766</subfield>
+      <subfield code="s">29958089</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupG.zip</subfield>
-      <subfield code="s">26246296</subfield>
+      <subfield code="s">29456872</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupH.zip</subfield>
-      <subfield code="s">30278831</subfield>
+      <subfield code="s">28325272</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupI.zip</subfield>
-      <subfield code="s">27269418</subfield>
+      <subfield code="s">26345217</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupJ.zip</subfield>
-      <subfield code="s">31671595</subfield>
+      <subfield code="s">30341706</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupK.zip</subfield>
-      <subfield code="s">31889944</subfield>
+      <subfield code="s">28588493</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupL.zip</subfield>
-      <subfield code="s">29825614</subfield>
+      <subfield code="s">29839505</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupM.zip</subfield>
-      <subfield code="s">30567649</subfield>
+      <subfield code="s">31028449</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupN.zip</subfield>
-      <subfield code="s">29326765</subfield>
+      <subfield code="s">30700501</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupO.zip</subfield>
-      <subfield code="s">29682700</subfield>
+      <subfield code="s">28702350</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupP.zip</subfield>
-      <subfield code="s">30258392</subfield>
+      <subfield code="s">33780657</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupQ.zip</subfield>
-      <subfield code="s">32118069</subfield>
+      <subfield code="s">31553316</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupR.zip</subfield>
-      <subfield code="s">31695252</subfield>
+      <subfield code="s">28552800</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupS.zip</subfield>
-      <subfield code="s">32038267</subfield>
+      <subfield code="s">28496517</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupT.zip</subfield>
-      <subfield code="s">27963600</subfield>
+      <subfield code="s">31352140</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -8613,9 +8613,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_31_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_31_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 31 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -8648,20 +8648,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -8676,102 +8676,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupA.zip</subfield>
-      <subfield code="s">30311903</subfield>
+      <subfield code="s">31867661</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupB.zip</subfield>
-      <subfield code="s">31455597</subfield>
+      <subfield code="s">28146365</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupC.zip</subfield>
-      <subfield code="s">29297281</subfield>
+      <subfield code="s">28738462</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupD.zip</subfield>
-      <subfield code="s">28856948</subfield>
+      <subfield code="s">24943626</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupE.zip</subfield>
-      <subfield code="s">27631047</subfield>
+      <subfield code="s">26886996</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupF.zip</subfield>
-      <subfield code="s">31554350</subfield>
+      <subfield code="s">27615180</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupG.zip</subfield>
-      <subfield code="s">27842289</subfield>
+      <subfield code="s">28844883</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupH.zip</subfield>
-      <subfield code="s">27819145</subfield>
+      <subfield code="s">27967948</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupI.zip</subfield>
-      <subfield code="s">30601204</subfield>
+      <subfield code="s">25734067</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupJ.zip</subfield>
-      <subfield code="s">29641754</subfield>
+      <subfield code="s">29253909</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupK.zip</subfield>
-      <subfield code="s">28621320</subfield>
+      <subfield code="s">27765497</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupL.zip</subfield>
-      <subfield code="s">27665280</subfield>
+      <subfield code="s">26937193</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupM.zip</subfield>
-      <subfield code="s">28702055</subfield>
+      <subfield code="s">28766371</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupN.zip</subfield>
-      <subfield code="s">26571442</subfield>
+      <subfield code="s">30138306</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupO.zip</subfield>
-      <subfield code="s">29791587</subfield>
+      <subfield code="s">27679308</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupP.zip</subfield>
-      <subfield code="s">29310859</subfield>
+      <subfield code="s">28573504</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupQ.zip</subfield>
-      <subfield code="s">28707583</subfield>
+      <subfield code="s">28739964</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupR.zip</subfield>
-      <subfield code="s">31272637</subfield>
+      <subfield code="s">27827644</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupS.zip</subfield>
-      <subfield code="s">26757405</subfield>
+      <subfield code="s">29274364</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupT.zip</subfield>
-      <subfield code="s">29442718</subfield>
+      <subfield code="s">29925397</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -8790,9 +8790,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_32_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_32_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 32 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -8825,20 +8825,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -8853,102 +8853,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupA.zip</subfield>
-      <subfield code="s">28192839</subfield>
+      <subfield code="s">25072447</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupB.zip</subfield>
-      <subfield code="s">26890431</subfield>
+      <subfield code="s">26372410</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupC.zip</subfield>
-      <subfield code="s">25612592</subfield>
+      <subfield code="s">26981291</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupD.zip</subfield>
-      <subfield code="s">30409779</subfield>
+      <subfield code="s">27794414</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupE.zip</subfield>
-      <subfield code="s">31172690</subfield>
+      <subfield code="s">28802074</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupF.zip</subfield>
-      <subfield code="s">30146151</subfield>
+      <subfield code="s">26256136</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupG.zip</subfield>
-      <subfield code="s">31033337</subfield>
+      <subfield code="s">26048374</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupH.zip</subfield>
-      <subfield code="s">29344380</subfield>
+      <subfield code="s">27291106</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupI.zip</subfield>
-      <subfield code="s">32167727</subfield>
+      <subfield code="s">25563541</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupJ.zip</subfield>
-      <subfield code="s">30411836</subfield>
+      <subfield code="s">27403474</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupK.zip</subfield>
-      <subfield code="s">31443215</subfield>
+      <subfield code="s">31386814</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupL.zip</subfield>
-      <subfield code="s">30564501</subfield>
+      <subfield code="s">28916509</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupM.zip</subfield>
-      <subfield code="s">28447910</subfield>
+      <subfield code="s">29679866</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupN.zip</subfield>
-      <subfield code="s">29350627</subfield>
+      <subfield code="s">30835803</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupO.zip</subfield>
-      <subfield code="s">27911123</subfield>
+      <subfield code="s">30135234</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupP.zip</subfield>
-      <subfield code="s">29148611</subfield>
+      <subfield code="s">29393844</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupQ.zip</subfield>
-      <subfield code="s">29480574</subfield>
+      <subfield code="s">29112507</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupR.zip</subfield>
-      <subfield code="s">26615710</subfield>
+      <subfield code="s">30128744</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupS.zip</subfield>
-      <subfield code="s">28202226</subfield>
+      <subfield code="s">27712487</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupT.zip</subfield>
-      <subfield code="s">29297063</subfield>
+      <subfield code="s">28236656</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -8967,9 +8967,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_33_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_33_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 33 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -9002,20 +9002,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -9030,102 +9030,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupA.zip</subfield>
-      <subfield code="s">27578548</subfield>
+      <subfield code="s">29599080</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupB.zip</subfield>
-      <subfield code="s">30447504</subfield>
+      <subfield code="s">29209294</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupC.zip</subfield>
-      <subfield code="s">30662811</subfield>
+      <subfield code="s">31773599</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupD.zip</subfield>
-      <subfield code="s">28587768</subfield>
+      <subfield code="s">25936478</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupE.zip</subfield>
-      <subfield code="s">30597991</subfield>
+      <subfield code="s">31237672</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupF.zip</subfield>
-      <subfield code="s">30919529</subfield>
+      <subfield code="s">30102353</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupG.zip</subfield>
-      <subfield code="s">29818896</subfield>
+      <subfield code="s">25871892</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupH.zip</subfield>
-      <subfield code="s">32167318</subfield>
+      <subfield code="s">27544584</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupI.zip</subfield>
-      <subfield code="s">29962705</subfield>
+      <subfield code="s">28547202</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupJ.zip</subfield>
-      <subfield code="s">30554959</subfield>
+      <subfield code="s">28942889</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupK.zip</subfield>
-      <subfield code="s">31188079</subfield>
+      <subfield code="s">28643461</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupL.zip</subfield>
-      <subfield code="s">30942650</subfield>
+      <subfield code="s">27753612</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupM.zip</subfield>
-      <subfield code="s">30085393</subfield>
+      <subfield code="s">28480360</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupN.zip</subfield>
-      <subfield code="s">29916279</subfield>
+      <subfield code="s">26285020</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupO.zip</subfield>
-      <subfield code="s">30902666</subfield>
+      <subfield code="s">29236073</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupP.zip</subfield>
-      <subfield code="s">29388177</subfield>
+      <subfield code="s">29332515</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupQ.zip</subfield>
-      <subfield code="s">30157745</subfield>
+      <subfield code="s">28261040</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupR.zip</subfield>
-      <subfield code="s">33400277</subfield>
+      <subfield code="s">28942529</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupS.zip</subfield>
-      <subfield code="s">31807981</subfield>
+      <subfield code="s">25398961</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupT.zip</subfield>
-      <subfield code="s">29278041</subfield>
+      <subfield code="s">27840209</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -9144,9 +9144,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_34_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_34_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 34 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -9179,20 +9179,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -9207,102 +9207,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupA.zip</subfield>
-      <subfield code="s">29055127</subfield>
+      <subfield code="s">29791304</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupB.zip</subfield>
-      <subfield code="s">29922371</subfield>
+      <subfield code="s">26824377</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupC.zip</subfield>
-      <subfield code="s">31908551</subfield>
+      <subfield code="s">28486888</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupD.zip</subfield>
-      <subfield code="s">28196003</subfield>
+      <subfield code="s">31157351</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupE.zip</subfield>
-      <subfield code="s">32574609</subfield>
+      <subfield code="s">27957462</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupF.zip</subfield>
-      <subfield code="s">32292765</subfield>
+      <subfield code="s">24967169</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupG.zip</subfield>
-      <subfield code="s">30362678</subfield>
+      <subfield code="s">25712582</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupH.zip</subfield>
-      <subfield code="s">30014547</subfield>
+      <subfield code="s">26477017</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupI.zip</subfield>
-      <subfield code="s">28058114</subfield>
+      <subfield code="s">27279657</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupJ.zip</subfield>
-      <subfield code="s">30409306</subfield>
+      <subfield code="s">28979754</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupK.zip</subfield>
-      <subfield code="s">32182444</subfield>
+      <subfield code="s">30266879</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupL.zip</subfield>
-      <subfield code="s">29371517</subfield>
+      <subfield code="s">29957961</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupM.zip</subfield>
-      <subfield code="s">28882696</subfield>
+      <subfield code="s">31951767</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupN.zip</subfield>
-      <subfield code="s">28739058</subfield>
+      <subfield code="s">29591786</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupO.zip</subfield>
-      <subfield code="s">31822832</subfield>
+      <subfield code="s">30539584</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupP.zip</subfield>
-      <subfield code="s">30561422</subfield>
+      <subfield code="s">32697905</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupQ.zip</subfield>
-      <subfield code="s">31686204</subfield>
+      <subfield code="s">30841834</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupR.zip</subfield>
-      <subfield code="s">28228387</subfield>
+      <subfield code="s">29357955</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupS.zip</subfield>
-      <subfield code="s">27817749</subfield>
+      <subfield code="s">30366345</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupT.zip</subfield>
-      <subfield code="s">30879302</subfield>
+      <subfield code="s">27662345</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -9321,9 +9321,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_35_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_35_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 35 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -9356,20 +9356,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -9384,102 +9384,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupA.zip</subfield>
-      <subfield code="s">28259629</subfield>
+      <subfield code="s">29708172</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupB.zip</subfield>
-      <subfield code="s">28979313</subfield>
+      <subfield code="s">29333802</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupC.zip</subfield>
-      <subfield code="s">32268032</subfield>
+      <subfield code="s">29785053</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupD.zip</subfield>
-      <subfield code="s">28032489</subfield>
+      <subfield code="s">25681994</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupE.zip</subfield>
-      <subfield code="s">30027593</subfield>
+      <subfield code="s">28408445</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupF.zip</subfield>
-      <subfield code="s">29310007</subfield>
+      <subfield code="s">29178616</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupG.zip</subfield>
-      <subfield code="s">28286469</subfield>
+      <subfield code="s">26935604</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupH.zip</subfield>
-      <subfield code="s">26295966</subfield>
+      <subfield code="s">27812952</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupI.zip</subfield>
-      <subfield code="s">29363366</subfield>
+      <subfield code="s">32110962</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupJ.zip</subfield>
-      <subfield code="s">28553994</subfield>
+      <subfield code="s">30035677</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupK.zip</subfield>
-      <subfield code="s">27988678</subfield>
+      <subfield code="s">31785243</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupL.zip</subfield>
-      <subfield code="s">28032622</subfield>
+      <subfield code="s">30188371</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupM.zip</subfield>
-      <subfield code="s">28853072</subfield>
+      <subfield code="s">31010072</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupN.zip</subfield>
-      <subfield code="s">28533715</subfield>
+      <subfield code="s">29318151</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupO.zip</subfield>
-      <subfield code="s">29484685</subfield>
+      <subfield code="s">28645427</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupP.zip</subfield>
-      <subfield code="s">33012769</subfield>
+      <subfield code="s">28407024</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupQ.zip</subfield>
-      <subfield code="s">31457408</subfield>
+      <subfield code="s">27905299</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupR.zip</subfield>
-      <subfield code="s">32479694</subfield>
+      <subfield code="s">27934708</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupS.zip</subfield>
-      <subfield code="s">28827721</subfield>
+      <subfield code="s">28081395</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupT.zip</subfield>
-      <subfield code="s">28614813</subfield>
+      <subfield code="s">27926551</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -9498,9 +9498,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_36_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_36_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 36 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -9533,20 +9533,20 @@ index</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a">A dataset of 1000 event display files accessible via
-HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
-by the ATLAS detector.</subfield>
+      HYPATIA as part of the Masterclasses Z-Path. The events were recorded in 2012
+      by the ATLAS detector.</subfield>
     </datafield>
     <datafield tag="581" ind1=" " ind2=" ">
       <subfield code="a">The dataset can be analysed by using HYPATIA, which
-can be found on the linked site in the section "Get to work! -> Data samples and tools".
-There you will also find a tally sheet and links to instructions on how to analyse the
-data found in the dataset. The section "Identifying Pariticles" will show how to
-find out which detector signature hints at which particle. "Identifying Events"
-details how to categorise events. Using the knowledge of these two sections,
-one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
-and to hunt for new particles.</subfield>
+      can be found on the linked site in the section "Get to work! -> Data samples and tools".
+      There you will also find a tally sheet and links to instructions on how to analyse the
+      data found in the dataset. The section "Identifying Pariticles" will show how to
+      find out which detector signature hints at which particle. "Identifying Events"
+      details how to categorise events. Using the knowledge of these two sections,
+      one can use the prescriptions in "Get to work! -> Do it!" to rediscover the Z boson
+      and to hunt for new particles.</subfield>
       <subfield
-code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
+          code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="653" ind1="1" ind2=" ">
       <subfield code="a">Masterclass</subfield>
@@ -9561,102 +9561,102 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupA.zip</subfield>
-      <subfield code="s">30229248</subfield>
+      <subfield code="s">27906622</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupB.zip</subfield>
-      <subfield code="s">32540534</subfield>
+      <subfield code="s">27828924</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupC.zip</subfield>
-      <subfield code="s">31356968</subfield>
+      <subfield code="s">27979553</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupD.zip</subfield>
-      <subfield code="s">29622872</subfield>
+      <subfield code="s">28469778</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupE.zip</subfield>
-      <subfield code="s">30325210</subfield>
+      <subfield code="s">31415719</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupF.zip</subfield>
-      <subfield code="s">29830248</subfield>
+      <subfield code="s">32607193</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupG.zip</subfield>
-      <subfield code="s">29452118</subfield>
+      <subfield code="s">30170679</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupH.zip</subfield>
-      <subfield code="s">29484260</subfield>
+      <subfield code="s">26952244</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupI.zip</subfield>
-      <subfield code="s">30130075</subfield>
+      <subfield code="s">29930669</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupJ.zip</subfield>
-      <subfield code="s">30766126</subfield>
+      <subfield code="s">29517242</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupK.zip</subfield>
-      <subfield code="s">30229878</subfield>
+      <subfield code="s">29249697</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupL.zip</subfield>
-      <subfield code="s">28678298</subfield>
+      <subfield code="s">27634954</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupM.zip</subfield>
-      <subfield code="s">29103710</subfield>
+      <subfield code="s">28848602</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupN.zip</subfield>
-      <subfield code="s">28869098</subfield>
+      <subfield code="s">30429486</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupO.zip</subfield>
-      <subfield code="s">29338474</subfield>
+      <subfield code="s">32239262</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupP.zip</subfield>
-      <subfield code="s">31091085</subfield>
+      <subfield code="s">31182696</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupQ.zip</subfield>
-      <subfield code="s">26787490</subfield>
+      <subfield code="s">27808659</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupR.zip</subfield>
-      <subfield code="s">27064281</subfield>
+      <subfield code="s">31134424</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupS.zip</subfield>
-      <subfield code="s">30110175</subfield>
+      <subfield code="s">29465112</subfield>
     </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupT.zip</subfield>
-      <subfield code="s">26066893</subfield>
+      <subfield code="s">27905291</subfield>
     </datafield>
     <datafield tag="960" ind1=" " ind2=" ">
       <subfield code="c">2015</subfield>
@@ -9675,9 +9675,9 @@ code="u">http://atlas.physicsmasterclasses.org/en/zpath.htm</subfield>
     </datafield>
     <datafield tag="FFT" ind1=" " ind2=" ">
       <subfield
-code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_37_file_index.txt</subfield>
+          code="a">/tmp/opendata.cern.ch-fft-file-cache/atlas-eos-file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_37_file_index.txt</subfield>
       <subfield code="z">ATLAS Masterclass ZPath 2015 dataset 37 file
-index</subfield>
+      index</subfield>
     </datafield>
   </record>
   <record>
@@ -9830,7 +9830,7 @@ index</subfield>
     <datafield tag="786" ind1=" " ind2=" ">
       <subfield code="a">ATLAS samples for 2016 open data release</subfield>
       <subfield code="w">3860</subfield>
-    </datafield>  
+    </datafield>
     <datafield tag="856" ind1="7" ind2=" ">
       <subfield code="2">xrootd</subfield>
       <subfield code="u">root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/Data/DataMuons.root</subfield>


### PR DESCRIPTION
* Updates EOS file listings (e.g. file sizes) for ATLAS ZPath 2015 datasets,
  following up the data file update done with Felix Socher. (closes #917)
    
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>