### PR TITLE
fixtures: EOS files for Data Policy records

### DIFF
--- a/cernopendata/jsonschemas/records/data-policies-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/data-policies-v1.0.0.json
@@ -99,17 +99,22 @@
         },
       }
     },
-    "_files": {
+    "files": {
       "type": "array",
       "items": {
         "type": "object",
         "properties": {
-          "type": {
-            "title": "type",
+          "uri": {
+            "title": "uri",
             "type": "string"
           },
-          "path": {
-            "title": "path",
+          "size": {
+            "title": "size",
+            "type": "integer",
+            "minimum": 0
+          },
+          "checksum": {
+            "title": "checksum",
             "type": "string"
           }
         }

--- a/cernopendata/mappings/records/data-policies-v1.0.0.json
+++ b/cernopendata/mappings/records/data-policies-v1.0.0.json
@@ -94,12 +94,15 @@
             }
           }
         },
-        "_files": {
+        "files": {
           "properties": {
-            "_type": {
+            "uri": {
               "type": "string"
             },
-            "path": {
+            "size": {
+              "type": "integer"
+            },
+            "checksum": {
               "type": "string"
             }
           }

--- a/cernopendata/modules/fixtures/data/data-policies-v1.0.0.json
+++ b/cernopendata/modules/fixtures/data/data-policies-v1.0.0.json
@@ -20,10 +20,11 @@
     "description": "5 p",
     "summary": "This document contains the LHCb Data Access Policy. This was adopted at the Collaboration Board meeting on 27th Feb 2013.",
     "collaboration": "LHCb collaboration",
-    "_files": [
+    "files": [
       {
-        "type": "local",
-        "path": "/tmp/opendata.cern.ch-fft-file-cache/data-policies/LHCb-Data-Policy.pdf"
+          "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/documentation/LHCb-Data-Policy.pdf",
+          "size": 254288,
+          "checksum": "5e48e8042c8edc2f828770b41e21562b5570d689"
       }
     ],
     "year": "2013",


### PR DESCRIPTION
* Introduces EOS file information for Data Policies demo records using the
  `files.{uri,size,checksum}` technique. Amends data model, mappings and
  fixtures.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>