### PR TITLE
templates: EGI FedCloud for CMS Learning Resources

### DIFF
--- a/invenio_opendata/base/templates/helpers/text/cms_learning_resources.html
+++ b/invenio_opendata/base/templates/helpers/text/cms_learning_resources.html
@@ -11,7 +11,6 @@
       <a href="http://www.helsinki.fi/~slehti/ComputingMethodsInHEP/ComputingMethodsInHEP.html">This introductory course</a> by S. Lehti is aimed at students with no prior knowledge of computing methods in high-energy physics. Prior knowledge of some programming language is needed. The course goes through basics of programming languages in high-energy physics (FORTRAN, C++, python), software for analysis and visualisation (ROOT), some software for calculating cross-sections and branching ratios, simulation of collisions (event generation), basics of CMS software (CMSSW) and an introduction to grid computing. This course is developed in the University of Helsinki for students interested in experimental particle physics.
     </p>
   </div>
-
 </div>
 
 <div class="resource-box">
@@ -28,7 +27,6 @@
     </div>
   </div>
 </div>
-
 
 <div class="resource-box">
   <div class="col-sm-3">
@@ -48,9 +46,6 @@
   </div>
 </div>
 
-
-
-
 <div class="resource-box">
   <div class="col-sm-9">
     <h2>Particle Physics Playground<a class="btn" href="http://particle-physics-playground.github.io/">Go to the Particle Physics Playground<span class="fa fa-external-link"></span></a></h2>
@@ -58,7 +53,6 @@
       This site, by Matt Bellis, provides exercises that use real data from CMS (and now CLEO!) to teach experimental particle physics. It is, however, not meant to be a fully comprehensive tutorial. The ideal student will have learned the basic concepts elsewhere (classroom setting, mentor, independent study), following which they will then use these exercises to test their understanding of the concepts and appreciate how "real scientists" work in this field.
     </p>
   </div>
-
   <div class="col-sm-3">
     <div class="learn-img">
       <img src="{{url_for('static', filename='img/ParticlePhysicsPlayground.png')}}" />
@@ -80,9 +74,7 @@
       Every year, thousands of high-school students all over the world become particle physicists for a day, and visit nearby CMS institutes and universities to perform real analyses using public CMS data. The CMS Masterclass exercise is developed by <a href="http://quarknet.fnal.gov/">QuarkNet</a> and conducted under the aegis of the <a href="http://cern.ch/ippog">International Particle Physics Outreach Group</a>.
     </p>
   </div>
-
 </div>
-
 
 <div class="resource-box">
   <div class="col-sm-9">
@@ -97,5 +89,19 @@
       <h6>Project map of the CMS e-Lab</h6>
     </div>
   </div>
+</div>
 
+<div class="resource-box">
+  <div class="col-sm-3">
+    <div class="learn-img">
+      <img src="{{url_for('static', filename='img/CMSMasterclass.jpg')}}" />
+      <h6>High-school students performing a CMS exercise</h6>
+    </div>
+  </div>
+  <div class="col-sm-9">
+    <h2>EGI FedCloud portal for CMS open data<a class="btn" href="http://cmsopendata.ifca.es/">Go to EGI FedCloud portal for CMS open data<span class="fa fa-external-link"></span></a></h2>
+    <p>
+      The IFCA CMS portal allows manipulation of data from the CERN Open Data Portal without requiring the users to install sophisticated informatics tools.  The portal uses CMS data from the CERN Open Data Portal.
+    </p>
+  </div>
 </div>


### PR DESCRIPTION
* Adds EGI FedCloud record to CMS Learning Resources collection page.
  (closes #1214)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>