### PR TITLE
OPERA: new datasets for forthcoming 2017 open data release

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -29,7 +29,8 @@ Quick installation instructions for an impatient Invenio developer::
    # now populate demo site with some records
    docker exec -i -t -u invenio opendatacernch_web_1 \
      inveniomanage demosite populate --packages=invenio_opendata.base \
-       -f invenio_opendata/testsuite/data/lhcb/lhcb-derived-datasets.xml \
+       -f invenio_opendata/testsuite/data/opera/opera-ecc-datasets.xml \
+       -f invenio_opendata/testsuite/data/opera/opera-ed-datasets.xml \
        -e force-recids --yes-i-know
    firefox http://127.0.0.1:28080/
 
@@ -142,6 +143,8 @@ populate *all* collections, you can use::
     -f invenio_opendata/testsuite/data/lhcb/lhcb-derived-datasets.xml \
     -f invenio_opendata/testsuite/data/lhcb/lhcb-learning-resources.xml \
     -f invenio_opendata/testsuite/data/lhcb/lhcb-tools.xml \
+    -f invenio_opendata/testsuite/data/opera/opera-ecc-datasets.xml \
+    -f invenio_opendata/testsuite/data/opera/opera-ed-datasets.xml \
     -f invenio_opendata/testsuite/data/data-policies.xml \
     -e force-recids --yes-i-know
 

--- a/invenio_opendata/testsuite/data/opera/opera-ecc-datasets.xml
+++ b/invenio_opendata/testsuite/data/opera/opera-ecc-datasets.xml
@@ -1,0 +1,42 @@
+<collection>
+  <record>
+    <controlfield tag="001">3901</controlfield>
+   <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">OPERA collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">OPERA Emulsion Cloud Chamber (ECC) open data release 2017 short title FIXME</subfield>
+    </datafield>
+    <datafield tag="246" ind1=" " ind2=" ">
+      <subfield code="a">OPERA Emulsion Cloud Chamber (ECC) open data release 2017 long title FIXME</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2017</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">This is longer description FIXME</subfield>
+    </datafield>
+    <datafield tag="540" ind1=" " ind2=" ">
+      <subfield code="a">CC0</subfield>
+    </datafield>
+    <datafield tag="556" ind1=" " ind2=" ">
+      <subfield code="a">This dataset has the following issues and limitations FIXME</subfield>
+    </datafield>
+    <datafield tag="567" ind1=" " ind2=" ">
+      <subfield code="a">Events in this dataset were selected as follows FIXME</subfield>
+    </datafield>
+    <datafield tag="581" ind1=" " ind2=" ">
+      <subfield code="a">You can access this dataset via the interactive even display FIXME</subfield>
+    </datafield>
+    <datafield tag="583" ind1=" " ind2=" ">
+      <subfield code="a">This dataset was validated as follows FIXME</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">OPERA-Emulsion-Detector-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Education</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/invenio_opendata/testsuite/data/opera/opera-ed-datasets.xml
+++ b/invenio_opendata/testsuite/data/opera/opera-ed-datasets.xml
@@ -1,0 +1,42 @@
+<collection>
+  <record>
+    <controlfield tag="001">3900</controlfield>
+   <datafield tag="110" ind1=" " ind2=" ">
+      <subfield code="a">OPERA collaboration</subfield>
+    </datafield>
+    <datafield tag="245" ind1=" " ind2=" ">
+      <subfield code="a">OPERA Electronic Detector (ED) open data release 2017 short title FIXME</subfield>
+    </datafield>
+    <datafield tag="246" ind1=" " ind2=" ">
+      <subfield code="a">OPERA Electronic Detector (ED) open data release 2017 long title FIXME</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2017</subfield>
+    </datafield>
+    <datafield tag="520" ind1=" " ind2=" ">
+      <subfield code="a">This is longer description FIXME</subfield>
+    </datafield>
+    <datafield tag="540" ind1=" " ind2=" ">
+      <subfield code="a">CC0</subfield>
+    </datafield>
+    <datafield tag="556" ind1=" " ind2=" ">
+      <subfield code="a">This dataset has the following issues and limitations FIXME</subfield>
+    </datafield>
+    <datafield tag="567" ind1=" " ind2=" ">
+      <subfield code="a">Events in this dataset were selected as follows FIXME</subfield>
+    </datafield>
+    <datafield tag="581" ind1=" " ind2=" ">
+      <subfield code="a">You can access this dataset via the interactive even display FIXME</subfield>
+    </datafield>
+    <datafield tag="583" ind1=" " ind2=" ">
+      <subfield code="a">This dataset was validated as follows FIXME</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">OPERA-Electronic-Detector-Datasets</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="b">Education</subfield>
+    </datafield>
+  </record>
+</collection>


### PR DESCRIPTION
* Adds new OPERA ED and ECC dataset records for the forthcoming 2017 open data
  release. Most of information is illustrative and will be filled later by the
  collaboration. (addresses #1242)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>