### PR TITLE
records: centralise local files on EOS for CMS dimuon-spectrum-2010

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-spectrum-2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-spectrum-2010.json
@@ -33,6 +33,32 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.TF26.KG2D", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:cf95f881471657d5807905291705f28e6e03c29e", 
+      "size": 342, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-spectrum-2010/BuildFile.xml"
+    }, 
+    {
+      "checksum": "sha1:eabdd35487945176f65b3b3f69c8ebfdb1dbf215", 
+      "size": 14689, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-spectrum-2010/DemoAnalyzer.cc"
+    }, 
+    {
+      "checksum": "sha1:8e6b39334d50d06713cdd396df119024a7663997", 
+      "size": 3525, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-spectrum-2010/demoanalyzer_cfg.py"
+    }, 
+    {
+      "checksum": "sha1:30e5d594bd2e341f9c998ce5a311328c3d2b2673", 
+      "size": 14935, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-spectrum-2010/Mudemo.root"
+    }
+  ], 
   "license": {
     "attribution": "GNU General Public License (GPL) version 3"
   }, 


### PR DESCRIPTION
* Centralises local files on EOS for cms-tools-dimuon-spectrum-2010 records.
  Enriches record metadata correspondingly. (closes #1717)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>