### PR TITLE
records: centralise local files on EOS for LHCb Derived Datasets

### DIFF
--- a/cernopendata/modules/fixtures/data/records/lhcb-derived-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/lhcb-derived-datasets.json
@@ -1071,6 +1071,13 @@
       "size": 584063, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_99.root"
+    }, 
+    {
+      "checksum": "sha1:579137902ed34fc2061f8023afd15beed05f73fc", 
+      "description": "LHCb Masterclass D0lifetime 2014 event files file index", 
+      "size": 18442, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/file-indexes/LHCb_MasterclassDatasets_D0lifetime_2014_eventfiles_file_index.txt"
     }
   ], 
   "keywords": [
@@ -1124,6 +1131,13 @@
       "size": 1289541, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/MasterclassData.root"
+    }, 
+    {
+      "checksum": "sha1:9a0d92c6159d4fa39f45e5f1b321eb0468a47558", 
+      "description": "LHCb Masterclass D0lifetime 2014 real measurement file index", 
+      "size": 101, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/file-indexes/LHCb_MasterclassDatasets_D0lifetime_2014_realmeasurement_file_index.txt"
     }
   ], 
   "keywords": [


### PR DESCRIPTION
* Centralises local files on EOS for LHCb Derived Datasets records.
  Enriches record metadata correspondingly. (closes #1723)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>