### PR TITLE
records: removed extra selection description

### DIFF
--- a/cernopendata/modules/fixtures/data/datasets/cms-2011-collision-datasets.json
+++ b/cernopendata/modules/fixtures/data/datasets/cms-2011-collision-datasets.json
@@ -111,9 +111,6 @@
             }
         ]
     },
-    "selection": {
-        "description": "Events stored in this dataset were selected by requiring that a muon was reconstructed in the final state. On top of this requirement, they were randomly selected in three physics runs taken in 2010, 2011 and 2012, in order to collect a sample close to 800 events, statistically sufficient to perform the multiplicity studies. This subset was analysed aiming at a detailed study of the multiplicity of charged particles produced in neutrino interactions as an important input to models of the hadronic shower generation"
-    },
     "accelerator": "CERN-LHC",
     "experiment": "CMS",
     "parent_dataset": {

--- a/cernopendata/modules/fixtures/data/software/cms-2010-software-validation.json
+++ b/cernopendata/modules/fixtures/data/software/cms-2010-software-validation.json
@@ -58,9 +58,6 @@
     "usage": {
         "description": "<p>If you do not have the CERN Virtual Machine for 2010 CMS data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2010\">How to install a CERN Virtual Machine</a>. Then install and run the Demo (demo analyzer) program following the instructions at <a href=\"/VM/CMS/2010#testvalidate2010\">How to Test & Validate</a>.</p> <p>To run the Commissioning sample validation, follow the instructions in the file readme.txt above.</p>"
     },
-    "selection": {
-        "description": "Events stored in this dataset were selected by requiring that a muon was reconstructed in the final state. On top of this requirement, they were randomly selected in three physics runs taken in 2010, 2011 and 2012, in order to collect a sample close to 800 events, statistically sufficient to perform the multiplicity studies. This subset was analysed aiming at a detailed study of the multiplicity of charged particles produced in neutrino interactions as an important input to models of the hadronic shower generation"
-    },
     "note": [
         {
             "description": "The default output of the code below is a ROOT file Mu00val.root"


### PR DESCRIPTION
* Removes a leftover OPERA selection description in CMS records. (closes #1467)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>