### PR TITLE
records: centralise local files on EOS for cms-tools-dimuon-filter

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-filter.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-filter.json
@@ -22,6 +22,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.QH46.CQZ9", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:86fec3767750ed038257cbff4d3b51b6a07e5b59", 
+      "size": 52792, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/SUSYBSMAnalysis-RazorFilter/SUSYBSMAnalysis-RazorFilter-1.0.0.tar.gz"
+    }
+  ], 
   "license": {
     "attribution": "MIT License (MIT)"
   }, 
@@ -92,6 +100,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.RB4W.3ZK9", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:ba925025b812392abe2aa716f681e6f9582f5d08", 
+      "size": 52754, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-filter/dimuon-filter-1.0.0.tar.gz"
+    }
+  ], 
   "license": {
     "attribution": "GNU General Public License (GPL) version 3"
   }, 


### PR DESCRIPTION
* Centralises local files on EOS for cms-tools-dimuon-filter records.
  Enriches record metadata correspondingly. (closes #1716)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>