### PR TITLE
Support for math content in TeX-syntax for HTML and Markdown (Mistune)

### DIFF
--- a/cernopendata/modules/markdown/__init__.py
+++ b/cernopendata/modules/markdown/__init__.py
@@ -28,4 +28,4 @@ from __future__ import absolute_import, print_function
 
 from .ext import CernopendataMarkdown
 
-__all__ = ('CernopendataMarkdown', )
+__all__ = ('CernopendataMarkdown', 'md')

--- a/cernopendata/modules/mistune/ext.py
+++ b/cernopendata/modules/mistune/ext.py
@@ -142,7 +142,7 @@ class CodeRenderer(mistune.Renderer):
 
 
 class CernopendataMistune(object):
-    """CernopendataMistune. Wrapper for Flask-Mistune extension.
+    r"""CernopendataMistune. Wrapper for Flask-Mistune extension.
 
     Needed in order to properly add Flask-Mistune to Flask application
     created in Invenio-style (using setup.py entrypoints).

--- a/cernopendata/modules/pages/views.py
+++ b/cernopendata/modules/pages/views.py
@@ -94,15 +94,20 @@ def md_debug():
     and just refresh the view.
     I.e. there is no need to re-populate db every time a change is made.
 
+    If DEBUG is not set this will redirect to homepage.
+
     Command `cernopendata collect -v` has to be run everytime
     there is a change in static resources.
 
     """
-    f = open('cernopendata/static/test_data/debug.md', 'r')
-    # return render_template_string(
-    #     u"{{ text|markdown }}", text=f.read().decode("utf-8"))
-    return render_template('cernopendata_pages/md_template.html',
-                           content=f.read().decode("utf-8"))
+    if current_app.config.get('DEBUG'):
+        f = open('cernopendata/static/test_data/debug.md', 'r')
+        # return render_template_string(
+        #     u"{{ text|markdown }}", text=f.read().decode("utf-8"))
+        return render_template('cernopendata_pages/md_template.html',
+                               content=f.read().decode("utf-8"))
+    else:
+        return redirect('/')
 
 
 @blueprint.route('/visualise/events')

--- a/cernopendata/static/test_data/debug.md
+++ b/cernopendata/static/test_data/debug.md
@@ -11,6 +11,16 @@
 
 <br>
 
+
+r"Euler's identity, $e^{i\pi}* = -1$, is widely considered the most beautiful theorem in mathematics."
+
+r"Euler's identity, $$e^{i\pi}* = -1$$, is widely considered the most beautiful theorem in mathematics."
+
+r"Euler's identity, \begin{equation*}e^{i\pi}* = -1\end{equation*}, is widely considered the most beautiful theorem in mathematics."
+
+r"Euler's identity, \[e^{i\pi}* = -1\], is widely considered the most beautiful theorem in mathematics."
+
+
 # <div id="what"> Introduction to “physics objects” </div>
 
 Particle colliders are the most powerful tools we have to study the building blocks of our Universe and the laws governing them. Gigantic detectors, such as CMS, act as cameras that take "photographs" of the particle collisions, allowing us to test our understanding of Nature.

--- a/cernopendata/templates/cernopendata_theme/page.html
+++ b/cernopendata/templates/cernopendata_theme/page.html
@@ -52,6 +52,7 @@
         });
     </script>
   {% endblock %}
+
   {%- block mathjax_support %}
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
@@ -65,6 +66,8 @@
         "HTML-CSS": { availableFonts: ["TeX"] }
       });
     </script>
+
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
   {% endblock %}
+
 {% endblock %}

--- a/cernopendata/templates/cernopendata_theme/page.html
+++ b/cernopendata/templates/cernopendata_theme/page.html
@@ -52,5 +52,19 @@
         });
     </script>
   {% endblock %}
+  {%- block mathjax_support %}
+    <script type="text/x-mathjax-config">
+      MathJax.Hub.Config({
+        extensions: ["tex2jax.js"],
+        jax: ["input/TeX", "output/HTML-CSS"],
+        tex2jax: {
+          inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+          displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+          processEscapes: true
+        },
+        "HTML-CSS": { availableFonts: ["TeX"] }
+      });
+    </script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
+  {% endblock %}
 {% endblock %}
-

--- a/scripts/create-instance.sh
+++ b/scripts/create-instance.sh
@@ -106,6 +106,9 @@ set -o errexit
 # install XRootD:
 pip install git+https://github.com/xrootd/xrootd-python.git@v0.3.0#egg=pyxrootd
 
+# install latest version of mistune-contrib:
+pip install git+https://github.com/lepture/mistune-contrib.git#egg=mistune-contrib
+
 # FIXME using personal forks until upstream PRs are issued and merged:
 pip install git+https://github.com/pamfilos/invenio-files-rest.git@eos-storage#egg=invenio-files-rest
 pip install git+https://github.com/pamfilos/invenio-xrootd.git@eos-storage#egg=invenio-xrootd

--- a/scripts/create-instance.sh
+++ b/scripts/create-instance.sh
@@ -106,7 +106,7 @@ set -o errexit
 # install XRootD:
 pip install git+https://github.com/xrootd/xrootd-python.git@v0.3.0#egg=pyxrootd
 
-# install latest version of mistune-contrib:
+# install latest version of mistune-contrib: (needed for Mistune Markdown parser)
 pip install git+https://github.com/lepture/mistune-contrib.git#egg=mistune-contrib
 
 # FIXME using personal forks until upstream PRs are issued and merged:

--- a/setup.py
+++ b/setup.py
@@ -98,6 +98,7 @@ install_requires = [
     'mistune>=0.7.4',
     'py-gfm>=0.1.3',
     'pymdown-extensions>=3.5',
+    'python-markdown-math>=0.3',
     'python-slugify>=1.2.4',
     'xrootdpyfs>=0.1.4',
 ]
@@ -148,7 +149,13 @@ setup(
             ':ispy_css',
         ],
         'invenio_base.apps': [
-            'cernopendata_xrootd = cernopendata.modules.xrootd:CODPXRootD'
+            'cernopendata_xrootd = cernopendata.modules.xrootd:CODPXRootD',
+            # cod_md and cod_mistune are just wrappers to init the actual
+            # markdown flask-extensions properly.
+            'cod_md = '
+            'cernopendata.modules.markdown.ext:CernopendataMarkdown',
+            # 'cod_mistune = '
+            # 'cernopendata.modules.mistune.ext:CernopendataMistune',
         ],
         'invenio_base.api_apps': [
             'cernopendata_xrootd = cernopendata.modules.xrootd:CODPXRootD'
@@ -159,12 +166,6 @@ setup(
             'cernopendata.modules.pages.views:blueprint',
             'cernopendata_theme = '
             'cernopendata.modules.theme.views:blueprint',
-        ],
-        'invenio_base.apps': [  # Wrappers for init of certain extensions.
-            # 'cod_md = '
-            # 'cernopendata.modules.markdown.ext:CernopendataMarkdown',
-            'cod_mistune = '
-            'cernopendata.modules.mistune.ext:CernopendataMistune',
         ],
         'invenio_config.module': [
             'cernopendata = cernopendata.config',


### PR DESCRIPTION
* Add MathJax.js to render content in TeX-syntax
* Make Mistune (markdown parser) and Python-Markdown compatible with TeX-syntax (`$ ... $`, `$$ ... $$`, `\begin ... \end`). Otherwise characters matching markdown control characters (e.g. `__ ... __` or `** ... **`) that reside inside TeX-content, might mess up the TeX-content.