### PR TITLE
records: PPP link fix

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-learning-resources.json
+++ b/cernopendata/modules/fixtures/data/records/cms-learning-resources.json
@@ -133,7 +133,7 @@
   "links": [
     {
       "description": "Go to the Particle Physics Playground", 
-      "url": "http://mattbellis.github.io/Particle-Physics-Playground/"
+      "url": "http://particle-physics-playground.github.io/"
     }
   ], 
   "recid": "52", 


### PR DESCRIPTION
* Fixes PPP link in CMS-Learning-Resources. (closes #1784)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>