### PR TITLE
records: centralise local files on EOS for atlas-derived-datasets

### DIFF
--- a/cernopendata/modules/fixtures/data/records/atlas-derived-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-derived-datasets.json
@@ -139,6 +139,13 @@
       "size": 8297961, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1T.zip"
+    }, 
+    {
+      "checksum": "sha1:0e939950342474f3bd3e35188a8b1a6c54fc8efe", 
+      "description": "ATLAS Masterclass WPath 2014 dataset 1 file index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_1_file_index.txt"
     }
   ], 
   "keywords": [
@@ -304,6 +311,13 @@
       "size": 8765904, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2T.zip"
+    }, 
+    {
+      "checksum": "sha1:19f9dd913e3909a8b0b271eb6c68f1a1b91b7635", 
+      "description": "ATLAS Masterclass WPath 2014 dataset 2 file index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_2_file_index.txt"
     }
   ], 
   "keywords": [
@@ -469,6 +483,13 @@
       "size": 8032391, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3T.zip"
+    }, 
+    {
+      "checksum": "sha1:9458f35cfba943ab50ace18067632e7f7350f897", 
+      "description": "ATLAS Masterclass WPath 2014 dataset 3 file index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_3_file_index.txt"
     }
   ], 
   "keywords": [
@@ -634,6 +655,13 @@
       "size": 8305498, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4T.zip"
+    }, 
+    {
+      "checksum": "sha1:baabd34e5eb1eca0df8450eb3f49d94251927689", 
+      "description": "ATLAS Masterclass WPath 2014 dataset 4 file index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_4_file_index.txt"
     }
   ], 
   "keywords": [
@@ -799,6 +827,13 @@
       "size": 8198176, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5T.zip"
+    }, 
+    {
+      "checksum": "sha1:e111b9f1495f05e0bae75d7fa02893328500ca65", 
+      "description": "ATLAS Masterclass WPath 2014 dataset 5 file index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_5_file_index.txt"
     }
   ], 
   "keywords": [
@@ -964,6 +999,13 @@
       "size": 8637499, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6T.zip"
+    }, 
+    {
+      "checksum": "sha1:4ba0cd08395b25272d5d69b261711fbef169174a", 
+      "description": "ATLAS Masterclass WPath 2014 dataset 6 file index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_6_file_index.txt"
     }
   ], 
   "keywords": [
@@ -1129,6 +1171,13 @@
       "size": 12512876, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1T.zip"
+    }, 
+    {
+      "checksum": "sha1:ae01e8162582ac968c0ab905a3f428b002121a9b", 
+      "description": "ATLAS Masterclass WPath 2015 dataset 1 file\n      index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_1_file_index.txt"
     }
   ], 
   "keywords": [
@@ -1294,6 +1343,13 @@
       "size": 11821966, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2T.zip"
+    }, 
+    {
+      "checksum": "sha1:b91bdb77921a1f47a7c95a75a3c9a9260b8c3266", 
+      "description": "ATLAS Masterclass WPath 2015 dataset 2 file\n      index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_2_file_index.txt"
     }
   ], 
   "keywords": [
@@ -1459,6 +1515,13 @@
       "size": 10964115, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3T.zip"
+    }, 
+    {
+      "checksum": "sha1:9194cb011e2a52122b07f3d85124ec81b92300e4", 
+      "description": "ATLAS Masterclass WPath 2015 dataset 3 file\n      index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_3_file_index.txt"
     }
   ], 
   "keywords": [
@@ -1624,6 +1687,13 @@
       "size": 12003126, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4T.zip"
+    }, 
+    {
+      "checksum": "sha1:afef1556624720f659aa1bf1eb65baa4d83d1ee8", 
+      "description": "ATLAS Masterclass WPath 2015 dataset 4 file\n      index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_4_file_index.txt"
     }
   ], 
   "keywords": [
@@ -1789,6 +1859,13 @@
       "size": 12183104, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5T.zip"
+    }, 
+    {
+      "checksum": "sha1:9e326b1bd615ea6141c253ef52db0cdb643daf9e", 
+      "description": "ATLAS Masterclass WPath 2015 dataset 5 file\n      index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_5_file_index.txt"
     }
   ], 
   "keywords": [
@@ -1954,6 +2031,13 @@
       "size": 10245624, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6T.zip"
+    }, 
+    {
+      "checksum": "sha1:f49dca3c4c46f801ea6301215c1957cee840abed", 
+      "description": "ATLAS Masterclass WPath 2015 dataset 6 file\n      index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_6_file_index.txt"
     }
   ], 
   "keywords": [
@@ -2119,6 +2203,13 @@
       "size": 11538696, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7T.zip"
+    }, 
+    {
+      "checksum": "sha1:863081e06706bb91b277c14ec0e52839d271c769", 
+      "description": "ATLAS Masterclass WPath 2015 dataset 7 file\n      index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_7_file_index.txt"
     }
   ], 
   "keywords": [
@@ -2284,6 +2375,13 @@
       "size": 11125793, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8T.zip"
+    }, 
+    {
+      "checksum": "sha1:4591a6340caaba53e7def12c7844e93a33c8f49c", 
+      "description": "ATLAS Masterclass WPath 2015 dataset 8 file\n      index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_8_file_index.txt"
     }
   ], 
   "keywords": [
@@ -2449,6 +2547,13 @@
       "size": 10890972, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9T.zip"
+    }, 
+    {
+      "checksum": "sha1:371f5619044a3752d5320591bf4ed890df02d0f2", 
+      "description": "ATLAS Masterclass WPath 2015 dataset 9 file\n      index", 
+      "size": 1700, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_9_file_index.txt"
     }
   ], 
   "keywords": [
@@ -2614,6 +2719,13 @@
       "size": 11837451, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10T.zip"
+    }, 
+    {
+      "checksum": "sha1:e1791e69339e27898e8b86715c0a89ba3a0f4f53", 
+      "description": "ATLAS Masterclass WPath 2015 dataset 10 file\n      index", 
+      "size": 1740, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_10_file_index.txt"
     }
   ], 
   "keywords": [
@@ -2779,6 +2891,13 @@
       "size": 11492346, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11T.zip"
+    }, 
+    {
+      "checksum": "sha1:138561889b4a7c692c81a25a8c4e27b79137f523", 
+      "description": "ATLAS Masterclass WPath 2015 dataset 11 file\n      index", 
+      "size": 1740, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_11_file_index.txt"
     }
   ], 
   "keywords": [
@@ -2944,6 +3063,13 @@
       "size": 12511530, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12T.zip"
+    }, 
+    {
+      "checksum": "sha1:b4e81bab8ffb298170b3ef3497f8ae486da2d605", 
+      "description": "ATLAS Masterclass WPath 2015 dataset 12 file\n      index", 
+      "size": 1740, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_12_file_index.txt"
     }
   ], 
   "keywords": [
@@ -3109,6 +3235,13 @@
       "size": 30257271, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:2e4cd6794a2961d86cc0f330e759bd5154ac1d53", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 1 file\n      index", 
+      "size": 1780, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_1_file_index.txt"
     }
   ], 
   "keywords": [
@@ -3274,6 +3407,13 @@
       "size": 32936560, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:2e5689eafbd3833177f84ef8e360d9b179068531", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 2 file\n      index", 
+      "size": 1780, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_2_file_index.txt"
     }
   ], 
   "keywords": [
@@ -3439,6 +3579,13 @@
       "size": 34328077, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:8f24e91338b32308302b704aaecf8205fe712e2a", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 3 file\n      index", 
+      "size": 1780, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_3_file_index.txt"
     }
   ], 
   "keywords": [
@@ -3604,6 +3751,13 @@
       "size": 28889206, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:18d751acc5de0997a217de9421369c24291f7c5b", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 4 file\n      index", 
+      "size": 1780, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_4_file_index.txt"
     }
   ], 
   "keywords": [
@@ -3769,6 +3923,13 @@
       "size": 29727784, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:e63b8364308d1dfe994e0590fd1a495a78662e4e", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 5 file\n      index", 
+      "size": 1780, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_5_file_index.txt"
     }
   ], 
   "keywords": [
@@ -3934,6 +4095,13 @@
       "size": 31905174, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:17a8c7cebda71a6fdf97548f0d24cd182c731462", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 6 file\n      index", 
+      "size": 1780, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_6_file_index.txt"
     }
   ], 
   "keywords": [
@@ -4099,6 +4267,13 @@
       "size": 33864284, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:15a2c6b407f608a176a5d24161694c31d9830135", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 7 file\n      index", 
+      "size": 1780, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_7_file_index.txt"
     }
   ], 
   "keywords": [
@@ -4264,6 +4439,13 @@
       "size": 31765379, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:6b0d554e95ce8540ae186a57759a1b99ceb8d0d5", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 8 file\n      index", 
+      "size": 1780, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_8_file_index.txt"
     }
   ], 
   "keywords": [
@@ -4429,6 +4611,13 @@
       "size": 29130389, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:630d308dfce0ed75f681b64724eb4e2188b47227", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 9 file\n      index", 
+      "size": 1780, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_9_file_index.txt"
     }
   ], 
   "keywords": [
@@ -4594,6 +4783,13 @@
       "size": 29231827, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:980314b47231068c0eddfc5c1f94e8c6323014aa", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 10 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_10_file_index.txt"
     }
   ], 
   "keywords": [
@@ -4759,6 +4955,13 @@
       "size": 28214087, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:4f0bf7b6930436cd7730b17c8cb6f9a2d9361b6e", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 11 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_11_file_index.txt"
     }
   ], 
   "keywords": [
@@ -4924,6 +5127,13 @@
       "size": 30559845, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:a0baa82c95bfe51067dc43ac0540244a667765d8", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 12 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_12_file_index.txt"
     }
   ], 
   "keywords": [
@@ -5089,6 +5299,13 @@
       "size": 31319897, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:8139cc68b8114240a0b3b0521d911282b6e55a7c", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 13 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_13_file_index.txt"
     }
   ], 
   "keywords": [
@@ -5254,6 +5471,13 @@
       "size": 29687975, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:dd4821bde3722e654126d03c662932fee9e174ec", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 14 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_14_file_index.txt"
     }
   ], 
   "keywords": [
@@ -5419,6 +5643,13 @@
       "size": 28278485, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:62776aaba5d264ef5c7775f23270180eb1fdd0cb", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 15 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_15_file_index.txt"
     }
   ], 
   "keywords": [
@@ -5584,6 +5815,13 @@
       "size": 28463904, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:f37829bc4069ef510544ad3c7f62055971ff271e", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 16 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_16_file_index.txt"
     }
   ], 
   "keywords": [
@@ -5749,6 +5987,13 @@
       "size": 27936425, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:9432088cd5da72e3684c4f3ef128d16dcc72e7ea", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 17 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_17_file_index.txt"
     }
   ], 
   "keywords": [
@@ -5914,6 +6159,13 @@
       "size": 28885465, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:a2b8a534f10577127ac01ba55fb8035db35c3a8d", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 18 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_18_file_index.txt"
     }
   ], 
   "keywords": [
@@ -6079,6 +6331,13 @@
       "size": 27873043, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:aa46e6d6f0f999b861268b6d8180816ba5d2d067", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 19 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_19_file_index.txt"
     }
   ], 
   "keywords": [
@@ -6244,6 +6503,13 @@
       "size": 28799653, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:ba8afd4280353328cc93d19c0980143e1f73d4af", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 20 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_20_file_index.txt"
     }
   ], 
   "keywords": [
@@ -6409,6 +6675,13 @@
       "size": 30556033, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:ec0bd3a4281303d33e39a8aa57f11bf98a5ea7a6", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 21 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_21_file_index.txt"
     }
   ], 
   "keywords": [
@@ -6574,6 +6847,13 @@
       "size": 29150470, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:cc3c0d1859bae8d749b46887189e5901228775f9", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 22 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_22_file_index.txt"
     }
   ], 
   "keywords": [
@@ -6739,6 +7019,13 @@
       "size": 30512962, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:8d34cd9d9ccd6e04c60ba08ac850a767b76b80b6", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 23 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_23_file_index.txt"
     }
   ], 
   "keywords": [
@@ -6904,6 +7191,13 @@
       "size": 27402723, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:798aa415677d73930155afdfdbf28dc8a385c916", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 24 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_24_file_index.txt"
     }
   ], 
   "keywords": [
@@ -7069,6 +7363,13 @@
       "size": 25819134, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:21f51eace6cd03b7e1ad086b9ed5b425130e9be3", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 25 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_25_file_index.txt"
     }
   ], 
   "keywords": [
@@ -7234,6 +7535,13 @@
       "size": 28281691, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:8b86f6d8e90b08475cc5530c820470e1e2ecf8e4", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 26 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_26_file_index.txt"
     }
   ], 
   "keywords": [
@@ -7399,6 +7707,13 @@
       "size": 27491162, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:eca7fcd0135a6c8e4b44c5566078f57603dfb691", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 27 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_27_file_index.txt"
     }
   ], 
   "keywords": [
@@ -7564,6 +7879,13 @@
       "size": 26618226, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:0789905c2fd72f8168fad1ca1bb9e73b67155244", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 28 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_28_file_index.txt"
     }
   ], 
   "keywords": [
@@ -7729,6 +8051,13 @@
       "size": 32668838, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:d84f5e76e97d5f33de89cffc669080ed3504d39f", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 29 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_29_file_index.txt"
     }
   ], 
   "keywords": [
@@ -7894,6 +8223,13 @@
       "size": 29107705, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:9a148ef491aa24ce3e38819428f461367bf6ddcf", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 30 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_30_file_index.txt"
     }
   ], 
   "keywords": [
@@ -8059,6 +8395,13 @@
       "size": 31352140, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:17d95e1592c4698aa3e70eae21c9ccd991d60f58", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 31 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_31_file_index.txt"
     }
   ], 
   "keywords": [
@@ -8224,6 +8567,13 @@
       "size": 29925397, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:7f048f83ed52158e32e09366c34eba8be99f1e87", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 32 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_32_file_index.txt"
     }
   ], 
   "keywords": [
@@ -8389,6 +8739,13 @@
       "size": 28236656, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:659b0fd0dcbe85dbb82af5c47887396016c2f928", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 33 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_33_file_index.txt"
     }
   ], 
   "keywords": [
@@ -8554,6 +8911,13 @@
       "size": 27840209, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:6cb709ad361941d79a1e19a0d0cf79a8987d251d", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 34 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_34_file_index.txt"
     }
   ], 
   "keywords": [
@@ -8719,6 +9083,13 @@
       "size": 27662345, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:8d2c79fb300f8a2b98b326790c4eccd3c7bdb540", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 35 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_35_file_index.txt"
     }
   ], 
   "keywords": [
@@ -8884,6 +9255,13 @@
       "size": 27926551, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:66e8b679a551005812fc59e17f0a0e3e1a6a9112", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 36 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_36_file_index.txt"
     }
   ], 
   "keywords": [
@@ -9049,6 +9427,13 @@
       "size": 27905291, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupT.zip"
+    }, 
+    {
+      "checksum": "sha1:66f59db29957b2e61b5f6cef083ca1049d853c11", 
+      "description": "ATLAS Masterclass ZPath 2015 dataset 37 file\n      index", 
+      "size": 1800, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_37_file_index.txt"
     }
   ], 
   "keywords": [
@@ -9108,6 +9493,13 @@
       "size": 746284873, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/Data/DataEgamma.root"
+    }, 
+    {
+      "checksum": "sha1:43be755b0921911f9f6e6fc8c4cd66cdb26b29b6", 
+      "description": "DataEgamma file index", 
+      "size": 94, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/DataEgamma_file_index.txt"
     }
   ], 
   "license": {
@@ -9181,6 +9573,13 @@
       "size": 619800948, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/Data/DataMuons.root"
+    }, 
+    {
+      "checksum": "sha1:0e3c8b09b2ec2d03cd93c8ba4aef3dfdc1cafd2d", 
+      "description": "DataMuons file index", 
+      "size": 93, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/DataMuons_file_index.txt"
     }
   ], 
   "license": {


### PR DESCRIPTION
* Centralises local files on EOS for atlas-derived-datasets records.
  Enriches record metadata correspondingly. (closes #1690)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>