### PR TITLE
records: centralise local files on EOS for CMS Masterclass files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-masterclass-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-masterclass-files.json
@@ -22,6 +22,44 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.N9MJ.QEEC", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:f21c34f039ed4652a235a3d3ddbcf79bfedd4e52", 
+      "size": 1256, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/4lepton.csv"
+    }, 
+    {
+      "checksum": "sha1:58e98e08de2695724d9985ff121cbe442507c78a", 
+      "size": 4086175, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/4lepton.ig"
+    }, 
+    {
+      "checksum": "sha1:927a8be894f8003e5fc0015f65f91bd850303d90", 
+      "size": 1966, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/4lepton.json"
+    }, 
+    {
+      "checksum": "sha1:c4b26032ab946c3b68f63d44dbf2c2005f5c062c", 
+      "size": 869, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/diphoton.csv"
+    }, 
+    {
+      "checksum": "sha1:86a4a2ed86ead248ae871ffb8a18d4772df0d93d", 
+      "size": 1909562, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/diphoton.ig"
+    }, 
+    {
+      "checksum": "sha1:f8c3d1a86c286d814f5b9b609196ac9ffde03c2a", 
+      "size": 1619, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/diphoton.json"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 
@@ -78,6 +116,140 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.SW96.PFX3", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8f3f4e054665eadd221181460bc7af39f9938535", 
+      "size": 374798, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi.csv"
+    }, 
+    {
+      "checksum": "sha1:689d44ca1becf0ba9c9f9c55779baa6f856487d6", 
+      "size": 44825530, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_7.ig"
+    }, 
+    {
+      "checksum": "sha1:ce79e708634d36aa6219c7cc978d543ee566230b", 
+      "size": 44952775, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_8.ig"
+    }, 
+    {
+      "checksum": "sha1:ac783c1a233e73817e8d33ab668853f2920c3f1b", 
+      "size": 45306364, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_9.ig"
+    }, 
+    {
+      "checksum": "sha1:57327c0d27c1e847195b15166138969185068ecb", 
+      "size": 45547341, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_10.ig"
+    }, 
+    {
+      "checksum": "sha1:f60004a7a8806670a52f181303a01f801dec1ca5", 
+      "size": 46411950, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_11.ig"
+    }, 
+    {
+      "checksum": "sha1:46e792a69624026ee1fe780134f4a809f2f2d581", 
+      "size": 44119119, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_12.ig"
+    }, 
+    {
+      "checksum": "sha1:598078e9db8745a15d636465c8feb8afd845b1dc", 
+      "size": 47770858, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_13.ig"
+    }, 
+    {
+      "checksum": "sha1:50093fd6eb08ead5cf0c7e01b81b31ef39816a73", 
+      "size": 44945861, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_14.ig"
+    }, 
+    {
+      "checksum": "sha1:019783e1e306855a3d7010a2ae466d1286c9c635", 
+      "size": 44963967, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_15.ig"
+    }, 
+    {
+      "checksum": "sha1:b7e98c79463a97a0b153bc5cb8d84c222d18d2ab", 
+      "size": 47308677, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_16.ig"
+    }, 
+    {
+      "checksum": "sha1:2fe01aabc46670d02755cbae35d510c71136228b", 
+      "size": 702717, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi.json"
+    }, 
+    {
+      "checksum": "sha1:18476822171c34c74b8b9fc4bd73c647fbcef3c9", 
+      "size": 47491270, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_17.ig"
+    }, 
+    {
+      "checksum": "sha1:9a1642fdd7b3fc6bf461934874681924313dd7ee", 
+      "size": 47915241, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_18.ig"
+    }, 
+    {
+      "checksum": "sha1:31fd21887e07b595f8e6c42d13b0392ad50cf635", 
+      "size": 46602078, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_19.ig"
+    }, 
+    {
+      "checksum": "sha1:076ed23f16608868fbfa76ffa1d8fd4ecb44d520", 
+      "size": 45516907, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_0.ig"
+    }, 
+    {
+      "checksum": "sha1:2b99fdc665f4ac3eba7b932523bfff74798f6aeb", 
+      "size": 45657377, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_1.ig"
+    }, 
+    {
+      "checksum": "sha1:17b7a088b32ff356d74a31b73ccb5066234ddae7", 
+      "size": 46542194, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_2.ig"
+    }, 
+    {
+      "checksum": "sha1:afb35a3569277ae40433a8ef32b98b732206ebe8", 
+      "size": 45653180, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_3.ig"
+    }, 
+    {
+      "checksum": "sha1:bf49e1d40871bae71617bf554785f3d6f368f927", 
+      "size": 46370345, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_4.ig"
+    }, 
+    {
+      "checksum": "sha1:944fee9f9ccc8ef1bce0e9725b61e3b8065c63c4", 
+      "size": 46211699, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_5.ig"
+    }, 
+    {
+      "checksum": "sha1:fba720fd0122f11c8ecdc79375f2d28efd01818d", 
+      "size": 45927075, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_6.ig"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 
@@ -131,6 +303,140 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.97YF.C4AH", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:cf8c5a799d04198bce1703b75632ceab336e69ec", 
+      "size": 69927400, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_0.ig"
+    }, 
+    {
+      "checksum": "sha1:db6e2eca98ae3177b5b4466beec841b3a5e5b94e", 
+      "size": 68038227, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_17.ig"
+    }, 
+    {
+      "checksum": "sha1:b0afc9ec54d0c7a777ea50467b3414eeeb73a7c3", 
+      "size": 75784837, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_18.ig"
+    }, 
+    {
+      "checksum": "sha1:2109a5e8459739b9c6f4ba41b571ff29f414c593", 
+      "size": 47582226, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_19.ig"
+    }, 
+    {
+      "checksum": "sha1:e5bf691fe186009e8428b7f2f036dea841eaeae7", 
+      "size": 73302582, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_2.ig"
+    }, 
+    {
+      "checksum": "sha1:835a30bca606b313d283487a3dcbc8e3433a3bc8", 
+      "size": 78761389, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_3.ig"
+    }, 
+    {
+      "checksum": "sha1:e3c98f28e2b457b6235b49ee4f73839948dd19ec", 
+      "size": 73108221, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_4.ig"
+    }, 
+    {
+      "checksum": "sha1:4b7bc394d9295e092122a49c3c573df3f7622edf", 
+      "size": 68270656, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_5.ig"
+    }, 
+    {
+      "checksum": "sha1:26f7d8c7bf80bcda76124964db70b0d07e475161", 
+      "size": 69185658, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_6.ig"
+    }, 
+    {
+      "checksum": "sha1:d7517dae798803f4e61e8c6b5402f654b0124cf2", 
+      "size": 72485687, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_7.ig"
+    }, 
+    {
+      "checksum": "sha1:0cc8285a4dd45a2a88eb1183045ac3675137ad86", 
+      "size": 73899071, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_8.ig"
+    }, 
+    {
+      "checksum": "sha1:7f32561472349a3efad4054399e4aa35f0023555", 
+      "size": 65154346, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_1.ig"
+    }, 
+    {
+      "checksum": "sha1:e7851e3989324edb7355796ec330987cc30d00f3", 
+      "size": 75402324, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_9.ig"
+    }, 
+    {
+      "checksum": "sha1:028a21b67beee2391ee6d974d351087533ff97e8", 
+      "size": 68566933, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_10.ig"
+    }, 
+    {
+      "checksum": "sha1:ecc1c92188f339b5a4b580d2a92732881edbc466", 
+      "size": 78080960, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_11.ig"
+    }, 
+    {
+      "checksum": "sha1:d7e24b7550ca7e2f8e8baae54a957c26c18f76ca", 
+      "size": 77894471, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_12.ig"
+    }, 
+    {
+      "checksum": "sha1:b232eacb7070f6756bf8a838a659e908c5aa6361", 
+      "size": 73451939, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_13.ig"
+    }, 
+    {
+      "checksum": "sha1:bf999e86abd0bc3d980d06324900c0b7c34d4d94", 
+      "size": 68881869, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_14.ig"
+    }, 
+    {
+      "checksum": "sha1:1b520486d11329d735d7c55ea590937cf9f19c41", 
+      "size": 68781154, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_15.ig"
+    }, 
+    {
+      "checksum": "sha1:6e2c402905a9692cd9a58fc9b513233243ea0203", 
+      "size": 68839305, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_16.ig"
+    }, 
+    {
+      "checksum": "sha1:e8d627d09338de61404a01f4782fbbbdb7528efb", 
+      "size": 295217, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi.csv"
+    }, 
+    {
+      "checksum": "sha1:d0fa31bfebd09c4ebefbd21a7b4892e99f7873d4", 
+      "size": 605140, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi.json"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 
@@ -184,6 +490,80 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.4M97.3SQ9", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:13af9d3b335203b9f37479116b988840d4a06316", 
+      "size": 31475756, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon.json"
+    }, 
+    {
+      "checksum": "sha1:6ef5cb831608826543cdfb75ff95687d417266c6", 
+      "size": 69359567, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_7.ig"
+    }, 
+    {
+      "checksum": "sha1:99a48d08ee4cd98550c6f8825584c9ae1bdb6984", 
+      "size": 68814448, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_8.ig"
+    }, 
+    {
+      "checksum": "sha1:b6cb4780c1899fead9e35006245a98e4c1d4ae0a", 
+      "size": 72381700, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_9.ig"
+    }, 
+    {
+      "checksum": "sha1:e0a804f51c188323b5c349737a6d3c433214a5a3", 
+      "size": 15075838, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon.csv"
+    }, 
+    {
+      "checksum": "sha1:69f3d7600aa83629876ae33f104192156d6ce4dc", 
+      "size": 66572060, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_0.ig"
+    }, 
+    {
+      "checksum": "sha1:35814129e7eff98d2ab64e2cbad27291c0308235", 
+      "size": 69169047, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_1.ig"
+    }, 
+    {
+      "checksum": "sha1:53986f4931b5ea329a50148771becdc42089ec04", 
+      "size": 67228960, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_2.ig"
+    }, 
+    {
+      "checksum": "sha1:54052f7072e4892a31f1cc6f4f9e314b0d7bebe1", 
+      "size": 67368771, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_3.ig"
+    }, 
+    {
+      "checksum": "sha1:53a44b80ff7284fff6fc2b1f5890d7d2e53badc0", 
+      "size": 67270859, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_4.ig"
+    }, 
+    {
+      "checksum": "sha1:a20ed0363c8f3a378ed098f50e915e624f799552", 
+      "size": 65705946, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_5.ig"
+    }, 
+    {
+      "checksum": "sha1:6496145160b1506255855348a273a7737ef22825", 
+      "size": 69157089, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_6.ig"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 
@@ -237,6 +617,80 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.PCSW.AHVG", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:a1353f14b41454d4f30b6f9e1cca3146a194d727", 
+      "size": 73189908, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_0.ig"
+    }, 
+    {
+      "checksum": "sha1:7ea9f9f0720c4d2b7261608317c0c0e01f75bd2c", 
+      "size": 14744033, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron.csv"
+    }, 
+    {
+      "checksum": "sha1:f6be560ec34f88b4ae3383bd87cf89e29f72e378", 
+      "size": 30243957, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron.json"
+    }, 
+    {
+      "checksum": "sha1:6228f89581167a0f4d4fd19ea2134d836ac13713", 
+      "size": 74858467, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_1.ig"
+    }, 
+    {
+      "checksum": "sha1:569897777d557ecc9652d56b8ab10509bed425d2", 
+      "size": 73117459, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_2.ig"
+    }, 
+    {
+      "checksum": "sha1:3c492d7ffba66981181a24143b70588828a3997a", 
+      "size": 74063911, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_3.ig"
+    }, 
+    {
+      "checksum": "sha1:ded514e061023b73551ea606c265a709c59c4394", 
+      "size": 72334392, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_4.ig"
+    }, 
+    {
+      "checksum": "sha1:4763808c4306240dc90c734a1aa8a11dfa0e252b", 
+      "size": 74669334, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_5.ig"
+    }, 
+    {
+      "checksum": "sha1:408505b86a6692b080ac7a4bcabffdf27f4d4ce5", 
+      "size": 75602074, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_6.ig"
+    }, 
+    {
+      "checksum": "sha1:0af2f867c3767847c0ca0f0412383df1e33f717d", 
+      "size": 73475769, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_7.ig"
+    }, 
+    {
+      "checksum": "sha1:44df68cf3c2a7c0e0c50532cbaa37573180ba99c", 
+      "size": 78400529, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_8.ig"
+    }, 
+    {
+      "checksum": "sha1:c0cb37eebae23021301ede1f4e2146fd3ef9a6b0", 
+      "size": 75413930, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_9.ig"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 
@@ -290,6 +744,140 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.P95A.KMRE", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:5dd936e5fe4ad06c0d0ce4db6173c48f4a3702db", 
+      "size": 72589491, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_0.ig"
+    }, 
+    {
+      "checksum": "sha1:b0d4e96d05d1637f1f08ef3a0441978060370a99", 
+      "size": 69319492, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_17.ig"
+    }, 
+    {
+      "checksum": "sha1:f693f7015e177e742adfb73b8001de9e52046e1c", 
+      "size": 73371933, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_18.ig"
+    }, 
+    {
+      "checksum": "sha1:906a61fa7b7c650a275749a445b28ebf720beb72", 
+      "size": 43562000, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_19.ig"
+    }, 
+    {
+      "checksum": "sha1:a928e317875e948abe8c4709ce67ce3196f8fe81", 
+      "size": 77272565, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_2.ig"
+    }, 
+    {
+      "checksum": "sha1:161beb76a10c52c18683a7d3329a33a758b822e5", 
+      "size": 83965754, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_3.ig"
+    }, 
+    {
+      "checksum": "sha1:acb1deb58e042f638cdaf209d7bb22ce874da6f2", 
+      "size": 84779897, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_4.ig"
+    }, 
+    {
+      "checksum": "sha1:c554a8832593915c245a4df109b5942986472fd6", 
+      "size": 75488170, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_5.ig"
+    }, 
+    {
+      "checksum": "sha1:b5dd313ee41077f23b7752ac4d6783cdbb65ddca", 
+      "size": 70368016, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_6.ig"
+    }, 
+    {
+      "checksum": "sha1:7028f7d5cc5e80318a7d7d62e2fb3aa3bb4a86b1", 
+      "size": 74599753, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_7.ig"
+    }, 
+    {
+      "checksum": "sha1:fdcbfc9bacfdee662c7e008798d2becb3f75ef3c", 
+      "size": 72520073, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_8.ig"
+    }, 
+    {
+      "checksum": "sha1:7b3023532762a9ac2689d293e47210a49466dcac", 
+      "size": 69478786, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_1.ig"
+    }, 
+    {
+      "checksum": "sha1:db58ff3d3d151883f405301b81bf7b4d1bc821a3", 
+      "size": 71570303, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_9.ig"
+    }, 
+    {
+      "checksum": "sha1:f250c07bc43c391856699e9c0790a831cf2869a1", 
+      "size": 76250474, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_10.ig"
+    }, 
+    {
+      "checksum": "sha1:ba82d4f9403f41afd60f86123cd2925daf3aacbe", 
+      "size": 66170855, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_11.ig"
+    }, 
+    {
+      "checksum": "sha1:38bd6216e4f43624bea8a368940d159fb585843d", 
+      "size": 77124049, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_12.ig"
+    }, 
+    {
+      "checksum": "sha1:9b26cafd563e9feb1ecaaeeb5ef7e5bdcac630ae", 
+      "size": 80943646, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_13.ig"
+    }, 
+    {
+      "checksum": "sha1:02deecddf23eb52406b6e3af31fd2bd52437610f", 
+      "size": 78726695, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_14.ig"
+    }, 
+    {
+      "checksum": "sha1:3b4422ceffaa2fdfe72dff9786af134207855592", 
+      "size": 71798975, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_15.ig"
+    }, 
+    {
+      "checksum": "sha1:2ab6a5a5ed65478d516d2627bffabef43dfc8b5b", 
+      "size": 67679915, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_16.ig"
+    }, 
+    {
+      "checksum": "sha1:c54b742b26cd3ded48684716a35e6edaadf92757", 
+      "size": 295203, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon.csv"
+    }, 
+    {
+      "checksum": "sha1:ffc73f0d954db941da877d459a69c34f8b791613", 
+      "size": 605126, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon.json"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 
@@ -343,6 +931,50 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.A6A3.43X5", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:8c60f830e48f5494ac701aaed823e8748718ebb1", 
+      "size": 138564, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee.csv"
+    }, 
+    {
+      "checksum": "sha1:fb07542706fd96161e2c6468b66c4aa7d005bbfe", 
+      "size": 247216, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee.json"
+    }, 
+    {
+      "checksum": "sha1:55ca8dc768c1ddfd17d4a2bc4d9b1f28655a3162", 
+      "size": 49249411, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee_0.ig"
+    }, 
+    {
+      "checksum": "sha1:6b86c50bdb35bade97c6f1e688b645eff894584a", 
+      "size": 47756345, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee_1.ig"
+    }, 
+    {
+      "checksum": "sha1:33b5291e3aa27c103c81c22affe087e38cd4b9cd", 
+      "size": 49727895, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee_2.ig"
+    }, 
+    {
+      "checksum": "sha1:412b511e1e2fcc2b0c6d3e673a3fabc702e365e5", 
+      "size": 47413375, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee_3.ig"
+    }, 
+    {
+      "checksum": "sha1:e9a1f04a124fc11a6eb6d3422811eb71e5be8ce9", 
+      "size": 50992971, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee_4.ig"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 
@@ -396,6 +1028,50 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.XBN9.HFGT", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:93d1784cdddbc6816e15294ef2fbfead3646168e", 
+      "size": 43191302, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu_0.ig"
+    }, 
+    {
+      "checksum": "sha1:1130b33123f7bedc2027423cb2909f5cdb53db28", 
+      "size": 42453798, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu_1.ig"
+    }, 
+    {
+      "checksum": "sha1:e9a95473eb5b9033090f87913acf16b249bd69ef", 
+      "size": 44167394, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu_2.ig"
+    }, 
+    {
+      "checksum": "sha1:a6033444d6a3e13627301c3553ed5ec365bc8900", 
+      "size": 44768415, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu_3.ig"
+    }, 
+    {
+      "checksum": "sha1:a6608cd860a035fda03669d780d55ce7816c4145", 
+      "size": 45457088, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu_4.ig"
+    }, 
+    {
+      "checksum": "sha1:dcc32850bae148c745031c342f618145b3ebdf93", 
+      "size": 470360, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu.csv"
+    }, 
+    {
+      "checksum": "sha1:06414d8c8c829791cb398f3babbd5ffa617d315d", 
+      "size": 848381, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu.json"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 
@@ -449,6 +1125,80 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.US2A.EKV9", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:850ceebe0ccc2e82d6ecee6296077f1af52a987e", 
+      "size": 118664, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu.csv"
+    }, 
+    {
+      "checksum": "sha1:627a52d0a244259de7f7a963fd9441736a1b2ecd", 
+      "size": 62907595, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_7.ig"
+    }, 
+    {
+      "checksum": "sha1:680e86adbbdfea1032f3df3815caaefa123faaa6", 
+      "size": 62674146, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_8.ig"
+    }, 
+    {
+      "checksum": "sha1:4f4879f60e22879f40dd09a46e8f932ad92d7a7b", 
+      "size": 61176750, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_9.ig"
+    }, 
+    {
+      "checksum": "sha1:3c1922bc3d13ebd998414d026c0e02e34ffa9d2c", 
+      "size": 214620, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu.json"
+    }, 
+    {
+      "checksum": "sha1:a0237e67f657df3be714f4b704570ac8a1db9600", 
+      "size": 64952388, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_0.ig"
+    }, 
+    {
+      "checksum": "sha1:c7ebca32f1ac93049544304a6551a0bb1e9e5ee5", 
+      "size": 60210853, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_1.ig"
+    }, 
+    {
+      "checksum": "sha1:8f0902d17ffa972aed348af33931eea8676bf7fd", 
+      "size": 61418718, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_2.ig"
+    }, 
+    {
+      "checksum": "sha1:178fef6536c09c781e006211a79c255c3f948743", 
+      "size": 63468946, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_3.ig"
+    }, 
+    {
+      "checksum": "sha1:6ff6900cdb1e7e1225be326cac32a14686efcc7b", 
+      "size": 62875572, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_4.ig"
+    }, 
+    {
+      "checksum": "sha1:556bed5ce721b88336a10204745bf7242d195fdd", 
+      "size": 61386136, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_5.ig"
+    }, 
+    {
+      "checksum": "sha1:b2a118efa7a9fa6bff3e53f0cc981ac08dd24f2e", 
+      "size": 62332632, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_6.ig"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 
@@ -502,6 +1252,80 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.SQG7.44B9", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:b94fccfa4d57f2715f89fdd3fbda2278bf82722d", 
+      "size": 118774, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu.csv"
+    }, 
+    {
+      "checksum": "sha1:14b06991e21b2d3d250cc4ca25b5decd3b6d7c1e", 
+      "size": 59026045, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_7.ig"
+    }, 
+    {
+      "checksum": "sha1:efe0842e6f8e5a5437ed8a968c199ad02a6fb37a", 
+      "size": 59259117, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_8.ig"
+    }, 
+    {
+      "checksum": "sha1:c28800ad6aa999d03b19596fa0bca56070ee0803", 
+      "size": 58035272, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_9.ig"
+    }, 
+    {
+      "checksum": "sha1:3732c3f5dae22572db43378272899d2b813d4d80", 
+      "size": 214730, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu.json"
+    }, 
+    {
+      "checksum": "sha1:3109f5c16305a17017f61c6059b4358cb477423a", 
+      "size": 61590952, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_0.ig"
+    }, 
+    {
+      "checksum": "sha1:3ad816062eaafa768e04ab7adf9020b27c0ac101", 
+      "size": 55434949, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_1.ig"
+    }, 
+    {
+      "checksum": "sha1:a2e53c9b8ed2797fe69f872eb2d3240028045785", 
+      "size": 58404898, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_2.ig"
+    }, 
+    {
+      "checksum": "sha1:c8274459786e9c5a5859cc013d0ef3e27e1a9b9c", 
+      "size": 56704404, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_3.ig"
+    }, 
+    {
+      "checksum": "sha1:55ddf00ee278dc10ac49306ce6b0e5581a69ef0b", 
+      "size": 59413356, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_4.ig"
+    }, 
+    {
+      "checksum": "sha1:11bf18417e638d0c574690742750fa41ecd1873e", 
+      "size": 60189101, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_5.ig"
+    }, 
+    {
+      "checksum": "sha1:4264d13bd949178997edc1b171adecc5ff5959d9", 
+      "size": 60361441, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_6.ig"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 
@@ -555,6 +1379,470 @@
   }, 
   "doi": "10.7483/OPENDATA.CMS.SSYF.EGXW", 
   "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:d77240bde483c8b0e061aa882485ae99240ccf63", 
+      "size": 8747, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_1-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:2e02ecffccc37b6bd44d8efc1b09e79a3ccd0642", 
+      "size": 10588, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_11-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:3362162a7465f1de489c892489dbe1b9b3640741", 
+      "size": 123, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_11-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:20fe6d102d3eed62808bf70959b8009fdea47af9", 
+      "size": 63150455, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_11.ig"
+    }, 
+    {
+      "checksum": "sha1:e2b01ee0801651c6e1cb2d20944c7c53eca43759", 
+      "size": 11650, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_12-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:7f6a2e9e3953fcd5110a56f623a5393201f03b93", 
+      "size": 10716, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_12-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:b0db7401b6ae827b4454d39dc64bc24da1252cc5", 
+      "size": 127, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_12-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:5df7427aa9b95fa0c9fda077cb0f8de50951dac0", 
+      "size": 59339377, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_12.ig"
+    }, 
+    {
+      "checksum": "sha1:14f2739184eeda5b50df808fb31dd0b632919f3b", 
+      "size": 13903, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_13-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:db1f6f251ade5e2c0a0224cbcbdbaeb82369a045", 
+      "size": 10996, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_13-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:2ead0e9864e2e583d78f0a0f6fb762c02044bc59", 
+      "size": 127, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_13-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:82ad8c8eabdd9bfc2fc2c6245e5608e7126f350c", 
+      "size": 10846, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_1-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:5a0c98e9c38b407a8f84bcd3e2c942496589bb5e", 
+      "size": 59788242, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_13.ig"
+    }, 
+    {
+      "checksum": "sha1:aad082eb92bf65f447249e3c17c3742fd16776c5", 
+      "size": 8379, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_14-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:278f6044be21d999fb934d1a650ee67587eeef89", 
+      "size": 11611, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_14-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:381b0e9d1dd19b207b673a71f233ca85674a8802", 
+      "size": 126, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_14-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:fb47eac65724eaa1c78f5b5eb25bed4ade997f11", 
+      "size": 64351304, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_14.ig"
+    }, 
+    {
+      "checksum": "sha1:dda63d9dfa0077446eed6e1cf11ecb5335e47a36", 
+      "size": 11599, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_15-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:dadcd9a2125e6cbca07a4206150dd1b84408e2fc", 
+      "size": 11490, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_15-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:ecf072fb20aea7f2f8e9cf7c9c2e2e87caf46abe", 
+      "size": 126, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_15-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:f733dc07b11d1fbe39c0ddd5cf73ed9b82ff8583", 
+      "size": 60762184, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_15.ig"
+    }, 
+    {
+      "checksum": "sha1:02af7c0c56d3351f3044369a3a13c6b1e2d113ac", 
+      "size": 15899, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_16-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:3362162a7465f1de489c892489dbe1b9b3640741", 
+      "size": 123, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_1-photons.csv"
+    }, 
+    {
+      "checksum": "sha1:dca8550db29425b4f450668e6e006c14b6a23a28", 
+      "size": 9926, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_16-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:6c9759369d4725c2e13385f4d61cab5084bf0568", 
+      "size": 123, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_16-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:0266109ce4cb76358cc3bdce794568b0d45a389d", 
+      "size": 59539570, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_16.ig"
+    }, 
+    {
+      "checksum": "sha1:219c0d72f79d713aa4be2a52f5428d5ad7145714", 
+      "size": 9093, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_17-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:97eb4aeafa8baee81743980eda0d042a8cd54309", 
+      "size": 10982, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_17-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:c5bf6fa4cc6a6654ef43be3f1a3bce4df1c6b2ac", 
+      "size": 123, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_17-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:8a0cbc766aea0b37b9204344e663f445e97f350b", 
+      "size": 62130580, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_17.ig"
+    }, 
+    {
+      "checksum": "sha1:e36ecbe54e1cbe78611b108aa2d762b20b354f07", 
+      "size": 13632, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_18-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:b914c33608c39fa087953def0624dc88f0caf148", 
+      "size": 10858, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_18-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:5edcd37a6c227bb3d48648896d9da27dc4163ec3", 
+      "size": 125, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_18-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:bb5daf4b6dad2fe1185a3f90083b760b5050de27", 
+      "size": 63466325, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_1.ig"
+    }, 
+    {
+      "checksum": "sha1:e23c6806c6199e4c1d47f8021fdaf9fb73f14c08", 
+      "size": 60314289, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_18.ig"
+    }, 
+    {
+      "checksum": "sha1:2559936f4b2dbde3592fcf1175ebc1a3ffb8de25", 
+      "size": 5403, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_19-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:bbbf6b7bfc2cb048ec9ee7cd526dade486de587a", 
+      "size": 12141, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_19-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:e27bea1440f7e35dc573c6e3eb3701374bc885b2", 
+      "size": 127, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_19-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:8d9465d32e8b5346c74f5ccafcef42c983aaf327", 
+      "size": 63208795, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_19.ig"
+    }, 
+    {
+      "checksum": "sha1:f046d5621f89534cc996b88a61cae0d7c3c3167e", 
+      "size": 10950, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_2-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:d0c63276928139fabfb4e94bf634e8b93d2c10a8", 
+      "size": 11224, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_2-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:b0db7401b6ae827b4454d39dc64bc24da1252cc5", 
+      "size": 127, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_2-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:9b4ab46c5067ef1f9af0d94439d566007401a3a9", 
+      "size": 62500899, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_2.ig"
+    }, 
+    {
+      "checksum": "sha1:243fa1f5be053c3cd6645078555b93d53af640b5", 
+      "size": 12781, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_3-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:97469fdc84ffcdb8dc6465852f296fdce812f788", 
+      "size": 6832, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_10-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:c54092f59c6d21cb8c9d007df05790ce5a83a977", 
+      "size": 11123, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_3-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:2ead0e9864e2e583d78f0a0f6fb762c02044bc59", 
+      "size": 127, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_3-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:7256a437f2c41bd757a73c42729dddea0cf8ab4b", 
+      "size": 61956913, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_3.ig"
+    }, 
+    {
+      "checksum": "sha1:b7d5520ac9fd413f0ce5aec2a1af52e89a7794d6", 
+      "size": 14707, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_4-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:e04c0494696c955c048588dfb147399a4cd2da83", 
+      "size": 10576, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_4-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:381b0e9d1dd19b207b673a71f233ca85674a8802", 
+      "size": 126, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_4-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:2460e09e47b0c7a71f08cab02d5efc1d4343fd78", 
+      "size": 62720130, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_4.ig"
+    }, 
+    {
+      "checksum": "sha1:da58cbb5990019fac8fb1596177b22a693e65157", 
+      "size": 9780, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_5-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:33c9b111a95daa910031966a93fcd2e395d8f406", 
+      "size": 11648, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_5-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:ecf072fb20aea7f2f8e9cf7c9c2e2e87caf46abe", 
+      "size": 126, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_5-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:69f38f19d0ce1a3d0b57fa3408f65d41eafd3ee3", 
+      "size": 11914, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_10-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:3d42c620f1b8d25ec708dfc53dfe5a55ced04a96", 
+      "size": 62710389, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_5.ig"
+    }, 
+    {
+      "checksum": "sha1:2df4a3c512fc9402cc175c1782219b25b48bc0c2", 
+      "size": 13387, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_6-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:82ca78a7f1ff2edf008323d59d1b5f3834a4c311", 
+      "size": 10751, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_6-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:6c9759369d4725c2e13385f4d61cab5084bf0568", 
+      "size": 123, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_6-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:d63398cb971e6af913073b6daa1ca860a1ee6173", 
+      "size": 61086654, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_6.ig"
+    }, 
+    {
+      "checksum": "sha1:d29a43d866765321407b48b6e520c635e771702e", 
+      "size": 15972, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_7-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:a5c826f9f0c48b6ee09b0192092d178af31b0835", 
+      "size": 10427, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_7-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:c5bf6fa4cc6a6654ef43be3f1a3bce4df1c6b2ac", 
+      "size": 123, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_7-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:5c9f8abf63cf07d143cd50cc4e0aeba3e7348396", 
+      "size": 65644163, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_7.ig"
+    }, 
+    {
+      "checksum": "sha1:5d1fb57c9f82c9dab5be0b5baa5979ef858b6e1a", 
+      "size": 9705, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_8-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:029dfd7f5bb4c0b65bda8207a8c14090140d7ca9", 
+      "size": 122, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_10-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:5b684724db9a5976230b682db1134b147b773b27", 
+      "size": 11796, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_8-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:5edcd37a6c227bb3d48648896d9da27dc4163ec3", 
+      "size": 125, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_8-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:1f0cbc195983a9972c08fea013c8370234a3711f", 
+      "size": 65166464, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_8.ig"
+    }, 
+    {
+      "checksum": "sha1:d65edeb4e766f0ce7480b31a7283aad67c26960e", 
+      "size": 6558, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_9-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:d08d55d4612ff8f8f5ce40dc33969553c3e8d4ba", 
+      "size": 12025, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_9-lnu.csv"
+    }, 
+    {
+      "checksum": "sha1:e27bea1440f7e35dc573c6e3eb3701374bc885b2", 
+      "size": 127, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_9-photon.csv"
+    }, 
+    {
+      "checksum": "sha1:3fda5f251d3d905047221d5c3a396fc58d05586d", 
+      "size": 57749966, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_9.ig"
+    }, 
+    {
+      "checksum": "sha1:0b731c14c94c1c3dcd1ba4b79631b8d388fbc0d5", 
+      "size": 59177597, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_10.ig"
+    }, 
+    {
+      "checksum": "sha1:ce3e341c86ef1b0d8d4b4754b4755859701c77b3", 
+      "size": 13871, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_11-leptons.csv"
+    }, 
+    {
+      "checksum": "sha1:63a458ac9397583bdda31147192b7cdca814b0da", 
+      "size": 728576, 
+      "type": "xrootd", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass-2014.xls"
+    }
+  ], 
   "license": {
     "attribution": "CC0"
   }, 


### PR DESCRIPTION
* Centralises local files on EOS for CMS Masterclass records.
  Enriches record metadata correspondingly. (closes #1709)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>