### PR TITLE
templates: redirect for getting-started

### DIFF
--- a/cernopendata/modules/pages/views.py
+++ b/cernopendata/modules/pages/views.py
@@ -253,6 +253,13 @@ def about_opera():
     return render_template('cernopendata_pages/about/about_opera.html')
 
 
+@blueprint.route('/getting-started/<exp>')
+def getting_started_redirect(exp):
+    """Redirects to associated experiment."""
+    return redirect('/articles/getting-started-with-%s-open-data' % exp,
+                    code=302)
+
+
 @blueprint.route('/vm/<exp>/<year>')
 def vm_redirect(exp, year):
     """Redirects to associated experiment."""


### PR DESCRIPTION
redirects:

`getting-started/alice` ->`/articles/getting-started-with-alice-open-data`
`getting-started/cms` -> `/articles/getting-started-with-cms-open-data`
`getting-started/lhcb` -> `/articles/getting-started-with-lhcb-open-data`
