### PR TITLE
records: centralise local files on EOS for ATLAS-Tools

### DIFF
--- a/cernopendata/modules/fixtures/data/records/atlas-tools.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-tools.json
@@ -27,6 +27,13 @@
       "size": 20115639, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/Software/Minerva2015.zip"
+    }, 
+    {
+      "checksum": "sha1:583df9c78fa30679c578acdc9ae9f4a6eb3a7342", 
+      "description": "ATLAS Masterclass WPath 2015 dataset Software file\nindex", 
+      "size": 211, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/Software/ATLAS_MasterclassDatasets_WPath_2015_dataset_Software_file_index.txt"
     }
   ], 
   "keywords": [
@@ -75,6 +82,13 @@
       "size": 26914, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/SW/atlas-outreach-data-tools-framework-1.1.tar.gz"
+    }, 
+    {
+      "checksum": "sha1:3ea993a89021a8c95350de069ff6a99af67072e8", 
+      "description": "atlas-outreach-data-tools-framework-1.1 file index", 
+      "size": 123, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/atlas-outreach-data-tools-framework-1.1_file_index.txt"
     }
   ], 
   "license": {
@@ -126,6 +140,13 @@
       "size": 4817828998, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/VM/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_S.vdi.gz"
+    }, 
+    {
+      "checksum": "sha1:4fc99f745ad084ace44e34c51c2d0a25f3d36eaa", 
+      "description": "ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_S file index", 
+      "size": 146, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_S_file_index.txt"
     }
   ], 
   "license": {
@@ -175,6 +196,13 @@
       "size": 10895737443, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/VM/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_M.vdi.gz"
+    }, 
+    {
+      "checksum": "sha1:b5b09fcf3078bca1775b364a08bb0e2b63ff98f3", 
+      "description": "ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_M file index", 
+      "size": 146, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_M_file_index.txt"
     }
   ], 
   "license": {
@@ -224,6 +252,13 @@
       "size": 5491698769, 
       "type": "xrootd", 
       "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/VM/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_N.vdi.gz"
+    }, 
+    {
+      "checksum": "sha1:8d1ffbc94dec76124893d0867898565d8682a629", 
+      "description": "ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_N file index", 
+      "size": 146, 
+      "type": "index", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/ScientificLinux67_ATLAS_Outreach_DataAndTools_July_2016-size_N_file_index.txt"
     }
   ], 
   "license": {


### PR DESCRIPTION
* Centralises local files on EOS for ATLAS-Tools records.
  Enriches record metadata correspondingly. (closes #1693)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>