### PR TITLE
records: centralise local files on EOS for cms-derived-csv-Run2011A

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-csv-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-csv-Run2011A.json
@@ -109,6 +109,56 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8a4c77c6b029232002d48fea7046b44dc0329a21", 
+      "size": 7969331, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/CSV/12Oct2013-v1/Wmunu.csv"
+    }, 
+    {
+      "checksum": "sha1:09e44f937604ebfcf376df1cde989f1fb8541036", 
+      "size": 9992209, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleElectron/CSV/12Oct2013-v1/Wenu.csv"
+    }, 
+    {
+      "checksum": "sha1:6c4240d2053407e6eacf42ea741381e3771727ca", 
+      "size": 970550, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/CSV/12Oct2013-v1/Zmumu.csv"
+    }, 
+    {
+      "checksum": "sha1:afb09475fefeba76b47c4b174d9f6f332a4481f0", 
+      "size": 1445651, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/CSV/12Oct2013-v1/Zee.csv"
+    }, 
+    {
+      "checksum": "sha1:a340510faad27eb26e7c5507bda17be245e51b58", 
+      "size": 11806904, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/CSV/12Oct2013-v1/Dimuon.csv"
+    }, 
+    {
+      "checksum": "sha1:0a5808fab9b380dce5d55f2aa5864f2931d49404", 
+      "size": 13935840, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/CSV/12Oct2013-v1/Dimuon.csv"
+    }, 
+    {
+      "checksum": "sha1:8cc5dae7b28a24ed17e7b1cf05cbb21092e8d85a", 
+      "size": 2639302, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/CSV/12Oct2013-v1/Jpsimumu.csv"
+    }, 
+    {
+      "checksum": "sha1:690bcbb7a3c9ae4f8bb9e74f284d1ce3c50dcf3e", 
+      "size": 2599212, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/CSV/12Oct2013-v1/Ymumu.csv"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 


### PR DESCRIPTION
* Centralises local files on EOS for cms-derived-csv-Run2011A records.
  Enriches record metadata correspondingly. (closes #1699)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>