### PR TITLE
records: centralise local files on EOS for ALICE-Derived-Datasets

### DIFF
--- a/cernopendata/modules/fixtures/data/records/alice-derived-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/alice-derived-datasets.json
@@ -87,6 +87,12 @@
       "size": 293121910, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/alice/masterclass/MasterClassesTree_LHC10h_Run139036.root"
+    }, 
+    {
+      "checksum": "sha1:d2f51ec54a49849419bfd4a91b54d0015b3f3e63", 
+      "size": 223, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/alice/LHC2010h_PbPb_VSD_139036.json"
     }
   ], 
   "keywords": [


### PR DESCRIPTION
* Centralises local files on EOS for ALICE-Derived-Datasets records.
  Enriches record metadata correspondingly. (closes #1686)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>