### PR TITLE
records: centralise local files on EOS for Data-Policies

### DIFF
--- a/cernopendata/modules/fixtures/data/records/data-policies.json
+++ b/cernopendata/modules/fixtures/data/records/data-policies.json
@@ -24,6 +24,14 @@
   }, 
   "doi": "10.7483/OPENDATA.LHCb.HKJW.TWSZ", 
   "experiment": "LHCb", 
+  "files": [
+    {
+      "checksum": "sha1:5e48e8042c8edc2f828770b41e21562b5570d689", 
+      "size": 254288, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/documentation/LHCb-Data-Policy.pdf"
+    }
+  ], 
   "language": "English", 
   "prepublication": {
     "date": "2013-04-22", 
@@ -58,6 +66,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.UDBF.JKR9", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0f0a2a6d8d1c0dc29e65f75a1d709d458e345cfb", 
+      "size": 79005, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/CMS-Data-Policy.pdf"
+    }
+  ], 
   "language": "English", 
   "prepublication": {
     "date": "2012-05-03", 
@@ -91,6 +107,14 @@
   }, 
   "doi": "10.7483/OPENDATA.ALICE.54NE.X2EA", 
   "experiment": "ALICE", 
+  "files": [
+    {
+      "checksum": "sha1:e08357793eb426d68c44b87e11adc77893f73ac0", 
+      "size": 480778, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/alice/documentation/ALICE-Data-Policy.pdf"
+    }
+  ], 
   "language": "English", 
   "prepublication": {
     "date": "2013-10-06", 
@@ -124,6 +148,14 @@
   }, 
   "doi": "10.7483/OPENDATA.ATLAS.T9YR.Y7MZ", 
   "experiment": "ATLAS", 
+  "files": [
+    {
+      "checksum": "sha1:0b34414d395228d6ae12834f0a0c5f5fd8dd4ce1", 
+      "size": 345466, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/documentation/ATLAS-Data-Policy.pdf"
+    }
+  ], 
   "language": "English", 
   "prepublication": {
     "date": "2014-06-20", 


### PR DESCRIPTION
* Centralises local files on EOS for Data-Policies. Enriches record metadata
  correspondingly. (closes #1722)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>