### PR TITLE
templates: evaluating markdown support (WIP)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -27,6 +27,7 @@ recursive-include cernopendata *.png
 recursive-include cernopendata *.scss
 recursive-include cernopendata *.svg
 recursive-include cernopendata *.tpl
+recursive-include cernopendata *.md
 recursive-include nginx *.conf
 recursive-include scripts *.cfg
 recursive-include scripts *.sh

--- a/cernopendata/modules/markdown/__init__.py
+++ b/cernopendata/modules/markdown/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Open Data Portal.
+# Copyright (C) 2017 CERN.
+#
+# CERN Open Data Portal is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Open Data Portal is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Open Data Portal; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""CODMarkdown. Wrapper for Flask-Markdown extension."""
+
+from __future__ import absolute_import, print_function
+
+from .ext import CernopendataMarkdown
+
+__all__ = ('CernopendataMarkdown', )

--- a/cernopendata/modules/markdown/ext.py
+++ b/cernopendata/modules/markdown/ext.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Open Data Portal.
+# Copyright (C) 2017 CERN.
+#
+# CERN Open Data Portal is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Open Data Portal is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Open Data Portal; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Initialization of CernopendataMarkdown."""
+
+from __future__ import absolute_import, print_function
+
+from flaskext.markdown import Markdown
+
+from mdx_gfm import GithubFlavoredMarkdownExtension
+
+from pymdownx.github import GithubExtension
+
+
+class CernopendataMarkdown(object):
+    """CernopendataMarkdown. Wrapper for Flask-Markdown extension.
+
+    Needed in order to add Flask-Markdown to Flask application
+    created in Invenio-style (using entrypoints).
+    """
+
+    def __init__(self, app=None):
+        """Extension initialization."""
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Flask application initialization."""
+        # Follow the Flask guidelines on usage of app.extensions
+        if not hasattr(app, 'extensions'):
+            app.extensions = {}
+        if 'cod-markdown' in app.extensions:
+            raise RuntimeError("Flask application already initialized")
+        app.extensions['cod-markdown'] = self
+
+        # Initialize Flask-Markdown extension
+        md = Markdown(app)
+
+        # Register Flask-Markdown extensions
+        # TODO: Define and add config entries to app.config.
+        # TODO: Init according options in app.config.
+
+        # https://github.com/Zopieux/py-gfm
+        # md.register_extension(GithubFlavoredMarkdownExtension)
+
+        # Alternative GFM extension:
+        # http://facelessuser.github.io/pymdown-extensions/extensions/github/
+        md.register_extension(GithubExtension)

--- a/cernopendata/modules/mistune/__init__.py
+++ b/cernopendata/modules/mistune/__init__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Open Data Portal.
+# Copyright (C) 2017 CERN.
+#
+# CERN Open Data Portal is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Open Data Portal is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Open Data Portal; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""CODMistune. Wrapper for Flask-Mistune extension."""
+
+from __future__ import absolute_import, print_function
+
+from .ext import CernopendataMistune
+
+__all__ = ('CernopendataMistune', )

--- a/cernopendata/modules/mistune/ext.py
+++ b/cernopendata/modules/mistune/ext.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Open Data Portal.
+# Copyright (C) 2017 CERN.
+#
+# CERN Open Data Portal is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Open Data Portal is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Open Data Portal; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Initialization of CernopendataMistune."""
+
+from __future__ import absolute_import, print_function
+
+from flask.ext.mistune import Mistune
+
+import mistune
+
+from pygments.formatters.html import HtmlFormatter
+from pygments.lexers import get_lexer_by_name
+from pygments import highlight
+import pygments.util
+
+
+class CodeHtmlFormatter(HtmlFormatter):
+    """Pygments formatter that adds HTML5 <code>-tag to generated html.
+
+    Add the <code>-tag after Pygments usual <div class="highlight">
+    and <pre> classes.
+    Based on example from http://pygments.org/docs/formatters/
+    """
+
+    def __init__(self, lang=False, **options):
+        """."""
+        self.lang = lang
+        super(CodeHtmlFormatter, self).__init__(**options)
+
+    def wrap(self, source, outfile):
+        """."""
+        return self._wrap_code(source)
+
+    def _wrap_code(self, source):
+        if self.lang:
+            yield 0, '<div class="highlight"><pre><code class="lang-{}">'.\
+                format(self.lang)
+        else:
+            yield 0, '<div class="highlight"><pre><code>'
+        for i, t in source:
+
+            yield i, t
+        yield 0, '</code></pre></div>'
+
+
+class CodeRenderer(mistune.Renderer):
+    """Renderer to support standard pygments-themes (adds highlight-class).
+
+    Based on https://github.com/asottile/markdown-code-blocks and on
+    https://github.com/lepture/mistune-contrib/blob/master/mistune_contrib/highlight.py
+    """
+
+    def block_code(self,
+                   code,
+                   lang,
+                   code_tag=True,
+                   inlinestyles=False,
+                   linenos=False):
+        """.
+
+        :param code_tag: If True html will contain <code>-tag.
+        :param inlinestyles: If True html contains inline styles.
+        :param linenos: If True html contains line numbers
+        :return:
+        """
+        try:
+            lexer = get_lexer_by_name(lang, stripnl=False)
+        except pygments.util.ClassNotFound:
+            lexer = get_lexer_by_name('text', stripnl=False)
+
+        if code_tag:
+            formatter = CodeHtmlFormatter(lang,
+                                          noclasses=inlinestyles,
+                                          linenos=linenos)
+        else:
+            formatter = HtmlFormatter(noclasses=inlinestyles, linenos=linenos)
+
+        return highlight(code, lexer=lexer, formatter=formatter)
+
+
+class CernopendataMistune(object):
+    """CernopendataMistune. Wrapper for Flask-Mistune extension.
+
+    Needed in order to properly add Flask-Mistune to Flask application
+    created in Invenio-style (using entrypoints).
+    """
+
+    def __init__(self, app=None):
+        """Extension initialization."""
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Flask application initialization."""
+        if not hasattr(app, 'extensions'):
+            app.extensions = {}
+        if 'cod-mistune' in app.extensions:
+            raise RuntimeError("Flask application already initialized")
+        app.extensions['cod-mistune'] = self
+
+        # Initialize Flask-Mistune extension.
+        # TODO: Define and add config entries to app.config.
+        # TODO: Init according options in app.config.
+
+        # Mistune with only HTML5 <code>-tag highlighting.
+        # Support for language specific highlight styles, with
+        # <code class="lang-XXX">.
+        # mistune = Mistune(app, escape=False, hard_wrap=True)
+
+        # Mistune with HTML5 <code>-tag highlight wrapped inside
+        # Pygments style <div class="highlight"><pre> highlight
+        # Provides support for Pygments and language specific highlight styles
+        mistune = Mistune(app,
+                          renderer=CodeRenderer(escape=False, hard_wrap=True))

--- a/cernopendata/modules/pages/views.py
+++ b/cernopendata/modules/pages/views.py
@@ -83,6 +83,34 @@ def index():
     return render_template('cernopendata_pages/index.html')
 
 
+@blueprint.route('/md/getting-started/CMS', methods=['HEAD', 'GET'])
+def md_getting_started_cms():
+    """Test Markdown rendering of Getting Started page."""
+    f = open('cernopendata/static/md/getting_started_cms.md', 'r')
+    # return render_template_string(
+    #     u"{{ text|markdown }}", text=f.read().decode("utf-8"))
+    return render_template('cernopendata_pages/md_template.html',
+                           content=f.read().decode("utf-8"))
+
+
+@blueprint.route('/md/VM/CMS', methods=['HEAD', 'GET'])
+def md_vm_cms():
+    """Test Markdown rendering of CMS VM page."""
+    f = open('cernopendata/static/md/vm_cms_2010.md', 'r')
+    # return render_template_string(
+    #     u"{{ text|markdown }}", text=f.read().decode("utf-8"))
+    return render_template('cernopendata_pages/md_template.html',
+                           content=f.read().decode("utf-8"))
+
+
+@blueprint.route('/md/about/CMS', methods=['HEAD', 'GET'])
+def md_about_cms():
+    """Test Markdown rendering of CMS about page."""
+    f = open('cernopendata/static/md/about_cms.md', 'r')
+    return render_template('cernopendata_pages/md_template.html',
+                           content=f.read().decode("utf-8"))
+
+
 @blueprint.route('/education')
 @blueprint.route('/education/<string:experiment>')
 @register_breadcrumb(blueprint, '.education.experiment',

--- a/cernopendata/modules/theme/static/scss/pygments_friendly.css
+++ b/cernopendata/modules/theme/static/scss/pygments_friendly.css
@@ -1,0 +1,70 @@
+/* Taken from https://github.com/richleland/pygments-css */
+.highlight .hll { background-color: #ffffcc }
+.highlight  { background: #f0f0f0; }
+.highlight .c { color: #60a0b0; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight .k { color: #007020; font-weight: bold } /* Keyword */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .ch { color: #60a0b0; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #60a0b0; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #007020 } /* Comment.Preproc */
+.highlight .cpf { color: #60a0b0; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #60a0b0; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #60a0b0; background-color: #fff0f0 } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #0044DD } /* Generic.Traceback */
+.highlight .kc { color: #007020; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #007020; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #007020; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #007020 } /* Keyword.Pseudo */
+.highlight .kr { color: #007020; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #902000 } /* Keyword.Type */
+.highlight .m { color: #40a070 } /* Literal.Number */
+.highlight .s { color: #4070a0 } /* Literal.String */
+.highlight .na { color: #4070a0 } /* Name.Attribute */
+.highlight .nb { color: #007020 } /* Name.Builtin */
+.highlight .nc { color: #0e84b5; font-weight: bold } /* Name.Class */
+.highlight .no { color: #60add5 } /* Name.Constant */
+.highlight .nd { color: #555555; font-weight: bold } /* Name.Decorator */
+.highlight .ni { color: #d55537; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #007020 } /* Name.Exception */
+.highlight .nf { color: #06287e } /* Name.Function */
+.highlight .nl { color: #002070; font-weight: bold } /* Name.Label */
+.highlight .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #062873; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #bb60d5 } /* Name.Variable */
+.highlight .ow { color: #007020; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #40a070 } /* Literal.Number.Bin */
+.highlight .mf { color: #40a070 } /* Literal.Number.Float */
+.highlight .mh { color: #40a070 } /* Literal.Number.Hex */
+.highlight .mi { color: #40a070 } /* Literal.Number.Integer */
+.highlight .mo { color: #40a070 } /* Literal.Number.Oct */
+.highlight .sa { color: #4070a0 } /* Literal.String.Affix */
+.highlight .sb { color: #4070a0 } /* Literal.String.Backtick */
+.highlight .sc { color: #4070a0 } /* Literal.String.Char */
+.highlight .dl { color: #4070a0 } /* Literal.String.Delimiter */
+.highlight .sd { color: #4070a0; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #4070a0 } /* Literal.String.Double */
+.highlight .se { color: #4070a0; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #4070a0 } /* Literal.String.Heredoc */
+.highlight .si { color: #70a0d0; font-style: italic } /* Literal.String.Interpol */
+.highlight .sx { color: #c65d09 } /* Literal.String.Other */
+.highlight .sr { color: #235388 } /* Literal.String.Regex */
+.highlight .s1 { color: #4070a0 } /* Literal.String.Single */
+.highlight .ss { color: #517918 } /* Literal.String.Symbol */
+.highlight .bp { color: #007020 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #06287e } /* Name.Function.Magic */
+.highlight .vc { color: #bb60d5 } /* Name.Variable.Class */
+.highlight .vg { color: #bb60d5 } /* Name.Variable.Global */
+.highlight .vi { color: #bb60d5 } /* Name.Variable.Instance */
+.highlight .vm { color: #bb60d5 } /* Name.Variable.Magic */
+.highlight .il { color: #40a070 } /* Literal.Number.Integer.Long */

--- a/cernopendata/modules/theme/static/scss/styles.scss
+++ b/cernopendata/modules/theme/static/scss/styles.scss
@@ -10,6 +10,7 @@ $fa-font-path: "/static/node_modules/font-awesome/fonts";
 @import "footer";
 @import "frontpage";
 @import "visualise";
+@import "pygments_friendly";
 
 html, body {
   /* The html and body elements cannot have any padding or margin. */

--- a/cernopendata/static/md/about_cms.md
+++ b/cernopendata/static/md/about_cms.md
@@ -1,0 +1,75 @@
+
+# About CMS
+
+The Compact Muon Solenoid (CMS) Experiment is one of the large particle detectors at CERN's Large Hadron Collider. The CMS Collaboration consists of more than 3000 scientists, engineers, technicians and students from 180+ institutes and universities from 40+ countries. You can find more information about the CMS [detector design](http://cms.web.cern.ch/news/cms-detector-design) and [overview](http://cms.web.cern.ch/news/detector-overview) on the official [CMS website](http://cern.ch/cms)
+
+<br>
+
+# About CMS data
+
+---
+
+## Data and analysis tools
+
+The following are provided through this portal:
+
+* Downloadable datasets
+    * [Primary datasets](/collection/CMS-Primary-Datasets): full reconstructed collision data with no other selections. The data here are referred to as "reconstructed data"; fragmented data from various sub-detectors are processed or "reconstructed" to provide coherent information about individual [physics objects](/about/CMS-Physics-Objects) such as electrons or particle jets.
+    * [Simulation data](/collection/CMS-Simulated-Datasets) (for data from 2011)
+    * Examples of [simplified datasets](/collection/CMS-Derived-Datasets) derived from the primary ones for use in different applications and analyses
+
+<br>
+
+* Tools
+    * A downloadable [Virtual Machine (VM)](/VM/CMS) image with the CMS software environment through which the primary datasets can be accessed
+    * An [analysis example chain](/getting-started/CMS), reading the primary dataset and producing intermediate derived data for the final analysis
+    * Ready-to-use online applications, such as [an event display](/visualise/events/CMS) and [simple histogramming software](/visualise/histograms/CMS)
+    * Source code for the various examples and applications, available in the [CMS Tools](/search?cc=CMS-Tools) collection
+
+---
+
+## Primary and simulated datasets
+
+* Collision data in the primary datasets are in a format known as AOD or Analysis Object Data, while simulated data are in a format called AODSIM.
+* AOD/AODSIM files contain the information that is needed for analysis:
+    * all the high-level [physics objects](/about/CMS-Physics-Objects) (such as muons, electrons, etc.);
+    * tracks with associated hits, calorimetric clusters with associated hits, vertices; and
+    * information about event selection (triggers), data needed for further selection and identification criteria for the physics objects.
+
+<br>
+
+* The file is not the final event interpretation with a simple list of particles.
+    * It contains several instances of the same physics object (i.e. a jet reconstructed with different algorithms).
+    * It may have double-counting (i.e. a physics object may appear as a single object of its own type, but it may also be part of a jet).
+    * Additional knowledge is needed to define a "good" physics object.
+    * Definition of same objects is different in each analysis.
+
+* The files can be read in [ROOT](http://root.cern.ch/), but they cannot be opened (and understood) as simple data tables.
+* Only the runs that are validated by data quality monitoring should be used in any analysis. The [list of the validated runs](/collection/CMS-Validation-Utilities) is provided.
+
+---
+
+## Disclaimer
+
+* The open data are released under the [Creative Commons CC0 waiver](http://creativecommons.org/publicdomain/zero/1.0/). Neither CMS or nor CERN endorse any works, scientific or otherwise, produced using these data.
+* All datasets will have a unique DOI that you are requested to cite in any applications or publications.</li>
+* Despite being processed, the high-level primary datasets remain complex and selection criteria need to be applied in order to analyse them, requiring some understanding of particle physics and detector functioning. The data cannot be viewed in simple data tables for spreadsheet-based analyses.
+* No further development is foreseen for either the data released or the software version needed to analyse them.
+    * The methods have evolved since the released data were recorded.</li>
+    * More advanced techniques are used with recent data but the software is not compatible out-of-the-box with older data samples.
+* The release of 2010 data is not accompanied by any simulated data. The release of 2011 data includes simulated data. However, this is not a full set of simulations, but only those datasets that have been reprocessed with a software release compatible with the 2011 collision data.</li>
+* If you are interested in more, please contact nearest [CMS university/institute](http://cms.web.cern.ch/content/cms-collaboration)
+
+---
+
+## Other CMS open data
+
+* All [CMS publications](http://cds.cern.ch/collection/CMS?ln=en) are open access.
+* [Some of the papers also include open data](https://inspirehep.net/search?p=collaboration%3A%27CMS%27+and+520__9%3Ahepdata) in the form of additional tables, plots, graphs and [Rivet]("https://rivet.hepforge.org/) packages.
+
+---
+
+## Policies
+
+* [Data preservation and open access policy](https://cms-docdb.cern.ch/cgi-bin/PublicDocDB/ShowDocument?docid=6032)
+* [Papers by CMS members using public data [internal]](https://cms-docdb.cern.ch/cgi-bin/DocDB/ShowDocument?docid=12242)

--- a/cernopendata/static/md/getting_started_cms.md
+++ b/cernopendata/static/md/getting_started_cms.md
@@ -1,0 +1,115 @@
+## "I have installed the CERN Virtual Machine: now what?"
+
+To analyse CMS data collected in 2010, you need **version 4.2.8** of CMSSW, supported only on **Scientific Linux 5**. If you are unfamiliar with Linux, take a look at [this short introduction to Linux](https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookBasicLinux) or try this interactive [command-line bootcamp](http://rik.smith-unna.com/command_line_bootcamp/). Once you have installed the [CMS-specific CERN Virtual Machine](/VM/CMS/2010), execute the following command in the terminal if you haven't done so before; it ensures that you have this version of CMSSW running:
+
+```shell
+$ cmsrel CMSSW_4_2_8
+```
+
+Then, make sure that you are always in the **CMSSW_4_2_8/src/** directory by entering the following command in the terminal (you must do so every time you boot the VM before you can proceed):
+
+```shell
+$ cd CMSSW_4_2_8/src/
+```
+
+## "OK! Where can I get the CMS data?"
+
+It is best if we start off with a quick introduction to **[ROOT](http://root.cern.ch)**. ROOT is the framework used by several particle-physics experiments to work with the collected data. Although analysis is not itself performed within the ROOT GUI, it is instructive to understand how these files are structured and what data and collections they contain.
+
+The primary data provided by CMS on the CERN Open Data Portal is in a format called "[Analysis Object Data](/about/CMS#what-data)" or AOD for short. These AOD files are prepared by piecing raw data collected by various sub-detectors of CMS and contain all the information that is needed for analysis. The files cannot be opened and understood as simple data tables but require ROOT in order to be read.
+
+So, let's see what an AOD file looks like and take ROOT for a spin!
+
+Making sure that you are in the **CMSSW_4_2_8/src/** folder, execute the following command in your terminal to launch the CMS analysis environment:
+
+```shell
+$ cmsenv
+```
+
+You can now open a CMS AOD file in ROOT. Let us open one of the files from the CERN Open Data Portal by entering the following command:
+
+```shell
+$ root root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/0000/00459D48-EB70-E011-AF09-90E6BA19A252.root
+```
+
+You will see the ROOT logo appear on screen. You can now open the ROOT GUI by entering:
+
+```shell
+TBrowser t
+```
+
+Excellent! You have successfully opened a CMS AOD file in ROOT. If this was the first time you've done so, pat yourself on the back. Now, to see what is inside this file, let us take a closer look at some collections of [physics objects](/about/CMS-Physics-Objects).
+
+On the left window of ROOT (see the screenshot below), double-click on the file name (`root://eospublic.cern.ch//eos/opendata/...`). You should see a list of entries under `Events`, each corresponding to a collection of reconstructed data. We are interested in the collections containing information about reconstructed physics objects.
+
+<img src="http://opendata.cern.ch/img/docs/Screenshot_001_Tbrowser_t.png" width="70%">
+
+`![Screenshot: After running 'TBrowser t'](http://opendata.cern.ch/img/docs/Screenshot_001_Tbrowser_t.png)`
+
+Let us take a peek, for example, at the electrons, which are found in `recoGsfElectrons_gsfElectrons__RECO`, as shown on the list of [physics objects](http://opendata.cern.ch/about/CMS-Physics-Objects). Look in there by double-clicking on that line and then double-clicking on `recoGsfElectrons_gsfElectrons__RECO.obj`. Here, you can have a look at various properties of this collection, such as the plot for the transverse momentum of the electrons: `recoGsfElectrons_gsfElectrons__RECO.obj.pt_`.
+
+You can exit the ROOT browser through the GUI by clicking on `Browser` on the menu and then clicking on `Quit Root` or by entering `.q` in the terminal.
+
+
+## "Nice! But how do I analyse these data?"
+
+In AOD files, reconstructed [physics objects](http://opendata.cern.ch/about/CMS-Physics-Objects) are included without checking their "quality", i.e. in case of our electron collection that you opened in ROOT, without ensuring that the reconstructed object is really an electron. In order to analyse only the "good quality" data, you must apply some selection criteria.
+
+With these criteria, you are in effect reducing the dataset, either in terms of the number of collisions events it contains or in terms of the information carried by each event. Following this, you run your analysis code on the reduced dataset.
+
+Depending on the nature of your analysis you *can* run your analysis code directly on the AOD files themselves, if needed, performing the selections along the way. However, this can be resource-intensive and is done only for very specific usecases.
+
+**NOTE**: To analyse the full event content, the analysis job needs access to the "condition data", such as the jet-energy corrections. Connections to the condition database are established by the CERN Virtual Machine needed to analyse CMS data from 2010. (To see how the connection to the condition database is established to analyse CMS data from 2011, you can check the ["pattuples2011" example](http://opendata.cern.ch/record/233).) For simpler analyses, where we use only physics objects needing no further data for corrections, you do not need to connect to the condition database. This is the case for the example for analysing the primary datasets below.
+
+Your final analysis is done using a software module called an "analyzer". If you have followed the validation step for the virtual machine setup, you have already produced and run a simple analyzer. You can specify your initial selection criteria within the analyzer to perform your analysis directly on the AOD files, or further elaborate the selections and other operations needed for analysing the reduced dataset. To learn more about configuring analyzers, follow [these instructions in the CMSSW WorkBook](https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookWriteFrameworkModule). Make sure, though, that you replace the release version (CMSSW_nnn) with the release that you are using, i.e. one that is compatible with the CMS open data.
+
+You can also pass the selection criteria through the configuration file. This file activates existing tools within CMSSW in order to perform the desired selections. If you have followed the validation step for the virtual machine setup, you have already seen a configuration file, which is used to give the parameters to the `cmsRun` executable. You can see how this is done in our analysis example.
+
+We will now take you through these steps through a couple of specially prepared example analyses.
+
+
+## Option A: Analysing the primary dataset
+
+As mentioned above, you do not typically perform an analysis directly on the AOD files. However, there may be cases when you can do so. Therefore, we have provided an example analysis to take you through the steps that you may need on the occassions that you want to analyse the AOD files directly. You can find the files and instructions in [this CMS Tools entry](http://opendata.cern.ch/record/560).
+
+
+## Option B: Analysing reduced datasets
+
+We start by applying selection cuts via the configuration file and reduce the AOD files into a format known as PATtuple. You can find more information about this data format (which gets its name from the CMS Physics Analysis Toolkit, or PAT) on the [CMSSW PAT WorkBook](https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookPAT).
+
+**Important**: Be aware that the instructions in the WorkBook are in use in CMS currently and have been updated for more recent CMSSW releases. With the 2010 data, you should always use the releases in the series of CMSSW_4_2 and not higher. Also note that more recent code does not work with older releases, so whenever you see `git cms-addpkg...` in the instruction, it is likely that the code package this command adds does not work with the release you need. However, the material under the pages gives you a good introduction to PAT.
+
+Code as well as instructions for producing PATtuples from the CMS open data can be found in [this GitHub repo](https://github.com/ayrodrig/pattuples2010). However, since it took a dedicated computing cluster nine days (!!!) to run this step and reduce the several TB of AOD files to a few GB of PATtuples, we have provided you with the PATtuples in that GitHub repo, saving you quite a lot of time! So you can jump to the next step, below ("Performing your analysis…"). Although you do not need to run this step, it is worth looking at [the configuration file](https://github.com/ayrodrig/pattuples2010/blob/master/PAT_data_repo.py):
+
+You can see that the line `removeAllPATObjectsBut(process, ['Muons','Electrons'])` removes all "PATObjects" but muon and electrons, which will be needed in the final analysis step of this example.
+
+Note also how only the validated runs are selected on lines:
+
+```python
+import FWCore.ParameterSet.Config as cms
+import PhysicsTools.PythonAnalysis.LumiList as LumiList
+myLumis = LumiList.LumiList(filename='Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt').getCMSSWString().split(',')
+process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange()
+process.source.lumisToProcess.extend(myLumis)
+```
+
+This selection must always be applied to any analysis on CMS open data, and to do so you must have the validation file downloaded to your local area.
+
+You can also see how the correct set of condition data are defined by mentioning the Global Tag on lines 45–46 in the file `PAT_data_repo.py`.
+
+
+## Performing your analysis on the PATtuples
+
+Now, as the intermediate PATtuple files have been produced for you, you can go directly to the next step, as described in [this second GitHub repo](https://github.com/ayrodrig/OutreachExercise2010) and follow the instructions on that page.
+
+Note that even though these are derived datasets, running the analysis code over the full data can take several hours. So if you want just give it a try, you can limit the number events or read only part of the files. Bear in mind that running on a low number of files will not give you a meaningful plot.
+
+Your analysis job is defined in `OutreachExercise2010/DecaysToLeptons/run/run.py`. The analysis code is in the files located in the `OutreachExercise2010/DecaysToLeptons/python` directory.
+
+This example uses IPython, which gets configured and starts the job with the following command:
+
+```python
+ipython run.py
+```
+
+That's it! Follow the rest of the instructions on the README and you have performed an analysis using data from CMS. Hope you enjoyed this exercise. Feel free to play around with the rest of the data and write your own analyzers and analysis code. (To exit IPython, enter `exit()`.)

--- a/cernopendata/static/md/vm_cms_2010.md
+++ b/cernopendata/static/md/vm_cms_2010.md
@@ -1,0 +1,176 @@
+The CMS-specific VM includes the [ROOT framework](http://root.cern.ch/) and [CMSSW](http://cms-sw.github.io/). Follow the instructions below to setup a CERN Virtual Machine on your computer. Then, go to [Getting Started with CMS data](http://opendata.cern.ch/getting-started/CMS)
+
+* How to install a CERN VM
+* Issues & Limitations
+* How to Test & Validate?
+
+## How to install a CERN Virtual Machine
+
+### Step 1: Installing VirtualBox
+
+VirtualBox is a free, open source and multiplatform application to run virtual machines: you can [download][installVB] the package for your platform from the Downloads page.
+
+You will need administrative ("root") privileges on every platform to perform the installation of VirtualBox.
+
+Note: the latest tested version of VirtualBox working with this CMS-specific CernVM image is 5.0.14. If you have troubles with the latest version of VirtualBox, pick that one: the full history of VirtualBox versions is available [on a different page][installVB2].
+
+
+### Step 2: Downloading and Creating a Virtual Machine
+
+**Important**: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see [Issues and Limitations][issues] if you encounter any problems with booting the VM.
+
+Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2011 CMS open data][cmsvmimage2011].
+
+By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings: in case of any problems with booting with these default settings, see [Issues and Limitations][issues]. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment
+
+
+## How to Test & Validate?
+
+The validation procedure tests that the CMS environment is installed and operational on your virtual machine, and that you have access to the ROOT files. You may skip this step if you want, and head straight to [Getting Started with CMS data][getstartedcms]. However, these steps give you a quick introduction to the CMS environment.
+
+### Set up the CMS environment and run a demo analyzer
+
+Open a terminal with the X terminal emulator (an icon bottom-left of the VM screen)
+Execute the following command; this command builds the local release area (the directory structure) for CMSSW, and only needs to be run once:
+
+```
+cmsrel CMSSW_5_3_32
+```
+
+Change to the ```CMSSW_5_3_32/src/``` directory:
+
+```
+cd CMSSW_5_3_32/src/
+```
+
+Then, run the following command to create the CMS runtime variables:
+
+```
+cmsenv
+```
+
+Create a working directory for the demo analyzer, change to that directory and create a "skeleton" for the analyzer:
+
+```
+mkdir Demo
+cd Demo
+mkedanlzr DemoAnalyzer
+```
+
+Compile the code:
+
+```
+cd DemoAnalyzer scram b
+```
+
+
+Change the file name in the configuration file ```demoanalyzer_cfg.py``` in the DemoAnalyzer directory: i.e. replace ```file:myfile.root``` with ```root://eospublic.cern.ch//eos/opendata/cms/Run2011A/ElectronHad/AOD/12Oct2013-v1/20001/001F9231-F141-E311-8F76-003048F00942.root```
+Change the max number of events to 10 (i.e change -1 to 10 in ```process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1)```).
+
+Move two directories back using:
+
+```
+cd ../..
+```
+
+And then run:
+
+```
+cmsRun Demo/DemoAnalyzer/demoanalyzer_cfg.py
+```
+
+You can consider your VM "validated" — i.e it gets access to and compiles the CMS software, and reads the CMS open data files — if you get an output like:
+
+
+```
+16-Mar-2016 15:45:13 CET Initiating request to open file root://eospublic.cern.ch//eos/opendata/cms/Run2011A/ElectronHad/AOD/12Oct2013-v1/20001/001F9231-F141-E311-8F76-003048F00942.root
+
+16-Mar-2016 15:45:17 CET Successfully opened file root://eospublic.cern.ch//eos/opendata/cms/Run2011A/ElectronHad/AOD/12Oct2013-v1/20001/001F9231-F141-E311-8F76-003048F00942.root
+
+Begin processing the 1st record. Run 166782, Event 340184599, LumiSection 309 at 16-Mar-2016 15:45:40.234 CET
+
+Begin processing the 2nd record. Run 166782, Event 340185007, LumiSection 309 at 16-Mar-2016 15:45:40.235 CET
+
+Begin processing the 3rd record. Run 166782, Event 340187903, LumiSection 309 at 16-Mar-2016 15:45:40.236 CET
+
+Begin processing the 4th record. Run 166782, Event 340227487, LumiSection 309 at 16-Mar-2016 15:45:40.237 CET
+
+Begin processing the 5th record. Run 166782, Event 340210607, LumiSection 309 at 16-Mar-2016 15:45:40.237 CET
+
+Begin processing the 6th record. Run 166782, Event 340256207, LumiSection 309 at 16-Mar-2016 15:45:40.238 CET
+
+Begin processing the 7th record. Run 166782, Event 340165759, LumiSection 309 at 16-Mar-2016 15:45:40.239 CET
+
+Begin processing the 8th record. Run 166782, Event 340396487, LumiSection 309 at 16-Mar-2016 15:45:40.239 CET
+
+Begin processing the 9th record. Run 166782, Event 340390767, LumiSection 309 at 16-Mar-2016 15:45:40.241 CET
+
+Begin processing the 10th record. Run 166782, Event 340435263, LumiSection 309 at 16-Mar-2016 15:45:40.241 CET
+
+16-Mar-2016 15:45:40 CET Closed file root://eospublic.cern.ch//eos/opendata/cms/Run2011A/ElectronHad/AOD/12Oct2013-v1/20001/001F9231-F141-E311-8F76-003048F00942.root
+
+MessageLogger Summary
+
+type category sev module subroutine count total
+
+1 fileAction -s file_close 1 1
+
+2 fileAction -s file_open 2 2
+
+type category Examples: run/evt run/evt run/evt
+
+1 fileAction PostEndRun
+
+2 fileAction pre-events pre-events
+
+Severity # Occurrences Total Occurrences
+
+System 3 3
+
+```
+
+## Known Issues & Limitations
+
+### Validation report
+
+Coming soon! Meanwhile, please check the validation report for the VM image for our 2010 data, which may contain information useful to you.
+
+### Known Issues FAQ
+
+
+```
+Q: The following error message appears when the Virtual Machine is started: "Could not start the machine CMS Open Data because the following physical network interfaces were not found: vboxnet0 (adapter 2). You can either change the machine's network settings or stop the machine."
+
+A: Change the Network settings for adapter 2 from "Host-only Adapter" to "NAT". The VM should then start correctly.
+
+Q: On Ubuntu running the latest version of VirtualBox, an error appears when opening the CMS-specific virtual machine: the message is about a missing path to a definition file.
+
+A: To fix this, open one of the (non-CMS-specific) CernVMs first, after which the CMS-specific one should load without the error message.
+
+Q: On Windows 7 and 8, this error message appears: "VT-X/AMD-V hardware acceleration is not available on your system. Your 64-bit guest will fail to detect a 64-but CPU and will not be able to boot."
+
+A: Check whether your processor supports the VT-X feature by going to http://ark.intel.com/: Intel® Virtualisation Technology (VT-x) should be checked as "yes". Then, when the host machine is booting (just after switching it on) press the appropriate function key to get to the setup, go to advanced settings, and enable the virtualisation extensions of the CPU. Note that some recent Acer Inspire laptop models do not give access to the VT-X feature in the BIOS setup even if the processor supports it.
+
+Q: The VM does not inherit the keyboard layout of the host machine.
+
+A: The layout can be changed by using setxkbmap from a terminal inside the Virtual Machine. For example a user with a Swiss keyboard with French variant would type setxkbmap 'ch(fr)' in the terminal and a user with a Finnish keyboard would type setxkbmap fi. This can also be solved by using the GUI, which can be launched either from the graphical menu in the lower left corner (Preferences → Keyboard) or by typing in the console: xfce4-keyboard-settings. In the Layout tab it is possible to change the keyboard model and the layout. If you wish to keep these settings after reboot, you should delete all the other layouts from the menu.
+
+Q: The default terminal does not accept (not even from the clipboard) nor display certain language-specific characters such as umlauts.
+
+A: Using a terminal such as xterm will allow reading and writing special characters.
+
+Q: Users who use high resolutions on small displays and have set their host machines DPI manually, for example through .Xresources on Linux (X11), may find that everything is too small to be read efficiently. (Also helpful to users who have difficulties in reading the fonts and other visual information on the image due to the size of the graphical components.)
+
+A: The DPI can easily be adjusted from Xfce menu → Preferences → Appearance → Fonts → DPI. This enhances the readability and general usability significantly.
+
+Q: Resizing the VM window doesn't resize its contents.
+
+A: This appears to only occur when a new VM image is launched for the first time. The contents should resize after several minutes (up to half an hour), and the problem should not manifest when the VM image is opened a second time.
+
+```
+
+[installVB]: <https://www.virtualbox.org/wiki/Downloads>
+[installVB2]: <https://www.virtualbox.org/wiki/Download_Old_Builds>
+[issues]: </VM/CMS#issues>
+[cmsvmimage2011]: </record/252>
+[getstartedcms]: </getting-started/CMS>

--- a/cernopendata/templates/cernopendata_pages/md_template.html
+++ b/cernopendata/templates/cernopendata_pages/md_template.html
@@ -1,0 +1,7 @@
+{%- extends config.BASE_TEMPLATE %}
+
+{% block page_body %}
+<div class="container">
+{{ content|markdown|safe }}
+</div>
+{% endblock  page_body %}

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,9 @@ install_requires = [
     'Flask-CeleryExt>=0.2.2',
     'Flask-BabelEx>=0.9.3',
     'Flask-Breadcrumbs>=0.4.0',
+    'Flask-Markdown>=0.3.0',
     'Flask-Menu>=0.5.0',
+    'Flask-Mistune>=0.1.1',
     'Flask>=0.11.1',
     'python-slugify>=1.2.4',
     'invenio-assets>=1.0.0b6',
@@ -91,6 +93,9 @@ install_requires = [
     'invenio-records>=1.0.0b1',
     'invenio-search-ui>=1.0.0a2',
     'invenio-search>=1.0.0a9',
+    'mistune>=0.7.4',
+    'py-gfm>=0.1.3',
+    'pymdown-extensions>=3.5',
 ]
 
 packages = find_packages()
@@ -132,6 +137,12 @@ setup(
             'cernopendata.modules.pages.views:blueprint',
             'cernopendata_theme = '
             'cernopendata.modules.theme.views:blueprint',
+        ],
+        'invenio_base.apps': [  # Wrappers for init of certain extensions.
+            # 'cod_md = '
+            # 'cernopendata.modules.markdown.ext:CernopendataMarkdown',
+            'cod_mistune = '
+            'cernopendata.modules.mistune.ext:CernopendataMistune',
         ],
         'invenio_config.module': [
                 'cernopendata = cernopendata.config',


### PR DESCRIPTION
* Two implementations to support GFM-style markdown in Jinja-templates
  for opendata.cern.ch.
  One with Flask-Markdown and one with Flask-Mistune.

* For both extensions a wrapper class is used to support customization
  of the extension in invenio-style startup process of entrypoints
  and custom loaders.

* A custom pygments renderer and formatter is used for Flask-Mistune
  in order to support pygments style code highlighting.
  Out-of-the-box only HTML5 `<code>`-tag is used.

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>