### PR TITLE
records: centralise local files on EOS for cms-csv-files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-csv-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-csv-files.json
@@ -62,6 +62,14 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.GACK.GEJA", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5ed734291260108476cc73ad6e6948e067af579a", 
+      "size": 1130837, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MultiJet/CSV/Apr21ReReco-v1/MultiJetRun2010B.csv.gz"
+    }
+  ], 
   "methodology": {
     "description": "The code that applies the selection and produces the csv files can be found here:", 
     "links": [
@@ -121,6 +129,74 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.CB8H.MFFA", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:c02038bcd10e2f99ec20ae48364138126c513707", 
+      "size": 1515458, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_0.csv"
+    }, 
+    {
+      "checksum": "sha1:28dadc13a7ad73129eb5b86d41e322da12e586bc", 
+      "size": 15164517, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B.csv"
+    }, 
+    {
+      "checksum": "sha1:0da2e87ae55446646d967043dd0287d2dfad6ef8", 
+      "size": 1519070, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_1.csv"
+    }, 
+    {
+      "checksum": "sha1:e37699128a5df23c72c3f82bee9100df1bc70ff9", 
+      "size": 1517788, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_2.csv"
+    }, 
+    {
+      "checksum": "sha1:7100d14b68117c814a31cceeb36e6da43a0072ac", 
+      "size": 1514795, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_3.csv"
+    }, 
+    {
+      "checksum": "sha1:737e01252db27aee177c3cd2872bcc3ff93001ac", 
+      "size": 1512480, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_4.csv"
+    }, 
+    {
+      "checksum": "sha1:a0e3101e59c5356c953f86011ac98c0e16a02d44", 
+      "size": 1513438, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_5.csv"
+    }, 
+    {
+      "checksum": "sha1:34fe3f34eb1706313b8d227f9749910200e7d196", 
+      "size": 1517489, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_6.csv"
+    }, 
+    {
+      "checksum": "sha1:cec72c075656abd838863a7701f3edf21248b8f6", 
+      "size": 1519419, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_7.csv"
+    }, 
+    {
+      "checksum": "sha1:28c1f2c6c0b1c9ba12674b557ae812f38941d968", 
+      "size": 1517741, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_8.csv"
+    }, 
+    {
+      "checksum": "sha1:a165e76d0909fc194cee33feea09033b9c203649", 
+      "size": 1517640, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_9.csv"
+    }
+  ], 
   "methodology": {
     "description": "The events in this derived dataset were selected because of the presence of precisely two muons with invariant mass between 2-110 GeV, one of which is a high-quality \"global\" muon. More information on the selections applied for the Mu primary dataset can be found there.", 
     "links": [


### PR DESCRIPTION
* Centralises local files on EOS for cms-csv-files records.
  Enriches record metadata correspondingly. (closes #1698)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>