### PR TITLE
records: centralise local files on EOS for cms-eventdisplay Run2011A

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2011A.json
@@ -26,6 +26,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.BK3T.NKC6", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a100d93d3b27def7954fa5827e9717ab4ec407cc", 
+      "size": 2411180, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/IG/12Oct2013-v1/BTag.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -97,6 +105,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.HWS8.QPHJ", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:2ebaaa08266c6369e929c5da38a56b2a40340ced", 
+      "size": 1798012, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/IG/12Oct2013-v1/DoubleElectron.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -168,6 +184,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.AVCS.4VTR", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:bab7be34c417b7ea9619ddca59cd4ba8cd7a5c6c", 
+      "size": 977790, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/IG/12Oct2013-v1/DoubleMu.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -239,6 +263,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.FXPP.WY5Y", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:304ad1e09d6f36882f54f54bd4375aa4271c7239", 
+      "size": 2303208, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/ElectronHad/IG/12Oct2013-v1/ElectronHad.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -310,6 +342,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.FQNV.4MZE", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d3c365fdd8221d3a987e77bc03118d459ce694b7", 
+      "size": 2211067, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/IG/12Oct2013-v1/HT.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -381,6 +421,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.VX5Q.36BB", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:65b943c86e7be81747d2518f4f8a8c801879da5f", 
+      "size": 1614085, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Jet/IG/12Oct2013-v1/Jet.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -452,6 +500,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.EZ2K.VK36", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d5c24fc8a9ec9707cc71270292302f68dec2176c", 
+      "size": 2150169, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MET/IG/12Oct2013-v1/MET.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -523,6 +579,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.SQDD.4EGN", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ed6721726c3b72c9565516907415e0af0e9ea932", 
+      "size": 1819169, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/METBTag/IG/12Oct2013-v1/METBTag.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -594,6 +658,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.WQU8.UAH7", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9e19755b7d8867e901a4a207eaf133c66b6b29d3", 
+      "size": 887210, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/IG/12Oct2013-v1/MinimumBias.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -665,6 +737,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.46XK.DKAV", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ec269bb6d933b977a09a0d10c93ca393234feee6", 
+      "size": 2163729, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuEG/IG/12Oct2013-v1/MuEG.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -736,6 +816,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.P3CK.DKN5", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:cfb3cb6d98eecd798a3a2a6a7f0f52729d59076e", 
+      "size": 2453022, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuHad/IG/12Oct2013-v1/MuHad.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -807,6 +895,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.Q6KF.BXJS", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:32b7aa78f6152ecc75061a04a0b65b344e197c30", 
+      "size": 2366586, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MultiJet/IG/12Oct2013-v1/MultiJet.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -878,6 +974,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.GKQH.NCFY", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:dce7399dc7441b72fe340076d2498c3abdd4a7bc", 
+      "size": 952330, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuOnia/IG/12Oct2013-v1/MuOnia.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -949,6 +1053,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.Q8M9.S7RD", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:10df9baf26e81e00c8232b64c4df9f1697b4093e", 
+      "size": 1753916, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Photon/IG/12Oct2013-v1/Photon.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -1020,6 +1132,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.FC2Q.7Z6D", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a19081ad26c63407d7eea74080e6ed046ac3f708", 
+      "size": 2651040, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/PhotonHad/IG/12Oct2013-v1/PhotonHad.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -1091,6 +1211,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.XGPV.HHBY", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a4acd4ea330c2438a1119438d7dfd8555cef2539", 
+      "size": 1813973, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleElectron/IG/12Oct2013-v1/SingleElectron.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -1162,6 +1290,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.27TB.JTEH", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d6580ac7560be6c87b1240560e788041fcb17ac0", 
+      "size": 1485070, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/IG/12Oct2013-v1/SingleMu.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -1233,6 +1369,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.TQNN.BRZE", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:967e6c356b93c0d0fe5de1897572330658957238", 
+      "size": 1392792, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Tau/IG/12Oct2013-v1/Tau.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [
@@ -1304,6 +1448,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.ZQAC.CERV", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:aef840b7d02da911cf1d802d9685084436006102", 
+      "size": 1603865, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/TauPlusX/IG/12Oct2013-v1/TauPlusX.ig"
+    }
+  ], 
   "methodology": {
     "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied. The software to produce these files is available in:", 
     "links": [


### PR DESCRIPTION
* Centralises local files on EOS for cms-eventdisplay-files-Run2011A records.
  Enriches record metadata correspondingly. (closes #1702)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>