### PR TITLE
records: centralise local files on EOS for OPERA datasets

### DIFF
--- a/cernopendata/modules/fixtures/data/records/opera-ecc-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/opera-ecc-datasets.json
@@ -74,6 +74,14 @@
   }, 
   "doi": "10.7483/OPENDATA.OPERA.BVC1.UI85", 
   "experiment": "OPERA", 
+  "files": [
+    {
+      "checksum": "sha1:5ffeb5d2d1e365ec9d5ebaf852c9141523fb3b7d", 
+      "size": 467580, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/opera/datasets/multiplicity/emulsion-data-for-track-multiplicity.zip"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 

--- a/cernopendata/modules/fixtures/data/records/opera-ed-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/opera-ed-datasets.json
@@ -21,6 +21,10 @@
       "variable": "amplR"
     }, 
     {
+      "description": "PMT amplitude reconstructed from the \"left\" and \"right\" side amplitudes of a scintillator strip taking into account light attenuation in a WLS fiber (in photo-electrons)", 
+      "variable": "amplRec"
+    }, 
+    {
       "description": "cluster length (in cm)", 
       "variable": "clLength"
     }, 
@@ -74,10 +78,18 @@
     ], 
     "number_events": 818, 
     "number_files": 1, 
-    "size": 3095697
+    "size": 5269628
   }, 
   "doi": "10.7483/OPENDATA.OPERA.HJC7.3DCC", 
   "experiment": "OPERA", 
+  "files": [
+    {
+      "checksum": "sha1:9e624ea97ccb57931901ec64e62c8553291f3d9a", 
+      "size": 5269628, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/opera/datasets/multiplicity/electronic-detector-data-for-multiplicity-studies.zip"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 


### PR DESCRIPTION
* Centralises local files on EOS for OPERA datasets. Enriches record metadata
  correspondingly. (closes #1725) (closes #1726) (closes #1727)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>