### PR TITLE
records: centralise local files on EOS for atlas-simulated-datasets

### DIFF
--- a/cernopendata/modules/fixtures/data/records/atlas-simulated-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-simulated-datasets.json
@@ -32,6 +32,13 @@
       "size": 64727099, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_105985.WW.root"
+    }, 
+    {
+      "checksum": "sha1:6b0362da276817f9e7e76dc19e200d17650af97e", 
+      "description": "mc_105985.WW file index", 
+      "size": 94, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_105985.WW_file_index.txt"
     }
   ], 
   "license": {
@@ -108,6 +115,13 @@
       "size": 19849729, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_105986.ZZ.root"
+    }, 
+    {
+      "checksum": "sha1:45c47263faa2f32af26647edc2d3c837f1fd8a0c", 
+      "description": "mc_105986.ZZ file index", 
+      "size": 94, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_105986.ZZ_file_index.txt"
     }
   ], 
   "license": {
@@ -184,6 +198,13 @@
       "size": 69459481, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_105987.WZ.root"
+    }, 
+    {
+      "checksum": "sha1:51469f8fb8744139f796cf687fd88a23fb212d74", 
+      "description": "mc_105987.WZ file index", 
+      "size": 94, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_105987.WZ_file_index.txt"
     }
   ], 
   "license": {
@@ -260,6 +281,13 @@
       "size": 21637659, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110090.stop_tchan_top.root"
+    }, 
+    {
+      "checksum": "sha1:5dae7933cd531a971d9e5918a9398c9feb3f76e1", 
+      "description": "mc_110090.stop_tchan_top file index", 
+      "size": 106, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110090.stop_tchan_top_file_index.txt"
     }
   ], 
   "license": {
@@ -336,6 +364,13 @@
       "size": 14509120, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110091.stop_tchan_antitop.root"
+    }, 
+    {
+      "checksum": "sha1:e9fd5833d406a12a438415ee26bdf09e78661d2d", 
+      "description": "mc_110091.stop_tchan_antitop file index", 
+      "size": 110, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110091.stop_tchan_antitop_file_index.txt"
     }
   ], 
   "license": {
@@ -412,6 +447,13 @@
       "size": 15148662, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110119.stop_schan.root"
+    }, 
+    {
+      "checksum": "sha1:f9a7f7dbee4f1b8bdc785c08df93ef6c3a3b950c", 
+      "description": "mc_110119.stop_schan file index", 
+      "size": 102, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110119.stop_schan_file_index.txt"
     }
   ], 
   "license": {
@@ -488,6 +530,13 @@
       "size": 26422422, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110140.stop_wtchan.root"
+    }, 
+    {
+      "checksum": "sha1:76b5a692f9f724d69e58bd60539863b94f13e3b2", 
+      "description": "mc_110140.stop_wtchan file index", 
+      "size": 103, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110140.stop_wtchan_file_index.txt"
     }
   ], 
   "license": {
@@ -564,6 +613,13 @@
       "size": 4389879, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110899.ZPrime400.root"
+    }, 
+    {
+      "checksum": "sha1:59b3536667a2fc4cd76bf86858874180c1afbeba", 
+      "description": "mc_110899.ZPrime400 file index", 
+      "size": 101, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110899.ZPrime400_file_index.txt"
     }
   ], 
   "license": {
@@ -640,6 +696,13 @@
       "size": 4765016, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110901.ZPrime500.root"
+    }, 
+    {
+      "checksum": "sha1:ad13d0e0a02830b960f89727356492af0e97d12a", 
+      "description": "mc_110901.ZPrime500 file index", 
+      "size": 101, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110901.ZPrime500_file_index.txt"
     }
   ], 
   "license": {
@@ -716,6 +779,13 @@
       "size": 5400815, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110902.ZPrime750.root"
+    }, 
+    {
+      "checksum": "sha1:be8e658e7a35ff33a09844ca2cd42fba32d1b27a", 
+      "description": "mc_110902.ZPrime750 file index", 
+      "size": 101, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110902.ZPrime750_file_index.txt"
     }
   ], 
   "license": {
@@ -792,6 +862,13 @@
       "size": 5678500, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110903.ZPrime1000.root"
+    }, 
+    {
+      "checksum": "sha1:65342d8a7a78d65f2abb6a4cb7f93f106ac9e8ce", 
+      "description": "mc_110903.ZPrime1000 file index", 
+      "size": 102, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110903.ZPrime1000_file_index.txt"
     }
   ], 
   "license": {
@@ -868,6 +945,13 @@
       "size": 5635939, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110904.ZPrime1250.root"
+    }, 
+    {
+      "checksum": "sha1:49fc84f300a72b06f3059fedf1f7ee8c829c5f04", 
+      "description": "mc_110904.ZPrime1250 file index", 
+      "size": 102, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110904.ZPrime1250_file_index.txt"
     }
   ], 
   "license": {
@@ -944,6 +1028,13 @@
       "size": 5474660, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110905.ZPrime1500.root"
+    }, 
+    {
+      "checksum": "sha1:2c54b2216ab29f870541da6272f1f3f0da592231", 
+      "description": "mc_110905.ZPrime1500 file index", 
+      "size": 102, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110905.ZPrime1500_file_index.txt"
     }
   ], 
   "license": {
@@ -1020,6 +1111,13 @@
       "size": 5241751, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110906.ZPrime1750.root"
+    }, 
+    {
+      "checksum": "sha1:7f0aa8c5f77d0629469e32ddccf7266cf1f98dd5", 
+      "description": "mc_110906.ZPrime1750 file index", 
+      "size": 102, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110906.ZPrime1750_file_index.txt"
     }
   ], 
   "license": {
@@ -1096,6 +1194,13 @@
       "size": 5000024, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110907.ZPrime2000.root"
+    }, 
+    {
+      "checksum": "sha1:22836dfb04723e84b1821436c6cdf9fbd2048c6a", 
+      "description": "mc_110907.ZPrime2000 file index", 
+      "size": 102, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110907.ZPrime2000_file_index.txt"
     }
   ], 
   "license": {
@@ -1172,6 +1277,13 @@
       "size": 4798092, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110908.ZPrime2250.root"
+    }, 
+    {
+      "checksum": "sha1:8f5e1480521d65780c512aa528e1669f4fe5db74", 
+      "description": "mc_110908.ZPrime2250 file index", 
+      "size": 102, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110908.ZPrime2250_file_index.txt"
     }
   ], 
   "license": {
@@ -1248,6 +1360,13 @@
       "size": 4610759, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110909.ZPrime2500.root"
+    }, 
+    {
+      "checksum": "sha1:e2fb15d972156c608bb0578edf583734ff7aaded", 
+      "description": "mc_110909.ZPrime2500 file index", 
+      "size": 102, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110909.ZPrime2500_file_index.txt"
     }
   ], 
   "license": {
@@ -1324,6 +1443,13 @@
       "size": 4408997, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110910.ZPrime3000.root"
+    }, 
+    {
+      "checksum": "sha1:28fa2d3eef8ecafb8a7ae913e775c26f80833496", 
+      "description": "mc_110910.ZPrime3000 file index", 
+      "size": 102, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110910.ZPrime3000_file_index.txt"
     }
   ], 
   "license": {
@@ -1400,6 +1526,13 @@
       "size": 5825184, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_117049.ttbar_had.root"
+    }, 
+    {
+      "checksum": "sha1:372e9a25d64ba0d9620933d044309afbb1af9e42", 
+      "description": "mc_117049.ttbar_had file index", 
+      "size": 101, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_117049.ttbar_had_file_index.txt"
     }
   ], 
   "license": {
@@ -1476,6 +1609,13 @@
       "size": 300090186, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_117050.ttbar_lep.root"
+    }, 
+    {
+      "checksum": "sha1:b222789b168ec73757861a972551ce6d15df3c65", 
+      "description": "mc_117050.ttbar_lep file index", 
+      "size": 101, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_117050.ttbar_lep_file_index.txt"
     }
   ], 
   "license": {
@@ -1552,6 +1692,13 @@
       "size": 966133549, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_147770.Zee.root"
+    }, 
+    {
+      "checksum": "sha1:0ec22fcf3672c4894cfc4a02077e2fd19eb5768c", 
+      "description": "mc_147770.Zee file index", 
+      "size": 95, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_147770.Zee_file_index.txt"
     }
   ], 
   "license": {
@@ -1628,6 +1775,13 @@
       "size": 946361551, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_147771.Zmumu.root"
+    }, 
+    {
+      "checksum": "sha1:db1963f48a5fd7593bb5cea95894dd0b1f547a2b", 
+      "description": "mc_147771.Zmumu file index", 
+      "size": 97, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_147771.Zmumu_file_index.txt"
     }
   ], 
   "license": {
@@ -1704,6 +1858,13 @@
       "size": 95788974, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_147772.Ztautau.root"
+    }, 
+    {
+      "checksum": "sha1:dca491d7f809386ecdcca3a2bb8538d95398cb0c", 
+      "description": "mc_147772.Ztautau file index", 
+      "size": 99, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_147772.Ztautau_file_index.txt"
     }
   ], 
   "license": {
@@ -1780,6 +1941,13 @@
       "size": 17580529, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_160155.ggH125_ZZ4lep.root"
+    }, 
+    {
+      "checksum": "sha1:5ca869a32b00263d9d0fb7621417d8bc635ae9f1", 
+      "description": "mc_160155.ggH125_ZZ4lep file index", 
+      "size": 105, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_160155.ggH125_ZZ4lep_file_index.txt"
     }
   ], 
   "license": {
@@ -1856,6 +2024,13 @@
       "size": 19380185, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_160205.VBFH125_ZZ4lep.root"
+    }, 
+    {
+      "checksum": "sha1:189d304908cc77bd57277710750752dc671eef10", 
+      "description": "mc_160205.VBFH125_ZZ4lep file index", 
+      "size": 106, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_160205.VBFH125_ZZ4lep_file_index.txt"
     }
   ], 
   "license": {
@@ -1932,6 +2107,13 @@
       "size": 13607410, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_161005.ggH125_WW2lep.root"
+    }, 
+    {
+      "checksum": "sha1:870a2dc7d73ccdd919694b9e52b891dc1f265567", 
+      "description": "mc_161005.ggH125_WW2lep file index", 
+      "size": 105, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_161005.ggH125_WW2lep_file_index.txt"
     }
   ], 
   "license": {
@@ -2008,6 +2190,13 @@
       "size": 15389694, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_161055.VBFH125_WW2lep.root"
+    }, 
+    {
+      "checksum": "sha1:3014b3b5d65a9cc16c87e1b4806f89fee819ac70", 
+      "description": "mc_161055.VBFH125_WW2lep file index", 
+      "size": 106, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_161055.VBFH125_WW2lep_file_index.txt"
     }
   ], 
   "license": {
@@ -2084,6 +2273,13 @@
       "size": 88002379, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167740.WenuWithB.root"
+    }, 
+    {
+      "checksum": "sha1:4762644180e4a4bf2d53d9f198cf243fb8d7cf7a", 
+      "description": "mc_167740.WenuWithB file index", 
+      "size": 101, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167740.WenuWithB_file_index.txt"
     }
   ], 
   "license": {
@@ -2160,6 +2356,13 @@
       "size": 305358713, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167741.WenuJetsBVeto.root"
+    }, 
+    {
+      "checksum": "sha1:bc613318223d2bae555453290608dffc52c039e1", 
+      "description": "mc_167741.WenuJetsBVeto file index", 
+      "size": 105, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167741.WenuJetsBVeto_file_index.txt"
     }
   ], 
   "license": {
@@ -2236,6 +2439,13 @@
       "size": 747210223, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167742.WenuNoJetsBVeto.root"
+    }, 
+    {
+      "checksum": "sha1:734e2c48e086b5d31ab49c8b96a6ffccc434e2bf", 
+      "description": "mc_167742.WenuNoJetsBVeto file index", 
+      "size": 107, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167742.WenuNoJetsBVeto_file_index.txt"
     }
   ], 
   "license": {
@@ -2312,6 +2522,13 @@
       "size": 86686414, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167743.WmunuWithB.root"
+    }, 
+    {
+      "checksum": "sha1:1c3a9725038565ad9b57abd8a0e5f489762f8728", 
+      "description": "mc_167743.WmunuWithB file index", 
+      "size": 102, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167743.WmunuWithB_file_index.txt"
     }
   ], 
   "license": {
@@ -2388,6 +2605,13 @@
       "size": 296131195, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167744.WmunuJetsBVeto.root"
+    }, 
+    {
+      "checksum": "sha1:734babf11fc95007d0532b2428d50f4ad7fef458", 
+      "description": "mc_167744.WmunuJetsBVeto file index", 
+      "size": 106, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167744.WmunuJetsBVeto_file_index.txt"
     }
   ], 
   "license": {
@@ -2464,6 +2688,13 @@
       "size": 689245060, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167745.WmunuNoJetsBVeto.root"
+    }, 
+    {
+      "checksum": "sha1:85af66043c143bc092e97beced849879104446ce", 
+      "description": "mc_167745.WmunuNoJetsBVeto file index", 
+      "size": 108, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167745.WmunuNoJetsBVeto_file_index.txt"
     }
   ], 
   "license": {
@@ -2540,6 +2771,13 @@
       "size": 12840353, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167746.WtaunuWithB.root"
+    }, 
+    {
+      "checksum": "sha1:8c0199782363ed8d89f66d5ba4841fad83e1b42e", 
+      "description": "mc_167746.WtaunuWithB file index", 
+      "size": 103, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167746.WtaunuWithB_file_index.txt"
     }
   ], 
   "license": {
@@ -2616,6 +2854,13 @@
       "size": 31642922, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167747.WtaunuJetsBVeto.root"
+    }, 
+    {
+      "checksum": "sha1:683ed792e12a674b0c28be1a28ea1c5baa98090d", 
+      "description": "mc_167747.WtaunuJetsBVeto file index", 
+      "size": 107, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167747.WtaunuJetsBVeto_file_index.txt"
     }
   ], 
   "license": {
@@ -2692,6 +2937,13 @@
       "size": 56349987, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167748.WtaunuNoJetsBVeto.root"
+    }, 
+    {
+      "checksum": "sha1:63b213f52777589b71981ee5a53b577a2e0fe246", 
+      "description": "mc_167748.WtaunuNoJetsBVeto file index", 
+      "size": 109, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167748.WtaunuNoJetsBVeto_file_index.txt"
     }
   ], 
   "license": {
@@ -2768,6 +3020,13 @@
       "size": 58248307, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173041.DYeeM08to15.root"
+    }, 
+    {
+      "checksum": "sha1:fc90de73e1112f3b90a26c19c819fa189cda66ba", 
+      "description": "mc_173041.DYeeM08to15 file index", 
+      "size": 103, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_173041.DYeeM08to15_file_index.txt"
     }
   ], 
   "license": {
@@ -2844,6 +3103,13 @@
       "size": 102182246, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173042.DYeeM15to40.root"
+    }, 
+    {
+      "checksum": "sha1:0e00c1719a2cde5173e166ed383b65757ef9678b", 
+      "description": "mc_173042.DYeeM15to40 file index", 
+      "size": 103, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_173042.DYeeM15to40_file_index.txt"
     }
   ], 
   "license": {
@@ -2920,6 +3186,13 @@
       "size": 76091119, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173043.DYmumuM08to15.root"
+    }, 
+    {
+      "checksum": "sha1:126995d67309c29ad08bc5b1db371aa7a9b89197", 
+      "description": "mc_173043.DYmumuM08to15 file index", 
+      "size": 105, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_173043.DYmumuM08to15_file_index.txt"
     }
   ], 
   "license": {
@@ -2996,6 +3269,13 @@
       "size": 105863682, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173044.DYmumuM15to40.root"
+    }, 
+    {
+      "checksum": "sha1:c77ca51a91b971ce5cacdb2b1c9dbf72cbcd124b", 
+      "description": "mc_173044.DYmumuM15to40 file index", 
+      "size": 105, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_173044.DYmumuM15to40_file_index.txt"
     }
   ], 
   "license": {
@@ -3072,6 +3352,13 @@
       "size": 1463082, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173045.DYtautauM08to15.root"
+    }, 
+    {
+      "checksum": "sha1:2af9e54ae009c365ed98dde1e3863d3149359e1b", 
+      "description": "mc_173045.DYtautauM08to15 file index", 
+      "size": 107, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_173045.DYtautauM08to15_file_index.txt"
     }
   ], 
   "license": {
@@ -3148,6 +3435,13 @@
       "size": 4629749, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173046.DYtautauM15to40.root"
+    }, 
+    {
+      "checksum": "sha1:0de82d71c3307d0302c4755c3e22f40c5dfed8c1", 
+      "description": "mc_173046.DYtautauM15to40 file index", 
+      "size": 107, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_173046.DYtautauM15to40_file_index.txt"
     }
   ], 
   "license": {


### PR DESCRIPTION
* Centralises local files on EOS for atlas-simulated-datasets records.
  Enriches record metadata correspondingly. (closes #1692)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>