### PR TITLE
CMS: link records to SW source

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-tools-cmssw-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-cmssw-Run2011A.xml
@@ -41,6 +41,9 @@
         <subfield code="a">CERN-LHC</subfield>
         <subfield code="e">CMS</subfield>
       </datafield>
+        <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">https://github.com/cms-sw/cmssw/tree/CMSSW_5_3_X</subfield>
+      </datafield>
       <datafield tag="964" ind1=" " ind2="0">
         <subfield code="c">Run2011A</subfield>
       </datafield>

--- a/invenio_opendata/testsuite/data/cms/cms-tools-cmssw.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-cmssw.xml
@@ -41,6 +41,9 @@
       <subfield code="a">CERN-LHC</subfield>
       <subfield code="e">CMS</subfield>
     </datafield>
+    <datafield tag="856" ind1="4" ind2=" ">
+      <subfield code="u">https://github.com/cms-sw/cmssw/tree/CMSSW_4_2_X</subfield>
+    </datafield>
     <datafield tag="964" ind1=" " ind2="0">
       <subfield code="c">Run2010B</subfield>
     </datafield>


### PR DESCRIPTION
- Addition of `856` to link to the SW source repositories (closes #1225) 

Signed-off-by: Artemis Lavasa artemis.lavasa@cern.ch