### PR TITLE
scripts: use invenio command to delete ES indeces

### DIFF
--- a/scripts/clean-instance.sh
+++ b/scripts/clean-instance.sh
@@ -106,4 +106,4 @@ set -o nounset
 ${INVENIO_WEB_INSTANCE} db destroy --yes-i-know
 
 # destroy indexes:
-curl -X DELETE "${INVENIO_ELASTICSEARCH_HOST}:9200/_all"
+${INVENIO_WEB_INSTANCE} index destroy --force --yes-i-know


### PR DESCRIPTION
* Changes the command used to clean the indeces since the `curl` call
  does not work currently on OpenShift. Moreover it follows latest
  Invenio-App-ILS documentation.

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>