### PR TITLE
records: centralise local files on EOS for cms-hamburg-files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-hamburg-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-hamburg-files.json
@@ -26,6 +26,14 @@
     "size": 17033333
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9befc2dcd08cace159db2357b91c73d08eff8e35", 
+      "size": 17033333, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/data.root"
+    }
+  ], 
   "publisher": "International Particle Physics Outreach Group", 
   "recid": "203", 
   "run_period": "Run2011A", 
@@ -74,6 +82,14 @@
     "size": 5492946
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9713d3bc9e1b48b50a8d56820e70f448d7bd165f", 
+      "size": 5492946, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/ttbar.root"
+    }
+  ], 
   "publisher": "International Particle Physics Outreach Group", 
   "recid": "204", 
   "run_period": "Run2011A", 
@@ -122,6 +138,14 @@
     "size": 5019104
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:e30dc4216ec4e5f9890aa7fdef4db775f3e6e634", 
+      "size": 5019104, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/wjets.root"
+    }
+  ], 
   "publisher": "International Particle Physics Outreach Group", 
   "recid": "205", 
   "run_period": "Run2011A", 
@@ -170,6 +194,14 @@
     "size": 4776709
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9004e67beea2dd7be0c703bc01afde6a295c990b", 
+      "size": 4776709, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/dy.root"
+    }
+  ], 
   "publisher": "International Particle Physics Outreach Group", 
   "recid": "206", 
   "run_period": "Run2011A", 
@@ -218,6 +250,14 @@
     "size": 338200
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:488d2d15c5f2e1c3446523f7da8b9a1c83340a64", 
+      "size": 338200, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/ww.root"
+    }
+  ], 
   "publisher": "International Particle Physics Outreach Group", 
   "recid": "207", 
   "run_period": "Run2011A", 
@@ -266,6 +306,14 @@
     "size": 264045
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:110f3ff2c10f947f78832d4ca25c88984450dbbe", 
+      "size": 264045, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/wz.root"
+    }
+  ], 
   "publisher": "International Particle Physics Outreach Group", 
   "recid": "208", 
   "run_period": "Run2011A", 
@@ -314,6 +362,14 @@
     "size": 217945
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ad1b1b7a7dda1cea99cbb302bb63267aabf41380", 
+      "size": 217945, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/zz.root"
+    }
+  ], 
   "publisher": "International Particle Physics Outreach Group", 
   "recid": "209", 
   "run_period": "Run2011A", 
@@ -362,6 +418,14 @@
     "size": 501641
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:db7ab560518387e9a5d01c9b3a65e3d48076b594", 
+      "size": 501641, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/single_top.root"
+    }
+  ], 
   "publisher": "International Particle Physics Outreach Group", 
   "recid": "210", 
   "run_period": "Run2011A", 
@@ -410,6 +474,14 @@
     "size": 24651
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8f81d597c42222210ea881695666e3dbd6db49c2", 
+      "size": 24651, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/qcd.root"
+    }
+  ], 
   "publisher": "International Particle Physics Outreach Group", 
   "recid": "211", 
   "run_period": "Run2011A", 
@@ -457,6 +529,14 @@
     "size": 33730560
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b703c0494e85b6914ef2aa960f01830e19ce97a2", 
+      "size": 33730560, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/HEPTutorial_0.tar"
+    }
+  ], 
   "publisher": "International Particle Physics Outreach Group", 
   "recid": "212", 
   "run_period": "Run2011A", 


### PR DESCRIPTION
* Centralises local files on EOS for cms-hamburg-files records.
  Enriches record metadata correspondingly. (closes #1704)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>