### PR TITLE
records: centralise local files on EOS for Open Data Instructions

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-open-data-instructions.json
+++ b/cernopendata/modules/fixtures/data/records/cms-open-data-instructions.json
@@ -19,6 +19,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:4cb6abb14d8c1a5524e8035ccfeeea740a1174ea", 
+      "size": 24607321, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/outreach-exercise-2010/OutreachExercise2010.m4v"
+    }
+  ], 
   "language": "English", 
   "publisher": "CERN Open Data Portal", 
   "recid": "55", 
@@ -209,6 +217,98 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d136b1913319f79aea6bb7db6b904845c2a74818", 
+      "size": 2408298, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/WorkGroup5_OpenData.pdf"
+    }, 
+    {
+      "checksum": "sha1:61e6768011c457a700908e4dbc8f2a9221b81665", 
+      "size": 222926, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/1_ClassroomActivitiesVisualisation.pdf"
+    }, 
+    {
+      "checksum": "sha1:19628d1958945a3a94dfafe1e3f77426805d98f1", 
+      "size": 335854, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/1_VisualisationOfEventsTutorial.pdf"
+    }, 
+    {
+      "checksum": "sha1:0a72dd8bae4e64dcfc62d880fa1eaf418af2f96d", 
+      "size": 1210860, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/2_ExcelExerciseForStudents.pdf"
+    }, 
+    {
+      "checksum": "sha1:bdde3ebbd3845b7f1bb66ddbab3aa2d18254d3aa", 
+      "size": 782744, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/3_DiMuonHistogramExcelInstructions.pdf"
+    }, 
+    {
+      "checksum": "sha1:06803250e7d3aaa177ee2962529b18c221cd830c", 
+      "size": 1570300, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/4_DiMuonHistogramSciLABInstructions.pdf"
+    }, 
+    {
+      "checksum": "sha1:fea8c4be798063229cb097b6d4e48896ef4f89f2", 
+      "size": 45035, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/4_DiMuonTeacherHandout.pdf"
+    }, 
+    {
+      "checksum": "sha1:f534d22ed0740f85a82b3f2f9c351899967535b7", 
+      "size": 578131, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/5_SharingJupyterNotebookInstructions.pdf"
+    }, 
+    {
+      "checksum": "sha1:8bd7cc1eee573d421ffd0de208e3b54988d81dd9", 
+      "size": 288293, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/1_ClassroomActivitiesVisualisation.docx"
+    }, 
+    {
+      "checksum": "sha1:733b858a39169fb67cbb084630c511a17e0aa66b", 
+      "size": 460846, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/1_VisualisationOfEventsTutorial.docx"
+    }, 
+    {
+      "checksum": "sha1:20ee1263545668a20d165f8ec592f70a9ef6f1bb", 
+      "size": 1836092, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/2_ExcelExerciseForStudents.docx"
+    }, 
+    {
+      "checksum": "sha1:27f3f91cc39cae7e224babaa3c496afc8d1f4590", 
+      "size": 931189, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/3_DiMuonHistogramExcelInstructions.docx"
+    }, 
+    {
+      "checksum": "sha1:53ef32733e8560002b57933684dbec2577ef8c21", 
+      "size": 1837202, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/4_DiMuonHistogramSciLABInstructions.docx"
+    }, 
+    {
+      "checksum": "sha1:7b1220171d300d605b2d4eda96efcc90c6bc6cbf", 
+      "size": 61443, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/4_DiMuonTeacherHandout.docx"
+    }, 
+    {
+      "checksum": "sha1:0c0ad5f73fd6dfa1f813cc1ab6ca46465fababa2", 
+      "size": 699329, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/5_SharingJupyterNotebookInstructions.docx"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "72", 
   "title": "Worksheets and instructions for schools prepared during the High School Teacher Programme 2016", 


### PR DESCRIPTION
* Centralises local files on EOS for CMS-Open-Data-Instructions records.
  Enriches record metadata correspondingly. (closes #1710)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>