### PR TITLE
records: centralise local files on EOS for CMS condition data 2011

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2011A.json
@@ -31,6 +31,12 @@
       "size": 11581209101, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/db/FT_53_LV5_AN1.tgz"
+    }, 
+    {
+      "checksum": "sha1:79e2deb030d88f054bd994f712a1ca018c0ed18b", 
+      "size": 145, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/db/file-indexes/CMS_Run2011A_db_FT_53_LV5_AN1_file_index.txt"
     }
   ], 
   "publisher": "CERN Open Data Portal", 
@@ -77,6 +83,12 @@
       "size": 165990768, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/db/START53_LV6A1.tgz"
+    }, 
+    {
+      "checksum": "sha1:a2f53ef78673c56e3ddae1d364fedc9aa45b6f61", 
+      "size": 145, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/db/file-indexes/CMS_Run2011A_db_START53_LV6A1_file_index.txt"
     }
   ], 
   "publisher": "CERN Open Data Portal", 


### PR DESCRIPTION
* Centralises local files on EOS for CMS condition data 2011 records.
  Enriches record metadata correspondingly. (closes #1696)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>