### PR TITLE
templates: fix labels

### DIFF
--- a/cernopendata/config.py
+++ b/cernopendata/config.py
@@ -238,6 +238,7 @@ RECORDS_REST_FACETS = {
             type=terms_filter('type'),
             subtype=terms_filter('subtype'),
             year=terms_filter('collections.year'),
+            tags=terms_filter('tags'),
             file_type=terms_filter('distribution.formats'),
             run=terms_filter(
                 'production_publication_distribution_manufacture_and_'

--- a/cernopendata/modules/theme/static/scss/styles.scss
+++ b/cernopendata/modules/theme/static/scss/styles.scss
@@ -43,4 +43,5 @@ results-brief {
 
 .label {
     display: inline-block;
+    padding: .3em .5em .4em
 }

--- a/cernopendata/modules/theme/static/scss/styles.scss
+++ b/cernopendata/modules/theme/static/scss/styles.scss
@@ -22,3 +22,25 @@ results-brief {
     list-style-type: none;
   }
 }
+
+.record-box {
+    position: relative;
+    margin: 15px;
+    height: 100%;
+}
+
+.tags-box {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    margin-bottom: 30px;
+    font-size: 0.9em;
+}
+
+.tags-box a {
+    text-decoration: None;
+}
+
+.label {
+    display: inline-block;
+}

--- a/cernopendata/static/templates/cernopendata_search_ui/results.html
+++ b/cernopendata/static/templates/cernopendata_search_ui/results.html
@@ -1,3 +1,3 @@
 <div class="row record-elem" ng-repeat="record in vm.invenioSearchResults.hits.hits track by $index">
-  <results-brief record="record" />
+    <results-brief record="record" />
 </div>

--- a/cernopendata/static/templates/faceted_results.html
+++ b/cernopendata/static/templates/faceted_results.html
@@ -1,22 +1,41 @@
 <div class="panel-body" style="max-height: 728px; overflow-y: scroll;">
-  <div ng-repeat="record in vm.invenioSearchResults.hits.hits track by $index">
-    <div class="col-sm-6 col-md-4">
-      <div class="thumbnail" style="height: 150px;">
-        <div class="caption">
-          <h3><a ng-href="/articles/{{record.metadata.control_number}}">{{record.metadata.title}}<a/></h3>
-          <span ng-repeat="tag in record.metadata.tags">
-              <span class="label label-warning">{{tag}}</span>
-          </span>
-          <span ng-repeat="collection in  record.metadata.collections">
-              <span class="label label-primary">{{collection.primary}}</span>
-              <span class="label label-success">{{collection.secondary}}</span>
-            </span>
+    <div ng-repeat="record in vm.invenioSearchResults.hits.hits track by $index">
+        <div class="col-sm-6 col-md-4">
+            <div class="thumbnail" style="height: 180px;">
+                <div class="record-box">
+                    <h3><a href="/articles/{{record.metadata.control_number}}">{{ record.metadata.title }}</a></h3>
+                    <h6 ng-if="record.metadata.created" style="text-align: right">
+                        {{ record.metadata.created }} 
+                        by {{ record.metadata.author }}
+                    </h6>
+                    <div class="tags-box">
+                        <a href="/search?type_pre={{record.metadata.type}}">
+                            <span class="label label-primary">
+                                {{ record.metadata.type }} 
+                            </span>
+                        </a>
+                        <a ng-if="record.subtype" href="/search?subtype_pre={{record.metadata.subtype}}"> 
+                            <span class="label label-info">
+                                {{ record.metadata.subtype }}
+                            </span>
+                        </a> 
+                        <a ng-repeat="tag in record.metadata.tags" href="/search?tags_pre={{tag}}"> 
+                            <span class="label label-default">
+                                {{ tag }} 
+                            </span>
+                        </a>
+                        <a href="/search?experiment_pre={{record.metadata.experiment}}">
+                            <span class="label label-warning">
+                                {{ record.metadata.experiment }} 
+                            </span>
+                        </a>
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
     </div>
-  </div>
-  <div ng-if="vm.invenioSearchResults.hits.hits == 0">
-      <p> No results.</p>
-  </div>
+    <div ng-if="vm.invenioSearchResults.hits.hits == 0">
+        <p> No results.</p>
+    </div>
 </div>
 

--- a/cernopendata/static/templates/search/briefs/articles.html
+++ b/cernopendata/static/templates/search/briefs/articles.html
@@ -1,22 +1,32 @@
-
-<h4>
-  <a target="_self" ng-href="/articles/{{record.metadata.control_number}}">
-    {{ record.metadata.title }}
-  </a>
-  <span class="btn btn-primary pull-right">Article</span>
-</h4>
-<p ng-if="record.metadata.short_description.content">{{record.metadata.short_description.content}}</p>
-<p ng-if="!record.metadata.short_description.content">{{record.metadata.body.content | limitTo: 200}}</p>
-<div class="text-right">
-  <ul class="list-inline">
-    <li>
-      <a ng-click="showSource=!showSource">
-        {{ showSource ? 'Hide source' : 'Show source' }}
-      </a>
-    </li>
-  </ul>
+<div>
+    <h4>
+        <a target="_self" ng-href="/articles/{{record.metadata.control_number}}">
+            {{ record.metadata.title }}
+        </a>
+    </h4>
+    <p ng-if="record.metadata.short_description.content">{{record.metadata.short_description.content}}</p>
+    <p ng-if="!record.metadata.short_description.content">{{record.metadata.body.content | limitTo: 200}}</p>
+    <div class="tags-box">
+        <a href="/search?type_pre={{record.metadata.type}}">
+            <span class="label label-primary">
+                {{ record.metadata.type }} 
+            </span>
+        </a>
+        <a ng-if="record.subtype" href="/search?subtype_pre={{record.metadata.subtype}}"> 
+            <span class="label label-info">
+                {{ record.metadata.subtype }}
+            </span>
+        </a> 
+        <a ng-repeat="tag in record.metadata.tags" href="/search?tags_pre={{tag}}"> 
+            <span class="label label-default">
+                {{ tag }} 
+            </span>
+        </a>
+        <a href="/search?experiment_pre={{record.metadata.experiment}}">
+            <span class="label label-warning">
+                {{ record.metadata.experiment }} 
+            </span>
+        </a>
+    </div>
+    <hr/>
 </div>
-<div ng-hide="!showSource">
-  <pre>{{ record | json }}</pre>
-</div>
-<hr/>

--- a/cernopendata/static/templates/search/briefs/dataset.html
+++ b/cernopendata/static/templates/search/briefs/dataset.html
@@ -1,31 +1,30 @@
 <!-- FIXME find a better way to set the record url -->
-<div class="row">
-  <div class="col-md-7">
+<div>
     <h4>
-      <a target="_self" ng-href="/datasets/{{ record.id }}">{{ record.metadata.title }}</a>
+        <a target="_self" ng-href="/datasets/{{ record.id }}">{{ record.metadata.title }}</a>
     </h4>
-  </div>
-  <div class="col-md-5">
-      <span class="pull-right">
-        <span class="btn btn-primary">{{record.metadata.type}}</span>
-        <span class="btn btn-primary">{{record.metadata.subtype}}</span>
-      </span>
-  </div>
+    <p style="margin-top: 1%;">{{ record.metadata.abstract | limitTo : 200}}...</p>
+    <div class="tags-box">
+        <a href="/search?type_pre={{record.metadata.type}}">
+            <span class="label label-primary">
+                {{ record.metadata.type }} 
+            </span>
+        </a>
+        <a ng-if="record.subtype" href="/search?subtype_pre={{record.metadata.subtype}}"> 
+            <span class="label label-info">
+                {{ record.metadata.subtype }}
+            </span>
+        </a> 
+        <a ng-repeat="tag in record.metadata.tags" href="/search?tags_pre={{tag}}"> 
+            <span class="label label-default">
+                {{ tag }} 
+            </span>
+        </a>
+        <a href="/search?experiment_pre={{record.metadata.experiment}}">
+            <span class="label label-warning">
+                {{ record.metadata.experiment }} 
+            </span>
+        </a>
+    </div>
+    <hr/>
 </div>
-<p style="margin-top: 1%;">{{ record.metadata.abstract | limitTo : 200}}...</p>
-<div class="row">
-  <div class="col-md-8">
-    <span class="label label-success">{{record.metadata.experiment}}</span>
-  </div>
-  <div class="col-md-4">
-    <span class="pull-right">
-      <a ng-click="showSource=!showSource">
-        {{ showSource ? 'Hide source' : 'Show source' }}
-      </a>
-    </span>
-  </div>
-</div>
-<div ng-hide="!showSource" style="margin-top: 2%">
-  <pre>{{ record | json }}</pre>
-</div>
-<hr/>

--- a/cernopendata/static/templates/search/briefs/default.html
+++ b/cernopendata/static/templates/search/briefs/default.html
@@ -1,31 +1,46 @@
 <!-- FIXME find a better way to set the record url -->
-<h4>
-  <a target="_self" ng-href="/records/{{ record.id }}">{{ record.metadata.title }}</a>
-  <span class="btn btn-primary pull-right">Record</span>
-</h4>
-<p>{{ record.metadata.summary }}</p>
-<div class="text-right">
-  <ul class="list-inline">
-    <li ng-show="record.metadata.added_entry_personal_name.length > 0">
-      <a ng-click="showAuthors=!showAuthors">
-        {{ showAuthors ? 'Hide authors' : 'Show authors' }}
-      </a>
-    </li>
-    <li>
-      <a ng-click="showSource=!showSource">
-        {{ showSource ? 'Hide source' : 'Show source' }}
-      </a>
-    </li>
-  </ul>
-</div>
-<div ng-hide="!showAuthors">
-  <ul>
-    <div ng-repeat='author in record.metadata.added_entry_personal_name'>
-      <li>{{ author.personal_name }}</li>
+<div>
+    <h4>
+        <a target="_self" ng-href="/records/{{ record.id }}">{{ record.metadata.title }}</a>
+    </h4>
+    <p>{{ record.metadata.summary }}</p>
+    <div class="text-right">
+        <ul class="list-inline">
+            <li ng-show="record.metadata.added_entry_personal_name.length > 0">
+                <a ng-click="showAuthors=!showAuthors">
+                    {{ showAuthors ? 'Hide authors' : 'Show authors' }}
+                </a>
+            </li>
+        </ul>
     </div>
-  </ul>
+    <div ng-hide="!showAuthors">
+        <ul>
+            <div ng-repeat='author in record.metadata.added_entry_personal_name'>
+                <li>{{ author.personal_name }}</li>
+            </div>
+        </ul>
+    </div>
+    <div class="tags-box">
+        <a href="/search?type_pre={{record.metadata.type}}">
+            <span class="label label-primary">
+                {{ record.metadata.type }} 
+            </span>
+        </a>
+        <a ng-if="record.subtype" href="/search?subtype_pre={{record.metadata.subtype}}"> 
+            <span class="label label-info">
+                {{ record.metadata.subtype }}
+            </span>
+        </a> 
+        <a ng-repeat="tag in record.metadata.tags" href="/search?tags_pre={{tag}}"> 
+            <span class="label label-default">
+                {{ tag }} 
+            </span>
+        </a>
+        <a href="/search?experiment_pre={{record.metadata.experiment}}">
+            <span class="label label-warning">
+                {{ record.metadata.experiment }} 
+            </span>
+        </a>
+    </div>
+    <hr/>
 </div>
-<div ng-hide="!showSource">
-  <pre>{{ record | json }}</pre>
-</div>
-<hr />

--- a/cernopendata/static/templates/search/briefs/software.html
+++ b/cernopendata/static/templates/search/briefs/software.html
@@ -1,33 +1,30 @@
 <!-- FIXME find a better way to set the record url -->
-<div class="row">
-  <div class="col-md-7">
+<div>
     <h4>
-      <a target="_self" ng-href="/software/{{ record.id }}">{{ record.metadata.title }}</a>
+        <a target="_self" ng-href="/software/{{ record.id }}">{{ record.metadata.title }}</a>
     </h4>
-  </div>
-  <div class="col-md-5">
-      <span class="pull-right">
-        <span class="btn btn-primary">{{record.metadata.type}}</span>
-        <span class="btn btn-primary">{{record.metadata.subtype}}</span>
-      </span>
-  </div>
+    <p style="margin-top: 1%;">{{ record.metadata.abstract | limitTo : 200}}...</p>
+    <div class="tags-box">
+        <a href="/search?type_pre={{record.metadata.type}}">
+            <span class="label label-primary">
+                {{ record.metadata.type }} 
+            </span>
+        </a>
+        <a ng-if="record.subtype" href="/search?subtype_pre={{record.metadata.subtype}}"> 
+            <span class="label label-info">
+                {{ record.metadata.subtype }}
+            </span>
+        </a> 
+        <a ng-repeat="tag in record.metadata.tags" href="/search?tags_pre={{tag}}"> 
+            <span class="label label-default">
+                {{ tag }} 
+            </span>
+        </a>
+        <a href="/search?experiment_pre={{record.metadata.experiment}}">
+            <span class="label label-warning">
+                {{ record.metadata.experiment }} 
+            </span>
+        </a>
+    </div>
+    <hr/>
 </div>
-<p style="margin-top: 1%;">{{ record.metadata.abstract | limitTo : 200}}...</p>
-<div class="row">
-  <div class="col-md-8">
-    <span class="label label-success">{{record.metadata.experiment}}</span>
-  </div>
-  <div class="col-md-4">
-    <span class="pull-right">
-      <a ng-click="showSource=!showSource">
-        {{ showSource ? 'Hide source' : 'Show source' }}
-      </a>
-    </span>
-  </div>
-</div>
-<div ng-hide="!showSource" style="margin-top: 2%">
-  <pre>{{ record | json }}</pre>
-</div>
-<hr/>
-
-

--- a/cernopendata/static/templates/search/briefs/terms.html
+++ b/cernopendata/static/templates/search/briefs/terms.html
@@ -1,21 +1,21 @@
-
-  <h4>
-    <a target="_self" ng-href="/glossary/{{record.metadata.control_number}}">
-      {{ record.metadata.anchor }}
-    </a>
-    <span class="btn btn-primary pull-right">Glossary Term</span>
-  </h4>
-  <p>{{ record.metadata.definition }}</p>
-  <div class="text-right">
-    <ul class="list-inline">
-      <li>
-        <a ng-click="showSource=!showSource">
-          {{ showSource ? 'Hide source' : 'Show source' }}
+<div>
+    <h4>
+        <a target="_self" ng-href="/glossary/{{record.metadata.control_number}}">
+            {{ record.metadata.anchor }}
         </a>
-      </li>
-    </ul>
-  </div>
-  <div ng-hide="!showSource">
-    <pre>{{ record | json }}</pre>
-  </div>
-  <hr/>
+    </h4>
+    <p>{{ record.metadata.definition }}</p>
+    <div class="tags-box">
+        <a href="/search?type_pre={{record.metadata.type}}">
+            <span class="label label-primary">
+                {{ record.metadata.type }} 
+            </span>
+        </a>
+        <a ng-if="record.subtype" href="/search?subtype_pre={{record.metadata.subtype}}"> 
+            <span class="label label-info">
+                {{ record.metadata.subtype }}
+            </span>
+        </a> 
+    </div>
+    <hr>
+</div>

--- a/cernopendata/templates/cernopendata_pages/index.html
+++ b/cernopendata/templates/cernopendata_pages/index.html
@@ -16,83 +16,111 @@
 
 {%- block page_body %}
 <div class="container">
-  <div class="row" style="margin-top: 3%;">
-    <div class="col-md-12">
-      <div class="panel panel-default">
-        <div class="panel-heading"><h4>The CERN Open Data portal is the access point to a growing range of data produced
-          through the research
-          performed at CERN. It disseminates the preserved output from various research activities, including
-          accompanying
-          software and documentation which is needed to understand and analyse the data being shared.</h4></div>
-      </div>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h2>News</h2>
+    <div class="row" style="margin-top: 3%;">
+        <div class="col-md-12">
+            <div class="panel panel-default">
+                <div class="panel-heading"><h4>The CERN Open Data portal is the access point to a growing range of data produced
+                        through the research
+                        performed at CERN. It disseminates the preserved output from various research activities, including
+                        accompanying
+                        software and documentation which is needed to understand and analyse the data being shared.</h4></div>
+            </div>
         </div>
-        <div class="panel-body">
-          <div class="row">
-            {% for r in records %}
-            <div class="col-sm-6 col-md-4">
-              <div class="thumbnail" style="height: 140px;">
-                <div class="caption">
-                  <h3><a href="/articles/{{r['_source']['control_number']}}">{{r['_source']['title']}}</a></h3>
-                  {% for collection in r['_source']['collections']%}
-                  <p>
-                    <span class="label label-primary">{{collection.primary}}</span>
-                    <span class="label label-success">{{collection.secondary}}</span>
-                  </p>
-                  {% endfor %}
-
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h2>News</h2>
                 </div>
-              </div>
+                <div class="panel-body">
+                    <div class="row">
+                        {% for record in records %}
+                        {% set record = record._source %}
+                        <div class="col-sm-6 col-md-4">
+                            <div class="thumbnail" style="height: 180px;">
+                                <div class="record-box">
+                                    <h3><a href="/articles/{{record.control_number}}">{{ record.title }}</a></h3>
+                                    {% if record.created or record.author %}
+                                    <h6 style="text-align: right">
+                                        {{ record.created }} 
+                                        {% if record.author %}
+                                        by {{ record.author }}
+                                        {% endif %}
+                                    </h6>
+                                    {% endif %}
+                                    <div class="tags-box">
+                                        <a href="/search?type_pre={{record.type}}">
+                                            <span class="label label-primary">
+                                                {{ record.type }} 
+                                            </span>
+                                        </a>
+                                        {% if record.subtype %}
+                                        <a href="/search?subtype_pre={{record.subtype}}"> 
+                                            <span class="label label-info">
+                                                {{ record.subtype }}
+                                            </span>
+                                        </a> 
+                                        {% endif %}
+                                        {% for tag in record.tags %}
+                                        <a href="/search?tags_pre={{tag}}"> 
+                                            <span class="label label-default">
+                                                {{ tag }} 
+                                            </span>
+                                        </a>
+                                        {% endfor %}
+                                        <a href="/search?experiment_pre={{record.experiment}}">
+                                            <span class="label label-warning">
+                                                {{ record.experiment }} 
+                                            </span>
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        {% endfor %}
+                    </div>
+                </div>
             </div>
-            {% endfor %}
-          </div>
         </div>
-      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-md-12">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          <h2>Visualise</h2>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h2>Visualise</h2>
+                </div>
+                <div class="panel-body">
+                    <div class="col-sm-6 col-md-4">
+                        <div class="thumbnail">
+                            <img  style="height: 126px;"  src="{{url_for('static', filename='img/cms_vis.png')}}">
+                            <div class="caption">
+                                <h3 class="text-center">Visualise CMS detector events</h3>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-4">
+                        <div class="thumbnail">
+                            <img style="height: 126px;" src="{{url_for('static', filename='img/opera_vis.png')}}">
+                            <div class="caption">
+                                <h3 class="text-center"><a href="{{url_for('.visualise_events', experiment='OPERA')}}">Visualise OPERA
+                                        detector events</a></h3>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-sm-6 col-md-4">
+                        <div class="thumbnail">
+                            <img style="height: 153px;" src="{{url_for('static', filename='img/visualisation/histogram.png')}}">
+                            <div class="caption">
+                                <h3 class="text-center"><a href="{{url_for('.visualise_histograms', experiment='CMS')}}">Visualise
+                                        histograms</a></h3>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
-        <div class="panel-body">
-          <div class="col-sm-6 col-md-4">
-            <div class="thumbnail">
-              <img  style="height: 126px;"  src="{{url_for('static', filename='img/cms_vis.png')}}">
-              <div class="caption">
-                <h3 class="text-center">Visualise CMS detector events</h3>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-md-4">
-            <div class="thumbnail">
-              <img style="height: 126px;" src="{{url_for('static', filename='img/opera_vis.png')}}">
-              <div class="caption">
-                <h3 class="text-center"><a href="{{url_for('.visualise_events', experiment='OPERA')}}">Visualise OPERA
-                  detector events</a></h3>
-              </div>
-            </div>
-          </div>
-          <div class="col-sm-6 col-md-4">
-            <div class="thumbnail">
-              <img style="height: 153px;" src="{{url_for('static', filename='img/visualisation/histogram.png')}}">
-              <div class="caption">
-                <h3 class="text-center"><a href="{{url_for('.visualise_histograms', experiment='CMS')}}">Visualise
-                  histograms</a></h3>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
 </div>
 {%- endblock %}
 


### PR DESCRIPTION
* Closes #1452 (tags will be clickable)
* Removes 'Show source' from results on search page
* Display labels for all kind of briefs in search results