### PR TITLE
records: centralise local files on EOS for CMS configuration files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-configuration-files-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-configuration-files-Run2011A.json
@@ -23,6 +23,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b888f714576906c13aa5b472c53b48459b70925e", 
+      "size": 9188, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91430774.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -62,6 +70,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:94288f8163dd4cebda83158cc16756a272af937e", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf05a71f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -101,6 +117,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7ef9ad4e4dfbd5de5d05fa1117d82000ce11b548", 
+      "size": 7516, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4515630011652d2fbae85c3707cb6ffb.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -140,6 +164,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7dbb7c6618f5332e0d4a7002f1d3819daad6c489", 
+      "size": 3626, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db28e87bf.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -179,6 +211,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ad2a9e0fab1cb89a0129587a0b67db6ed416dbf1", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a69a2.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -218,6 +258,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:240634a0bdcd36280af25c803d7b3d955ffbe0a4", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6ce248.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -257,6 +305,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9a89b18c841f2330beedb7d7a609689683530ded", 
+      "size": 3612, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f51aba8.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -296,6 +352,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:261d14c1154c208df2939f07cdb7d13beed397aa", 
+      "size": 3628, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db28f4f49.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -335,6 +399,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:47dfad1061ec5865c175c3de2fc53f9e52ea821f", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f910174222c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -374,6 +446,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:08aa578d126eec68b473aefbcfada1668eb320ae", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91638ee9.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -413,6 +493,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c9246676ddbb5c467862e0ae8ef4b9e36420f4bc", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e703c2e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -452,6 +540,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0fa97cdc60747a739c064483b037e49ddb9179c1", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6c7389.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -491,6 +587,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ee3e7d4a5b0568571230389741bdb12ac8123e84", 
+      "size": 3078, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc95bbd6e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -530,6 +634,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3a070e01ebab1e58d725eb5f6f6fa77986eb94e6", 
+      "size": 2576, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc942efba.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -569,6 +681,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d7d7e1909ca9bc8915b083140723f0a9ff851775", 
+      "size": 9053, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7c7c0e8e128b3d1a9f287090342346e0.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -608,6 +728,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ab202bf01b7a27e8e67d660395a127464a587fe8", 
+      "size": 6019, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd8d1a0.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -647,6 +775,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:12d6dd7faf721012814a8913c9dd16213ad47cfe", 
+      "size": 7505, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4a1f22052abb5b3c51ee42f4dcdee483.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -686,6 +822,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:2cf8e3d7abaf0664b10c3fe214b7e5ffd96a547e", 
+      "size": 6463, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf082009.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -725,6 +869,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8fc7e41cf49c99d06a247590891cfeb6a4f83db8", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a2a58.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -764,6 +916,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f8cbfd1b70b7bca4c6e85cb8da32c6920f2b190e", 
+      "size": 6022, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695ce3da3f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -803,6 +963,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a2bfae01067e557c67be20179f16941ef2706215", 
+      "size": 7241, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf0e401e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -842,6 +1010,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7d39b9d6fff8f6768502755885c3294dd51edfcb", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6c4391.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -881,6 +1057,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:44abaa260453fe2b9f02389de4864a6ec87c483a", 
+      "size": 7006, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de55910b1.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -920,6 +1104,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:beaeeaf02816e004f8c541093bbdad17518d7bb7", 
+      "size": 2075, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf0d425d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -959,6 +1151,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6c35a2af9bd0685422518ac199d4dfa246a33e5f", 
+      "size": 3655, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6c3430.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -998,6 +1198,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5064e7bb19fd542b53325f38fa33ce5f22f4106f", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6c544b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1037,6 +1245,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:dd0c6760fa82d6345d4cdcf79e82bd4a77ba1e89", 
+      "size": 3608, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f4f38c2.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1076,6 +1292,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:eac4c9ee8c15f93f75ab2e16394b015dc512214f", 
+      "size": 3588, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a3e9a49adb11d7079eda533cfa26a199.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1115,6 +1339,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e0de75f083b3393e40063740b6b5757adc45222e", 
+      "size": 9028, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/532578856e4aba9f49cb063f9baed097.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1154,6 +1386,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ddd868b26eff3f6b70a50aa15adf283c31c9581c", 
+      "size": 7506, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/82684178352d5f0db3b347b48c60ffe7.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1193,6 +1433,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9242072d824b6687186b6264916067c820376ba7", 
+      "size": 8063, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c8c18849c66ed34bafa1f8cb42279272.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1232,6 +1480,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ba56fe56f5c5c5c726a5d5c630dab62a5369d009", 
+      "size": 8883, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b25309c97c5b8870f77c36c91bb9bb48.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1271,6 +1527,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:41b6f8564c73b88e213dd3808fe016e5c6d99708", 
+      "size": 3631, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f39b8d56dd05ca1999a63e01752419fa.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1310,6 +1574,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6090de2a28dfcac89f7bf0a001c744c56f5cb0b5", 
+      "size": 9193, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b914912ac.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1349,6 +1621,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:83a6de8867661efee14c1cea713da28b359dc8ae", 
+      "size": 2105, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cc9663d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1388,6 +1668,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5996a7119398bbf146d07c5ea6a09fa852a165bc", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b914557cf.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1427,6 +1715,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9495a0f2c4e76a4b7f1651131306b7fa41d459aa", 
+      "size": 2574, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc9384974.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1466,6 +1762,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:11f814844d34267841ead56fb7c4a07fefff3c12", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b78f836a8fc0457f3d1cf47679205dce.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1505,6 +1809,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e55155c031b33679317c953c4638f17a6b13ddfe", 
+      "size": 13553, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cbb3e0ee51f19be8f8a04cf25963e402.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1544,6 +1856,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6f6992baf376cb13bc4b0f9be645b25997f1d1d0", 
+      "size": 109920, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7b0f1f8e4df3d63108f095f9fa57f554.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1583,6 +1903,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:026d376a80037e9c008d58f45edf1d2dcafac704", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f91017475f2.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1622,6 +1950,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8e259660eddd9a5b19aa38348ccc016aa1b9e20b", 
+      "size": 8878, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9143d801.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1661,6 +1997,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9922ca38f56c1f85a5ee3faad8e19ea7617d7a10", 
+      "size": 7015, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0cac1a565bda09ad57a6810efe437c3a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1700,6 +2044,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:eb6259b81a0ab6b779efd910fb9ab3c69a3786e2", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6d0236.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1739,6 +2091,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:090eda0a849326b5ef7bff290fa918804dd9f952", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53eec1a6e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1778,6 +2138,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d5f0a255145f181f08fbaefb6d6bafa9be5fb1a9", 
+      "size": 3661, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f39b8d56dd05ca1999a63e017523ff89.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1817,6 +2185,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c686dd33a8338de7f6f6b46e849d214ade51bda1", 
+      "size": 5104, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6c6ff3f35efb680aebe72ced3d0211de.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1856,6 +2232,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c112fb70975528a61354a9888df2f9aa538a1295", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf2c69c1.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1895,6 +2279,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:2c361197d98a497694fa3d6ec8aa7124df2dccd0", 
+      "size": 2582, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6c4978.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1934,6 +2326,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d6f4c2fda14775befa2d93794af91bc1f1665ca5", 
+      "size": 6412, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8d6b90fd328fcdf734c4595f7086f4aa.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1973,6 +2373,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b8620b8b9e1cc5fa0cf2912aa5c3088d55c0a6bd", 
+      "size": 2583, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6cc7f4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2012,6 +2420,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7800a87d6ebc39bd59fc2ad86039c8f5be380c5d", 
+      "size": 8906, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101748d9e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2051,6 +2467,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6e35a92ac0659c609b84c2eb4122d34f0577a01c", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91457b5a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2090,6 +2514,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:1112a30de70e7e9ee6d42ef77e11235f02687888", 
+      "size": 2584, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6ce5eb.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2129,6 +2561,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:2cb1c8e30b2d002dca212564ec53b584ee92ba64", 
+      "size": 7785, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9e0fb63675bdd7dc5283db9af45df5c2.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2168,6 +2608,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:579a635c725bc084c55e5aa8763ab739114d52ad", 
+      "size": 7199, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de556aa6a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2207,6 +2655,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6558387744dc5fff9a6d89b8934b00fbe0584f3e", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e7205ac.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2246,6 +2702,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:67920ad25e4547d48dd153aa5145153c04a85f2c", 
+      "size": 7781, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4a1f22052abb5b3c51ee42f4dcdf63a5.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2285,6 +2749,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d7f5a524970a2b0496405d45c1e3c1f638f8af33", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f91017460b2.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2324,6 +2796,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3a89c524e92195c57343561eef2306efbf678bc9", 
+      "size": 3590, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/2e0a80c07f23808d4b75c974eaf58837.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2363,6 +2843,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:05fdb8a10b1e3e458ffffddd41a03184f9e13180", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a3d21.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2402,6 +2890,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ec264e08ab409cc539680bfb4beb6e0fda2d973e", 
+      "size": 3653, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6b5c4e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2441,6 +2937,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:29a30e30b569021e52490074647ac6f562044dc3", 
+      "size": 3618, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f520eec.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2480,6 +2984,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:92aeaa1f0d59dbcd015339f0ccb16fec82133b8d", 
+      "size": 7238, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f5cf4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2519,6 +3031,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:2569ab442a9977e620517c58f1608f776da7300a", 
+      "size": 3662, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f39b8d56dd05ca1999a63e017523fa17.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2558,6 +3078,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f8a181ee7b0552003e8a30e74551f5ef442e7dda", 
+      "size": 6945, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/caf0a1e27e00a4ac2cf66edbe3650da8.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2597,6 +3125,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:19e27a23f026f4ac62ad281c4342914d12d81fc3", 
+      "size": 6408, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8d6b90fd328fcdf734c4595f708e40a7.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2636,6 +3172,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6bcb3f1f7cdfebaeb4b96fe48c7ea94d3efa763b", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101741485.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2675,6 +3219,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a11406b1b6bbc9e795b1032fb0f371a78f46c7c8", 
+      "size": 9193, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b915008a0.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2714,6 +3266,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:32d21fbc2557cdee5a782a47e1835c8f3eac20ca", 
+      "size": 7525, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4515630011652d2fbae85c3707cb762c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2753,6 +3313,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6523837b2f2aa6fded16be5569532f76e335f508", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01b27e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2792,6 +3360,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:992fcc577694d2ad875cfcae9f25e57ddc677d82", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba690346afb7.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2831,6 +3407,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c94f57636a2a5bdd75e1e4f8263dc5487af316f4", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e91b14d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2870,6 +3454,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5066fac8b9297fc64b22e9b0e6f8eddfaba03c4a", 
+      "size": 3686, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c9e000c71f90818cafc2ea88b2e7e184.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2909,6 +3501,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5a904ff782a7cf8306de9e3e1fc7f7aaf0babce7", 
+      "size": 3646, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6602d94fea27826ae6e8e0fcd3cb1667.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2948,6 +3548,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:986f5ee69da8ec661f0cacf6ecb1ec45335c9a7a", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf3961dd.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2987,6 +3595,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:eb8b80bf80684de6869680591ea17eed3888b3ab", 
+      "size": 8876, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8c6e215a3026002258a2dbea0b28203e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3026,6 +3642,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ed107bc1b2f996d581fc61462bcfa16a7e2c612b", 
+      "size": 2582, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6cd449.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3065,6 +3689,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3eac79969359b12217fddb1b884dd246268909c0", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6c4942.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3104,6 +3736,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:280390ca0dd4407801b3ca1d26bfa85911f44306", 
+      "size": 4388, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9181dcfde0729882b44992132015be09.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3143,6 +3783,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:cee4d84c6ef5455de1d67373f9e585a96a359a4b", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101743bed.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3182,6 +3830,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c487dc52db5b96c3e864372b0886e64ca9f3ae72", 
+      "size": 7241, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191ef9d6.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3221,6 +3877,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3eb254a2812df3cca007058c737e4ea621e7900c", 
+      "size": 6643, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/1156e999350f625b865f0777d7f9b7df.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3260,6 +3924,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:881dba5e6f2fe17b125e79eff595468cc1d63a3c", 
+      "size": 6660, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de55404a1.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3299,6 +3971,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7168d7938791aa1827badd26876a4e91cad15bfb", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb886a3.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3338,6 +4018,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:bd54c25ac1f580dcfb345bd34b374d62a97d2843", 
+      "size": 4388, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0cac1a565bda09ad57a6810efe44961c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3377,6 +4065,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f8c049baec392caf7d1851a0ccdc2d1c8bf6c7f5", 
+      "size": 6828, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/2f1e2ccb71a5dc3b16aeb4bc3e72fdb1.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3416,6 +4112,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:82d4ea264712a6cb50d42d70613b6d02fcd44d15", 
+      "size": 2586, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ec457e6.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3455,6 +4159,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:998c4c66c648981e3275fb366b7e00b75f284712", 
+      "size": 7573, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9ebe5de2113c461586671dca1e09299d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3494,6 +4206,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:545e6c5e75db771bea50d892fc8e9cf1b492328c", 
+      "size": 30740, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd5176f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3533,6 +4253,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:797a732e146832d1ca674d9fe552189d404635fc", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a093c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3572,6 +4300,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:76ed142bfe4337ffd6dbb7e72ba69c4c2294f45a", 
+      "size": 3058, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc95bd0a9.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3611,6 +4347,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:476d65a34087808b57b2a29c5e25ca5db16df160", 
+      "size": 7213, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de555c9b3.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3650,6 +4394,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d92813bf39d353977a38884ea4d420010c76f478", 
+      "size": 6015, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cdafbdd.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3689,6 +4441,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:89ac2c8cc82bb31eb8a8c27238b6f927fbb3ebd2", 
+      "size": 7244, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f0786.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3728,6 +4488,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:08e5551c036ecfcccf12517ffbc224a27f6f8c52", 
+      "size": 3629, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db2908f57.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3767,6 +4535,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d012255f5b26779ebce72a4d09f1c625e9eacf12", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91639ba5.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3806,6 +4582,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8c942e6da7a1129a350d9f46c0bf64104b8dd0da", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8a7af.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3845,6 +4629,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:023e2fe97e15f39afa9588094a2ac277ba45b4d0", 
+      "size": 3218, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4f1f909dc818ac109c868566853a100b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3884,6 +4676,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6b1358532bdd39305b59295e8b4211fac561286a", 
+      "size": 2575, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc9456bf3.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3923,6 +4723,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b1690c757ad3bee2e1b9e7ca4a3e19e832ec5012", 
+      "size": 2301, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b365e646c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3962,6 +4770,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:48c7bf5a19eb0051323839d319498087418c52d4", 
+      "size": 7053, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/eee98ac39b28e880d1fcff7934dc2071.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4001,6 +4817,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0f3553b2a45c5817ce2d9bd056a5a87dfbfdd333", 
+      "size": 2108, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd575d6.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4040,6 +4864,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8a318ccfb51f763d9011803aca0596cae3535869", 
+      "size": 5937, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cdb4a55.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4079,6 +4911,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6818aa3d8b54fb32200e1592248ab4b8a4a0efb0", 
+      "size": 7781, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9e0fb63675bdd7dc5283db9af45da3f9.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4118,6 +4958,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f4f84870f3e498f971edd66bd2d2862a0a045f4d", 
+      "size": 3646, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6b5026.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4157,6 +5005,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:429068c0e39efdb1ae28b8e609ec81fb6b09b870", 
+      "size": 3028, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc95bc89c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4196,6 +5052,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ee1388e5f7770828ac20e89d58b17b0a7857698e", 
+      "size": 6649, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/1156e999350f625b865f0777d7f89e82.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4235,6 +5099,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:56a6fb6e166fe198d5ee754569d2648f4876db07", 
+      "size": 7048, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/787d59798ba1957342f08d4d11fd40d1.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4274,6 +5146,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:242e4c55af9d68dc72b1ec3061b6e8af8729344c", 
+      "size": 6019, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/5a969e363f8f7c70403095bd1ed4059a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4313,6 +5193,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:24ce88e4e3dbcd8a03b4ee06c822bf655bb2ab75", 
+      "size": 2295, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b36620512.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4352,6 +5240,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:466997049a1988aa2d5f61bdb2085c844598525d", 
+      "size": 3680, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c9e000c71f90818cafc2ea88b2e7e2b7.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4391,6 +5287,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b75cfb962d1c834988deb036ff400f10545e11c6", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53eea9c7b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4430,6 +5334,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:95251d193fe6df9320be273e2415a7e6f076aaf7", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b914fc3e6.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4469,6 +5381,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:fed0d98dd58df647685a79a4dbef0494baff0561", 
+      "size": 9193, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b914fe535.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4508,6 +5428,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5f2fc5911c1eb597a529e4a881e5e578630bc036", 
+      "size": 2582, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6ccb70.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4547,6 +5475,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3d48ac14fc37e7a2efad1b45027fb80275700b76", 
+      "size": 6784, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c729fce63ed969fa8b51acab368c394e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4586,6 +5522,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:95d5b4542a9560e49ca759f4b7bccb98935cc0bc", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf0149b4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4625,6 +5569,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b023f87cee2049bf0762dd3fa8cffa72388b690a", 
+      "size": 8919, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/40f18a4101a71b9631b737ae01700e35.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4664,6 +5616,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5188f62d13898aa5c02a3282ce14cc928ea39aa0", 
+      "size": 6993, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b17ed01fdcb093aaf395ab27ff34e3bd.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4703,6 +5663,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3c009bce88bd0e7174d39e64fc2d07beaa038899", 
+      "size": 3328, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6c6ff3f35efb680aebe72ced3d024dc2.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4742,6 +5710,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8eef78c8edb77d6153ce7755a639aa522aea051a", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8bd98.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4781,6 +5757,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b3de37f0f8322f905e024d3b27a0c893dd748b5f", 
+      "size": 2566, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101742e06.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4820,6 +5804,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a2a7cd22d0a4fca075a345e7cb95440df8f75ec0", 
+      "size": 6016, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8d6b90fd328fcdf734c4595f7091cd60.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4859,6 +5851,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:4c16f6416636ff47172e7e43fe2cd598dd5895af", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e7089e4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4898,6 +5898,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:bb202a99d65cb611fa35ab9dfc9aa7258c1584d0", 
+      "size": 4388, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/51bf5a6e98020fb8fa6dece923ed59d1.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4937,6 +5945,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:37771a1ee467c12e25515b2057e24cff0a5d8698", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e708382.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -4976,6 +5992,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6c984b471b424026634664c7abe7c419a76cb551", 
+      "size": 7860, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/983b066ccca9897c4131e0559ae28aa4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5015,6 +6039,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b6ec8ceb28632ca0ff0c97f8b99e663e0743ef46", 
+      "size": 9000, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/532578856e4aba9f49cb063f9baec169.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5054,6 +6086,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:cc69a5ffbc0dd7b51e8dc646b264faa0bf1cafe1", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb89677.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5093,6 +6133,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5fd8c98292cd39373c25c3d941b71dd33bf23f68", 
+      "size": 2997, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0de33f0c9cb94c9f73cd4e86d85bc166.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5132,6 +6180,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3638241d38e36c2bb924435aa2ff4b3ccf53ac35", 
+      "size": 3618, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/fa79ed2f93428d49ddb4d27246d78312.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5171,6 +6227,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a24fe1fd7aa8e44c73f6f3f3e98adb23f11b765d", 
+      "size": 7045, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/29be6bf0a7154bef099908f61c134f32.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5210,6 +6274,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:fcc1dd233f47b2d53484257606ace57fb678050a", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ebc76de.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5249,6 +6321,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:fbb4f80b59b82269c6701ce2591161a05c279452", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b78f836a8fc0457f3d1cf4767948a508.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5288,6 +6368,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:48362197d8bf479d3be3dc4ea7141a731dea38f1", 
+      "size": 2590, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6dfc47.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5327,6 +6415,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:deeeeec7e38780e81cd1e5d757bba1233918e2c5", 
+      "size": 4378, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6c6ff3f35efb680aebe72ced3d010e42.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5366,6 +6462,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:bed1919d53f7c5533c417db3b804975d792c3432", 
+      "size": 7239, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f8a11.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5405,6 +6509,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:4f0dcf6432949d3a20d5fb01dee3f0fc41ae1b25", 
+      "size": 3699, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4866695a076ae48d093c752532bd8bff.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5444,6 +6556,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:17971c6346f0cc5d31c922201e66dfd1e0612362", 
+      "size": 3627, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db28f6a0b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5483,6 +6603,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c0c527a9d28e4676ed2c9538f51ec2006138a99d", 
+      "size": 6780, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/664dd7856adaa0b955b09f1433e374c4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5522,6 +6650,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:70c47dabdc82a66208d164f6b912a63b7d455406", 
+      "size": 6019, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd75400.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5561,6 +6697,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5e43cdfe7e1b82070705d4959a2dbeef3c3ec24c", 
+      "size": 3647, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6b61a1.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5600,6 +6744,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5064f7963e161b3a9f6057b87a9aee7bedf782b1", 
+      "size": 9191, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9142fcdd.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5639,6 +6791,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:43fcf5f189b1104f0c80e49bea1f55a6c6a7cdd4", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba69033f98ec.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5678,6 +6838,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c4a3fda9cdc22984d1203eb82b3ec3d80dc1e4ae", 
+      "size": 2576, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc93d44ba.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5717,6 +6885,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:69463be8fbf2b33c15ad1cb55967709f7cf09db3", 
+      "size": 6651, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/796833acecbdb5e17bde7cd309059294.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5756,6 +6932,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:60dde75280999dfd27c972305ae6d1a9cc9ee64e", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8ae2b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5795,6 +6979,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c75b361195c97bca6101c5fbf4b438777a47541d", 
+      "size": 3608, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f521a2e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5834,6 +7026,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b9c56d3a8ffb2fd63e9ba63fb6a4c79a2495c3ca", 
+      "size": 2108, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd570f4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5873,6 +7073,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ec1ce5ed53f5967780c0cad984a71e87485ec50c", 
+      "size": 6662, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de558d69d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5912,6 +7120,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3f996deb7e5df654c6d1450bde4e5caa95d90338", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8a909.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5951,6 +7167,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d86381bb8bd8b660f8e768fb7ac656045d654ba7", 
+      "size": 3596, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/2e0a80c07f23808d4b75c974eaf56214.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -5990,6 +7214,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ff90ab67897c89b901fd966c01b0d5623a8fca32", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f91017424d9.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6029,6 +7261,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:eaab3d46448d32f3c624072c6436fa0d8de10ed6", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a0ec2.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6068,6 +7308,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:89b779daab56faf04f2db06a6547a826b691733c", 
+      "size": 6014, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cda3a44.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6107,6 +7355,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c8daf4535029bd1f7e399e7f24eed58aae3f01c3", 
+      "size": 2586, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc942b5c9.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6146,6 +7402,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:14dcd68f0b65ece975fed0b3f28efa2aa70ca0f6", 
+      "size": 7498, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4515630011652d2fbae85c3707cb6303.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6185,6 +7449,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9ecb81837e60e8e848dd153cb85918d6391f918b", 
+      "size": 3088, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc95e0251.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6224,6 +7496,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f07ca9241e89fbde90a4d1cde71b71410ee67a15", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53e0089cb.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6263,6 +7543,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6e416461ccd3fbbc20831c86e0cb1233149372c7", 
+      "size": 9061, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/532578856e4aba9f49cb063f9baec55b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6302,6 +7590,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:61a909bc6d442806dbbed09917dbfa0b4b113262", 
+      "size": 191427, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8d6b90fd328fcdf734c4595f70e2c87c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6341,6 +7637,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ac3ac86dd5a2fd2fb8a04d08abf95a804c8e36df", 
+      "size": 3651, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/88d21e388acd9191c9e326ff6dc48d10.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6380,6 +7684,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:4ec27a63592ce2563374fa7d54895fdf5f6fa817", 
+      "size": 9186, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9163813d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6419,6 +7731,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:4ca0d62cae4cbc87041a0dfb188b146e8181008b", 
+      "size": 7241, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf097785.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6458,6 +7778,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:146eac0915ffeb0f5194e5e18f111e3362f303fa", 
+      "size": 9191, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a7718.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6497,6 +7825,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:318fad05b4fdaffd65f20d793d338dc6698e6ce8", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01bf87.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6536,6 +7872,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:440cb6440428816b1a7c7082e17d64de04c99e29", 
+      "size": 6987, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/584825b69f5a095993efd0af12bb5e42.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6575,6 +7919,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d283e6b467b1a76181f0763578333863229216ab", 
+      "size": 4153, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/51bf5a6e98020fb8fa6dece923ed48d8.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6614,6 +7966,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:cff0bd10ff6eb22ed7bc1e1dc7a13577c250c83d", 
+      "size": 141650, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7b0f1f8e4df3d63108f095f9fa57f7ab.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6653,6 +8013,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:2efe43ffa30b784a28e63faf9131d57ec091075c", 
+      "size": 7444, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9e0fb63675bdd7dc5283db9af45dee2f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6692,6 +8060,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d7affeb844dd13d5f3cef573edddbc125708b496", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6ce0aa.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6731,6 +8107,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0306007ce8d749af6d5f1213906c7b638ff47262", 
+      "size": 3653, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e8df5e4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6770,6 +8154,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5fa45aa840d6b5d22d26a25e2730917d104874d6", 
+      "size": 2578, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ebd51c7.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6809,6 +8201,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c71611e75f56ab56ef04d37e4e2d3c795c2481a6", 
+      "size": 2579, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc91b8a2d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6848,6 +8248,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e4dee16d3a9b49385a756ce3a6276eaed73925b8", 
+      "size": 3048, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f23324c0cc10d31c5a86d5e5ecc18194.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6887,6 +8295,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e550001fce90a0697a806c10befa2466c9d86360", 
+      "size": 7699, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/5889fd7a33a3028626be5391385a468f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6926,6 +8342,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e66659dcd52028397cb2d874f11a4493e26e5f03", 
+      "size": 7205, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/fc458394c2843a2ab77397966d51b3c0.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -6965,6 +8389,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:1692cfac175d0ddd6cb9ddf2b647f0414d443cc3", 
+      "size": 3646, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/222fee3fd4cf6edf83c4f37ad062d132.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7004,6 +8436,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:17fc5427d6a232d1e3690a756764b7efab816f0e", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf081293.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7043,6 +8483,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:42969e538d0738a6636b9fd2ac3882779b436bbc", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf370842.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7082,6 +8530,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ca48d3aac49139f9156db8021b0e84dc3fa41953", 
+      "size": 4388, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/2f1e2ccb71a5dc3b16aeb4bc3e7300cc.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7121,6 +8577,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:51cd4ad6b7eda182a758436d289d61cf04d32bd5", 
+      "size": 2101, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695ccc7bf7.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7160,6 +8624,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:dd8b0f8d708ec0a55215825affbee487de200f3d", 
+      "size": 4388, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/1f48c8f34162458caedc7b1af94a232c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7199,6 +8671,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:60e16bcd4ac3b738d5106d9ef904c2d04ef99ac3", 
+      "size": 3645, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/88d21e388acd9191c9e326ff6dc478a3.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7238,6 +8718,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3450ea755a8943f6458c6268d165f33d8205e79a", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e703972.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7277,6 +8765,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ca82da6daea52920d67cae28e48ec82881042c11", 
+      "size": 3654, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6ce548.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7316,6 +8812,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f4d7935482f5b41df0f631d2c5d86bf78d60faa7", 
+      "size": 6026, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cdca324.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7355,6 +8859,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3e918c28a8a3f92e54376ee1b6174cf26694c733", 
+      "size": 242502, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/88d21e388acd9191c9e326ff6dcafcff.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7394,6 +8906,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0a504cf4cc17e47375c4852f67a145bee68eaa30", 
+      "size": 4388, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e057b5071cdc2df588be80e24a131404.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7433,6 +8953,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:83be02df6d7829caf20400d67b8c22fb036e451a", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf3cf54d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7472,6 +9000,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:026f766a8eeb3f5e4cdedb8911cef559e7bd223c", 
+      "size": 4388, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b17ed01fdcb093aaf395ab27ff353404.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7511,6 +9047,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:316fd73fb6f4f22360fa9818aa066280a5105822", 
+      "size": 7783, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4a1f22052abb5b3c51ee42f4dcdf5de7.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7550,6 +9094,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:1f5443979b4de6300d8daaa39e16a86495fe8728", 
+      "size": 4291, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d7c7e40a2583db7d5ecc08b5c9b12d26.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7589,6 +9141,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c58e2bf867b27120390c4c14ea98faaf9b7d05e0", 
+      "size": 6019, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd7a448.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7628,6 +9188,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:fa76f0185015c924783bca03b96be637f8b341b8", 
+      "size": 3648, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6b407b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7667,6 +9235,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e1925424feaf57fc6bca667745aa5b03196a766f", 
+      "size": 8904, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/584825b69f5a095993efd0af12bb32cd.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7706,6 +9282,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:58beb2d4dfd5a0bad53cd2d51b8fd3dd2ac3200b", 
+      "size": 6960, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9181dcfde0729882b449921320147b6e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7745,6 +9329,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:aec5c055435fd14d0bf3d1d31de94235a0d14218", 
+      "size": 216191, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/04afaf020d06de306b97edf3a0461d24.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7784,6 +9376,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d1c814d007f3d056e81a9895cb57f17269315e4c", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf024c8a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7823,6 +9423,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:1657eb999a281e3af8425b137c7ada1139e16953", 
+      "size": 84927, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/339cd62364712af8a4d594691b415ac1.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7862,6 +9470,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:eccecbbb7af0c87dd8a42e8f4d4995f1b26c8272", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e8ea2cd.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7901,6 +9517,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:4514048dab811bf094aba76fc5774c4b22e31032", 
+      "size": 3662, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db2931b0d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7940,6 +9564,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8b7d5d4958c4d690297ca0ec8b821a8dd41d7391", 
+      "size": 8876, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/5d08a4b52573d04c228c9be58e7ba7ed.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -7979,6 +9611,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a816a0c3c5d270972a7e767a118318bc57730e45", 
+      "size": 7004, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/1f48c8f34162458caedc7b1af94a180a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8018,6 +9658,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e0159de048d160c96dc480fe9e07a0f87463fd73", 
+      "size": 8135, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf09dde3.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8057,6 +9705,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8d4498f32fdc504f55dbf8401a9b4b79fde43a3f", 
+      "size": 3629, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db28f7d3f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8096,6 +9752,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:972110569119d35fcaf2b70290ff4f461dda2bcb", 
+      "size": 9188, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9163680d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8135,6 +9799,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d88f29472951fc0042992783bd10bd58cfaa95ff", 
+      "size": 16761, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/76dd68e16f83f9e75ac62a241e2ff844.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8174,6 +9846,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e243c9be023f56acdf46887cee5d58eeff02537b", 
+      "size": 2078, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01ca14.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8213,6 +9893,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:135c4e18f63c067eede0fbb118a622ed07914786", 
+      "size": 2105, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/3aca8f1bdff067de8609ce4479b9fffc.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8252,6 +9940,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:78a4c0e30a16c8b87b9d6f3e036fe244fe7afcf4", 
+      "size": 6016, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cdb60c7.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8291,6 +9987,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6020b9ea3922281f1734c45d669c9685ba00f1a6", 
+      "size": 7240, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f6796.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8330,6 +10034,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:83488c36608fa7c23223acae657215188ebacba1", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ebefdcb.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8369,6 +10081,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:350072253ec2b0a6defb5ec2d2cfaf5ed43e706f", 
+      "size": 8879, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/5d08a4b52573d04c228c9be58e7c9ab8.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8408,6 +10128,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9a74b4f774b4bc83c21435c7e8eaed243b7bb445", 
+      "size": 2587, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc94e8056.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8447,6 +10175,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f4b498d0e41ac6d60456b4f612db1becb24a8ab6", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8c7ef.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8486,6 +10222,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f9fefd8338c60c0e61e6d61bbb6a480ea07576b4", 
+      "size": 6460, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf09a4d8.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8525,6 +10269,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6928b3f4807f5e69a6d64e4902936792760ae40d", 
+      "size": 4639, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6c6ff3f35efb680aebe72ced3d012006.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8564,6 +10316,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b282d9b50d9e8e99fcc86ecbe5977c1bdc8ebc8f", 
+      "size": 8997, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7c7c0e8e128b3d1a9f287090342312e2.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8603,6 +10363,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5dfe18c814013080e16e28ae6562f208c538bd0c", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ec793ac.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8642,6 +10410,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:93fda8d108ba47ef0f5d9464f52a4e1fee8c5cb0", 
+      "size": 3680, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c9e000c71f90818cafc2ea88b2e7f02c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8681,6 +10457,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5c4a6ba8c5ed6670298cb8327a056f4ab0514ac6", 
+      "size": 2582, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6cfb7b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8720,6 +10504,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9cb2691360651fddf25287a7dfb26999be228fe7", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91455828.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8759,6 +10551,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d61f638afcea3ef067553bd9cd1ebcdc77a3df0e", 
+      "size": 2583, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6d0393.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8798,6 +10598,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:74062da093f1a5d505c9d40fcb4e05f05c4e88a5", 
+      "size": 3653, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db2951c61.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8837,6 +10645,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:4919bb00ef282b5bf2621202c5bbbc453dd76aa3", 
+      "size": 9045, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cbb3e0ee51f19be8f8a04cf25963e11a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8876,6 +10692,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8f9c4cd6d56418f81e0853c38435b4d39c5481e0", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf371d91.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8915,6 +10739,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:90a9e707ff67776256312f2de43f5d2b30913f23", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9143d1cf.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8954,6 +10786,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e3d7d68729ab51674b910cca93794016bd1d6423", 
+      "size": 8906, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c08df1fda127154276e899c872a73726.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -8993,6 +10833,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5dd8feacf7327028ac4d48de522934f1c1fae730", 
+      "size": 3556, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/bba69ae19e1fbc577b22ff7379801965.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9032,6 +10880,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:55a172fde945971ffe02f5063479a475a30a2ff1", 
+      "size": 7240, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f4e0a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9071,6 +10927,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a50a22ae390db084b9a65728f0a7c0959145d337", 
+      "size": 4579, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6c6ff3f35efb680aebe72ced3d0114b3.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9110,6 +10974,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:120a0a87ca44e89b9603fb3ff4994db59fee8eb0", 
+      "size": 3608, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f4f344f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9149,6 +11021,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:265bf2acacb86ba571ed4ef9aa432970f5c33bdf", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf3692b1.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9188,6 +11068,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:62d9dc0be600ac72e9e94e6657a2d259f00f946e", 
+      "size": 2102, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd7ae8d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9227,6 +11115,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:1d85de67874827ba6a4db43667b23a0e3d052901", 
+      "size": 2577, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc94e7575.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9266,6 +11162,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3da3b85cc67071033c46c8e743dd4662c6ad79e5", 
+      "size": 3684, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c9e000c71f90818cafc2ea88b2e92143.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9305,6 +11209,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0b08d3d853e3df2c63b08570b0dba9a2b039a352", 
+      "size": 3629, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db28f5b74.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9344,6 +11256,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f6ee5221fa8cc0d93a2008b145b8432a7e6c4dc0", 
+      "size": 7217, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de559091e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9383,6 +11303,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:536e34c84fa2ce8020bb65ffc284daee423a519b", 
+      "size": 2997, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0de33f0c9cb94c9f73cd4e86d85bb408.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9422,6 +11350,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b91becd2daeeb02a9c971f58e3dda275d43050e9", 
+      "size": 3068, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc95ea473.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9461,6 +11397,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e4e985c6430c6b827d945450097469799100aa78", 
+      "size": 3645, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/222fee3fd4cf6edf83c4f37ad06aee2e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9500,6 +11444,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:87b9ee78ba6fca1194fa06e010e93fbcb72178ef", 
+      "size": 3626, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f39b8d56dd05ca1999a63e017522b2bd.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9539,6 +11491,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3ecc9e026f49922862a6f4f3c302957986b76513", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e701da7.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9578,6 +11538,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:580481f40e88422d55a64eb5ee8f6342b83f12a5", 
+      "size": 8912, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b78f836a8fc0457f3d1cf476794b8075.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9617,6 +11585,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:07edfb7cc6131a4d0f92d89390cd6bca4e8485eb", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba69033fa308.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9656,6 +11632,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c0836dfbdcb98f5808f2a95946256b33301a8690", 
+      "size": 2588, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6c4761.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9695,6 +11679,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7319437f96d04c6c454f82490174743b1ccac6e3", 
+      "size": 3645, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/222fee3fd4cf6edf83c4f37ad06ace96.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9734,6 +11726,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:964125ff9ea69421a3f2ddb3e21e03c5a3b624e0", 
+      "size": 8038, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9ebe5de2113c461586671dca1e0933a5.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9773,6 +11773,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3f345a2683e77249f1581f5710546532c5b58f02", 
+      "size": 4388, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/787d59798ba1957342f08d4d11fd908b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9812,6 +11820,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e97b0c1d246dffdf5c35a21892b3d8f39d933b20", 
+      "size": 6027, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cda44c5.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9851,6 +11867,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:472d950294deaa857b6ca610bdff8e4a16c15359", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ec02a75.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9890,6 +11914,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:364dbbc3a2892f87cdf88235ec71aa36431f87c8", 
+      "size": 8876, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f0d6b2bf7129ab2b0e2d083668b685d9.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9929,6 +11961,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:67bd0e77ad4112a3bfceeb48d38e3b0db9a1c884", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf010f0e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -9968,6 +12008,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:49214a29bdb73629630ca5099183377ff4202297", 
+      "size": 7514, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/510c7148bdece85b1d05dd872b265ad9.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10007,6 +12055,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c21c4c58c250d34f1f70aa357f8ecf1294d41ed1", 
+      "size": 2294, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b365fdf38.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10046,6 +12102,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8db031bffac5d6855e5781b34fb74885495b073f", 
+      "size": 3627, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db28f6d80.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10085,6 +12149,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:1701acda1b674a8719ad26a1a035ac945fa2dae3", 
+      "size": 4140, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d4a9628510529dee2af9af0bc92340b8.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10124,6 +12196,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:054bb7d0a1b39b6a11411509e77b208eac26984a", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b914fc5e9.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10163,6 +12243,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:cd2de3b4c99749723bbb74bd38c19e91ffe3367f", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf378daa.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10202,6 +12290,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b3f3bafb00341816287e1ce0a3fe1655c890a5bd", 
+      "size": 3645, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e71ebbc.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10241,6 +12337,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5f2b6634ef6f72caf0040e3fa7d35efada22a43b", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf02765b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10280,6 +12384,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:76ec2090389e3566e9df3b13582de186f76d1a9e", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba69033e3a47.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10319,6 +12431,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a50c9ccfdaa989fcf215b1356d913e897f0e6848", 
+      "size": 82932, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8d6b90fd328fcdf734c4595f70e92ced.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10358,6 +12478,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:1544adfa55c1765abaa885ed95ffb86f53e8a86a", 
+      "size": 9033, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7c7c0e8e128b3d1a9f28709034230d8c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10397,6 +12525,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:77768e30d9fa0afbfc0eda2015d1390cd57792f0", 
+      "size": 9192, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/bae16f62ba4e90393266e2b342d1d10a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10436,6 +12572,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:593234af2ddf7834d6f1ea49fac67362c8e14af0", 
+      "size": 7241, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f5c81.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10475,6 +12619,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d3af536645e797e0603147e36a5a659318734834", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101741df0.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10514,6 +12666,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6dad7675b99e0dc9178f25a8b5c21683df7ec5d6", 
+      "size": 9191, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9144bb8e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10553,6 +12713,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:986158cb7af0e08d97d4e776d2b646039a3f94fb", 
+      "size": 2105, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd7ae5f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10592,6 +12760,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:77763d5b299a72955b32762c2ecb071c208cf74e", 
+      "size": 138112, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cceb077.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10631,6 +12807,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8cd10c8db8274257f319822f2fd76e59bc1065dd", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf017225.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10670,6 +12854,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b1a7d7bfd658520c25476dbaa9316e3896861f4d", 
+      "size": 6643, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d1e71d39919455bc55d126c5a80192dd.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10709,6 +12901,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:fae89b0789b1a0199ea66795f248e17a30524be0", 
+      "size": 3577, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a3e9a49adb11d7079eda533cfa1f8b39.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10748,6 +12948,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e9b06475be487afa46ca87da5fe6511d329c5d00", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53e006ee3.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10787,6 +12995,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f2db3021eac8cc6c5c8f8d2834132c08f50c2a8b", 
+      "size": 3646, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/88d21e388acd9191c9e326ff6dc48a67.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10826,6 +13042,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:96c9509b02677b2a80a75bb1c1c9a05c156cd17e", 
+      "size": 7239, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f57e2.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10865,6 +13089,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f15b549aa2b66e559349ca23eee5c73c9bc0f3ae", 
+      "size": 9188, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a55aa.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10904,6 +13136,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:bc270346c1fe282524b6ca360249df5bdd044f63", 
+      "size": 2098, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf00f661.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10943,6 +13183,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:fff88ebb8256662898eaf93075e67fe38037d87f", 
+      "size": 3948, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/62bbbeb9072f4819cb9a6a0673240e80.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -10982,6 +13230,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8abd573c3932d1d2105d00c5384b4d75d3fe60dd", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8b900.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11021,6 +13277,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f068aaba4356498fb8cf706072972df6839b82a1", 
+      "size": 3586, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/2e0a80c07f23808d4b75c974eaf57bbc.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11060,6 +13324,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:4f3b16011ae23362cf78da184a4badd14484ed6d", 
+      "size": 7377, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a18d736b69d54ffbc617374d326dd3fd.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11099,6 +13371,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:31818fc4048ee7aebec97fbe97af66001541b144", 
+      "size": 3651, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/222fee3fd4cf6edf83c4f37ad06b200b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11138,6 +13418,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:692d1de962b9ae4398fa43c7c9a7f584a5dad53c", 
+      "size": 7242, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f1560.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11177,6 +13465,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:66fbce279cfe11e8d06819a296fd2d87a8286713", 
+      "size": 7254, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/45f0d743eb37f734b1c0870479dd06d4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11216,6 +13512,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:831655207b437a5c2cca64c48711238942ef04f8", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf023d61.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11255,6 +13559,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:87ca44956fd8c88747bfc8087a05f43f82818937", 
+      "size": 2588, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6c3c6d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11294,6 +13606,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6b618ce2033452739a088bd95fdc2fb3cebf22b0", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf369d8a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11333,6 +13653,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:af8b11f69474ff197c843ae49f8ecf3338d2e1e5", 
+      "size": 16107, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/76dd68e16f83f9e75ac62a241e303b48.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11372,6 +13700,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:64af224ac79381c457742adadd2ff0434e321c70", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf023e33.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11411,6 +13747,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9c521d9ecb3e9843dd5cbba098d15673811631ff", 
+      "size": 2584, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6d091f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11450,6 +13794,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6e486e73fe14a5fa7a2b78ee3e4c17a2fb729bcf", 
+      "size": 4653, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d7c7e40a2583db7d5ecc08b5c9b12a62.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11489,6 +13841,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:00b4352d0c4c1eb24bc6f1edd0d2532426b937d1", 
+      "size": 7200, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de559dfbe.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11528,6 +13888,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ea2bf5aede9bcb5af7d252f443c61c65e525b436", 
+      "size": 8898, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/41e90e49470d54645977450d28d23740.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11567,6 +13935,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:008f0bba811c158201897d8be08aecf8b8c88f99", 
+      "size": 2583, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6d0bcd.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11606,6 +13982,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9aba4461b8b731577fbb583be610ab2edeaceec0", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101745520.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11645,6 +14029,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e11ad03151316330e0d560d07bac41436df8945d", 
+      "size": 3618, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f51f811.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11684,6 +14076,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:179e80985976b64469ceca4f8d9674a15857d930", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01ef7b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11723,6 +14123,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:28c3f9398a7a83a3545b684672e3efa0aeee63ba", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf026adc.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11762,6 +14170,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:26cdead8271f7525aed587f00e7c0dd26292ddfc", 
+      "size": 8046, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9ebe5de2113c461586671dca1e091d6b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11801,6 +14217,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:80689e56293b5abb58b54d27921ad1985d6bc8d5", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf013da9.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11840,6 +14264,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5baca0af1d25bb4fda2b6988123726ee320ca469", 
+      "size": 4388, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d4a9628510529dee2af9af0bc92626b6.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11879,6 +14311,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b1a8d1ab0c33848771e53961173cfd4af27948cf", 
+      "size": 2294, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b365e5591.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11918,6 +14358,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d18370ed00d509900ba2e03f43a8fd08126032da", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba690346aaf5.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11957,6 +14405,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c176900ca1c91d5beec45c8b3654357036d36385", 
+      "size": 8919, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/40f18a4101a71b9631b737ae01701b7a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -11996,6 +14452,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e9851f5597f2bd46f349d7b87578a1153f45605a", 
+      "size": 2586, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ec04500.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12035,6 +14499,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b9a5320e0ad0e6c879b6abecab05989690c5b983", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101744b84.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12074,6 +14546,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:240b7fdfd1c6b62d04ed937e0363d566ed85ed72", 
+      "size": 9193, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9144e254.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12113,6 +14593,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a521580a55923295062580f6a484e8c816c7140c", 
+      "size": 7158, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a97027acd9102d625e32a3b4f78e7a14.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12152,6 +14640,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:185330356f929c10b6689537a4916e74bd917d03", 
+      "size": 3628, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f39b8d56dd05ca1999a63e017522bc72.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12191,6 +14687,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:07989e8fae7cbf382a13b6765fc978054d0680e7", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f910173f2f5.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12230,6 +14734,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:eb6d23a8469d236d427f91cc7456d9d2da09cebb", 
+      "size": 3573, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a3e9a49adb11d7079eda533cfa1f9ee3.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12269,6 +14781,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3c7ca92e6e3ecdf988de7efbb60e8bb1b64c2af5", 
+      "size": 4340, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/caf0a1e27e00a4ac2cf66edbe3651f28.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12308,6 +14828,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a4aa55e50daf04945766f62b4208b2a25fd58c1b", 
+      "size": 7398, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cbb3e0ee51f19be8f8a04cf2596463d2.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12347,6 +14875,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b0c9adb0ede099ebc34191076643d0e0534063c9", 
+      "size": 7185, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/35f991cb1c1e772c0acaa98f4c796a89.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12386,6 +14922,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:309941d0955addec5835d0a70460c73b62ef599e", 
+      "size": 17052, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/796833acecbdb5e17bde7cd309059dc6.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12425,6 +14969,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c053dc11a0ecb43da8abacbb70d1a8e4b1b31d23", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf3cf4ac.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12464,6 +15016,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d6ee57f7d0655880bb0df00e8a1b105f9cd5af58", 
+      "size": 6461, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf2cf92b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12503,6 +15063,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:91bc17e7d66ea714efc44332cd41b24a3a80a88f", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a5f6b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12542,6 +15110,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:59702644a06f2a386daef4b1968397fe6525d9d4", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91500162.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12581,6 +15157,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f9e436e6372f1796ab038fdf12240cac39fae860", 
+      "size": 24190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd507b4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12620,6 +15204,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:aca3a3ec9f2effe93e3529dc05334be06472913c", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101746b88.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12659,6 +15251,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a1f4146ff83eb1946ba9ff3adce67e484154331e", 
+      "size": 2288, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b365ee6ab.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12698,6 +15298,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7196f40804374641f7396c382a280f2ee4e647b8", 
+      "size": 3654, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db2932a7d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12737,6 +15345,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a1d227edf8faac72d3bfb7c9ab5ef2f4536ed224", 
+      "size": 2589, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc9289a21.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12776,6 +15392,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0ac7bb5ff2d8116ebfae7601918c17239a4705d1", 
+      "size": 3653, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6b7105.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12815,6 +15439,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b5b4161562b210c56beece3701b04360b5db208a", 
+      "size": 7129, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de567d3b6.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12854,6 +15486,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7fbcfd2e4b8284cb085e3465fe1f90a327231967", 
+      "size": 10290, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/76dd68e16f83f9e75ac62a241e301035.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12893,6 +15533,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8585fe4023b84c9710eff63efd033f480cfd3e62", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf39cbbe.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12932,6 +15580,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8eb78834c08bc8116b1aeae78b9d2f2dce8a9488", 
+      "size": 3693, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4866695a076ae48d093c752532bd8133.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -12971,6 +15627,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ae0d0d01e6c9d39eba88b15a5650f7b15a985d7e", 
+      "size": 8046, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/bd00ebc013d37b71001c73501add57a1.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13010,6 +15674,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b86a7148d363f6fa1e73b8f4006faa32f450982d", 
+      "size": 2104, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd7295f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13049,6 +15721,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e65690981a1ea0bb31be15e9d02fdd59376d0f27", 
+      "size": 8238, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a18d736b69d54ffbc617374d326decc3.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13088,6 +15768,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b01abffcc5630ca7ee62ef1fc999c07878583f0a", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e70bbef.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13127,6 +15815,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:bc5a4fde2e96fd47c58f686937485b49bcfd4df5", 
+      "size": 2997, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0de33f0c9cb94c9f73cd4e86d8560a62.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13166,6 +15862,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ddc8ea9a392eb75670e8671c454348ede55ba0b8", 
+      "size": 7241, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f1c3a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13205,6 +15909,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8bab8d4e2ed49865f381678e7273672f3dc3823e", 
+      "size": 2997, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0de33f0c9cb94c9f73cd4e86d85b9364.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13244,6 +15956,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:767008751ed5690de2850364155e89dd4f846c05", 
+      "size": 3647, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6602d94fea27826ae6e8e0fcd3ca7156.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13283,6 +16003,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b995419d7b25b7d00b28d0d1dea74c8100a6806c", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01d739.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13322,6 +16050,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:df457e52c24496199bd2355a369e3b73008c7fe3", 
+      "size": 4008, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/62bbbeb9072f4819cb9a6a067323e45d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13361,6 +16097,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f33e64ed184165c39d5d5dbb573139f061eaa944", 
+      "size": 33375, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e9503a7214b07c7c615203890ad7407d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13400,6 +16144,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a330df215d89a3efae81980a1ae0f19646a1d9c2", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6c984f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13439,6 +16191,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a54d3623cc09e40d185ea6d26bdecf2d29586f16", 
+      "size": 2667, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101744922.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13478,6 +16238,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0c9c1c4f7d01c9e11684fbf9609f21c38ca310e6", 
+      "size": 3495, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/01a9d2b5582107b1dbc8e080145c42b4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13517,6 +16285,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f906fad07b7f27bca9188f59bf2aa48c468370c6", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101746efa.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13556,6 +16332,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9ae2bf4267c6d22e4e72027dd966f593c416780a", 
+      "size": 2585, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6cf399.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13595,6 +16379,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:634161bd2fbe58b82f9127c33e37d9f7d4df1795", 
+      "size": 7167, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f7f84.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13634,6 +16426,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c36ed3caff04b06cb0c33859ce913501321cce25", 
+      "size": 3645, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/88d21e388acd9191c9e326ff6dc45c17.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13673,6 +16473,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:887cf51ce1f3af2997d6e02664d3bd4a5f08dda3", 
+      "size": 7259, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d7c7e40a2583db7d5ecc08b5c9b04488.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13712,6 +16520,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c8175acdaae5a6ce5e9679f02da3fec91a50557b", 
+      "size": 3631, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db2952010.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13751,6 +16567,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:55ff5d8cb7a6a857a8f62eff638dacad09ca0972", 
+      "size": 9868, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/3b550de389a8797af7b60cb845542d62.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13790,6 +16614,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:672ec453fe15f7524aad9d55b1d594ed268e0905", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101740763.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13829,6 +16661,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:26cc0f6197537859786c8971810883bf14d55dff", 
+      "size": 8933, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f0d6b2bf7129ab2b0e2d083668b67ca0.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13868,6 +16708,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5c355c5d571fc80b5309a4ceb8e8039491f1e62e", 
+      "size": 3653, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db293246a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13907,6 +16755,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d7ef85843b4d1d42d555c161a347da4f9316cbf2", 
+      "size": 3629, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f39b8d56dd05ca1999a63e0175229881.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13946,6 +16802,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:cf854e2034f1dbce9e01bd2714bd5e2b0df1fd5b", 
+      "size": 62931, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e9503a7214b07c7c615203890adecf09.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -13985,6 +16849,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b873a368c5ce8119097a508b175a948d79c70508", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf024355.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14024,6 +16896,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ee3d772543c75a8f203409456a21e083d9665741", 
+      "size": 4038, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/62bbbeb9072f4819cb9a6a067323f1ba.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14063,6 +16943,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:006611ae47d1104c7f673f601a980df02d2256f5", 
+      "size": 11114, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cbb3e0ee51f19be8f8a04cf25964189c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14102,6 +16990,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:277c0a32aa90ecd9e37e5f422b16232764253910", 
+      "size": 111304, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8d6b90fd328fcdf734c4595f70da3faf.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14141,6 +17037,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f1bca1884265215d9b17fc57efeec5923d36f6b7", 
+      "size": 6663, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de555da99.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14180,6 +17084,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c9a846b601e9eae24cf8940ae766c525537abe8c", 
+      "size": 2577, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ebcc0db.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14219,6 +17131,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:332176224ba5567f557e502b0e1ee4537d1d302a", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01534f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14258,6 +17178,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7dfac0fc48fca6fa2bf3bcd40f6ac767402fb992", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb89c0b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14297,6 +17225,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:dd14d943c7c5782de0684a56b98d63961694cc62", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba6903468f82.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14336,6 +17272,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ffcf60fa24578938cff854624aa3b221e0c26941", 
+      "size": 23945, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695ccc51b5.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14375,6 +17319,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:2425cc0b3350a258ca91e59e4ddf95c2d39bc7d4", 
+      "size": 9191, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9150006a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14414,6 +17366,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:28baca7e23f10c5367e58b534dcfb746820d782d", 
+      "size": 3590, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a3e9a49adb11d7079eda533cfa1f8236.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14453,6 +17413,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:82cca52739cf5bef4ba3b8968769d8946430ed50", 
+      "size": 2997, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0de33f0c9cb94c9f73cd4e86d85bc34e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14492,6 +17460,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d32b90494f471984e8f7aed0acf19f6abc61c99c", 
+      "size": 6960, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e057b5071cdc2df588be80e24a11fb92.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14531,6 +17507,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:07c7c06cdcd05bff6897762d7fe7fc86243a7e2c", 
+      "size": 2583, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6cf6f4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14570,6 +17554,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6c12e70e50bc03fc3eacbaf89e0eac9953275e5a", 
+      "size": 9185, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf0a2a9b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14609,6 +17601,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ba91a4f6ae47d2ae480dcde165df79e92e0f23ce", 
+      "size": 3693, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4866695a076ae48d093c752532bd83d4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14648,6 +17648,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c8821effea5b54cf6497cdbd8cd553f7e8cee5ca", 
+      "size": 3680, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c9e000c71f90818cafc2ea88b2e7dc6e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14687,6 +17695,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ed103d9b78a022eae7ca9ec8a2fc38d94a9c7da9", 
+      "size": 7201, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de553ce09.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14726,6 +17742,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:354ee2b867a613870cd05b29d979e2991a2ede60", 
+      "size": 9193, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916352f3.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14765,6 +17789,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5de1a6dee7a5504c0dd6704d16a6fb276689507a", 
+      "size": 9190, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9142efe4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14804,6 +17836,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f1195289e79936cba7100993ad8c91a4bf5b1bdd", 
+      "size": 2565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8c957.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14843,6 +17883,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:cdf36cbd1f4801ecb56865c6c14f36f9d5deec60", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e702e3f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14882,6 +17930,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:1634345e7deb08f57af305b828e45a2bd347a2c5", 
+      "size": 3654, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6bdbeb.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14921,6 +17977,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3df75c25ce4d5028a09541be6e1ab97d19d8993f", 
+      "size": 4388, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c729fce63ed969fa8b51acab368c66c5.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14960,6 +18024,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c71aa7d57625f797da8f6c196aefbb8d6f69eb17", 
+      "size": 2575, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc92f24fc.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -14999,6 +18071,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6af36aada8d28ed89f1d0f55ec2fc53f7c513ccc", 
+      "size": 8997, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7c7c0e8e128b3d1a9f28709034231c06.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15038,6 +18118,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:919f780d21aea866d85a344512f2eba3818b47bc", 
+      "size": 4609, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d7c7e40a2583db7d5ecc08b5c9b12c79.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15077,6 +18165,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b9255e80e37992e45774ca86263d32a136ef5b35", 
+      "size": 3612, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f520829.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15116,6 +18212,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3579c523b05b0c12de3da22895813d8fdfe8cd88", 
+      "size": 2293, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b36619685.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15155,6 +18259,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:05fdd326937498367cdd533f15356f78827e1c58", 
+      "size": 11629, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d7c7e40a2583db7d5ecc08b5c9b03da0.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15194,6 +18306,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c19f912496dbc93fabb163e29db3483e958cc18d", 
+      "size": 2600, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba69033fb1f0.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15233,6 +18353,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:21da2da6fc4a375f7ece9508dd7839b095a2f48c", 
+      "size": 9873, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9ee7ac18c8fac8c1a71e3a640bffcea0.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15272,6 +18400,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:57fad0049269093a3c1cc2f5c363df9917a9d7a5", 
+      "size": 2667, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f910174234f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15311,6 +18447,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3e709bf33dedb20d6390d468132b4b879e89a961", 
+      "size": 4068, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/62bbbeb9072f4819cb9a6a067323c437.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15350,6 +18494,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c3740a8da8e4e50e8f3a97e1c3e98595479f5571", 
+      "size": 2597, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ec3b2e7.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15389,6 +18541,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3323ee57c3aad731f97ed92fc137ed541969a6e1", 
+      "size": 4098, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/62bbbeb9072f4819cb9a6a0673241858.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15428,6 +18588,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a87abb193e8cb6474c29408ff8e623dff9e5243e", 
+      "size": 7505, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4a1f22052abb5b3c51ee42f4dcde9c69.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15467,6 +18635,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:4d683f0c1083f26a7c6c611d3a7d4b4212900cdc", 
+      "size": 2077, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01a589.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15506,6 +18682,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9ac9ae029cfe088296b27e937b1fac5d3db5efb7", 
+      "size": 3644, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e91811a.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15545,6 +18729,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:33fb52e7db643b28a0f342ccc8121b9dc9cdabdf", 
+      "size": 2303, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b3660cc77.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15584,6 +18776,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d96ccc03a2cf3d0f71406cb2710257efeece539a", 
+      "size": 7006, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de5556901.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15623,6 +18823,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:286ece8dced265d1db509145fbfc135e64779e43", 
+      "size": 9188, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91695301.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15662,6 +18870,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:863d43ec17d59b2d9cb80fa60c9fbffcd0f07dfc", 
+      "size": 3929, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/62bbbeb9072f4819cb9a6a067324280c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15701,6 +18917,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f6cc4c10eab1f5b2fc960391850563552b729f64", 
+      "size": 6019, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd9eb0e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15740,6 +18964,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:575029c211662f8cf9b9b69575b80e9f8f56deed", 
+      "size": 3588, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a3e9a49adb11d7079eda533cfa1ee549.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15779,6 +19011,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0fe02b9b42ff513309a296d98a4a1a32dee05307", 
+      "size": 6651, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/1156e999350f625b865f0777d7f9562d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15818,6 +19058,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5c676d499048be3df7dc59d2efc0ba0ad8e900e0", 
+      "size": 2074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf018ce5.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15857,6 +19105,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:cb343785ab838977a2cb4cf4b3143f968eb8f2a8", 
+      "size": 7244, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f06e4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15896,6 +19152,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0108aed065c109efdbe82d33975c8e5bb44dc3c9", 
+      "size": 4340, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/664dd7856adaa0b955b09f1433e38123.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15935,6 +19199,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c584f4c2d1446f0012ae39d3c738f9522c610207", 
+      "size": 3680, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c9e000c71f90818cafc2ea88b2e7da63.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -15974,6 +19246,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:39136eb6cf80977d6d7e6d73a3be9ad6ec662b68", 
+      "size": 9191, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b914461c7.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16013,6 +19293,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:31f273c10a920412785444fa54df009a81e3d557", 
+      "size": 2997, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a97027acd9102d625e32a3b4f78c79ac.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16052,6 +19340,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:2928ee56c5dfc6c46165fbf139904eb5a4f04ea8", 
+      "size": 2093, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf00ffcf.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16091,6 +19387,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:71334c348823d47b5220a166f1f71e65d3d0bacb", 
+      "size": 4595, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e958aa8.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16130,6 +19434,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:874873bfab129bf792cb6e2abf3eff49912ec8c3", 
+      "size": 4590, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e97b7c2.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16169,6 +19481,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:1c76982e4631b4f6fd58bd71005c0168ff9fc3f8", 
+      "size": 4591, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e972c4b.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16208,6 +19528,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b29184313a41e4e14bdfbe060c8aae8635f10f0a", 
+      "size": 6697, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e9527d4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16247,6 +19575,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f4bb3aac04c80c74a3678064591ac959715282c8", 
+      "size": 4592, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e936581.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16286,6 +19622,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:efbf56cf3aa01cbf14be96540509382464e5a75e", 
+      "size": 8819, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e995804.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16325,6 +19669,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e058b214b6ccdb7d241cdca3035e069586e1c138", 
+      "size": 4598, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e9675f4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16364,6 +19716,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7195cd810d3f75854c099d01385a4ec1d3b601a5", 
+      "size": 4590, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e963393.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16403,6 +19763,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:4d7f787feeaf74f881225e1d94ea99ffc79e5cc6", 
+      "size": 4594, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e9c2b96.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16442,6 +19810,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8dc80bf12b23c5c3e4d59d9f340be4bb60b63097", 
+      "size": 7384, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e983f2e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16481,6 +19857,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:600801b794353db544d839de5865888a059cff94", 
+      "size": 4593, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e927f5e.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16520,6 +19904,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f5de088b2661b4f90c16faed795480c29a5a3096", 
+      "size": 4596, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e9a2f16.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16559,6 +19951,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:db5449f68580b3b3c1cac34daf7f0cb5298da9e4", 
+      "size": 4589, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e992c09.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16598,6 +19998,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:53684fd5872c549832c01380bb8a0803acd3b408", 
+      "size": 6638, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e92401d.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16637,6 +20045,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:34dc861c42a4d0d5169420f7758de1a3226fe775", 
+      "size": 4590, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e95b846.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16676,6 +20092,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:732578bd3e439f0ba341c2791d157b507aadd735", 
+      "size": 4595, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e3db18c.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16715,6 +20139,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:093756b71baab4992a859361fed18108a8bdf36d", 
+      "size": 6697, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e463912.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16754,6 +20186,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8051630d516bb6555f8ee74469b48eda73b6b850", 
+      "size": 8756, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e9b3301.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16793,6 +20233,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c9f2c680d94e3f21802149fee16692264c7ca84c", 
+      "size": 4602, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e40a16f.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -16832,6 +20280,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:aefd0dd405f9b452042a03409d290b2e51228100", 
+      "size": 4591, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e91fbd4.configFile.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 

--- a/cernopendata/modules/fixtures/data/records/cms-hlt-2011-configuration-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-hlt-2011-configuration-files.json
@@ -22,6 +22,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:684787321494b0ff15481a3b069eed3c5bbb7b88", 
+      "size": 1463387, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.4_HLT_V4.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -60,6 +68,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c9cf102ed538ee15d3e6a9b6cf67830b41c8c7b8", 
+      "size": 1538053, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1.4e33_v1.1_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -98,6 +114,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6ae48d518ef8ce75390ddac049417559127885b7", 
+      "size": 1655327, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_2e33_v1.2_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -136,6 +160,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3cbbd0f05f1094a77250ac92635660abec01bbaf", 
+      "size": 1959685, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e33_v2.2_HLT_V4.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -174,6 +206,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:bdc40f32ffd2f69904c669fd0bb8d3a6d3f0ada7", 
+      "size": 952467, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.3_HLT_V4.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -212,6 +252,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:4eaac0f6ca18ef0f7fd672b63b44beac4070b11a", 
+      "size": 1093353, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.1_HLT_V6.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -250,6 +298,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:46415dac64446e03cffc114f192519fe64a1f1fa", 
+      "size": 355630, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.1_HIHLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -288,6 +344,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b7703d351bea098eeab9307f53b64449995dbc17", 
+      "size": 1655583, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_2e33_v1.2_HLT_V7.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -326,6 +390,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3806fbb369c19d64e8df3c91c6ef1ef561562dd5", 
+      "size": 1079939, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.2_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -364,6 +436,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:89803a6b07a1811ff4e3084ca2febf1d7fd91e87", 
+      "size": 1080191, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.2_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -402,6 +482,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:afd9287dc83b4f0177bf0bc482114fdf6e8d829a", 
+      "size": 1720507, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v1.2_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -440,6 +528,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:80bed2e30b257b794b3f56afd17c0d44b14701f6", 
+      "size": 1755310, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.2_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -478,6 +574,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:19e986d975ccd5cc395acd87ef799b7db442ef7e", 
+      "size": 1761005, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v4.0_HLT_V6.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -516,6 +620,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f487680640461da96a64243d4e66de1295e9e377", 
+      "size": 1069189, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.1_HLT_V6.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -554,6 +666,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7f14be7413d6a43a583a0c3a7ef7de46968b87ca", 
+      "size": 1086697, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.3_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -592,6 +712,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0d0594a2e557389306e979436c1317ffb6eb4122", 
+      "size": 1095518, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.2_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -630,6 +758,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:1bf95c8fa1ed4f8194307c96ec3f98bc691dbf31", 
+      "size": 355854, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.0_HIHLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -668,6 +804,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:599e549a2456a97d15ed27fa64f762418249f0b6", 
+      "size": 952435, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.2_HLT_V5.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -706,6 +850,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:55d12e7b08d19f5f04a6d2fedbbbd03a80a741c5", 
+      "size": 957304, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.3_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -744,6 +896,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:dc96ab0ae2478a4afdd6eca11e36161fb61ce068", 
+      "size": 1655605, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_2e33_v1.2_HLT_V4.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -782,6 +942,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:27048cb24c8f3628abb5f1ee07bc62f4d05969d4", 
+      "size": 365129, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.7_HIHLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -820,6 +988,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ea1e0682432490569fc8064eba5eae7cf4d178c7", 
+      "size": 952166, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.2_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -858,6 +1034,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b8fe17febc060f255b9ac0e726f5ad69c178b755", 
+      "size": 1957879, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e33_v2.2_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -896,6 +1080,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f35a4d5d047340b02e481cbd828fc3f395325c39", 
+      "size": 1291047, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v1.3_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -934,6 +1126,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:2b0ac3f16474ad53e5e54e9f1a19e6bf39e6335f", 
+      "size": 957307, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.3_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -972,6 +1172,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ed9bb9eba76eaa2f8702bef97ed7340a0dbb0fbe", 
+      "size": 1538081, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1.4e33_v1.2_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1010,6 +1218,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e07d18bd08bf877d21dd35c65ad6ddb5b3993aa2", 
+      "size": 1464179, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.4_HLT_V8.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1048,6 +1264,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8ca10eb17a7814b11800dc0158d2a981719e0725", 
+      "size": 1463128, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.4_HLT_V5.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1086,6 +1310,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:072f428c0645bf8e0a7743ac945c6c54db2e7ff2", 
+      "size": 1720465, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v1.1_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1124,6 +1356,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e4ef4cef8e730ad6b58cd4fb392d3f63e1b853cf", 
+      "size": 365379, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.4_HIHLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1162,6 +1402,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:090959f22f76339cc05735f7ba68bec539e09603", 
+      "size": 1292225, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v1.3_HLT_V12.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1200,6 +1448,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:640abaa547cee8c9e0a671e97899ac7aaa358830", 
+      "size": 1756534, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v3.0_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1238,6 +1494,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:bb8b8e079c2ed0a9f8eb60d9943dff8f4a3eafbe", 
+      "size": 365123, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.6_HIHLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1276,6 +1540,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:195a8182f9539c39959327f4ced8c5d720650e15", 
+      "size": 1463128, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.4_HLT_V6.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1314,6 +1586,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e4bee4bd32474e861a78bcb35478fd4a9d9b6cec", 
+      "size": 1093621, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.1_HLT_V8.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1352,6 +1632,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:84c1dedaee8bac400610739867a3cf456b8549ae", 
+      "size": 1291841, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v1.3_HLT_V6.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1390,6 +1678,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:565cbdd10b0ffab52c3d5247be4e6558cd8bb85b", 
+      "size": 1754542, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.0_HLT_V7.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1428,6 +1724,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e33f5e2eda27e827f68c9beb471ff217d8d15356", 
+      "size": 1759388, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v3.1_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1466,6 +1770,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:bf1f6e55af90306fe75e38058e856f0d2448cb37", 
+      "size": 952322, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.2_HLT_V7.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1504,6 +1816,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d1ddcf853e69103608c0884e38be182dd21a3be1", 
+      "size": 330986, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_2760GeV_v1.1_HLT_V4.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1542,6 +1862,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:68d9fa0394240d6b7655d20ffb6fe6345ef0786c", 
+      "size": 330985, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_2760GeV_v1.1_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1580,6 +1908,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3634d27a332c73ccf073774971204349bf9f727d", 
+      "size": 1760998, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v4.0_HLT_V5.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1618,6 +1954,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9cb205e00208e001b0e960f5e16f7942050aca44", 
+      "size": 1757243, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.1_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1656,6 +2000,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ae90495c781c41e0d3851a76fde8fe8d9d852efe", 
+      "size": 957785, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.2_HLT_V7.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1694,6 +2046,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7b4369ac26f897018217848149ffeb4c379a4c92", 
+      "size": 1462994, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.5_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1732,6 +2092,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c593aadbf03385e65cbf949c48dd5b1260aee275", 
+      "size": 1655603, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_2e33_v1.2_HLT_V5.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1770,6 +2138,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:237b42d9d7a2f9d61cf8ef9570ecdcce473b9bd4", 
+      "size": 363139, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.3_HIHLT_V5.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1808,6 +2184,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e24bcd2d8bf2b188d9963633fd04c12d5d3dc755", 
+      "size": 362205, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.2_HIHLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1846,6 +2230,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3ce978992a4b32c10b50750c1af35e8dab39d4e1", 
+      "size": 1463878, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.4_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1884,6 +2276,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a5e29a83cb10545a3da0e88616af744e3340134c", 
+      "size": 957517, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.1_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1922,6 +2322,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a58a1256ca0a621f5497e95ffe6338e79bc08eef", 
+      "size": 1068666, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.1_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1960,6 +2368,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:720836630a8971e18eee942e15c5e9fc3f1f339e", 
+      "size": 1638691, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_2e33_v1.1_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -1998,6 +2414,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6b4d66f1d4407d0daca0ed3a0264ce19bb6e9692", 
+      "size": 957793, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.2_HLT_V5.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2036,6 +2460,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:47fc06a4bd39ef516ef132b957cbbff16bc4f969", 
+      "size": 1292502, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v1.3_HLT_V13.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2074,6 +2506,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:197b61dd21ffd10bc0320784323f523c6962c520", 
+      "size": 952306, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.2_HLT_V6.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2112,6 +2552,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3ce68ddd40b74cfc5ecdaf71260d5745c4c94e0a", 
+      "size": 1068383, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.1_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2150,6 +2598,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0fd5e5d618d42fe9c8edaf54aebead5f5ccf8668", 
+      "size": 1720455, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v1.1_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2188,6 +2644,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b533efd324806c790d9efbf6a1ce0090d11b6417", 
+      "size": 1638691, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_2e33_v1.1_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2226,6 +2690,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9ba1ad246cee6279071ee3ee27d212bfd9089bdc", 
+      "size": 1080191, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.2_HLT_V4.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2264,6 +2736,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:92a86b2262d501e9b541561c6b448d331963ab31", 
+      "size": 952318, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.2_HLT_V8.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2302,6 +2782,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:40997d3b7050a806d470f41eaf1125d5ecb26f11", 
+      "size": 363139, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.3_HIHLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2340,6 +2828,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:53c85ba3ad2b0e5c1287909eccc418d10b143946", 
+      "size": 1763875, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v5.0_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2378,6 +2874,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8793ef5c6921daff7e93985fd3c8db902d3b3d1e", 
+      "size": 1538078, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1.4e33_v1.2_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2416,6 +2920,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:4f20c561f9f8e92aeaabe0f5aeff436af9ab1c1d", 
+      "size": 1086697, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.3_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2454,6 +2966,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d518f4c31b63026d8691267880aea9dab382e8b8", 
+      "size": 355854, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.0_HIHLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2492,6 +3012,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:771b75eea7fc55eb3f2077f1f8ebcf193a5b5f12", 
+      "size": 330986, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_2760GeV_v1.1_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2530,6 +3058,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c7b44b364be8c8ac3bc082dc4672c1ca43be3982", 
+      "size": 1093353, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.1_HLT_V5.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2568,6 +3104,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:448793811f09368d2571284a24113df37595d1bf", 
+      "size": 1761035, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v4.0_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2606,6 +3150,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:323b323e1ef8344a24417174052b812064d459a2", 
+      "size": 1761035, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v4.0_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2644,6 +3196,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:005df47fabe8712d30b2a85a93cec20a00688d67", 
+      "size": 1068664, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.1_HLT_V5.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2682,6 +3242,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b963125f7a7ef94e352ca3e487be5a99e129c9a9", 
+      "size": 957791, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.2_HLT_V6.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2720,6 +3288,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7ea0447b5043c977ba97bff6b9b675637b4a7991", 
+      "size": 1802511, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e33_v1.4_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2758,6 +3334,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:45c7604cdc60433147bc7d868e4e8be6a86f5894", 
+      "size": 1291550, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v1.3_HLT_V7.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2796,6 +3380,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9cabb4ca4587d42ac5a574382eeb2edf4b81eab9", 
+      "size": 952467, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.3_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2834,6 +3426,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6cc1f2b88fe4ba2337ef228f8d6aa75790daeda4", 
+      "size": 1802115, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e33_v1.4_HLT_V5.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2872,6 +3472,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:fc4659a5970b25d80d5f7f188efda12c429dcaf6", 
+      "size": 1465184, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.3_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2910,6 +3518,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:2dcdb90e655bc6d763520415576fb79a51f6db9b", 
+      "size": 1755681, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.3_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2948,6 +3564,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ab2a82110c628da35349d56783d6d678c468afa4", 
+      "size": 1753085, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.0_HLT_V4.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -2986,6 +3610,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0731e73efed5d61b9d7a5c178ea4182b8132cc99", 
+      "size": 1755306, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.2_HLT_V3.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3024,6 +3656,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:08542eb90a66f4e7127f87e6c30d57dbbd70786f", 
+      "size": 1757246, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.1_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3062,6 +3702,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6e94e9bb7710088aad6bca583feeb9d0ddfa760f", 
+      "size": 1086697, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.3_HLT_V4.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3100,6 +3748,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:de92e8d199fe95c79d918246031071c0c66895f0", 
+      "size": 1720464, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v1.1_HLT_V4.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3138,6 +3794,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:88f57667e9b50bce7327186f92f16ded7e862573", 
+      "size": 365274, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.6_HIHLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3176,6 +3840,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9e79fff0801341d77a2f1d437704c4dfd7f36114", 
+      "size": 1465150, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.3_HLT_V1.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 
@@ -3214,6 +3886,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:52b4142b2f7e2b87c81c063f98d9e0088c951eb7", 
+      "size": 957601, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.2_HLT_V2.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 

--- a/cernopendata/modules/fixtures/data/records/cms-pileup-configuration-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-pileup-configuration-files.json
@@ -22,6 +22,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:adc9110968b5c5aca80c5914ef7bb46423b7c05c", 
+      "size": 3418, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/mix_2011_FinalDist_OOTPU_cfi.py"
+    }
+  ], 
   "note": {
     "description": " This file describes the exact setup for the\n      CMS software executable which was used in a data-processing step. It is\n      provided only <i>for information purposes</i>. Although all the components\n      required to <i>analyse</i> the public primary datasets - such as\n      corresponding input data, condition data, software version - are provided\n      on this portal, it is not necessarily possible to <i>reproduce</i> all the\n      described data-processing steps. "
   }, 


### PR DESCRIPTION
* Centralises local files on EOS for CMS configuration files records. Enriches
  record metadata correspondingly. (closes #1697) (closes #1705) (closes #1711)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>