### PR TITLE
celery: add Celery 4 config variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,8 @@ web:
     - APP_CACHE_REDIS_HOST=redis
     - APP_CACHE_REDIS_URL=redis://redis:6379/0
     - APP_ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/1
-    - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672/
+    - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 3
+    - APP_CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 4
     - APP_CELERY_RESULT_BACKEND=redis://redis:6379/2
     - APP_SEARCH_ELASTIC_HOSTS=elasticsearch
   volumes:
@@ -61,7 +62,8 @@ worker:
     - APP_CACHE_REDIS_HOST=redis
     - APP_CACHE_REDIS_URL=redis://redis:6379/0
     - APP_ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/1
-    - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672/
+    - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 3
+    - APP_CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 4
     - APP_CELERY_RESULT_BACKEND=redis://redis:6379/2
     - APP_SEARCH_ELASTIC_HOSTS=elasticsearch
   volumes:

--- a/scripts/instance.cfg
+++ b/scripts/instance.cfg
@@ -7,7 +7,8 @@ CACHE_REDIS_URL='redis://{{ environ('INVENIO_REDIS_HOST') }}:6379/0'
 ACCOUNTS_SESSION_REDIS_URL='redis://{{ environ('INVENIO_REDIS_HOST') }}:6379/1'
 
 # Celery
-BROKER_URL='amqp://guest:guest@{{ environ('INVENIO_RABBITMQ_HOST') }}:5672/'
+BROKER_URL='amqp://guest:guest@{{ environ('INVENIO_RABBITMQ_HOST') }}:5672/'  # Celery 3
+CELERY_BROKER_URL='amqp://guest:guest@{{ environ('INVENIO_RABBITMQ_HOST') }}:5672/'  # Celery 4
 CELERY_RESULT_BACKEND='redis://{{ environ('INVENIO_REDIS_HOST') }}:6379/2'
 
 # Elasticsearch


### PR DESCRIPTION
* Adds CELERY_BROKER_URL config variable for Celery 4. (closes #1340)

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>