### PR TITLE
docker: nginx static asset exposure fix

### DIFF
--- a/.inveniorc
+++ b/.inveniorc
@@ -22,4 +22,4 @@ export INVENIO_WORKER_HOST=192.168.50.15
 #
 # vagrant up
 # vagrant ssh web -c 'source .inveniorc && /vagrant/scripts/install.sh'
-# curl http://0.0.0.0:5000/records/1
+# curl http://0.0.0.0/

--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -16,7 +16,7 @@ Docker:
    $ docker-compose build
    $ docker-compose up
    $ docker-compose run --rm web ./scripts/populate-instance.sh
-   $ firefox http://0.0.0.0:5000/
+   $ firefox http://0.0.0.0/
 
 Please note that populating the site with all example records is an optional
 step that may take considerable time (30 minutes or more).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -114,6 +114,10 @@ nginx:
   build: ./nginx
   ports:
     - "80:80"
+  volumes:
+    - ../devmodules:/devmodules
+    - ./cernopendata:/code/cernopendata
+    - ./scripts:/code/scripts
   volumes_from:
     - static
   links:


### PR DESCRIPTION
* Fixes exposure of static assets in the `nginx` container by mounting
  cernopendata source code volume, similarly to the `web` container. This is
  necessary after the change in the asset storage configuration policy from
  `file` to `link` that was done around
  5bd4955c2a986f9de08574083c56578effaf8795.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>