### PR TITLE
records: centralise local files on EOS for CMS Validation 2010

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-validation-code-Run2010B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validation-code-Run2010B.json
@@ -35,6 +35,86 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.A8CP.HBJQ", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3db193e02aaf2353702962f3988afe8b8461ae7d", 
+      "size": 2348, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/readme.txt"
+    }, 
+    {
+      "checksum": "sha1:cf95f881471657d5807905291705f28e6e03c29e", 
+      "size": 342, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/BuildFile.xml"
+    }, 
+    {
+      "checksum": "sha1:eabdd35487945176f65b3b3f69c8ebfdb1dbf215", 
+      "size": 14689, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/DemoAnalyzer.cc"
+    }, 
+    {
+      "checksum": "sha1:8e6b39334d50d06713cdd396df119024a7663997", 
+      "size": 3525, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/demoanalyzer_cfg.py"
+    }, 
+    {
+      "checksum": "sha1:cd71a4adf5d271c3ac525b59cc84ed3c60f8d6f5", 
+      "size": 6520, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/mergeMu.C"
+    }, 
+    {
+      "checksum": "sha1:3485a7f4bbe931354c8597988359c2daec66eae1", 
+      "size": 27652, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/Mu00val.root"
+    }, 
+    {
+      "checksum": "sha1:283c10eb8401553cbebfa94b5266c237f4e88521", 
+      "size": 24866, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/Mu01val.root"
+    }, 
+    {
+      "checksum": "sha1:b4575eba4c16efd2f18fbf8db878086134956023", 
+      "size": 24974, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/Mu02val.root"
+    }, 
+    {
+      "checksum": "sha1:46bcff4375ae31003f5476c99b1f12f1bade9dfa", 
+      "size": 27294, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/Mu03val.root"
+    }, 
+    {
+      "checksum": "sha1:1933ba8f87feb256cda768d5b7a99c5021edcfcc", 
+      "size": 23793, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/Mu04val.root"
+    }, 
+    {
+      "checksum": "sha1:87e04662bf4a3c0c0c38b4ada4f9de33998a28c7", 
+      "size": 24515, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/Mu05val.root"
+    }, 
+    {
+      "checksum": "sha1:0c291100eb91e4ed7b4acd3546c9daad95570a0d", 
+      "size": 30798, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/MuAllval.root"
+    }, 
+    {
+      "checksum": "sha1:dde185fa7692a427a5ae6c3999aa534c1ed4e61d", 
+      "size": 27277, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/MuMonitorval.root"
+    }
+  ], 
   "license": {
     "attribution": "GNU General Public License (GPL) version 3"
   }, 
@@ -116,6 +196,68 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.W26R.J96R", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3db193e02aaf2353702962f3988afe8b8461ae7d", 
+      "size": 2348, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/readme.txt"
+    }, 
+    {
+      "checksum": "sha1:cf95f881471657d5807905291705f28e6e03c29e", 
+      "size": 342, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/BuildFile.xml"
+    }, 
+    {
+      "checksum": "sha1:eabdd35487945176f65b3b3f69c8ebfdb1dbf215", 
+      "size": 14689, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/DemoAnalyzer.cc"
+    }, 
+    {
+      "checksum": "sha1:8e6b39334d50d06713cdd396df119024a7663997", 
+      "size": 3525, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/demoanalyzer_cfg.py"
+    }, 
+    {
+      "checksum": "sha1:4fe00dda18d5d38d87d57c983554faf824e0aa74", 
+      "size": 6492, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/mergeCommissioning.C"
+    }, 
+    {
+      "checksum": "sha1:ca8005c0a8be7797165a7e5583f83596f854e453", 
+      "size": 27352, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/Commissioning00val.root"
+    }, 
+    {
+      "checksum": "sha1:ed0fb21a65999b3b2bbca2d8c289fecc7a970471", 
+      "size": 13126, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/Commissioning02val.root"
+    }, 
+    {
+      "checksum": "sha1:0d7044e5b5bbe4d9821da24b3676b0dfcfcb850a", 
+      "size": 17156, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/Commissioning03val.root"
+    }, 
+    {
+      "checksum": "sha1:9f58835feedc78e82f40e56f1679b07de021fb6b", 
+      "size": 14857, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/Commissioning04val.root"
+    }, 
+    {
+      "checksum": "sha1:3eb21dfdfdecbba56a1a6f169289e2cec76eba84", 
+      "size": 29766, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/CommissioningAllval.root"
+    }
+  ], 
   "license": {
     "attribution": "GNU General Public License (GPL) version 3"
   }, 
@@ -194,6 +336,86 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.GBZR.7F2A", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:3db193e02aaf2353702962f3988afe8b8461ae7d", 
+      "size": 2348, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/readme.txt"
+    }, 
+    {
+      "checksum": "sha1:cf95f881471657d5807905291705f28e6e03c29e", 
+      "size": 342, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/BuildFile.xml"
+    }, 
+    {
+      "checksum": "sha1:eabdd35487945176f65b3b3f69c8ebfdb1dbf215", 
+      "size": 14689, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/DemoAnalyzer.cc"
+    }, 
+    {
+      "checksum": "sha1:8e6b39334d50d06713cdd396df119024a7663997", 
+      "size": 3525, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/demoanalyzer_cfg.py"
+    }, 
+    {
+      "checksum": "sha1:de37b52c5803e4435f9f3db22560c07c2917d461", 
+      "size": 6612, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/mergeMinBias.C"
+    }, 
+    {
+      "checksum": "sha1:4e7d5590c7e5538a35f95c1950a3b9c19b35152d", 
+      "size": 39167, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias00val.root"
+    }, 
+    {
+      "checksum": "sha1:048cb2d27a5d7599acd0efe597f93d817651a53e", 
+      "size": 32569, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias01val.root"
+    }, 
+    {
+      "checksum": "sha1:797f93b85c9b2d927a2b26a9d47084be0abf7a44", 
+      "size": 33286, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias02val.root"
+    }, 
+    {
+      "checksum": "sha1:f72690821f3d3bc50d73a6fbd2cf7cd153e55ac9", 
+      "size": 27977, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias03val.root"
+    }, 
+    {
+      "checksum": "sha1:8d045ce9a30b98a90d462f375f02e7e19c43affa", 
+      "size": 34695, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias04val.root"
+    }, 
+    {
+      "checksum": "sha1:7855abac09eef94a9123b72cc2518a9bb5ae9554", 
+      "size": 31223, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias05val.root"
+    }, 
+    {
+      "checksum": "sha1:967938d36e456272babfd5ead74b676531c25f7a", 
+      "size": 31683, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias06val.root"
+    }, 
+    {
+      "checksum": "sha1:bb817cde1b7244702f88fb9959272714767686a4", 
+      "size": 41131, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBiasAllval.root"
+    }
+  ], 
   "license": {
     "attribution": "GNU General Public License (GPL) version 3"
   }, 


### PR DESCRIPTION
* Centralises local files on EOS for cms-validation-code-Run2010B records.
  Enriches record metadata correspondingly. (closes #1721)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>