### PR TITLE
records: centralise local files on EOS for cms-eventdisplay-files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files.json
@@ -26,6 +26,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.6DJ2.GQGB", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:48499564c2525bc63725e2af58f2fa3d0f64121e", 
+      "size": 2678577, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/IG/Apr21ReReco-v1/BTau.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -97,6 +105,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.ZTTM.57D5", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:379b271729979ce90eeade4d042e87aa7a965a90", 
+      "size": 2073957, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/IG/Apr21ReReco-v1/EGMonitor.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -168,6 +184,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.BMB2.5N4P", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e4807eec7bbcddd1695b27865aa0e87cb333c1b7", 
+      "size": 2624275, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/IG/Apr21ReReco-v1/Electron.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -239,6 +263,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.HBGJ.B7QH", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f832d2484a7ab9728670af5c057386bd1707feb1", 
+      "size": 2790679, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/IG/Apr21ReReco-v1/Jet.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -310,6 +342,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.VFPT.38KQ", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d8f557c22874369c6784eec4ff970b7d7761f854", 
+      "size": 2362008, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/IG/Apr21ReReco-v1/JetMETTauMonitor.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -381,6 +421,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.F54E.Q75K", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e386298f835c6bb78fdd37c5f37eadfc0d24404c", 
+      "size": 1422441, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/IG/Apr21ReReco-v1/METFwd.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -452,6 +500,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.GQQD.GDB6", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:927cd0b0650e6aa544ac11dcf3972bb25b5b4d52", 
+      "size": 1850051, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/IG/Apr21ReReco-v1/Mu.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -523,6 +579,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.RVAU.XCT2", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:1e6356f236ecaa92d42347c3a6fc0073561d5371", 
+      "size": 1647687, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuMonitor/IG/Apr21ReReco-v1/MuMonitor.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -594,6 +658,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.HUBM.PXA2", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f1ca77749350eaff219edb4493971f90144325be", 
+      "size": 1713609, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/IG/Apr21ReReco-v1/MuOnia.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -665,6 +737,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.DCZH.4FTA", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7af68d773bf17dbd1e5ded609267095374644056", 
+      "size": 3191630, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MultiJet/IG/Apr21ReReco-v1/MultiJet.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -736,6 +816,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.WWTV.7A82", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:56bad74163cb1775e2e2d75e538230a45feb62c3", 
+      "size": 2789061, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/IG/Apr21ReReco-v1/Photon.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -807,6 +895,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.ZUH9.ZSZW", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:32434e15cb103281459249e86dd313121f75f50b", 
+      "size": 1452517, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Commissioning/IG/Apr21ReReco-v1/Commissioning.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -878,6 +974,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.9N7C.DRN7", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a54ec4cdcee29379572555d0cf5b64cdd783d95d", 
+      "size": 1145257, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/IG/Apr21ReReco-v1/MinimumBias.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart from accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -949,6 +1053,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.QZZX.4TZG", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:976f037abde65797cc2be2eef4ee1f116c8ced3d", 
+      "size": 618628, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/ZeroBias/IG/Apr21ReReco-v1/ZeroBias.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection is applied. The software to produce these files is available in:", 
     "links": [


### PR DESCRIPTION
* Centralises local files on EOS for cms-eventdisplay-files records.
  Enriches record metadata correspondingly. (closes #1703)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>