### PR TITLE
CMS: vertex distance fix

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-tools-ana-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-ana-Run2011A.xml
@@ -133,7 +133,7 @@
       <li>In the ZZ analysis two Z candidates are required, and for both candidates, two leptons with opposite charge are required. The first Z candidate is required to have higher lepton momentum: 20 GeV for the first lepton and 10 GeV for the second lepton. The invariant mass is required to be in the range 40 GeV to 120 GeV. The second candidate is required to have an invariant mass higher then 4 GeV. The first candidate is the one with the invariant mass closest to the Z boson mass.</li></ol></p>
       <p>Selection criteria for electron candidates:
       <ul class="text"><li>pT > 7 GeV and |η| &lt; 2.5;</li>
-      <li>Distance between the electron z-vertex and the interaction z-vertex &lt; 0.02 cm;</li>
+      <li>Distance between the electron z-vertex and the interaction z-vertex &lt; 0.2 cm;</li>
       <li>Transverse impact parameter w.r.t. the beam spot &lt; 0.04 cm;</li>
       <li>Symmetrised impact parameter w.r.t. the beam sport &lt; 4 cm;</li>
       <li>Photon conversion rejection: number of lost hits in the tracker &lt; 1;</li>
@@ -142,7 +142,7 @@
       <p>Selection criteria for muon candidates:
       <ul class="text">
       <li>pT &gt; 5 GeV and |η| &lt; 2.4;</li>
-      <li>Distance between the muon z-vertex and the interaction z-vertex &lt; 0.02 cm;</li>
+      <li>Distance between the muon z-vertex and the interaction z-vertex &lt; 0.2 cm;</li>
       <li>Is a GlobalMuon and TrackerMuon;</li>
       <li>Number of valid hits in the inner tracker &gt; 10;</li>
       <li>χ2 /ndo f &lt; 10 for the global muon fit;</li>

--- a/invenio_opendata/testsuite/data/cms/cms-tools-ana.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-tools-ana.xml
@@ -136,7 +136,7 @@
       <li>In the ZZ analysis two Z candidates are required, and for both candidates, two leptons with opposite charge are required. The first Z candidate is required to have higher lepton momentum: 20 GeV for the first lepton and 10 GeV for the second lepton. The invariant mass is required to be in the range 40 GeV to 120 GeV. The second candidate is required to have an invariant mass higher then 4 GeV. The first candidate is the one with the invariant mass closest to the Z boson mass.</li></ol></p>
       <p>Selection criteria for electron candidates:
       <ul class="text"><li>pT > 7 GeV and |η| &lt; 2.5;</li>
-      <li>Distance between the electron z-vertex and the interaction z-vertex &lt; 0.02 cm;</li>
+      <li>Distance between the electron z-vertex and the interaction z-vertex &lt; 0.2 cm;</li>
       <li>Transverse impact parameter w.r.t. the beam spot &lt; 0.04 cm;</li>
       <li>Symmetrised impact parameter w.r.t. the beam sport &lt; 4 cm;</li>
       <li>Photon conversion rejection: number of lost hits in the tracker &lt; 1;</li>
@@ -145,7 +145,7 @@
       <p>Selection criteria for muon candidates:
       <ul class="text">
       <li>pT &gt; 5 GeV and |η| &lt; 2.4;</li>
-      <li>Distance between the muon z-vertex and the interaction z-vertex &lt; 0.02 cm;</li>
+      <li>Distance between the muon z-vertex and the interaction z-vertex &lt; 0.2 cm;</li>
       <li>Is a GlobalMuon and TrackerMuon;</li>
       <li>Number of valid hits in the inner tracker &gt; 10;</li>
       <li>χ2 /ndo f &lt; 10 for the global muon fit;</li>


### PR DESCRIPTION
* Fixes vertex distance typo (0.02cm -> 0.2cm). (closes #1264)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>