### PR TITLE
records: centralise local files on EOS for CMS Derived PATtuples

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana.json
@@ -60,6 +60,12 @@
       "size": 17184641930, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/PATtuples/Mu_PAT_data_500files_6.root"
+    }, 
+    {
+      "checksum": "sha1:8052ce9c1dce19e177bd903e167f5db0c6e33b09", 
+      "size": 558, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/PATtuples/file-indexes/CMS_Run2010B_Mu_PATtuples_file_index.txt"
     }
   ], 
   "license": {
@@ -181,6 +187,12 @@
       "size": 19878754480, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/PATtuples/Electron_PAT_data_500files_6.root"
+    }, 
+    {
+      "checksum": "sha1:afdd7a69b341ccb1f2e0db820680a29e016e4a5a", 
+      "size": 630, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/PATtuples/file-indexes/CMS_Run2010B_Electron_PATtuples_file_index.txt"
     }
   ], 
   "license": {


### PR DESCRIPTION
* Centralises local files on EOS for cms-derived-pattuples-ana records.
  Enriches record metadata correspondingly. (closes #1701)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>