### PR TITLE
nginx: add caching layer

### DIFF
--- a/nginx/cernopendata.conf
+++ b/nginx/cernopendata.conf
@@ -1,7 +1,16 @@
 
+# Cache for ''*/files/*'
+proxy_cache_path /var/cache/nginx/cache_cod_files levels=1:2 keys_zone=cache_cod_files:100m inactive=60m max_size=500m use_temp_path=off;
+
+# Cache for anything else than '*/files/*'
+proxy_cache_path /var/cache/nginx/cache_cod_global levels=1:2 keys_zone=cache_cod_global:100m inactive=60m max_size=500m use_temp_path=off;
+
+large_client_header_buffers 8 32k;
+
 server {
-    listen 80;
-    server_name localhost;
+    listen 80 default;
+    server_name _ "";
+    server_tokens off;
     charset utf-8;
 
     # Tell nginx to rewrite URI if the path contains uppercase characters and
@@ -22,16 +31,30 @@ server {
         root /usr/local/var/cernopendata/var/cernopendata-instance;
     }
 
-    location / {
-        proxy_pass http://web:5000;
-        proxy_set_header Host $host;
+    # Cache any URL that has '/files/' pattern in it.
+    # (e.g. '/records/123/files/abc', '/dataset/test/files/storage/higgs.txt')
+    location ~ ^/.+/files/.+ {
+        proxy_cache cache_cod_files;
+        proxy_cache_key $host$uri$is_args$args;
+        proxy_cache_valid 200 301 302 30m;
+        expires 1h;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_ignore_headers Set-Cookie;
+        proxy_pass http://web:5000;
     }
 
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /usr/share/nginx/html;
+    location / {
+        proxy_cache cache_cod_global;
+        proxy_cache_key $host$uri$is_args$args;
+        proxy_cache_valid 200 301 302 30m;
+        expires 1h;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_ignore_headers Set-Cookie;
+        proxy_pass http://web:5000;
     }
 
 }


### PR DESCRIPTION
* Add caching layer in nginx.
  Quite aggressive caching policy, as everything that is not available
  on EOS or under '/files' is cached.
  Note that path '/files' should be cached in the future.
  (addresses #1728)

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>