### PR TITLE
records: centralise local files on EOS for CMS Derived PATtuples 11

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana-Run2011A.json
@@ -348,6 +348,12 @@
       "size": 184750662, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/PATtuples/Mu_PAT_data_500files_54.root"
+    }, 
+    {
+      "checksum": "sha1:284ed728c5d2d499dcc847768b82395f36d848b3", 
+      "size": 5400, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/PATtuples/file-indexes/CMS_Run2011A_DoubleMu_PATtuples_file_index.txt"
     }
   ], 
   "license": {
@@ -841,6 +847,12 @@
       "size": 5820205562, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/PATtuples/Electron_PAT_data_500files_68.root"
+    }, 
+    {
+      "checksum": "sha1:1a488a7298f9494bd15d1fbce29320c6d997ce98", 
+      "size": 7616, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/PATtuples/file-indexes/CMS_Run2011A_DoubleElectron_PATtuples_file_index.txt"
     }
   ], 
   "license": {


### PR DESCRIPTION
* Centralises local files on EOS for cms-derived-pattuples-ana-Run2011A records.
  Enriches record metadata correspondingly. (closes #1700)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>