### PR TITLE
records: centralise local files on EOS for CMS-Validated-Runs

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-validated-runs.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validated-runs.json
@@ -21,6 +21,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.YDT4.BW6J", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0eefeb12a61efb2faeeb2a3e7b8fb387556a8350", 
+      "size": 8873, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/2010/Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt"
+    }
+  ], 
   "note": {
     "description": "This list covers all p-p data taking in 2010. The public data (RunB) is part of this list, between run numbers 146428 and 149294."
   }, 
@@ -79,6 +87,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.3Q75.7835", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:dd2122be57d2c5ad297283820d66b2313de95f64", 
+      "size": 19347, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/2011/Cert_160404-180252_7TeV_ReRecoNov08_Collisions11_JSON.txt"
+    }
+  ], 
   "note": {
     "description": "The list covers all p-p data taking in 2011. The public data (RunA) is part of this list, between run numbers 160431 and 173692."
   }, 


### PR DESCRIPTION
* Centralises local files on EOS for CMS-Validated-Runs records.
  Enriches record metadata correspondingly. (closes #1720)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>