### PR TITLE
records: centralise local files on EOS for Author-Lists

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-author-list-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-author-list-Run2011A.json
@@ -19854,6 +19854,14 @@
       "pdf"
     ]
   }, 
+  "files": [
+    {
+      "checksum": "sha1:8d6b9e4fdd4e109d3b802f4b9ca7fc49739b7b45", 
+      "size": 221620, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/cms-author-list-2011.pdf"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "451", 
   "run_period": "Run2011A", 

--- a/cernopendata/modules/fixtures/data/records/cms-author-list.json
+++ b/cernopendata/modules/fixtures/data/records/cms-author-list.json
@@ -19029,6 +19029,14 @@
       "pdf"
     ]
   }, 
+  "files": [
+    {
+      "checksum": "sha1:bd91887ec0d4a998d5b8619f94e7683402803e09", 
+      "size": 229896, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/cms-author-list-2010.pdf"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "450", 
   "run_period": "Run2010B", 

--- a/cernopendata/modules/fixtures/data/records/opera-author-list.json
+++ b/cernopendata/modules/fixtures/data/records/opera-author-list.json
@@ -531,6 +531,14 @@
       "pdf"
     ]
   }, 
+  "files": [
+    {
+      "checksum": "sha1:565bea3e714cc47501e351018df89f8457f83237", 
+      "size": 228582, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/opera/documentation/opera-author-list-2017.pdf"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "452", 
   "title": "OPERA author list for the 2017 data release", 


### PR DESCRIPTION
* Centralises local files on EOS for Author-Lists. Enriches record metadata
  correspondingly. (closes #1694) (closes #1695) (closes #1724)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>