### PR TITLE
records: centralise local files on EOS for atlas-all-samples

### DIFF
--- a/cernopendata/modules/fixtures/data/records/atlas-all-samples.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-all-samples.json
@@ -28,6 +28,13 @@
       "size": 5982176723, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/complete_set_of_ATLAS_open_data_samples_July_2016.zip"
+    }, 
+    {
+      "checksum": "sha1:722264ff62d4854cd6efba51da93548361b2861c", 
+      "description": "complete_set_of_ATLAS_open_data_samples_July_2016 file index", 
+      "size": 127, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/complete_set_of_ATLAS_open_data_samples_July_2016_file_index.txt"
     }
   ], 
   "license": {


### PR DESCRIPTION
* Centralises local files on EOS for atlas-all-samples records.
  Enriches record metadata correspondingly. (closes #1689)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>