### PR TITLE
records: centralise local files on EOS for CMS L1 Trigger Info

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-l1-trigger-information-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-l1-trigger-information-Run2011A.json
@@ -52,6 +52,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:358ff14572147a14c96dc995539c2088606a493c", 
+      "size": 1320569, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v0_L1T_Scales_20101224_Imp0_0x101e.html"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "3701", 
   "run_period": "Run2011A", 
@@ -87,6 +95,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8c02402d42ce269feaa94f600ddcdfff3ca00377", 
+      "size": 2143499, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v1_L1T_Scales_20101224_Imp0_0x101f.html"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "3702", 
   "run_period": "Run2011A", 
@@ -122,6 +138,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:488c6ebc619727271d5e1b877498c3e56c3f32e4", 
+      "size": 2132671, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v2_L1T_Scales_20101224_Imp0_0x1020.html"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "3703", 
   "run_period": "Run2011A", 
@@ -157,6 +181,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5ea0b594b96bb5c4902856455310413e976f901a", 
+      "size": 2144756, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v3_L1T_Scales_20101224_Imp0_0x1021.html"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "3704", 
   "run_period": "Run2011A", 
@@ -192,6 +224,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5400c3fe94796cb98c6bf40c8d7758c70d387b3c", 
+      "size": 2266449, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v4_L1T_Scales_20101224_Imp0_0x1022.html"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "3705", 
   "run_period": "Run2011A", 
@@ -227,6 +267,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6b0df268e06b43ac7f7dd9431ad3106b77623b25", 
+      "size": 2346311, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v5_L1T_Scales_20101224_Imp0_0x1023.html"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "3706", 
   "run_period": "Run2011A", 
@@ -262,6 +310,14 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a2913c6b9c22af214712cd880964310347544107", 
+      "size": 2408843, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v6_L1T_Scales_20101224_Imp0_0x1024.html"
+    }
+  ], 
   "publisher": "CERN Open Data Portal", 
   "recid": "3707", 
   "run_period": "Run2011A", 


### PR DESCRIPTION
* Centralises local files on EOS for CMS-Trigger-Information records.
  Enriches record metadata correspondingly. (closes #1706)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>