### PR TITLE
records: centralise local files on EOS for ATLAS-Higgs-Challenge-2014

### DIFF
--- a/cernopendata/modules/fixtures/data/records/atlas-higgs-challenge-2014.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-higgs-challenge-2014.json
@@ -163,6 +163,14 @@
   }, 
   "doi": "10.7483/OPENDATA.ATLAS.ZBP2.M5T8", 
   "experiment": "ATLAS", 
+  "files": [
+    {
+      "checksum": "sha1:639b1dbd97a709a739122a9a5dcd99b49d55d86c", 
+      "size": 65630848, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/higgs-challenge-2014/atlas-higgs-challenge-2014-v2.csv.gz"
+    }
+  ], 
   "links": [
     {
       "description": "Go to the Higgs Boson Machine Learning Challenge on Kaggle", 
@@ -243,6 +251,14 @@
   }, 
   "doi": "10.7483/OPENDATA.ATLAS.MQ5J.GHXA", 
   "experiment": "ATLAS", 
+  "files": [
+    {
+      "checksum": "sha1:91d16d6e44f837083f93513d42221c71c39e81a9", 
+      "size": 381738, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/higgs-challenge-2014/atlas-higgs-challenge-2014.pdf"
+    }
+  ], 
   "links": [
     {
       "description": "Go to the Higgs Boson Machine Learning Challenge on Kaggle", 
@@ -330,6 +346,14 @@
   }, 
   "doi": "10.7483/OPENDATA.ATLAS.DFGK.DB9U", 
   "experiment": "ATLAS", 
+  "files": [
+    {
+      "checksum": "sha1:29dbd473108a291e354b9913027714ca163e2686", 
+      "size": 24467, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/higgs-challenge-2014/HiggsML2014-1.0.tar.gz"
+    }
+  ], 
   "license": {
     "attribution": "GNU General Public License (GPL) version 3"
   }, 


### PR DESCRIPTION
* Centralises local files on EOS for ATLAS-Higgs-Challenge-2014 records.
  Enriches record metadata correspondingly. (closes #1691)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>