### PR TITLE
records: centralise local files on EOS for CMS-Learning-Resources

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-learning-resources.json
+++ b/cernopendata/modules/fixtures/data/records/cms-learning-resources.json
@@ -22,6 +22,38 @@
     ]
   }, 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d867d94b052d96842fe9d7315cc08ee3086c9e91", 
+      "size": 176942, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/TutorialDocu_3.pdf"
+    }, 
+    {
+      "checksum": "sha1:f7675608139f2f6fe149b091f6c49127f5c550c3", 
+      "size": 50493, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/TutorialExercisesPart1_2.pdf"
+    }, 
+    {
+      "checksum": "sha1:894c700036c048be44441c0ab375f0705746b115", 
+      "size": 58664, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/TutorialExercisesPart2_2.pdf"
+    }, 
+    {
+      "checksum": "sha1:a419d01f7e714413e4646065b5d3b1eefff9e8fb", 
+      "size": 72563, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/TutorialExercisesPart3_2.pdf"
+    }, 
+    {
+      "checksum": "sha1:a7b769d106be94a229730b1e5ed4f5cd628b07cd", 
+      "size": 60883, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/TutorialExercisesPart4_1.pdf"
+    }
+  ], 
   "keywords": [
     "external resource"
   ], 


### PR DESCRIPTION
* Centralises local files on EOS for CMS-Learning-Resources records.
  Enriches record metadata correspondingly. (closes #1707)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>