### PR TITLE
records: centralise local files on EOS for cms-tools-vm-image

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
@@ -19,6 +19,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3a5d1ca5041a83a0db1c835b6e7af18d46e2ceb0", 
+      "size": 9159569, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/CMS-OpenData-1.0.0-rc7.ova"
+    }
+  ], 
   "methodology": {
     "description": "The contextualisation scripts used for setting up the CMS VM images are available at", 
     "links": [
@@ -87,6 +95,26 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:36392732a8f4b391ff2dab0e00cbbcbb8f778be7", 
+      "size": 182, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/cernvm-script"
+    }, 
+    {
+      "checksum": "sha1:63c718d5106c3a4a1482d46f37f7ef2db21f7f0f", 
+      "size": 3756, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/cms-user-data.txt"
+    }, 
+    {
+      "checksum": "sha1:3248e8702168d4f3389eee14e31df330e27089ac", 
+      "size": 153, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/opendata-desktop-settings"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "249", 
   "relations": [


### PR DESCRIPTION
* Centralises local files on EOS for cms-tools-vm-image records.
  Enriches record metadata correspondingly. (closes #1719)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>