### PR TITLE
CMS: DOI for CMS luminosity information records

### DIFF
--- a/invenio_opendata/testsuite/data/cms/cms-luminosity-information.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-luminosity-information.xml
@@ -1,6 +1,10 @@
 <collection xmlns="http://www.loc.gov/MARC21/slim">
   <record>
     <controlfield tag="001">1050</controlfield>
+    <datafield tag="024" ind1="7" ind2=" ">
+      <subfield code="a">10.7483/OPENDATA.CMS.WTXQ.PCF8</subfield>
+      <subfield code="2">DOI</subfield>
+    </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS Collaboration</subfield>
       <subfield code="w">451</subfield>
@@ -13,7 +17,7 @@
       <subfield code="c">2017</subfield>
     </datafield>
     <datafield tag="264" ind1=" " ind2="0">
-      <subfield code="c">2011</subfield>
+      <subfield code="c">2010</subfield>
     </datafield>
     <datafield tag="520" ind1=" " ind2=" ">
       <subfield code="a"><![CDATA[ The integrated luminosity for validated runs and luminosity sections of the 2010 public data (RunB) is available in the table <a href="/record/1050/files/2010RunBlumi.txt">2010RunBlumi.txt</a>. (The integrated luminosity for validated runs and luminosity sections of all 2010 p-p data taking is available in <a href="/record/1050/files/2010lumi.txt">2010lumi.txt</a>.) In your estimate for the integrated luminosity, check for which runs the trigger you have selected is active and sum the values for those runs. The uncertainty in the luminosity measurement of 2010 data should be considered as 11% (reference <a href="https://cds.cern.ch/record/1279145/files/EWK-10-004-pas.pdf">CMS PAS EWK-10-004</a>). ]]></subfield>
@@ -40,6 +44,10 @@
   </record>
   <record>
     <controlfield tag="001">1051</controlfield>
+    <datafield tag="024" ind1="7" ind2=" ">
+      <subfield code="a">10.7483/OPENDATA.CMS.FPPH.Q7S2</subfield>
+      <subfield code="2">DOI</subfield>
+    </datafield>
     <datafield tag="110" ind1=" " ind2=" ">
       <subfield code="a">CMS Collaboration</subfield>
       <subfield code="w">451</subfield>


### PR DESCRIPTION
* Assigns DOIs.
* Corrects field 264 in record 1050. (addresses #1138) (PR #1277)