### PR TITLE
templates: no CMS Luminosity Information under /educate

### DIFF
--- a/invenio_opendata/base/templates/helpers/collections_educate.html
+++ b/invenio_opendata/base/templates/helpers/collections_educate.html
@@ -5,7 +5,7 @@
         <div class="coll-overview row">
             <ul>
                 {% for collection in exp_collection.collection_children_r recursive %}
-                {% if collection.name not in ['CMS-Primary-Datasets', 'CMS-Simulated-Datasets', 'CMS-Validated-Runs', 'CMS-Validation-Utilities', 'CMS-Condition-Data', 'CMS-Configuration-Files', 'CMS-Trigger-Information'] %}
+                {% if collection.name not in ['CMS-Primary-Datasets', 'CMS-Simulated-Datasets', 'CMS-Validated-Runs', 'CMS-Validation-Utilities', 'CMS-Condition-Data', 'CMS-Configuration-Files', 'CMS-Trigger-Information', 'CMS-Luminosity-Information'] %}
                 {% set portalboxes = {'desc': 'Description goes here..', 'image': 'default.png'} %}
                 {% for pb in collection.portalboxes %}
                 {% if (pb.portalbox.title == 'description') %}


### PR DESCRIPTION
* Fixes /educate page not to display the CMS Luminosity Information collection.
  The collection is now displayed under /research only.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>