### PR TITLE
docker: fix user-id related permission errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,9 @@ RUN chgrp -R 0 ${INVENIO_INSTANCE_PATH} && \
     chmod g=u /etc/passwd && \
     chmod ug+x /code/scripts/docker-entrypoint.sh
 
-RUN adduser --uid 1001 invenio --gid 0 && \
+RUN adduser --uid 1000 invenio --gid 0 && \
     chown -R invenio:root /code
-USER 1001
+USER 1000
 ENTRYPOINT [ "/code/scripts/docker-entrypoint.sh" ]
 
 # Start the CERN Open Data Portal application:


### PR DESCRIPTION
  * Change default user-id used in Dockerfile to 1000 (typical UID of
    first non-root user used in many Linux distributions) in order to
    fix permission errors that sometimes arise after making changes to
    files or folder mounted to web- and worker-containers.

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>