### PR TITLE
CMS: updates to CSV Run2011A files

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -108,6 +108,7 @@ populate *all* collections, you can use::
     -f invenio_opendata/testsuite/data/cms/cms-author-list.xml \
     -f invenio_opendata/testsuite/data/cms/cms-csv-files.xml \
     -f invenio_opendata/testsuite/data/cms/cms-derived-pattuples-ana.xml \
+    -f invenio_opendata/testsuite/data/cms/cms-derived-csv-Run2011A.xml \
     -f invenio_opendata/testsuite/data/cms/cms-eventdisplay-files.xml \
     -f invenio_opendata/testsuite/data/cms/cms-eventdisplay-files-Run2011A.xml \
     -f invenio_opendata/testsuite/data/cms/cms-hamburg-files.xml \

--- a/invenio_opendata/testsuite/data/cms/cms-derived-csv-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-derived-csv-Run2011A.xml
@@ -1,10 +1,6 @@
 <collection>
   <record>
-    <controlfield tag="001"></controlfield>
-    <datafield tag="024" ind1="7" ind2=" ">
-      <subfield code="2">DOI</subfield>
-      <subfield code="a"></subfield>
-    </datafield>
+    <controlfield tag="001">545</controlfield>
     <datafield tag="245" ind1="" ind2="">
       <subfield code="a">Datasets derived from the Run2011A SingleElectron, SingleMu, DoubleElectron, and DoubleMu primary datasets</subfield>
     </datafield>
@@ -22,7 +18,7 @@
       <subfield code="a">CC0</subfield>
     </datafield>
     <datafield tag="567" ind1="" ind2="">
-      <subfield code="a">
+      <subfield code="a"><![CDATA[
       <p>
         <p><strong>Wmunu</strong></p>
         <p>An event was selected if there was one (and only one) global muon in the event that satisfies: pT > 25.0 GeV and |eta| < 2.1. Furthermore, the event was rejected if there was another global muon in the event with pT > 10 GeV in the acceptance region |eta| < 2.4.</p>
@@ -61,7 +57,7 @@
           An event was selected if there were two muons in the event, both with |eta| < 2.4, at least one muon was a global muon, the invariant mass of the two muons was > 8 GeV and < 12 GeV, and they have opposite-sign charge.
         </p>
       </p>
-      </subfield>
+      ]]></subfield>
     </datafield>
     <datafield tag="556" ind1="" ind2="">
       <subfield code="a">These data were selected for use in education and outreach and contain a subset of the total event information. They are not suitable for a full physics analysis.</subfield>
@@ -178,11 +174,11 @@
       <subfield code="n">Wenu</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zmumu_SingleMu_Run2011A.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zmumu_DoubleMu_Run2011A.csv</subfield>
       <subfield code="n">Zmumu</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">
-      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zee_SingleElectron_Run2011A.csv</subfield>
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zee_DoubleElectron_Run2011A.csv</subfield>
       <subfield code="n">Zee</subfield>
     </datafield>
     <datafield tag="FFT" ind1="" ind2="">

--- a/invenio_opendata/testsuite/data/cms/cms-derived-csv-Run2011A.xml
+++ b/invenio_opendata/testsuite/data/cms/cms-derived-csv-Run2011A.xml
@@ -1,0 +1,205 @@
+<collection>
+  <record>
+    <controlfield tag="001"></controlfield>
+    <datafield tag="024" ind1="7" ind2=" ">
+      <subfield code="2">DOI</subfield>
+      <subfield code="a"></subfield>
+    </datafield>
+    <datafield tag="245" ind1="" ind2="">
+      <subfield code="a">Datasets derived from the Run2011A SingleElectron, SingleMu, DoubleElectron, and DoubleMu primary datasets</subfield>
+    </datafield>
+    <datafield tag="260" ind1=" " ind2=" ">
+      <subfield code="b">CERN Open Data Portal</subfield>
+      <subfield code="c">2017</subfield>
+    </datafield>
+    <datafield tag="100" ind1="" ind2="">
+      <subfield code="a">McCauley, Thomas</subfield>
+    </datafield>
+    <datafield tag="520" ind1="" ind2="">
+      <subfield code="a">These data were selected from the primary datasets in order to obtain candidate J/psi and Y events, candidate W and Z boson events, and general di-electron and dimuon spectra.</subfield>
+    </datafield>
+    <datafield tag="540" ind1=" " ind2=" ">
+      <subfield code="a">CC0</subfield>
+    </datafield>
+    <datafield tag="567" ind1="" ind2="">
+      <subfield code="a">
+      <p>
+        <p><strong>Wmunu</strong></p>
+        <p>An event was selected if there was one (and only one) global muon in the event that satisfies: pT > 25.0 GeV and |eta| < 2.1. Furthermore, the event was rejected if there was another global muon in the event with pT > 10 GeV in the acceptance region |eta| < 2.4.</p>
+      </p>
+      <p>
+        <p><strong>Wenu</strong></p>
+        <p>An event was selected if there is was one electron in the event with pT > 25.0 GeV. Furthermore, the event was rejected if there was a second electron present with pT > 20 GeV.</p>
+      </p>
+      <p>
+        <p><strong>Zee</strong></p>
+        <p>
+          An event was selected if there were two electrons in the event with pT > 25 GeV and the invariant mass of the two electrons was > 60 GeV and < 120 GeV.
+        </p>
+      </p>
+      <p>
+        <p><strong>Zmumu</strong></p>
+        <p>
+          An event was selected if there were two muons in the event with pT > 20 GeV and |eta| < 2.1 and the invariant mass of the two muons was > 60 GeV and < 120 GeV.
+        </p>
+      </p>
+      <p>
+        <p><strong>Dimuon</strong></p>
+        <p>
+          An event was selected if there were two muons in the event, both with |eta| < 2.4, at least one muon was a global muon, the invariant mass of the two muons was > 0.3 GeV and < 300 GeV, and they have opposite-sign charge.
+        </p>
+      </p>
+      <p>
+        <p><strong>Jpsimumu</strong></p>
+        <p>
+          An event was selected if there were two muons in the event, both with |eta| < 2.4, at least one muon was a global muon, the invariant mass of the two muons was > 2 GeV and < 5 GeV, and they have opposite-sign charge.
+        </p>
+      </p>
+      <p>
+        <p><strong>Ymumu</strong></p>
+        <p>
+          An event was selected if there were two muons in the event, both with |eta| < 2.4, at least one muon was a global muon, the invariant mass of the two muons was > 8 GeV and < 12 GeV, and they have opposite-sign charge.
+        </p>
+      </p>
+      </subfield>
+    </datafield>
+    <datafield tag="556" ind1="" ind2="">
+      <subfield code="a">These data were selected for use in education and outreach and contain a subset of the total event information. They are not suitable for a full physics analysis.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">Run</subfield>
+      <subfield code="g">The run number of the event.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">Event</subfield>
+      <subfield code="g">The event number.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">E,px,py,pz</subfield>
+      <subfield code="g">For a lepton, either a muon or an electron, the total energy and components of the momemtum (in GeV).</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">pt</subfield>
+      <subfield code="g">The transverse momentum of the lepton (in units of GeV), either a muon or an electron.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">eta</subfield>
+      <subfield code="g">The pseudorapidity of the lepton, either a muon or an electron.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">phi</subfield>
+      <subfield code="g">The phi angle (in radians) of the lepton, either a muon or an electron.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">Q</subfield>
+      <subfield code="g">The charge of the lepton, either a muon or an electron.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">M</subfield>
+      <subfield code="g">The invariant mass (in GeV) of either two muons or two electrons.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">chiSq</subfield>
+      <subfield code="g">The chi-squared per degree-of-freedom of the lepton, either a muon or an electron.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">dxy</subfield>
+      <subfield code="g">The impact parameter in the transverse plane with respect to the vertex of the muon or electron.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">iso</subfield>
+      <subfield code="g">The combined isolation (Itrack + Iecal + Ihcal) of the muon.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">MET</subfield>
+      <subfield code="g">The missing transverse momentum of the event (in units of GeV).</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">phiMET</subfield>
+      <subfield code="g">The phi angle (in radians) of the missing transverse momentum.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">type</subfield>
+      <subfield code="g">For an electron, either EB or EE: whether the electron is in the barrel or in the endcap.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">type</subfield>
+      <subfield code="g">For a muon, either T or G: whether the muon is a tracker or global muon.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">delEta</subfield>
+      <subfield code="g">The difference in eta (in radians) between the electron track and the associated cluster in the ECAL.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">delPhi</subfield>
+      <subfield code="g">The difference in phi (in radians) between the electron track and the associated cluster in the ECAL.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">sigmaEtaEta</subfield>
+      <subfield code="g">The weighted cluster rms along eta for an electron.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">HoverE</subfield>
+      <subfield code="g">The energy of the electron in the HCAL divided by the energy of the electron in the ECAL. </subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">isoTrack</subfield>
+      <subfield code="g">The isolation variable for the electron in the tracker.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">isoEcal</subfield>
+      <subfield code="g">The isolation variable for the electron in the ECAL.</subfield>
+    </datafield>
+    <datafield tag="505" ind1=" " ind2=" ">
+      <subfield code="t">isoHcal</subfield>
+      <subfield code="g">The isolation variable for the electron in the HCAL.</subfield>
+    </datafield>
+    <datafield tag="581" ind1=" " ind2=" ">
+      <subfield code="a">The data can be analyzed using a Jupyter notebook:</subfield>
+      <subfield code="u">https://github.com/cmsopendata-finland/kurssimateriaali</subfield>
+      <subfield code="y">CMS Open Data Finland</subfield>
+    </datafield>
+    <datafield tag="693" ind1=" " ind2=" ">
+      <subfield code="a">CERN-LHC</subfield>
+      <subfield code="e">CMS</subfield>
+    </datafield>
+    <datafield tag="964" ind1=" " ind2="0">
+      <subfield code="c">Run2011A</subfield>
+    </datafield>
+    <datafield tag="980" ind1=" " ind2=" ">
+      <subfield code="a">CMS-Derived-Datasets</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1="" ind2="">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wmunu_SingleMu_Run2011A.csv</subfield>
+      <subfield code="n">Wmunu</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1="" ind2="">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Wenu_SingleElectron_Run2011A.csv</subfield>
+      <subfield code="n">Wenu</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1="" ind2="">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zmumu_SingleMu_Run2011A.csv</subfield>
+      <subfield code="n">Zmumu</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1="" ind2="">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Zee_SingleElectron_Run2011A.csv</subfield>
+      <subfield code="n">Zee</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1="" ind2="">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Dimuon_SingleMu_Run2011A.csv</subfield>
+      <subfield code="n">Dimuon SingleMu</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1="" ind2="">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Dimuon_DoubleMu_Run2011A.csv</subfield>
+      <subfield code="n">Dimuon DoubleMu</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1="" ind2="">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Jpsimumu_DoubleMu_Run2011A.csv</subfield>
+      <subfield code="n">Jpsimumu</subfield>
+    </datafield>
+    <datafield tag="FFT" ind1="" ind2="">
+      <subfield code="a">/tmp/opendata.cern.ch-fft-file-cache/cms-docdb-files/Ymumu_DoubleMu_Run2011A.csv</subfield>
+      <subfield code="n">Ymumu</subfield>
+    </datafield>
+  </record>
+</collection>

--- a/scripts/populate-fft-file-cache.sh
+++ b/scripts/populate-fft-file-cache.sh
@@ -292,7 +292,14 @@ $WGET -O $OUTDIR/cms-docdb-files/SingleElectron_Run2011A.ig "$DOCDB?docid=12752&
 $WGET -O $OUTDIR/cms-docdb-files/SingleMu_Run2011A.ig "$DOCDB?docid=12752&amp;filename=SingleMu_Run2011A.ig"
 $WGET -O $OUTDIR/cms-docdb-files/TauPlusX_Run2011A.ig "$DOCDB?docid=12752&amp;filename=TauPlusX_Run2011A.ig"
 $WGET -O $OUTDIR/cms-docdb-files/Tau_Run2011A.ig "$DOCDB?docid=12752&amp;filename=Tau_Run2011A.ig"
-
+$WGET -O $OUTDIR/cms-docdb-files/Wenu_SingleElectron_Run2011A.csv "$DOCDB?docid=13329&amp;filename=Wenu_SingleElectron_Run2011A.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Wmunu_SingleMu_Run2011A.csv "$DOCDB?docid=13329&amp;filename=Wmunu_SingleMu_Run2011A.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Zee_DoubleElectron_Run2011A.csv "$DOCDB?docid=13329&amp;filename=Zee_DoubleElectron_Run2011A.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Zmumu_DoubleMu_Run2011A.csv "$DOCDB?docid=13329&amp;filename=Zmumu_DoubleMu_Run2011A.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Dimuon_SingleMu_Run2011A.csv "$DOCDB?docid=13329&amp;filename=Dimuon_SingleMu_Run2011A.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Dimuon_DoubleMu_Run2011A.csv "$DOCDB?docid=13329&amp;filename=Dimuon_DoubleMu_Run2011A.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Jpsimumu_DoubleMu_Run2011A.csv "$DOCDB?docid=13329&amp;filename=Jpsimumu_DoubleMu_Run2011A.csv"
+$WGET -O $OUTDIR/cms-docdb-files/Ymumu_DoubleMu_Run2011A.csv "$DOCDB?docid=13329&amp;filename=Ymumu_DoubleMu_Run2011A.csv"
 
 # cernvm files:
 mkdir -p $OUTDIR/cernvm-files


### PR DESCRIPTION
```
commit 043f286c1c10e3f2ac4afa5d8f08239bcafb4c75 (HEAD -> pr-1283, origin/pr-1283)
Author: Tibor Simko <tibor.simko@cern.ch>
Date:   Wed Jul 5 14:29:42 2017 +0200

    CMS: updates to CSV Run2011A files
    
    * Removes unused DOI field, adds record ID, adds necessary CDATA wrapper, and
      corrects SingleMu to DoubleMu for two input files. Plugs the new MARCXML file
      into installation documentation. (closes #1139) (PR #1283)
    
    Signed-off-by: Tibor Simko <tibor.simko@cern.ch>

commit 18e430f40ffbdfb138151db4a0c6507e13018813
Author: Thomas McCauley <thomas.mccauley@cern.ch>
Date:   Wed Jun 7 12:26:10 2017 +0100

    CMS: CSV files for Run2011A
    
    * Adds XML file for CSV file records.
    
    * Adds dimuon CSV file reference in MARCXML and download script.
    
    * Adds dimuon CSV from DoubleMu dataset.
    
    * Adds descriptions for CSV columns.
    
    * Adds Jpsimumu and Ymumu metadata.
      (addresses #1139) (PR #1283)
```