### PR TITLE
templates: basic record display updates

### DIFF
--- a/cernopendata/config.py
+++ b/cernopendata/config.py
@@ -105,7 +105,7 @@ RECORDS_UI_ENDPOINTS = dict(
     recid=dict(
         pid_type='recid',
         route='/record/<pid_value>',
-        template='cernopendata_records_ui/records/detail.html',
+        template='cernopendata_records_ui/records/record_detail.html',
         permission_factory_imp=None,
         record_class='invenio_records_files.api:Record',
     ),

--- a/cernopendata/static/templates/faceted_results.html
+++ b/cernopendata/static/templates/faceted_results.html
@@ -13,11 +13,11 @@
       <p ng-if="record.metadata.short_description.content">{{record.metadata.short_description.content}}</p>
       <p ng-if="!record.metadata.short_description.content">{{record.metadata.body.content | limitTo: 200}}<span ng-if="record.metadata.body.content">...</span></p>
       <div class="tags-box-search-results">
-        <a class="badge badge-success custom-badge-success" href="/search?type={{record.metadata.type}}">
-          {{ record.metadata.type }}
+        <a class="badge badge-success custom-badge-success" href="/search?type={{record.metadata.type.primary}}">
+          {{ record.metadata.type.primary }}
         </a>
-        <a class="badge badge-info" ng-if="record.subtype" href="/search?subtype={{record.metadata.subtype}}">
-          {{ record.metadata.subtype }}
+        <a class="badge badge-info" ng-if="record.metadata.type.secondary" href="/search?subtype={{record.metadata.type.secondary[0]}}">
+          {{ record.metadata.type.secondary[0] }}
         </a>
         <a class="badge badge-secondary" ng-repeat="tag in record.metadata.tags" href="/search?tags={{tag}}">
           {{ tag }}
@@ -32,5 +32,3 @@
     </div>
   </div>
 </div>
-
-

--- a/cernopendata/static/templates/search/briefs/articles.html
+++ b/cernopendata/static/templates/search/briefs/articles.html
@@ -8,11 +8,11 @@
     <p ng-if="record.metadata.short_description.content">{{record.metadata.short_description.content}}</p>
     <p ng-if="!record.metadata.short_description.content">{{record.metadata.body.content | limitTo: 200}}...</p>
     <div class="tags-box-search-results">
-      <a class="badge badge-success custom-badge-success" href="/search?type={{record.metadata.type}}">
-        {{ record.metadata.type }}
+      <a class="badge badge-success custom-badge-success" href="/search?type={{record.metadata.type.primary}}">
+        {{ record.metadata.type.primary }}
       </a>
-      <a  class="badge badge-info" ng-if="record.subtype" href="/search?subtype={{record.metadata.subtype}}">
-        {{ record.metadata.subtype }}
+      <a class="badge badge-info" ng-if="record.metadata.type.secondary" href="/search?subtype={{record.metadata.type.secondary[0]}}">
+        {{ record.metadata.type.secondary[0] }}
       </a>
       <a class="badge badge-secondary" ng-repeat="tag in record.metadata.tags" href="/search?tags={{tag}}">
         {{ tag }}

--- a/cernopendata/static/templates/search/briefs/record.html
+++ b/cernopendata/static/templates/search/briefs/record.html
@@ -2,9 +2,9 @@
 <div class="card">
   <div class="card-body">
     <h4>
-      <a target="_self" ng-href="/record/{{ record.id }}">{{ record.metadata.title }}</a>
+      <a target="_self" ng-href="/datasets/{{ record.metadata.control_number }}">{{ record.metadata.title }}</a>
     </h4>
-    <p>{{ record.metadata.abstract.description }}</p>
+    <p class="mt-1">{{ record.metadata.abstract.description | limitTo : 200}}...</p>
     <div class="tags-box-search-results">
       <a class="badge badge-success custom-badge-success" href="/search?type={{record.metadata.type.primary}}">
         {{ record.metadata.type.primary }}

--- a/cernopendata/static/templates/search/briefs/terms.html
+++ b/cernopendata/static/templates/search/briefs/terms.html
@@ -7,11 +7,11 @@
     </h4>
     <p>{{ record.metadata.definition }}</p>
     <div class="tags-box-search-results">
-      <a class="badge badge-success custom-badge-success" href="/search?type={{record.metadata.type}}">
-        {{ record.metadata.type }}
+      <a class="badge badge-success custom-badge-success" href="/search?type={{record.metadata.type.primary}}">
+        {{ record.metadata.type.primary }}
       </a>
-      <a class="badge badge-info" ng-if="record.subtype" href="/search?subtype={{record.metadata.subtype}}">
-        {{ record.metadata.subtype }}
+      <a class="badge badge-info" ng-if="record.metadata.type.secondary" href="/search?subtype={{record.metadata.type.secondary[0]}}">
+        {{ record.metadata.type.secondary[0] }}
       </a>
     </div>
   </div>

--- a/cernopendata/templates/cernopendata_pages/index.html
+++ b/cernopendata/templates/cernopendata_pages/index.html
@@ -57,9 +57,11 @@
                   {% endif %}
                 </p>
                 <div class="tags-box">
-                  <a href="/search?type_pre={{record.type}}" class="badge  badge-success custom-badge-success">{{ record.type }}</a>
-                  {% if record.subtype %}
-                  <a href="/search?subtype_pre={{record.subtype}}" class="badge  badge-info">{{ record.subtype }}</a>
+                  <a href="/search?type_pre={{record.type.primary}}" class="badge  badge-success custom-badge-success">{{ record.type.primary }}</a>
+                  {% if record.type.secondary %}
+                    {% for subtype in record.type.secondary %}
+                      <a href="/search?subtype_pre={{subtype}}" class="badge  badge-info">{{ subtype }}</a>
+                    {% endfor %}
                   {% endif %}
                   {% for tag in record.tags %}
                   <a href="/search?tags_pre={{tag}}" class="badge badge-secondary">{{ tag }}</a>

--- a/cernopendata/templates/cernopendata_records_ui/records/detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/detail.html
@@ -15,16 +15,18 @@
               <small>{{record.date_published}}</small>
             </h3>
             <div class="row">
-              {% if record.additional_title %}
+              {% if record.title_additional %}
               <div class="col-md-12">
-                {{record.additional_title}}
+                {{record.title_additional}}
               </div>
               {% endif %}
               <div class="col-md-12">
                 {% for author in record.authors %}
                 <small>{{author.name}}</small>
                 {% endfor %}
+                {% if record.collaboration %}
                 <span class="badge badge-success">{{record.collaboration.name}}</span>
+                {% endif %}
                 {% if record.year %}
                 <span class="badge badge-success">{{record.year}} Run</span>
                 {% endif %}
@@ -36,7 +38,10 @@
               {% for author in record.authors %}
               <span>{{author.name}}.</span>
               {% endfor %}
-              <span>{{record.collaboration.name}} ({{record.date_published}}). {{record.additional_title}}. CERN Open Data Portal.
+              <span>
+                {% if record.collaboration %}
+                  {{record.collaboration.name}}
+                {% endif %} ({{record.date_published}}). {{record.title_additional}}. CERN Open Data Portal.
                                 {% if record.doi %}
                                   <label>DOI:</label>
                                   <a href="http://doi.org/{{record.doi}}">{{record.doi}}</a>
@@ -66,7 +71,7 @@
               <div class="row">
                 <div class="col-md-12">
                   <h3>Description</h3>
-                  <p>{{record.abstract}}</p>
+                  <p>{{record.abstract.description}}</p>
                 </div>
               </div>
               {% endif %}
@@ -133,4 +138,3 @@
 </script>
 {% endif %}
 {% endblock javascript %}
-

--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -1,0 +1,167 @@
+{%- extends "cernopendata_records_ui/records/detail.html" %}
+
+
+{%- block page_body %}
+<div class="container-fluid background">
+  <div class="container">
+    <div class="row">
+      <div class="col-md-10">
+        <div class="card card-style">
+          <div class="card-body">
+            {% block heading %}
+            {{super()}}
+            {% endblock heading %}
+          </div>
+          <div class="card card-style">
+            <div class="card-body">
+              {% block metadata_block %}
+              {{ super() }}
+              {% if record.relations %}
+              <div class="row">
+                <div class="col-md-12">
+                  <h3>Related Datasets</h3>
+                  {% for relation in record.relations %}
+                  <p>{{relation.description}} <br><a href="/record/{{relation.recid}}">{{relation.recid}}</a></p>
+                  {% if relation.type and not relation.description %}
+                    <p>{{relation.type}}</p>
+                  {% endif %}
+                  {% if relation.title %}
+                    <p>{{relation.title}}</p>
+                  {% endif %}
+                  {% endfor %}
+                </div>
+              </div>
+              {% endif %}
+              {% if record.distribution %}
+              <div class="row">
+                <div class="col-md-12">
+                  <h3>Characteristics</h3>
+                  <label>Dataset:</label>
+                  <span><strong>{{record.distribution.number_events}}</strong> events</span>
+                  <span><strong>{{record.distribution.number_files}}</strong> files</span>
+                  <span><strong>{{record.distribution.size | filesizeformat }}</strong> in total</span>
+                </div>
+              </div>
+              {% endif %}
+              {% if record.system_details %}
+              <div class="row">
+                <div class="col-md-12">
+                  <h3>System Details</h3>
+                  <label>Global tag:</label>
+                  <span>{{record.system_details.global_tag}}</span>
+                  <br>
+                  <label>Release:</label>
+                  <span>{{record.system_details.release}}</span>
+                </div>
+              </div>
+              {% endif %}
+              {% endblock metadata_block %}
+
+              {% block files_block %} {{ files_box(record, 'datid') }} {% endblock files_block %}
+
+              {% if record.dataset_semantics %}
+              <div class="row">
+                <div class="col-md-12">
+                  <h3>Dataset Semantics</h3>
+                  {% for semantic in record.dataset_semantics %}
+                  <label>{{semantic.variable}}:</label>
+                  <span>{{semantic.description}}</span><br>
+                  {% endfor %}
+                </div>
+              </div>
+              {% endif %}
+
+              {% if record.selection %}
+              <div class="row">
+                <div class="col-md-12">
+                  <h3>How were these data selected</h3>
+                  <p>{{ record.selection.description }}</p>
+                </div>
+              </div>
+              {% endif %}
+
+              {% if record.methodology %}
+              <div class="row">
+                <div class="col-md-12">
+                  <h3>How were these data selected?</h3>
+                  <p>{{record.methodology.description | safe}}</p>
+                </div>
+              </div>
+              {% endif %}
+
+              {% if record.generation %}
+              <div class="row">
+                <div class="col-md-12">
+                  <h3>How were these data selected?</h3>
+                  <p>{{record.generation.description}}</p>
+                  {% for step in record.generation.steps %}
+                  <label>{{step.type}}</label>
+                  <p>{{step.note}}</p>
+                  <p>{{step.release}}</p>
+                  <p>{{step.global_tag}}</p>
+                  {% for conf_file in step.configuration_files %}
+                  <p><a href="/record/{{conf_file.recid}}">{{conf_file.description}}</a></p>
+                  <p><a href="/search?q={{conf_file.title}}">{{conf_file.title}}</a></p>
+                  {% endfor %}
+                  {% endfor %}
+                </div>
+              </div>
+              {% endif %}
+              {% if record.validation %}
+              <div class="row">
+                <div class="col-md-12">
+                  <h3>How were these data validated?</h3>
+                  <p>{{record.validation.description}}</p>
+                  {% for link in record.validation.links %}
+                  <p><a href="{{link.url}}">{{link.description}}</a></p>
+                  {% endfor %}
+                </div>
+              </div>
+              {% endif %}
+              {% if record.usage %}
+              <div class="row">
+                <div class="col-md-12">
+                  <h3>How can you use these data?</h3>
+                  <p>{{record.usage.description}}</p>
+                  {% for link in record.usage.links %}
+                  <p><a href="{{link.url}}">{{link.description}}</a></p>
+                  {% endfor %}
+                </div>
+              </div>
+              {% endif %}
+              {% if record.note %}
+              <div class="row">
+                <div class="col-md-12">
+                  <h3>Issues & Limitations</h3>
+                  <p>{{record.note.description}}</p>
+                  {% for link in record.note.links %}
+                  <p><a href="/record/{{link.recid}}">{{link.recid}}</a></p>
+                  {% endfor %}
+                </div>
+              </div>
+              {% endif %}
+              {% block disclaimer %}
+              {{super()}}
+              {% endblock disclaimer %}
+            </div>
+          </div>
+        </div>
+      </div>
+      {% block export %}
+      <div class="col-md-2">
+        <div class="card card-style">
+          <div class="card-body">
+            <h4> Export </h4>
+            <ul class="list-inline">
+              <li><a
+                href="{{ url_for('invenio_records_ui.recid_export', pid_value=pid.pid_value, format='json') }}">JSON</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      {% endblock export %}
+    </div>
+  </div>
+</div>
+{%- endblock %}


### PR DESCRIPTION
* Updates record display templates to catch up with the basic issues such as
  type/subtype changes and labels, the abstract summary display, the additional
  title display, the optional collaboration field, the better completeness of
  information in the detailed record pages, etc.

* Note: the fully complete and fully prettified detailed record information
  display is out of the scope of the current focus on record files. This will be
  tackled later.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>