### PR TITLE
installation: pyxrootd inside venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,8 @@ RUN /code/scripts/create-instance.sh
 
 # Make given VENV default:
 ENV PATH=/home/invenio/.virtualenvs/cernopendata/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-ENV VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python
-RUN echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
+ENV VIRTUALENVWRAPPER_PYTHON=/usr/bin/python
+RUN echo "source /usr/bin/virtualenvwrapper.sh" >> ~/.bashrc
 RUN echo "workon cernopendata" >> ~/.bashrc
 
 # Start the CERN Open Data Portal application:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ web:
   command: /bin/bash -c "cernopendata run -h 0.0.0.0"
   environment:
     - PATH=/home/invenio/.virtualenvs/cernopendata/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python
+    - VIRTUALENVWRAPPER_PYTHON=/usr/bin/python
     - APP_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://cernopendata:dbpass123@postgresql:5432/cernopendata
     - APP_CACHE_REDIS_HOST=redis
     - APP_CACHE_REDIS_URL=redis://redis:6379/0
@@ -57,7 +57,7 @@ worker:
   command: "celery worker -A cernopendata.celery --loglevel=INFO"
   environment:
     - PATH=/home/invenio/.virtualenvs/cernopendata/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - VIRTUALENVWRAPPER_PYTHON=/usr/local/bin/python
+    - VIRTUALENVWRAPPER_PYTHON=/usr/bin/python
     - APP_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://cernopendata:dbpass123@postgresql:5432/cernopendata
     - APP_CACHE_REDIS_HOST=redis
     - APP_CACHE_REDIS_URL=redis://redis:6379/0

--- a/scripts/create-instance.sh
+++ b/scripts/create-instance.sh
@@ -96,12 +96,15 @@ source $(which virtualenvwrapper.sh)
 scriptpathname=$(cd "$(dirname $0)" && pwd)
 
 # sphinxdoc-create-virtual-environment-begin
-mkvirtualenv --system-site-packages ${INVENIO_WEB_VENV}
+mkvirtualenv ${INVENIO_WEB_VENV}
 # sphinxdoc-create-virtual-environment-end
 
 # quit on errors and unbound symbols:
 set -o errexit
 # set -o nounset
+
+# install XRootD:
+pip install git+https://github.com/xrootd/xrootd-python.git#egg=pyxrootd
 
 # FIXME using personal forks until upstream PRs are issued and merged:
 pip install git+https://github.com/pamfilos/invenio-files-rest.git@eos-storage#egg=invenio-files-rest

--- a/scripts/provision-web.sh
+++ b/scripts/provision-web.sh
@@ -134,6 +134,7 @@ provision_web_xrootd_centos7 () {
     $sudo yum install -y \
           xrootd \
           xrootd-client \
+          xrootd-client-devel \
           xrootd-python
 }
 


### PR DESCRIPTION
* Installs pyxrootd inside Python virtual environment instead of using CentOS7
  system package. Amends Python paths as per the change of the base image to
  CentOS7. (closes #1414)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>