### PR TITLE
records: datasets and software

### DIFF
--- a/cernopendata/jsonschemas/records/datasets-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/datasets-v1.0.0.json
@@ -248,14 +248,22 @@
           "type": "string"
         }
       },
-      "files": {
+      "_files": {
         "type": "array",
-        "minItems": 1,
         "uniqueItems": true,
         "items": {
           "type": "object",
           "properties": {
             "uri": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            },
+            "bucket": {
+              "type": "string"
+            },
+            "version_id": {
               "type": "string"
             },
             "size": {

--- a/cernopendata/jsonschemas/records/datasets-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/datasets-v1.0.0.json
@@ -1,0 +1,278 @@
+{
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "description": "Datasets",
+  "type": "array",
+  "minItems": 1,
+  "uniqueItems": true,
+  "items": {
+    "type": "object",
+    "properties": {
+      "recid": {
+        "type": "string"
+      },
+      "doi": {
+        "type": "string"
+      },
+      "collaboration": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "recid": {
+            "type": "integer"
+          }
+        }
+      },
+      "type": {
+        "type": "string"
+      },
+      "subtype": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "additional_title": {
+        "type": "string"
+      },
+      "distribution": {
+        "type": "object",
+        "properties": {
+          "formats": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "string"
+            }
+          },
+          "number_events": {
+            "type": "string"
+          },
+          "number_files": {
+            "type": "string"
+          },
+          "size": {
+            "type": "string"
+          }
+        }
+      },
+      "publisher": {
+        "type": "string"
+      },
+      "date_published": {
+        "type": "string"
+      },
+      "date_created": {
+        "type": "string"
+      },
+      "date_reprocessed": {
+        "type": "string"
+      },
+      "system_details": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "release": {
+            "type": "string"
+          },
+          "global_tag": {
+            "type": "string"
+          }
+        }
+      },
+      "abstract": {
+        "type": "string"
+      },
+      "license": {
+        "type": "object",
+        "properties": {
+          "attribution": {
+            "type": "string"
+          }
+        }
+      },
+      "note": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "links": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "recid": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "generation": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "steps": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "note": {
+                  "type": "string"
+                },
+                "configuration_files": {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "recid": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "validation": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "links": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "usage": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "links": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "selection": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "accelerator": {
+        "type": "string"
+      },
+      "experiment": {
+        "type": "string"
+      },
+      "parent_dataset": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string"
+          }
+        }
+      },
+      "collision_information": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "energy": {
+            "type": "string"
+          }
+        }
+      },
+      "run_period": {
+        "type": "string"
+      },
+      "collections": {
+        "type": "array",
+        "minItems": 1,
+        "uniqueItems": true,
+        "items": {
+          "type": "string"
+        }
+      },
+      "files": {
+        "type": "array",
+        "minItems": 1,
+        "uniqueItems": true,
+        "items": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string"
+            },
+            "size": {
+              "type": "integer"
+            },
+            "type": {
+              "type": "string"
+            },
+            "description": {
+              "type": "string"
+            },
+            "checksum": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/cernopendata/jsonschemas/records/software-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/software-v1.0.0.json
@@ -1,0 +1,203 @@
+{
+  "$schema": "http://json-schema.org/draft-03/schema#",
+  "description": "Software",
+  "type": "array",
+  "minItems": 1,
+  "uniqueItems": true,
+  "items": {
+    "type": "object",
+    "properties": {
+      "recid": {
+        "type": "string"
+      },
+      "doi": {
+        "type": "string"
+      },
+      "authors": {
+        "type": "array",
+        "minItems": 1,
+        "uniqueItems": true,
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "type": {
+        "type": "string"
+      },
+      "subtype": {
+        "type": "string"
+      },
+      "title": {
+        "type": "string"
+      },
+      "distribution": {
+        "type": "object",
+        "properties": {
+          "format": {
+            "type": "string"
+          },
+          "number_files": {
+            "type": "string"
+          },
+          "size": {
+            "type": "string"
+          }
+        }
+      },
+      "publisher": {
+        "type": "string"
+      },
+      "date_published": {
+        "type": "string"
+      },
+      "date_created": {
+        "type": "string"
+      },
+      "system_details": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "release": {
+            "type": "string"
+          },
+          "recid": {
+            "type": "string"
+          }
+        }
+      },
+      "abstract": {
+        "type": "string"
+      },
+      "license": {
+        "type": "object",
+        "properties": {
+          "attribution": {
+            "type": "string"
+          }
+        }
+      },
+      "documentation": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "validation": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "links": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "recid": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "use_with": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "links": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "recid": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "usage": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "selection": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          }
+        }
+      },
+      "note": {
+        "type": "array",
+        "minItems": 1,
+        "uniqueItems": true,
+        "items": {
+          "type": "object",
+          "properties": {
+            "description": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "accelerator": {
+        "type": "string"
+      },
+      "experiment": {
+        "type": "string"
+      },
+      "run_period": {
+        "type": "string"
+      },
+      "collections": {
+        "type": "array",
+        "minItems": 1,
+        "uniqueItems": true,
+        "items": {
+          "type": "string"
+        }
+      },
+      "files": {
+        "type": "array",
+        "minItems": 1,
+        "uniqueItems": true,
+        "items": {
+          "type": "object",
+          "properties": {
+            "uri": {
+              "type": "string"
+            },
+            "size": {
+              "type": "integer"
+            },
+            "checksum": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/cernopendata/jsonschemas/records/software-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/software-v1.0.0.json
@@ -179,14 +179,22 @@
           "type": "string"
         }
       },
-      "files": {
+      "_files": {
         "type": "array",
-        "minItems": 1,
         "uniqueItems": true,
         "items": {
           "type": "object",
           "properties": {
             "uri": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            },
+            "bucket": {
+              "type": "string"
+            },
+            "version_id": {
               "type": "string"
             },
             "size": {

--- a/cernopendata/modules/fixtures/data/datasets/cms-2011-collision-datasets.json
+++ b/cernopendata/modules/fixtures/data/datasets/cms-2011-collision-datasets.json
@@ -1,0 +1,2592 @@
+[
+{
+    "recid": "15",
+    "doi": "10.7483/OPENDATA.CMS.N372.QF6S",
+    "collaboration": {
+        "name": "CMS collaboration",
+        "recid": 451
+    },
+    "type": "Dataset",
+    "subtype": "Collision Data",
+    "title": "/BTag/Run2011A-12Oct2013-v1/AOD",
+    "additional_title": "BTag primary dataset in AOD format from RunA of 2011 (/BTag/Run2011A-12Oct2013-v1/AOD)",
+    "distribution": {
+        "formats": [
+            "root",
+            "aod"
+        ],
+        "number_events": "11759539",
+        "number_files": "489",
+        "size": "1838495301652"
+    },
+    "publisher": "CERN Open Data Portal",
+    "date_published": "2016",
+    "date_created": "2010",
+    "date_reprocessed": "2011",
+    "system_details": {
+        "description": "Recommended release and global tag for analysis",
+        "release": "CMSSW_5_3_32",
+        "global_tag": "FT_53_LV5_AN1"
+    },
+    "abstract": "BTag primary dataset in AOD format from RunA of 2011. Run period from run number 160404 to 173692.",
+    "license": {
+        "attribution": "CC0"
+    },
+    "note": {
+        "description": "This dataset contains all runs from 2011 RunA. The list of validated runs, which must be applied to all analyses, can be found in",
+        "links": [
+            {
+                "recid": "1001"
+            }
+        ]
+    },
+    "generation": {
+        "description": "Dataset defined for the calibration of b-quark tag algorithms. Events stored in this primary dataset were selected because of the presence of at least two high-energy jets, where one of them is tagged as a b-quark jet with a soft muon from the b-quark decay in the event.",
+        "steps": [
+            {
+                "type": "HLT",
+                "note": "The collision data were assigned to different RAW datasets using the following ",
+                "configuration_files": [
+                    {
+                        "description": "HLT configuration",
+                        "recid": "1700"
+                    }
+                ]
+            },
+            {
+                "type": "RECO",
+                "note": "This primary AOD dataset was processed from the RAW dataset by the following step:",
+                "release": "CMSSW_5_3_12_patch1",
+                "global_tag": "FT_R_53_LV5::All",
+                "configuration_files": [
+                    {
+                        "description": "Configuration file for RECO step reco_2011A_BTag",
+                        "recid": "3603"
+                    }
+                ]
+            },
+            {
+                "type": "HLT trigger paths",
+                "note": "",
+                "configuration_files": [
+                    {
+                        "title": "HLT_BTagMu_DiJet110_Mu5"
+                    },
+                    {
+                        "title": "HLT_BTagMu_DiJet20_Mu5"
+                    },
+                    {
+                        "title": "HLT_BTagMu_DiJet40_Mu5"
+                    },
+                    {
+                        "title": "HLT_BTagMu_DiJet70_Mu5"
+                    }
+                ]
+            }
+        ]
+    },
+    "validation": {
+        "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+        "links": [
+            {
+                "url": "http://iopscience.iop.org/1742-6596/219/7/072020/pdf/1742-6596_219_7_072020.pdf",
+                "description": "The CMS Data Quality Monitoring software experience and future improvements"
+            },
+            {
+                "url": "http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf",
+                "description": "The CMS data quality monitoring software: experience and future prospects"
+            }
+        ]
+    },
+    "usage": {
+        "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in",
+        "links": [
+            {
+                "url": "http://opendata.cern.ch/VM/CMS#2011",
+                "description": "How to install the CMS Virtual Machine"
+            },
+            {
+                "url": "http://opendata.cern.ch/getting-started/CMS#2011",
+                "description": "Getting started with CMS open data"
+            }
+        ]
+    },
+    "selection": {
+        "description": "Events stored in this dataset were selected by requiring that a muon was reconstructed in the final state. On top of this requirement, they were randomly selected in three physics runs taken in 2010, 2011 and 2012, in order to collect a sample close to 800 events, statistically sufficient to perform the multiplicity studies. This subset was analysed aiming at a detailed study of the multiplicity of charged particles produced in neutrino interactions as an important input to models of the hadronic shower generation"
+    },
+    "accelerator": "CERN-LHC",
+    "experiment": "CMS",
+    "parent_dataset": {
+        "title": "/BTag/Run2011A-v1/RAW"
+    },
+    "collision_information": {
+        "type": "pp",
+        "energy": "7 TeV"
+    },
+    "run_period": "Run2011A",
+    "collections": [
+        "CMS-Primary-Datasets"
+    ],
+    "files": [
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_BTag_AOD_12Oct2013-v1_00000_file_index.txt",
+            "size": 122,
+            "type": "index",
+            "description": "BTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+            "checksum": "sha1:a0c48ed090c7e5d88d8a4c73b5e99f2ab188f957"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_BTag_AOD_12Oct2013-v1_20000_file_index.txt",
+            "size": 59536,
+            "type": "index",
+            "description": "BTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+            "checksum": "sha1:b9ca7077636e006d44469ef878810cc716352458"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/00000/802CF580-BB46-E311-8D89-00261894388D.root",
+            "size": 886706228,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/00376186-543E-E311-8D30-002618943857.root",
+            "size": 3876676097,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0080432E-043E-E311-B4CB-00248C0BE01E.root",
+            "size": 2779358372,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/00867474-453E-E311-A450-003048FFD7C2.root",
+            "size": 3857729224,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/02012C2B-323E-E311-897E-003048FFD736.root",
+            "size": 2183634785,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/02116E88-003E-E311-A1A9-0025905964BA.root",
+            "size": 4195728466,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0216066B-3A3E-E311-ABD0-003048FFD732.root",
+            "size": 3893538194,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/02477509-3D3E-E311-A230-00261894389A.root",
+            "size": 3884261055,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/02581093-3E3E-E311-8235-00248C55CC3C.root",
+            "size": 3935265131,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0297C037-2D3E-E311-83A2-00259059649C.root",
+            "size": 4210261676,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/04359AB0-083E-E311-9931-0030486792B8.root",
+            "size": 3220554260,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/046737D2-FE3D-E311-9D6F-0026189438B4.root",
+            "size": 2687420453,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0601ADAC-353E-E311-9148-003048FF9AA6.root",
+            "size": 3934186461,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0608F658-343E-E311-B48A-00304867BEDE.root",
+            "size": 2624867959,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/062F9868-013E-E311-8D7B-0025905938AA.root",
+            "size": 4188799405,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0635991C-413E-E311-B66A-002618943915.root",
+            "size": 4039246198,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/063E7003-483E-E311-904A-00304867BF18.root",
+            "size": 3856289078,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0643CAA5-553E-E311-90CA-00304867BF18.root",
+            "size": 3943558551,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/065603C6-523E-E311-976E-003048FFD770.root",
+            "size": 4187610758,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0805FDA2-113E-E311-BE1E-00261894387C.root",
+            "size": 2471795166,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/084777C9-4C3E-E311-B2BA-00261894393A.root",
+            "size": 4052525325,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/08874443-3E3E-E311-9B4A-0026189438B0.root",
+            "size": 4012114214,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0896492D-313E-E311-BEE1-002618943858.root",
+            "size": 4263197798,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/08BB739B-733E-E311-A0C3-003048678B18.root",
+            "size": 2641959194,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/08E8E762-4C3E-E311-8443-002354EF3BE2.root",
+            "size": 3586305295,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/08F7E8B4-353E-E311-BBCF-003048FFCBA8.root",
+            "size": 3917166408,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0A39DE3B-2A3E-E311-8D70-003048D3FC94.root",
+            "size": 4082807414,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0A5DA3F9-233E-E311-B53C-0025905964BA.root",
+            "size": 4082366596,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0A929BD4-1B3E-E311-B70F-0026189438D3.root",
+            "size": 2184692630,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0ADCC5D1-543E-E311-B2BE-0026189438C0.root",
+            "size": 3890656113,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0C017AE6-5A3E-E311-B418-002618943821.root",
+            "size": 3476986356,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0C2826FB-593E-E311-9968-0025905964B6.root",
+            "size": 3627014883,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0C3827DD-2A3E-E311-8E14-00304867920C.root",
+            "size": 4136010283,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0C54FF98-3E3E-E311-99B2-002618FDA207.root",
+            "size": 4205511304,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0C9C9FC3-F43D-E311-9557-002618943970.root",
+            "size": 2941170932,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0CBDC3DD-493E-E311-B593-002618943832.root",
+            "size": 4006614703,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0CE7CB14-4F3E-E311-8829-0025905964BE.root",
+            "size": 4067472063,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/0E3E76D8-373E-E311-A724-002354EF3BDF.root",
+            "size": 4304401602,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/1041A0C2-413E-E311-B36B-002618FDA279.root",
+            "size": 4148623377,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/10C31438-3F3E-E311-8C8E-00261894394B.root",
+            "size": 4164370398,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/10F7BB16-493E-E311-AFF7-003048FFD752.root",
+            "size": 4229483195,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/127CF8DE-493E-E311-8184-00261894380A.root",
+            "size": 4072313422,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/129DA3CE-4C3E-E311-AF4D-003048678B5E.root",
+            "size": 3931578609,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/1458F2C7-4C3E-E311-88EE-003048FFD744.root",
+            "size": 4030877727,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/14B19678-F43D-E311-97B7-003048678E8A.root",
+            "size": 4094669764,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/1623D0E6-413E-E311-9F92-002618943960.root",
+            "size": 3827977391,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/163BDBBE-143E-E311-9041-00261894394D.root",
+            "size": 2231331177,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/18295587-503E-E311-B5B3-0025905964A2.root",
+            "size": 4120528264,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/183CE417-2D3E-E311-975B-0026189437FE.root",
+            "size": 3904077356,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/186A17DA-453E-E311-B3E8-002590596484.root",
+            "size": 3883073090,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/18A844FF-2D3E-E311-8D02-002618943924.root",
+            "size": 4212392292,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/18CDF876-283E-E311-AEEC-002618943845.root",
+            "size": 4232542677,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/18FE2D36-3F3E-E311-B066-002618943896.root",
+            "size": 4203080835,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/1A0C0457-423E-E311-AB78-002618943880.root",
+            "size": 3686498628,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/1A76BAB4-283E-E311-867F-0025905964BE.root",
+            "size": 4214072388,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/1AA4D333-2B3E-E311-B066-003048678BE6.root",
+            "size": 3784009166,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/1E286468-1F3E-E311-8CCF-00261894394F.root",
+            "size": 4161680887,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/1E39C3A9-273E-E311-95FA-003048678B18.root",
+            "size": 2903906193,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/1E4DF408-3D3E-E311-8068-002618943925.root",
+            "size": 4103266532,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/1E51F476-F83D-E311-BABA-003048FFCB6A.root",
+            "size": 2689322836,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/1E5EF5F3-533E-E311-B643-003048678E92.root",
+            "size": 3880238154,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/1EC9033A-3F3E-E311-A478-00259059642A.root",
+            "size": 4080316213,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/20305EA9-343E-E311-A03C-003048FFD730.root",
+            "size": 4115240481,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/205EA93E-033E-E311-937F-0026189438AC.root",
+            "size": 2910455232,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/20629CB9-2C3E-E311-8CD3-00261894387A.root",
+            "size": 4101044825,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/20E1B80A-2C3E-E311-AEB2-003048678AE2.root",
+            "size": 4100472743,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2269B1BC-333E-E311-B8A9-0025905964C0.root",
+            "size": 4204332759,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/227890A6-293E-E311-B036-002618943821.root",
+            "size": 3921864979,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/22A8D118-413E-E311-83C9-003048678F8E.root",
+            "size": 4157486220,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/22AF93D3-EA3D-E311-AE63-002618943900.root",
+            "size": 2429307810,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/22E30A0A-2C3E-E311-9EC9-0026189438FE.root",
+            "size": 3964683999,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/22F95767-393E-E311-AE69-003048679076.root",
+            "size": 3992353111,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/240A3D9E-373E-E311-949B-0026189438C9.root",
+            "size": 4212636833,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/244F1F93-3E3E-E311-8BCC-002354EF3BD0.root",
+            "size": 4108606498,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/248DFC14-3D3E-E311-99B4-003048FFCB8C.root",
+            "size": 2751115687,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/24A21CF0-3B3E-E311-8811-00261894389A.root",
+            "size": 4045595082,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/24D4AB8A-3F3E-E311-927A-00248C0BE014.root",
+            "size": 3503756872,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/264C3E03-473E-E311-88FA-002590593920.root",
+            "size": 3999379116,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/267221E8-F93D-E311-B7D3-00304867C1BC.root",
+            "size": 2282367972,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/26EE215C-273E-E311-957A-0026189438F4.root",
+            "size": 4087282612,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2881DB64-393E-E311-9A88-003048678C06.root",
+            "size": 3917211195,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2A38E2E7-4B3E-E311-942C-003048FFD720.root",
+            "size": 3764796052,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2A5DC8A5-283E-E311-9D68-003048FFD756.root",
+            "size": 3925620038,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2A806ABE-3B3E-E311-BF7D-0025905938A8.root",
+            "size": 4281589099,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2AFD55D1-4C3E-E311-B314-0026189438F5.root",
+            "size": 2567451122,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2C3FCF58-263E-E311-8BC3-00261894398B.root",
+            "size": 3596148207,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2C65273E-313E-E311-A557-003048678BF4.root",
+            "size": 4024691669,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2C99B146-423E-E311-B0C7-00261894384F.root",
+            "size": 4248639710,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2CB38D17-3A3E-E311-BBF6-00304867C0EA.root",
+            "size": 3946888573,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2E5A0D59-483E-E311-A0B2-00261894388A.root",
+            "size": 4247121633,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2E5AFA7F-573E-E311-869E-00261894386E.root",
+            "size": 3815270955,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2E62E09C-473E-E311-B263-0025905964B2.root",
+            "size": 4057777314,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/2E70B8D3-253E-E311-98F5-002618943933.root",
+            "size": 3920786055,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/304F927F-553E-E311-803C-002618943960.root",
+            "size": 4034394312,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/308C6E3D-513E-E311-B0F2-003048FFD754.root",
+            "size": 3436949293,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/30C8BFC0-3B3E-E311-BC0C-002354EF3BDF.root",
+            "size": 4000507653,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/30D00CBE-253E-E311-960F-002354EF3BE2.root",
+            "size": 2684017892,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/32005ED9-453E-E311-9D64-00248C0BE018.root",
+            "size": 3876208307,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/32C8775B-283E-E311-A199-00261894383B.root",
+            "size": 4027305183,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/340AAFD2-3F3E-E311-A99D-003048FFD71E.root",
+            "size": 4217996016,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/34472F8D-4A3E-E311-9362-0026189438D6.root",
+            "size": 3906289436,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/345DC8A9-423E-E311-85B9-002618943857.root",
+            "size": 3372209902,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3471AC10-203E-E311-B683-003048678ED2.root",
+            "size": 3783672695,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/347915D6-2A3E-E311-89F7-0026189438DE.root",
+            "size": 4189828732,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/34E3739D-593E-E311-8054-0026189438B1.root",
+            "size": 2165972197,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/36199659-613E-E311-8DC9-0025905964BC.root",
+            "size": 3391707333,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/361B1423-363E-E311-9242-002590596486.root",
+            "size": 3018749741,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/369840E2-3B3E-E311-A86B-003048678FEA.root",
+            "size": 3793406909,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3698C5DF-363E-E311-A46C-003048FFD7BE.root",
+            "size": 3890856528,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/36CF619E-4F3E-E311-AC01-003048FF9AC6.root",
+            "size": 3922093495,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/38605EBF-2B3E-E311-9F43-002618943845.root",
+            "size": 4134114542,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3871B66E-273E-E311-BDE5-002618943800.root",
+            "size": 4184389740,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/389CCD3D-2A3E-E311-B17A-002354EF3BE0.root",
+            "size": 3806013071,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/38BFFFF1-483E-E311-BD9A-002618943915.root",
+            "size": 4168821588,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/38E90D8F-373E-E311-B3B1-002618943870.root",
+            "size": 3735929215,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/38F776D6-4B3E-E311-87E8-003048FFCB6A.root",
+            "size": 3900864937,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/38F8112D-403E-E311-8DD2-003048678AFA.root",
+            "size": 3241406097,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3A5AD9E2-2C3E-E311-8105-003048FFD796.root",
+            "size": 4179856244,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3A8A4A86-383E-E311-BFE1-002618943939.root",
+            "size": 3815675779,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3AA791B4-2D3E-E311-9D3D-0026189438C9.root",
+            "size": 4103231751,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3AF1CE34-FE3D-E311-8AD9-0026189438CF.root",
+            "size": 4064002976,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3C07D514-003E-E311-92FE-00261894398A.root",
+            "size": 4221273876,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3C13EBEF-483E-E311-B79A-00259059642A.root",
+            "size": 3889807725,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3C73B992-4F3E-E311-B7AD-003048D15E02.root",
+            "size": 4244751580,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3CC32962-423E-E311-ABE7-002618943957.root",
+            "size": 4277335869,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3E179E77-443E-E311-8C2C-002618943910.root",
+            "size": 3805956975,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3E4E69BB-5D3E-E311-A533-002618FDA248.root",
+            "size": 4036985126,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/3EB1D57D-EA3D-E311-B904-003048679228.root",
+            "size": 2231497364,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/403295F8-363E-E311-8ECD-003048FFD736.root",
+            "size": 3810791155,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/405710A8-283E-E311-B5A1-00261894393D.root",
+            "size": 4177485831,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/40678A4C-593E-E311-BE7B-002354EF3BE4.root",
+            "size": 4122884534,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/408CCCDF-0E3E-E311-A714-00261894396D.root",
+            "size": 2913577216,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/42C1DB15-513E-E311-94D7-002618943933.root",
+            "size": 4144752188,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/42C94C18-533E-E311-9012-00261894393B.root",
+            "size": 2298591700,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/42D89293-373E-E311-8D13-0025905938D4.root",
+            "size": 3807352028,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/44089217-F13D-E311-A8AD-002590593902.root",
+            "size": 3845240571,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4428F945-313E-E311-BA4B-003048FFCB84.root",
+            "size": 3851585101,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/44505C7F-3F3E-E311-93DF-003048FFD76E.root",
+            "size": 3835672124,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/44609BFC-363E-E311-A5C2-00261894395B.root",
+            "size": 4187183589,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/449B7E9A-253E-E311-9F36-00261894396A.root",
+            "size": 4093908007,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/44DAFBDF-2D3E-E311-AA5F-0026189437FD.root",
+            "size": 3960570819,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4640C84E-2B3E-E311-B0FA-002590596486.root",
+            "size": 4187020329,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/46419DC8-263E-E311-9E04-002618943964.root",
+            "size": 4020517527,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/466E4906-2E3E-E311-A038-003048678AFA.root",
+            "size": 4241578871,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/468E074E-493E-E311-8D34-00261894388A.root",
+            "size": 4226343857,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4698A750-5B3E-E311-BDE0-0026189438E1.root",
+            "size": 3441799443,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/46BB86F7-573E-E311-88A9-0026189438C9.root",
+            "size": 3805646016,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/489349FC-423E-E311-8776-0026189438B9.root",
+            "size": 3918556473,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/48CBCD7C-513E-E311-8687-002590593878.root",
+            "size": 3896606089,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4A0BC6E1-2A3E-E311-A538-003048FFD71A.root",
+            "size": 3966996955,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4A19137A-323E-E311-BF8A-002618943919.root",
+            "size": 3721796620,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4A411299-503E-E311-B0C3-003048FFCB96.root",
+            "size": 4152171977,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4AF9AA98-3C3E-E311-A0CA-002618943971.root",
+            "size": 4126520328,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4C084968-453E-E311-AC25-0026189438EB.root",
+            "size": 4131990969,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4C4E9222-333E-E311-8DF7-002618943920.root",
+            "size": 3376253555,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4C4F096B-453E-E311-9E46-0026189438A2.root",
+            "size": 4175283991,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4CC0D097-4E3E-E311-B1B7-003048FFD730.root",
+            "size": 3776899213,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4E0BD2BD-253E-E311-ABEC-003048678B18.root",
+            "size": 4073723840,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4E13FB2F-4B3E-E311-8D94-003048678B14.root",
+            "size": 4013486181,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4E52766A-E33D-E311-8A15-002618943832.root",
+            "size": 2637929678,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4E698723-393E-E311-A7E2-003048678E52.root",
+            "size": 2704968595,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/4EEF8487-383E-E311-A85D-0026189438D7.root",
+            "size": 4263230688,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/50179106-3D3E-E311-AD7F-00261894380D.root",
+            "size": 4021897265,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/501D452A-4B3E-E311-90BA-00261894393D.root",
+            "size": 3764606920,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/50553992-253E-E311-AE06-00261894386A.root",
+            "size": 3905497381,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5093C1F5-233E-E311-90E2-00261894392D.root",
+            "size": 4096869499,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/50A816FD-573E-E311-B26E-0026189438B9.root",
+            "size": 2406472710,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/50B72875-413E-E311-A320-003048FFD760.root",
+            "size": 4042792097,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/520E1A87-303E-E311-9257-003048FFD730.root",
+            "size": 4172055377,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/52596A89-243E-E311-AD0C-003048678BE6.root",
+            "size": 4252299847,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/52FE50A6-213E-E311-8F2A-00261894395C.root",
+            "size": 4157570064,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5430D89E-4F3E-E311-A9A5-00261894388A.root",
+            "size": 2613676309,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5442A4E7-373E-E311-968C-0025905964B4.root",
+            "size": 3150942640,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/545151B0-1C3E-E311-85CF-002618943880.root",
+            "size": 3819493956,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/54854FB5-353E-E311-A0A7-0026189438E7.root",
+            "size": 4223816488,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/54A85226-1C3E-E311-B41A-003048678B8E.root",
+            "size": 3989621186,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/560C26E8-073E-E311-818F-00259059642E.root",
+            "size": 3700836215,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/563866F5-473E-E311-A2FA-003048FFD7C2.root",
+            "size": 4151168739,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/569B9347-423E-E311-87DD-0026189438AC.root",
+            "size": 3991294937,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/56C5B613-473E-E311-A650-0025905822B6.root",
+            "size": 4091339644,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5833715C-063E-E311-87C3-003048678B1A.root",
+            "size": 4110063654,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5A7EE22A-293E-E311-97A3-002618943800.root",
+            "size": 2899402556,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5A8B217B-FB3D-E311-B62A-002618943964.root",
+            "size": 3126136648,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5AAF8779-183E-E311-8758-002618943882.root",
+            "size": 3618106991,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5AB21CD7-453E-E311-BA05-0025905964BA.root",
+            "size": 3256019009,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5ABE46C0-4E3E-E311-B3B8-00261894392F.root",
+            "size": 4209010745,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5C9DF7C2-283E-E311-82CA-002618943862.root",
+            "size": 3833729134,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5CAE839A-093E-E311-946F-003048679228.root",
+            "size": 2319647480,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5E276D78-3A3E-E311-9796-003048FF9AA6.root",
+            "size": 4210046156,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/5ED3AD37-023E-E311-8C27-003048679168.root",
+            "size": 3854670228,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/60058DF1-2F3E-E311-9E0A-002618943869.root",
+            "size": 4086831333,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/621EDD2E-4B3E-E311-A9D3-003048FFD744.root",
+            "size": 3952618416,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/62874668-3A3E-E311-818C-003048679214.root",
+            "size": 3929469756,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/62B60B6C-333E-E311-A37D-002618943956.root",
+            "size": 3744902398,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/62CA4A8A-3F3E-E311-A428-00261894390C.root",
+            "size": 3860800245,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/64278FC6-2D3E-E311-9BEA-003048FFD75C.root",
+            "size": 4245176188,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/6446DEF9-3B3E-E311-8FA6-0025905964BC.root",
+            "size": 3828424313,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/64DBE83E-1B3E-E311-BF60-002618943940.root",
+            "size": 2200447284,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/6634A7B3-413E-E311-ADEF-00261894382D.root",
+            "size": 4048058217,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/6648BCF9-593E-E311-8242-003048679076.root",
+            "size": 2689376244,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/666B311F-333E-E311-BC0C-0025905964BA.root",
+            "size": 4164063352,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/66801CD4-5A3E-E311-9C7D-002618943800.root",
+            "size": 3854520758,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/66E4E401-2E3E-E311-BB84-002618943849.root",
+            "size": 3859251598,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/684AFC62-2A3E-E311-9D50-003048FF86CA.root",
+            "size": 4083718876,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/68CBE5E9-473E-E311-8E14-00304867918A.root",
+            "size": 2166702344,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/68FD42B8-2B3E-E311-8E63-002618943956.root",
+            "size": 4231455104,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/6A8552D6-233E-E311-A399-002618943919.root",
+            "size": 4123271795,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/6C28D0C1-293E-E311-A9AC-00261894385A.root",
+            "size": 3910311226,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/6C51DF35-003E-E311-A863-003048FFD756.root",
+            "size": 2415522277,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/6CD636EE-473E-E311-B6DB-003048FFCC2C.root",
+            "size": 4140336399,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/6CE45049-603E-E311-974B-003048FFD754.root",
+            "size": 2521465659,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/6E70D1B3-463E-E311-BA2F-003048FFD75C.root",
+            "size": 4003896043,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/702D9E02-493E-E311-9D43-002618943874.root",
+            "size": 4195311008,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/70753A35-3C3E-E311-99AE-002618943867.root",
+            "size": 3866823888,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/70BBA233-3F3E-E311-9F08-00261894398A.root",
+            "size": 3991664632,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/70BE7400-433E-E311-8A95-003048FFD744.root",
+            "size": 3883342362,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/70F89650-643E-E311-92AE-00261894390E.root",
+            "size": 2333437277,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7217A318-FC3D-E311-8C15-00261894382A.root",
+            "size": 2721753762,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/72233506-2F3E-E311-87A2-002618FDA26D.root",
+            "size": 2149235860,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/725BD01A-013E-E311-A997-003048FFD756.root",
+            "size": 4129058946,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/72F92552-493E-E311-A691-003048FFD728.root",
+            "size": 3999042835,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/742DC449-283E-E311-9332-002618943807.root",
+            "size": 4017717769,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7457C8F6-513E-E311-82E2-003048678FF4.root",
+            "size": 4189151530,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/760683BA-3B3E-E311-87C9-0026189438AC.root",
+            "size": 3851007073,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/762C8263-2C3E-E311-BB2F-002618943959.root",
+            "size": 4013000152,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/766F7C6C-FF3D-E311-BD82-002354EF3BDE.root",
+            "size": 4192366190,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7679BDB1-283E-E311-B1F7-00248C0BE005.root",
+            "size": 4023961055,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/767C6934-293E-E311-AC3B-003048FFCBFC.root",
+            "size": 3933514205,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/76848AA0-433E-E311-8D05-0026189438F5.root",
+            "size": 4268457765,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7826A108-303E-E311-8622-003048FFCC0A.root",
+            "size": 4120979422,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/789BB49B-693E-E311-B481-002618943821.root",
+            "size": 2809906265,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/78A30EFA-FE3D-E311-9603-002618943978.root",
+            "size": 3904679504,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7A1CD9EF-3B3E-E311-BF79-003048678A6C.root",
+            "size": 4082821252,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7A8277DB-4B3E-E311-A845-002590593876.root",
+            "size": 4194322084,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7AA6BA1D-343E-E311-A5C5-0026189438E9.root",
+            "size": 2361256819,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7AC181DF-4E3E-E311-8FBE-0026189438C4.root",
+            "size": 4024575990,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7AC67866-583E-E311-9F01-003048678B26.root",
+            "size": 2342467483,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7AFFB853-013E-E311-9230-003048678F74.root",
+            "size": 3651537520,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7C118BCF-3A3E-E311-9FE8-0025905964C4.root",
+            "size": 4082104200,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7C6A953A-3F3E-E311-8D85-00261894389A.root",
+            "size": 4272212192,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7C6FFB22-323E-E311-9103-002590593902.root",
+            "size": 4077631761,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7E8093AA-2C3E-E311-AD82-002618943980.root",
+            "size": 4252707474,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7E9C9DF3-533E-E311-9F47-003048D3C010.root",
+            "size": 4262815551,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7EDFEE26-413E-E311-A725-0025905964C2.root",
+            "size": 4246084826,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/7EF1FBD4-553E-E311-A8C9-002618943915.root",
+            "size": 2804284332,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/80192291-3F3E-E311-AEC7-0026189438EA.root",
+            "size": 4097027910,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/80BC6726-2B3E-E311-BC8A-003048FFCBB0.root",
+            "size": 4125692390,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/80C31E1B-2D3E-E311-A672-0026189438AB.root",
+            "size": 4027300229,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/822560E1-2A3E-E311-94AB-002618FDA259.root",
+            "size": 4043414892,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/82443C74-3D3E-E311-AFC4-003048678B30.root",
+            "size": 3780763922,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/825A0626-333E-E311-B4BE-0025905964B2.root",
+            "size": 3720374839,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/825A9727-2D3E-E311-B615-002590596468.root",
+            "size": 4226724783,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/828290AA-2E3E-E311-88EA-002618943908.root",
+            "size": 3993231113,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/828F67E4-2E3E-E311-853C-002618FDA265.root",
+            "size": 3982766383,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8415E4F7-2F3E-E311-95BF-0025905964C2.root",
+            "size": 4080028527,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/84ABE01B-333E-E311-B903-0026189438F4.root",
+            "size": 4106448904,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/84FCCB74-0C3E-E311-B5E1-00259059642E.root",
+            "size": 2309801667,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/88105F01-433E-E311-B0BE-0030486790B8.root",
+            "size": 3909658200,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/883A5D6F-F33D-E311-9388-003048678FF4.root",
+            "size": 3513010676,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/88483D9A-433E-E311-8D80-003048679294.root",
+            "size": 3975644754,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8858BFBC-203E-E311-A0E8-003048678ED2.root",
+            "size": 2586330378,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8863B6C8-443E-E311-BB85-003048FFD756.root",
+            "size": 3807853584,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/88FD583B-313E-E311-8783-0026189437F5.root",
+            "size": 3768934998,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8A05D48B-383E-E311-B7FB-003048FFCB6A.root",
+            "size": 3135120602,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8A86BD7E-3F3E-E311-97F9-003048FFD76E.root",
+            "size": 2638508143,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8A8B3DBA-423E-E311-8847-003048FFCB84.root",
+            "size": 4058864938,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8A8FAE26-F83D-E311-AFD4-002354EF3BDE.root",
+            "size": 3888478855,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8ABA74A9-383E-E311-9E5D-003048FFCBB0.root",
+            "size": 4185179764,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8C3A2BFD-423E-E311-9AC9-002618943924.root",
+            "size": 4261482613,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8CC356B8-193E-E311-A090-003048FFD736.root",
+            "size": 3035247434,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8CDDCF06-2E3E-E311-A5A8-002618FDA265.root",
+            "size": 3132768148,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8E8E47CB-523E-E311-B58C-00248C0BE018.root",
+            "size": 2492614493,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/8ECCAC41-5C3E-E311-839F-003048678B08.root",
+            "size": 2207735248,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9068CDAB-293E-E311-9B88-003048D15E2C.root",
+            "size": 4117894005,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/90E70F30-5C3E-E311-B39A-00261894386D.root",
+            "size": 3802100493,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/921CB8B8-4E3E-E311-A82B-0026189438E7.root",
+            "size": 4050614500,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/921F6E1C-413E-E311-BD10-00259059642A.root",
+            "size": 4278156965,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9227BE99-3E3E-E311-8225-0025905938B4.root",
+            "size": 2330546630,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/925BC64C-093E-E311-B064-002618943807.root",
+            "size": 3353564308,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/928D7F1A-413E-E311-80D8-003048678BB2.root",
+            "size": 4003614641,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/92BE19C8-3B3E-E311-A5A5-00304867908C.root",
+            "size": 4221043181,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/92FC562F-4F3E-E311-BB99-003048678ADA.root",
+            "size": 3960490254,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/944CF331-313E-E311-A747-00261894390E.root",
+            "size": 4123063809,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/94521E38-F03D-E311-A72F-0026189438C9.root",
+            "size": 2937227059,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/94541AAF-433E-E311-8E7F-002590596468.root",
+            "size": 4124004138,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/949AE1F4-453E-E311-85DA-003048FFD752.root",
+            "size": 3953580866,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/94E4A394-443E-E311-A189-00304867904E.root",
+            "size": 3615427404,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/96076BDF-443E-E311-8851-002618943807.root",
+            "size": 3450317509,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9627E433-4D3E-E311-B55A-003048FFD744.root",
+            "size": 4026121015,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9631D770-5E3E-E311-950A-002618943866.root",
+            "size": 4226890080,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/964009B1-463E-E311-8D08-002618943964.root",
+            "size": 4243159808,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9643F981-323E-E311-9BE8-00259059649C.root",
+            "size": 2921253881,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/96DCA65A-4A3E-E311-9345-002618943940.root",
+            "size": 4125518106,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9843100B-363E-E311-A03A-0026189438E4.root",
+            "size": 4050495200,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/987683F6-353E-E311-8590-002618943885.root",
+            "size": 4145529416,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/98925886-4B3E-E311-AD1E-003048678BE6.root",
+            "size": 3992331404,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/98CC9187-313E-E311-8885-00304867BED8.root",
+            "size": 4058173447,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/98DF11B2-463E-E311-88B8-002618FDA26D.root",
+            "size": 4180447838,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9A87E595-4E3E-E311-87D4-00259059391E.root",
+            "size": 4127746477,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9A89918F-F23D-E311-94B4-00304867926C.root",
+            "size": 3721827239,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9A94EA1A-3A3E-E311-A581-00261894394A.root",
+            "size": 3309293710,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9AA79328-393E-E311-9555-003048678E52.root",
+            "size": 4073965985,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9AD0DC9F-4F3E-E311-A4AB-003048FFCC2C.root",
+            "size": 4026910393,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9C326209-573E-E311-88DF-002618943831.root",
+            "size": 4201293864,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9C616DD3-2A3E-E311-B280-00261894393B.root",
+            "size": 3914607937,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9C73EAC0-443E-E311-8BB2-002618943811.root",
+            "size": 3844333478,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9CA4F11A-3A3E-E311-8FB0-00261894395C.root",
+            "size": 3863626503,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9E44E1DC-223E-E311-A078-00261894398C.root",
+            "size": 4178357142,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9E457F0A-3D3E-E311-94EA-00248C55CC97.root",
+            "size": 4180194131,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9E6581F8-3B3E-E311-9D3B-003048FF9AA6.root",
+            "size": 3887537625,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9E7EC941-1E3E-E311-905B-0026189438BD.root",
+            "size": 4023454116,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9E86B26A-453E-E311-9109-003048FFD736.root",
+            "size": 3992582504,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9EB64A7D-1A3E-E311-AA8F-0026189438B5.root",
+            "size": 2836114235,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9ED2A179-413E-E311-873B-0025905964BA.root",
+            "size": 3915991568,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/9EE281CB-183E-E311-8AB2-00261894397B.root",
+            "size": 2202339463,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A0091024-FF3D-E311-AC77-002590593920.root",
+            "size": 3279256637,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A039A849-523E-E311-B70A-0026189438D2.root",
+            "size": 3960832444,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A05A1620-473E-E311-AFA9-0026189437EB.root",
+            "size": 4114647178,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A068D51F-393E-E311-9BE5-00304867C04E.root",
+            "size": 4159059273,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A225732E-4B3E-E311-8899-0026189438B1.root",
+            "size": 3307855053,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A228DE2E-503E-E311-9A60-003048678ADA.root",
+            "size": 3941177408,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A2900E27-0B3E-E311-B352-00261894398D.root",
+            "size": 2511568852,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A2AE117C-3A3E-E311-BD5D-002618943959.root",
+            "size": 4191609185,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A2BCC500-3A3E-E311-9DC9-003048FFCBB0.root",
+            "size": 2709275929,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A413CB56-033E-E311-BE4A-002618943864.root",
+            "size": 4008722391,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A4268498-4F3E-E311-99C4-00261894391F.root",
+            "size": 4065955857,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A45A697A-313E-E311-9329-003048D15DDA.root",
+            "size": 3986051539,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A4617807-343E-E311-9D83-002618943970.root",
+            "size": 4013889902,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A4E929A1-2E3E-E311-ADFA-002618943869.root",
+            "size": 4244938946,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A4F31A9A-0D3E-E311-B6B7-003048FFD7D4.root",
+            "size": 2793146171,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A603EF9E-273E-E311-AB46-0025905964BA.root",
+            "size": 4009034583,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A6665F12-1D3E-E311-B099-002618943860.root",
+            "size": 4144701463,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/A6FA2898-573E-E311-B54D-00304867924E.root",
+            "size": 3385965210,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/AA033B17-053E-E311-B379-003048FFCC0A.root",
+            "size": 2943438138,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/AA37E65B-273E-E311-8E22-002618943882.root",
+            "size": 4079356021,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/AAFBC2E8-493E-E311-9DFF-0030486792A8.root",
+            "size": 4126217216,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/AC4EBBE7-433E-E311-AB9B-002618FDA204.root",
+            "size": 4100559487,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/AC60E04B-3A3E-E311-A94F-0025905938A8.root",
+            "size": 4099547086,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/ACB150E1-6A3E-E311-B4F3-00261894394F.root",
+            "size": 2269754392,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/ACDC7A01-463E-E311-911E-003048FF86CA.root",
+            "size": 4044268946,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/ACE9A607-3E3E-E311-91A8-003048FFD752.root",
+            "size": 3975018561,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/AE076333-313E-E311-A166-002590596498.root",
+            "size": 4214281961,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/AE096C8C-4A3E-E311-BA5D-003048678E6E.root",
+            "size": 3859236487,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/AE7265B9-293E-E311-966F-002618943916.root",
+            "size": 3885634632,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/AE9DB110-4C3E-E311-9A5C-002354EF3BE3.root",
+            "size": 4071456804,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B024E2BF-563E-E311-A956-003048FFD7BE.root",
+            "size": 3959593216,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B03575FC-4D3E-E311-93C6-0026189438EA.root",
+            "size": 4160445448,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B042DC5D-283E-E311-8032-003048678B86.root",
+            "size": 3908647617,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B084135C-383E-E311-B6A1-002618943876.root",
+            "size": 3851660308,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B0C28650-423E-E311-B76E-002618FDA250.root",
+            "size": 3993954159,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B20C7EBA-583E-E311-9FD0-002618FDA279.root",
+            "size": 3790648002,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B2AA6EA1-2E3E-E311-9182-002354EF3BE6.root",
+            "size": 3209374927,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B2AF801B-523E-E311-B465-003048FFD796.root",
+            "size": 3643344711,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B424D1C2-4C3E-E311-8256-00304867906C.root",
+            "size": 4259782618,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B44C7F4C-333E-E311-B6DA-00304867915A.root",
+            "size": 3915828940,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B4C07733-EF3D-E311-8824-003048678DD6.root",
+            "size": 3002397175,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B4DDE5BB-2B3E-E311-B61C-00259059642A.root",
+            "size": 4157204563,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B4E9257C-3D3E-E311-B9D6-002618943906.root",
+            "size": 4064703619,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B4F2311A-3A3E-E311-83DD-00304867D836.root",
+            "size": 4211584913,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B60164B6-2D3E-E311-9EA7-002354EF3BE0.root",
+            "size": 4018843277,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B608EE41-023E-E311-BCC3-003048FFD752.root",
+            "size": 4139107568,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B6422F26-253E-E311-9D07-002590593920.root",
+            "size": 4237109251,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B67A809E-373E-E311-BFA6-003048FFD7C2.root",
+            "size": 2975019686,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B6E0CE35-503E-E311-A8F4-002618943905.root",
+            "size": 4168604385,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B6E22FE4-433E-E311-827D-0026189438F5.root",
+            "size": 4106220367,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B8237505-273E-E311-AC1B-00261894392C.root",
+            "size": 2917472866,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B859D14C-3E3E-E311-B7EA-0025905964A2.root",
+            "size": 4283827124,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B88B1D7B-233E-E311-93BB-003048FFD7C2.root",
+            "size": 4029711993,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/B8D4B957-343E-E311-AE97-0026189437F8.root",
+            "size": 4063689668,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/BA27CF3A-F63D-E311-A2E3-0030486792A8.root",
+            "size": 3592610605,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/BA69D879-753E-E311-A04B-002590593920.root",
+            "size": 2755447155,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/BA6D569E-ED3D-E311-9F5A-002618943886.root",
+            "size": 3244443999,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/BAEB1E9E-473E-E311-AA15-003048679012.root",
+            "size": 3977627535,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/BCED0BE0-373E-E311-8AD6-0026189438C2.root",
+            "size": 4039941435,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C01D66F6-243E-E311-B7D6-002618943894.root",
+            "size": 4249964685,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C02B89E1-493E-E311-A1F0-00304867920A.root",
+            "size": 4181661206,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C0420F3B-2B3E-E311-A983-002354EF3BE1.root",
+            "size": 3854206376,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C06F642B-403E-E311-A480-003048D15E2C.root",
+            "size": 3994723917,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C0F2EB05-473E-E311-A7CB-0026189438F5.root",
+            "size": 3649286492,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C20EEA39-293E-E311-B25C-0026189438A9.root",
+            "size": 3908302976,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C252EA1F-2C3E-E311-A3D8-00248C55CC40.root",
+            "size": 3946404171,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C2F14A5F-383E-E311-B1FF-003048678A6C.root",
+            "size": 3933856934,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C404AD2F-4B3E-E311-8822-002618943811.root",
+            "size": 4128518510,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C404BF12-473E-E311-87C7-002590593920.root",
+            "size": 3951080748,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C40963A1-3C3E-E311-820D-002618943811.root",
+            "size": 2926450908,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C40CC79D-2E3E-E311-BF85-00261894387E.root",
+            "size": 3921262786,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C4CE4C25-413E-E311-B001-0026189438EA.root",
+            "size": 4176344107,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C4D3D53C-463E-E311-9E7F-00304867920C.root",
+            "size": 4177378450,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C61CFDBA-F13D-E311-80A9-002590596486.root",
+            "size": 4287011444,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C6308ED2-023E-E311-A14C-00261894383E.root",
+            "size": 3745447390,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C666C5F6-483E-E311-AAD3-002590593902.root",
+            "size": 4250589702,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C6C852B0-F03D-E311-B469-003048FFCC0A.root",
+            "size": 3233741059,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C6DCFA88-383E-E311-ACBA-002618943811.root",
+            "size": 4020758211,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C83C0297-433E-E311-9FD7-0026189438AC.root",
+            "size": 3842870025,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C88DB987-543E-E311-9AE7-003048678A7E.root",
+            "size": 3681292088,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C89BD2AB-223E-E311-8EA6-0025905964C0.root",
+            "size": 4132305371,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/C8EE6E8B-3F3E-E311-9D07-00259059649C.root",
+            "size": 3879335518,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/CA5B8874-413E-E311-A145-002618943868.root",
+            "size": 4098590484,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/CA8CC0BC-2B3E-E311-A8A0-0026189437F8.root",
+            "size": 3501428931,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/CC43C0D7-2A3E-E311-9173-003048FFD732.root",
+            "size": 4246305527,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/CC8785D0-413E-E311-89AD-0025905964B4.root",
+            "size": 4175249378,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/CC91D1F4-213E-E311-A872-003048678ED2.root",
+            "size": 2683398229,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/CE061421-413E-E311-BCF7-003048FFCB74.root",
+            "size": 4211734608,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/CE908A20-373E-E311-954D-00259059391E.root",
+            "size": 3985894173,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D0971D71-5E3E-E311-91D0-003048678BAE.root",
+            "size": 3154301812,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D0B8C668-4C3E-E311-803E-0026189438EA.root",
+            "size": 2564540402,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D2E6BD9D-4A3E-E311-98B4-003048678DD6.root",
+            "size": 3882065021,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D40E92DB-223E-E311-8B6C-0025905964A2.root",
+            "size": 3383110738,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D42AFF65-5F3E-E311-A3E3-0025905964B2.root",
+            "size": 3017724156,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D42FFB32-413E-E311-9B5F-0025905938A4.root",
+            "size": 4044060016,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D47597B4-413E-E311-8F12-002618943986.root",
+            "size": 4178459542,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D4C4079F-473E-E311-B63A-002618943922.root",
+            "size": 4184336412,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D4D266E5-2F3E-E311-99F2-003048D3FC94.root",
+            "size": 4077446063,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D4D57F8C-3F3E-E311-BCCF-003048FFCB74.root",
+            "size": 3877638256,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D6772F48-3A3E-E311-82BF-00259059391E.root",
+            "size": 4294539880,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D69FF34D-FD3D-E311-95A0-002618943913.root",
+            "size": 2643723070,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D6C9AE55-973E-E311-BFA9-002618943857.root",
+            "size": 2626972948,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D823D40B-473E-E311-A1D0-0025905822B6.root",
+            "size": 4194861820,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D8627526-F73D-E311-BD78-0026189438B8.root",
+            "size": 3359738811,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D886D3FD-603E-E311-8BA1-00261894388B.root",
+            "size": 3839309081,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D8D58A39-653E-E311-912A-002618943868.root",
+            "size": 3936727303,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/D8FD7F6A-3A3E-E311-88D1-0025905938B4.root",
+            "size": 3871712275,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DA3409B1-1D3E-E311-B41D-002618943821.root",
+            "size": 4281340809,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DA5EAE4E-423E-E311-93B8-0025905964C0.root",
+            "size": 3886198383,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DAAA3BB3-363E-E311-BEE9-0030486791F2.root",
+            "size": 4122957995,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DADC044E-823E-E311-A03B-003048678F84.root",
+            "size": 2249227082,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DC52610C-2C3E-E311-BBA3-00261894380A.root",
+            "size": 3871016457,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DC74B1E5-533E-E311-90BB-003048FFCB96.root",
+            "size": 3995518233,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DCAE211F-4D3E-E311-A472-003048678ADA.root",
+            "size": 4179615886,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DCF6905C-263E-E311-BABF-0025905938A8.root",
+            "size": 4104921347,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DE2D6E7D-303E-E311-9C92-00261894394D.root",
+            "size": 3963320679,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DEA079B3-173E-E311-B913-0025905938A8.root",
+            "size": 3277863605,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DEA6C754-4A3E-E311-B580-003048FF9AC6.root",
+            "size": 3802757333,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DEB82E1F-393E-E311-B2C5-00261894394A.root",
+            "size": 3938392639,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DEF0334B-3E3E-E311-B5A7-003048678B3C.root",
+            "size": 4196832509,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/DEF47D66-2A3E-E311-9C33-003048FFCC18.root",
+            "size": 3891685089,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/E02C30FE-2D3E-E311-AFFE-002618943921.root",
+            "size": 3932411016,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/E08EECAA-353E-E311-85A0-003048FFD770.root",
+            "size": 4110478580,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/E298507D-253E-E311-9EBB-00261894382D.root",
+            "size": 3915687766,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/E29A5482-383E-E311-AE61-003048679164.root",
+            "size": 3996422065,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/E40F444B-593E-E311-A121-00261894398C.root",
+            "size": 4046110825,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/E46FE7C9-273E-E311-880C-00304867C1BA.root",
+            "size": 4254338989,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/E4FFC37D-EE3D-E311-9CD0-00261894390E.root",
+            "size": 3627750768,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/E647862E-633E-E311-9128-003048FFCBA4.root",
+            "size": 4087410498,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/E84E195D-483E-E311-A874-002618943842.root",
+            "size": 4008067754,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/E89FEA1E-413E-E311-AFDF-002618FDA216.root",
+            "size": 4047598979,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/EA1118E9-343E-E311-99B3-003048FFD79C.root",
+            "size": 3850022219,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/EA2A40D5-5C3E-E311-B537-002618943933.root",
+            "size": 3774466762,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/EAB8A522-303E-E311-9D26-00259059649C.root",
+            "size": 3421797060,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/EADEA1F1-2F3E-E311-9EB4-003048678DD6.root",
+            "size": 3648167008,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/EC16EEED-2F3E-E311-BA55-003048FFD760.root",
+            "size": 4057912196,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/EC8F78E4-493E-E311-9BFF-0026189437EB.root",
+            "size": 4123249008,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/ECAC00EA-493E-E311-BA8F-002618FDA207.root",
+            "size": 4014129621,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/ECAD25C9-443E-E311-99C6-003048FFD744.root",
+            "size": 3932141316,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/ECB99D9E-2C3E-E311-9BF8-002354EF3BE1.root",
+            "size": 3941198971,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/EE306464-683E-E311-851D-003048FFD728.root",
+            "size": 2343698197,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/EEC0E4FE-493E-E311-A8D2-0030486792F0.root",
+            "size": 3714840662,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/EEC4707C-323E-E311-994A-0026189437F5.root",
+            "size": 3939093350,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/EECCDD1C-4F3E-E311-86D3-002590593876.root",
+            "size": 4111399058,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F038C397-4E3E-E311-BCEE-003048FFD754.root",
+            "size": 3956235072,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F064BDE0-2A3E-E311-8717-003048678B34.root",
+            "size": 4153129950,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F08A74DE-543E-E311-83AF-003048FFD7BE.root",
+            "size": 3826974233,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F2207FE2-4E3E-E311-8834-002618943894.root",
+            "size": 2870790352,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F23466B4-2C3E-E311-9F61-003048FFCBB0.root",
+            "size": 3842168705,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F288DAC2-413E-E311-A2CC-003048678BAE.root",
+            "size": 4218993786,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F2BF91C1-3B3E-E311-B254-00261894388F.root",
+            "size": 3554703405,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F40C2B73-3D3E-E311-AA9C-00304867D838.root",
+            "size": 3901046440,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F456F325-413E-E311-90E5-002618943807.root",
+            "size": 2151701334,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F4C06464-4A3E-E311-B18C-002618943920.root",
+            "size": 3894809850,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F6171889-553E-E311-BA70-002618943901.root",
+            "size": 3759737965,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F6814478-483E-E311-A2F2-003048D15E02.root",
+            "size": 3963873005,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F69ECEF3-343E-E311-83B0-00248C0BE013.root",
+            "size": 4046775033,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F6A8E451-523E-E311-B26F-003048FFD732.root",
+            "size": 4281586834,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F6B4FE88-543E-E311-914D-002618943874.root",
+            "size": 2172921269,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F8A6DAE8-013E-E311-87AC-002354EF3BDE.root",
+            "size": 3880884584,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F8A8DD1E-6C3E-E311-A617-002618943969.root",
+            "size": 2299449328,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/F8D9AD66-283E-E311-A4D8-0026189438F5.root",
+            "size": 4265762523,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/FA1B6C20-213E-E311-8C00-002618943935.root",
+            "size": 4084455530,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/FA9081EA-493E-E311-B8A3-002618943869.root",
+            "size": 4213454446,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/FAF178E7-443E-E311-A0F3-00261894392B.root",
+            "size": 3859957729,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/FC2967BE-3B3E-E311-A0A8-00304867918A.root",
+            "size": 4222648090,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/FC6D1185-543E-E311-9702-002618FDA208.root",
+            "size": 3794805180,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/FC75C14D-423E-E311-9F74-0026189438DE.root",
+            "size": 4059585691,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/FC825082-303E-E311-9E92-002618943833.root",
+            "size": 4120490236,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/FC9D4520-413E-E311-A2CA-003048678B7C.root",
+            "size": 3877590160,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/FC9FDB0F-373E-E311-BB73-0025905938A8.root",
+            "size": 3912284133,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/FCF13BBC-413E-E311-A1DE-00261894388B.root",
+            "size": 4154237397,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/FE107CEC-2D3E-E311-A83C-002590596498.root",
+            "size": 4200926581,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/20000/FE34EA2D-3C3E-E311-B231-002590596486.root",
+            "size": 4037966016,
+            "checksum": "sha1:0000000000000000000000000000000000000000"
+        }
+    ]
+}
+]

--- a/cernopendata/modules/fixtures/data/datasets/opera-multiplicity-datasets.json
+++ b/cernopendata/modules/fixtures/data/datasets/opera-multiplicity-datasets.json
@@ -1,0 +1,200 @@
+[
+{
+    "recid": "3900",
+    "doi": "10.7483/OPENDATA.OPERA.HJC7.3DCC",
+    "collaboration": {
+        "name": "OPERA collaboration",
+        "recid": 452
+    },
+    "type": "Dataset",
+    "subtype": "Derived Dataset",
+    "title": "Electronic detector data for multiplicity studies",
+    "additional_title": "Electronic detector data for multiplicity studies",
+    "distribution": {
+        "formats": [
+            "csv"
+        ],
+        "number_events": "818",
+        "number_files": "1",
+        "size": "5269628"
+    },
+    "publisher": "CERN Open Data Portal",
+    "date_published": "2017",
+    "date_created": "2010-2012",
+    "dataset_semantics": [
+        {
+            "variable": "amplL",
+            "description": "PMT amplitude measured from the \"left\" side of a scintillator strip (in photo-electrons)"
+        },
+        {
+            "variable": "amplR",
+            "description": "PMT amplitude measured from the \"right\" side of a scintillator strip (in photo-electrons)"
+        },
+        {
+            "variable": "amplRec",
+            "description": "PMT amplitude reconstructed from the \"left\" and \"right\" side amplitudes of a scintillator strip taking into account light attenuation in a WLS fiber (in photo-electrons)"
+        },
+        {
+            "variable": "clLength",
+            "description": "cluster length (in cm)"
+        },
+        {
+            "variable": "driftDist",
+            "description": "drift distance (in cm)"
+        },
+        {
+            "variable": "enHad",
+            "description": "energy of a hadron jet (in GeV)"
+        },
+        {
+            "variable": "enNeu",
+            "description": "energy of a neutrino (in GeV)"
+        },
+        {
+            "variable": "enVis",
+            "description": "visible energy (in MeV)"
+        },
+        {
+            "variable": "evID",
+            "description": "event Id (11-digit number)"
+        },
+        {
+            "variable": "muMom",
+            "description": "momentum of a muon (in GeV/c)"
+        },
+        {
+            "variable": "posX",
+            "description": "X position of a drift tube, RPC, Target Tracker hit in the OPERA detector system of reference (in cm)"
+        },
+        {
+            "variable": "posY",
+            "description": "Y position of an RPC hit in the OPERA detector system of reference (in cm)"
+        },
+        {
+            "variable": "posZ",
+            "description": "Z position of a drift tube, RPC, Target Tracker hit in the OPERA detector system of reference (in cm)"
+        },
+        {
+            "variable": "timestamp",
+            "description": "event time in milliseconds since 01/01/1970"
+        }
+    ],
+    "abstract": "The dataset was extracted from the official OPERA data repository. It contains 818 muon neutrino interactions with the lead target where a muon was reconstructed in the final state. This happens in the so-called charged-current interactions of a muon neutrino. For this data sample, the Collaboration performed a dedicated analysis, with a detailed classification of all particles produced at the neutrino interaction on top of the muon. Indeed, in a muon neutrino interaction with the nucleons of the lead target, different hadrons are produced: the so-called shower hadrons and nuclear fragments produced in the break-up and in the evaporation of the target nucleus. The detailed study of the multiplicity of the hadrons produced provides insights on the mechanism of the hadronic shower formation. This data record contains all the electronic detector hits produced by the neutrino interactions in their propagation through the detector, except in the emulsion films. It includes hits in the scintillating target tracker, drift tubes and resistive plate chambers. The hits in the drift tubes and in the resistive plate chambers are used to reconstruct the muon tracks and measure its charge and momentum. The hits in the target tracker are used to predict the location of the neutrino interaction in the target units, the so-called bricks. This leads to the subsequent phase of the analysis where the neutrino interaction is located with micrometric accuracy and all tracks attached are measured",
+    "license": {
+        "attribution": "CC0"
+    },
+    "selection": {
+        "description": "Events stored in this dataset were selected by requiring that a muon was reconstructed in the final state. On top of this requirement, they were randomly selected in three physics runs taken in 2010, 2011 and 2012, in order to collect a sample close to 800 events, statistically sufficient to perform the multiplicity studies. This subset was analysed aiming at a detailed study of the multiplicity of charged particles produced in neutrino interactions as an important input to models of the hadronic shower generation"
+    },
+    "validation": {
+        "description": "During the data taking, all the runs recorded by OPERA are certified as good for physics analysis if the trigger and all sub-detectors show the expected performance. Moreover, the time stamp of the event should lie within the gate open by the CNGS beam signal. The data certification is based first on the offline shifters evaluation and later on the feedback provided by all sub-detector experts. Based on the above information, stored in a specific database, the Data Quality Monitoring group verifies the consistency of the certification and prepares an ascii file of certified runs to be used for physics analysis. Calibration procedures taking into account the specific geometry of the target associated to each event are applied to raw data and they are converted into a root file for each event that is then used for physics analysis"
+    },
+    "accelerator": "CERN-SPS",
+    "experiment": "OPERA",
+    "collections": [
+        "OPERA-Electronic-Detector-Datasets"
+    ],
+    "files": [
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/opera/datasets/multiplicity/electronic-detector-data-for-multiplicity-studies.zip",
+            "size": 5269628,
+            "checksum": "sha1:9e624ea97ccb57931901ec64e62c8553291f3d9a"
+        }
+    ]
+},
+{
+    "recid": "3901",
+    "doi": "10.7483/OPENDATA.OPERA.BVC1.UI85",
+    "collaboration": {
+        "name": "OPERA collaboration",
+        "recid": 452
+    },
+    "type": "Dataset",
+    "subtype": "Derived Dataset",
+    "title": "Emulsion data for track multiplicity",
+    "additional_title": "Emulsion data for track multiplicity",
+    "distribution": {
+        "formats": [
+            "csv"
+        ],
+        "number_events": "818",
+        "number_files": "1",
+        "size": "467580"
+    },
+    "publisher_name": "CERN Open Data Portal",
+    "date_published": "2017",
+    "date_created": "2010-2012",
+    "dataset_semantics": [
+        {
+            "variable": "evID",
+            "description": "event Id (11-digit number)"
+        },
+        {
+            "variable": "globPosX",
+            "description": "X position of a vertex in the OPERA detector system of reference (in cm)"
+        },
+        {
+            "variable": "globPosY",
+            "description": "Y position of a vertex in the OPERA detector system of reference (in cm)"
+        },
+        {
+            "variable": "globPosZ",
+            "description": "Z position of a vertex in the OPERA detector system of reference (in cm)"
+        },
+        {
+            "variable": "mult",
+            "description": "number of ECC tracks attached to the vertex"
+        },
+        {
+            "variable": "posX",
+            "description": "X position of a track/vertex in the OPERA brick system of reference (in micrometers)"
+        },
+        {
+            "variable": "posY",
+            "description": "Y position of a track/vertex in the OPERA brick system of reference (in micrometers)"
+        },
+        {
+            "variable": "posZ",
+            "description": "Z position of a track/vertex in the OPERA brick system of reference (in micrometers)"
+        },
+        {
+            "variable": "slopeXZ",
+            "description": "tangent of a track angle in XZ view"
+        },
+        {
+            "variable": "slopeYZ",
+            "description": "tangent of a track angle in YZ view"
+        },
+        {
+            "variable": "timestamp",
+            "description": "time in milliseconds since 01/01/1970"
+        },
+        {
+            "variable": "trType",
+            "description": "type of a track: 1 - muon; 2 - hadron; 3 - electron; 4 - black; 5 - back black; 6 - gray; 7 - back gray"
+        }
+    ],
+    "abstract": "The dataset was extracted from the official OPERA data repository. It contains 818 muon neutrino interactions with the lead target where a muon was reconstructed in the final state. This happens in the so-called charged-current interactions of a muon neutrino. For this data sample, the Collaboration performed a dedicated analysis, with a detailed classification of all particles produced at the neutrino interaction on top of the muon. Indeed, in a muon neutrino interaction with the nucleons of the lead target, different hadrons are produced: the so-called shower hadrons and nuclear fragments produced in the break-up and in the evaporation of the target nucleus. The detailed study of the multiplicity of the hadrons produced provides insights on the mechanism of the hadronic shower formation.  This data record contains the information of the neutrino interaction vertices including all the emulsion tracks produced in the interactions. The location of the neutrino interaction and the measurement of the trajectories of all the particles produced is the final step of the event analysis, after the identification of the neutrino interaction bricks done with the electronic detector data. The tracks include nuclear fragments moving both forward and backward. The available information includes minimum ionisation tracks produced in the hadronic shower, heavy ionising particles produced in the nuclear break-up and evaporation",
+    "license": {
+        "attribution": "CC0"
+    },
+    "selection": {
+        "description": "Events stored in this dataset were selected by requiring that a muon was reconstructed in the final state. On top of this requirement, they were randomly selected in three physics runs taken in 2010, 2011 and 2012, in order to collect a sample close to 800 events, statistically sufficient to perform the multiplicity studies. This subset was analysed aiming at a detailed study of the multiplicity of charged particles produced in neutrino interactions as an important input to models of the hadronic shower generation"
+    },
+    "validation": {
+        "description": "During the data taking, all the runs recorded by OPERA are certified as good for physics analysis if the trigger and all sub-detectors show the expected performance. Moreover, the time stamp of the event should lie within the gate open by the CNGS beam signal.  The data certification is based first on the offline shifters evaluation and later on the feedback provided by all sub-detector experts. Based on the above information, stored in a specific database, the Data Quality Monitoring group verifies the consistency of the certification and prepares an ascii file of certified runs to be used for physics analysis. For this specific data record, dedicated calibration procedures are performed to align the emulsion films each other and with the electronic detectors. These procedures with the corresponding results are saved in a dedicated database where data quality experts certify the results and prepare files to be used for the track and vertex reconstruction, thus being available for physics analysis"
+    },
+    "accelerator": "CERN-SPS",
+    "experiment": "OPERA",
+    "collections": [
+        "OPERA-Emulsion-Detector-Datasets"
+    ],
+    "files": [
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/opera/datasets/multiplicity/emulsion-data-for-track-multiplicity.zip",
+            "size": 467580,
+            "checksum": "sha1:5ffeb5d2d1e365ec9d5ebaf852c9141523fb3b7d"
+        }
+    ]
+}
+]

--- a/cernopendata/modules/fixtures/data/software/cms-2010-software-validation.json
+++ b/cernopendata/modules/fixtures/data/software/cms-2010-software-validation.json
@@ -1,0 +1,128 @@
+[
+{
+    "recid": "461",
+    "doi": "10.7483/OPENDATA.CMS.W26R.J96R",
+    "authors": [
+        {
+            "name": "Geiser, Achim"
+        },
+        {
+            "name": "Dutta, Irene"
+        },
+        {
+            "name": "Hirvonsalo, Harri"
+        },
+        {
+            "name": "Sheeran, Bridget"
+        }
+    ],
+    "type": "Software",
+    "subtype": "Validation",
+    "title": "Validation code for 2010 Commissioning dataset, based on dimuon mass spectrum",
+    "distribution": {
+        "format": "",
+        "number_files": "",
+        "size": ""
+    },
+    "publisher": "CERN Open Data Portal",
+    "date_published": "2016",
+    "date_created": "2010",
+    "system_details": {
+        "description": "Use this code with the CMS Open Data VM environment",
+        "release": "CMSSW_4_2_8",
+        "recid": "250"
+    },
+    "abstract": "<p>This code for validation and benchmarking of the Commissioning dataset is set up at Research level, i.e. it requires university-student-level programming experience. Minimal acquaintance with Linux and the ROOT analysis package (<a href=\"https://root.cern.ch/\">https://root.cern.ch/</a>) as well as a basic text editor is needed. Note that the code in this category is not meant to be a pedagogical example but is a validation tool. </p>",
+    "license": {
+        "attribution": "GNU General Public License (GPL) version 3"
+    },
+    "documentation": {
+        "description": "This dataset contains all runs from 2011 RunA. The list of validated runs, which must be applied to all analyses, can be found in"
+    },
+    "validation": {
+        "description": "Only the list of validated runs are accepted:",
+        "links": [
+            {
+                "recid": "1000"
+            }
+        ]
+    },
+    "use_with": {
+        "description": "Use this with 2010 Commissioning primary dataset (see detailed instructions in readme.txt and code).",
+        "links": [
+            {
+                "recid": "2"
+            }
+        ]
+    },
+    "usage": {
+        "description": "<p>If you do not have the CERN Virtual Machine for 2010 CMS data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2010\">How to install a CERN Virtual Machine</a>. Then install and run the Demo (demo analyzer) program following the instructions at <a href=\"/VM/CMS/2010#testvalidate2010\">How to Test & Validate</a>.</p> <p>To run the Commissioning sample validation, follow the instructions in the file readme.txt above.</p>"
+    },
+    "selection": {
+        "description": "Events stored in this dataset were selected by requiring that a muon was reconstructed in the final state. On top of this requirement, they were randomly selected in three physics runs taken in 2010, 2011 and 2012, in order to collect a sample close to 800 events, statistically sufficient to perform the multiplicity studies. This subset was analysed aiming at a detailed study of the multiplicity of charged particles produced in neutrino interactions as an important input to models of the hadronic shower generation"
+    },
+    "note": [
+        {
+            "description": "The default output of the code below is a ROOT file Mu00val.root"
+        }
+    ],
+    "accelerator": "CERN-LHC",
+    "experiment": "CMS",
+    "run_period": "Run2010B",
+    "collections": [
+        "CMS-Validation-Utilities"
+    ],
+    "files": [
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-code-run2010b-commisionning/readme.txt",
+            "size": 2971,
+            "checksum": "sha1:ec21bd5b6beabc7b06665324e77dfee9a132ea6f"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-code-run2010b-commisionning/BuildFile.xml",
+            "size": 342,
+            "checksum": "sha1:cf95f881471657d5807905291705f28e6e03c29e"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-code-run2010b-commisionning/DemoAnalyzer.cc",
+            "size": 29410,
+            "checksum": "sha1:cf95f881471657d5807905291705f28e6e03c29e"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-code-run2010b-commisionning/demoanalyzer_cfg.py",
+            "size": 5228,
+            "checksum": "sha1:56243e93c147688cbf01b40064ed4cfd28f91036"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-code-run2010b-commisionning/mergeCommissioning.C",
+            "size": 6492,
+            "checksum": "sha1:4fe00dda18d5d38d87d57c983554faf824e0aa74"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-code-run2010b-commisionning/CommissioningAllval.root",
+            "size": 29766,
+            "checksum": "sha1:3eb21dfdfdecbba56a1a6f169289e2cec76eba84"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-code-run2010b-commisionning/Commissioning00val.root",
+            "size": 27352,
+            "checksum": "sha1:ca8005c0a8be7797165a7e5583f83596f854e453"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-code-run2010b-commisionning/Commissioning02val.root",
+            "size": 13126,
+            "checksum": "sha1:ed0fb21a65999b3b2bbca2d8c289fecc7a970471"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-code-run2010b-commisionning/Commissioning03val.root",
+            "size": 17156,
+            "checksum": "sha1:0d7044e5b5bbe4d9821da24b3676b0dfcfcb850a"
+        },
+        {
+            "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-code-run2010b-commisionning/Commissioning04val.root",
+            "size": 14857,
+            "checksum": "sha1:9f58835feedc78e82f40e56f1679b07de021fb6b"
+        }
+    ]
+}
+]

--- a/cernopendata/modules/records/minters/recid.py
+++ b/cernopendata/modules/records/minters/recid.py
@@ -2,18 +2,21 @@
 
 from __future__ import absolute_import, print_function
 
-from slugify import slugify
-
 from ..providers.recid import RecordUUIDProvider
 
 
 def cernopendata_recid_minter(record_uuid, data):
     """Mint deposit's PID."""
+    if 'id' in data:
+        recid = data['id']
+    else:
+        recid = data['recid']
+
     provider = RecordUUIDProvider.create(
         object_type='rec',
         pid_type='recid',
         object_uuid=record_uuid,
-        pid_value=str(data['id'])
+        pid_value=str(recid)
     )
 
     data['control_number'] = provider.pid.pid_value

--- a/scripts/populate-instance.sh
+++ b/scripts/populate-instance.sh
@@ -126,6 +126,8 @@ ${INVENIO_WEB_INSTANCE} fixtures pids
 ${INVENIO_WEB_INSTANCE} fixtures terms
 ${INVENIO_WEB_INSTANCE} fixtures articles
 ${INVENIO_WEB_INSTANCE} fixtures data_policies
+${INVENIO_WEB_INSTANCE} fixtures datasets
+${INVENIO_WEB_INSTANCE} fixtures software
 # sphinxdoc-populate-with-demo-records-end
 
 # sphinxdoc-index-all-records-begin


### PR DESCRIPTION
- c83f8314d9382dcb3e7a374d660c07d765c03479 fixtures: datasets and software
- 1cce4883639866239170872e3860d2d2e5eb6fad records: JSON schemas for datasets and software
- 62ceb9a4ba7859503e563b4ca02c13aee273545c records: CMS datasets and software
- cf73f096834863de3acbebad2883c4a0269b2438 records: OPERA datasets and events
