### PR TITLE
records: centralise local files on EOS for cms-tools-vm-image 2011

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
@@ -19,6 +19,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:7ea617ce250cb3794c6e3b57a0eff38c15fa5938", 
+      "size": 18145280, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2011/CMS-Open-Data-1.2.0.ova"
+    }
+  ], 
   "methodology": {
     "description": "The contextualisation scripts used for setting up the CMS VM images are available at", 
     "links": [
@@ -87,6 +95,26 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:36392732a8f4b391ff2dab0e00cbbcbb8f778be7", 
+      "size": 182, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2011/cernvm-script"
+    }, 
+    {
+      "checksum": "sha1:63c718d5106c3a4a1482d46f37f7ef2db21f7f0f", 
+      "size": 3756, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2011/cms-user-data.txt"
+    }, 
+    {
+      "checksum": "sha1:3248e8702168d4f3389eee14e31df330e27089ac", 
+      "size": 153, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2011/opendata-desktop-settings"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "251", 
   "relations": [


### PR DESCRIPTION
* Centralises local files on EOS for cms-tools-vm-image-Run2011A records.
  Enriches record metadata correspondingly. (closes #1718)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>