### PR TITLE
records: centralise local files on EOS for CMS Luminosity Info

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-luminosity-information.json
+++ b/cernopendata/modules/fixtures/data/records/cms-luminosity-information.json
@@ -20,6 +20,20 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.WTXQ.PCF8", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c101dbd1bea6c4a0f4e0b02344693ff3c5d0272f", 
+      "size": 63840, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2010/2010lumi.txt"
+    }, 
+    {
+      "checksum": "sha1:47372391f417cec0e886fd912fccd37131530b1a", 
+      "size": 21429, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2010/2010RunBlumi.txt"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "1050", 
   "run_period": "Run2010B", 
@@ -54,6 +68,32 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.FPPH.Q7S2", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:57e6f5c4d46ac496ac1536f39e9a2b8e07d2d527", 
+      "size": 49349, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2011/2011lumi.txt"
+    }, 
+    {
+      "checksum": "sha1:64a5b4e899a1d25166d62d58c17444144e18fea7", 
+      "size": 33867, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2011/2011RunAlumi.txt"
+    }, 
+    {
+      "checksum": "sha1:eff396954645741f78e8cfa6e2d2b875aac8e3c5", 
+      "size": 13708129, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2011/2011lumibyls.csv"
+    }, 
+    {
+      "checksum": "sha1:7e144b4b568a336d22f2915b9fac22fc4c3cc1e2", 
+      "size": 41460, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2011/prescale2011.txt"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "1051", 
   "run_period": "Run2011A", 


### PR DESCRIPTION
* Centralises local files on EOS for CMS-Luminosity-Information records.
  Enriches record metadata correspondingly. (closes #1708)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>