### PR TITLE
records: centralise local files on EOS for ALICE-Learning-Resources

### DIFF
--- a/cernopendata/modules/fixtures/data/records/alice-learning-resources.json
+++ b/cernopendata/modules/fixtures/data/records/alice-learning-resources.json
@@ -16,6 +16,14 @@
     ]
   }, 
   "experiment": "ALICE", 
+  "files": [
+    {
+      "checksum": "sha1:2a6d0a372b14f4bccf62b5a658d66c3a591915d4", 
+      "size": 403277, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/alice/documentation/1103106_20-A4-at-144-dpi.jpg"
+    }
+  ], 
   "keywords": [
     "masterclasses", 
     "external resource"


### PR DESCRIPTION
* Centralises local files on EOS for ALICE-Learning-Resources records.
  Enriches record metadata correspondingly. (closes #1687)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>