### PR TITLE
static: resultsbrief case fix

### DIFF
--- a/cernopendata/modules/theme/bundles.py
+++ b/cernopendata/modules/theme/bundles.py
@@ -69,7 +69,7 @@ css = NpmBundle(
 
 search_js = NpmBundle(
     'node_modules/angular-sanitize/angular-sanitize.js',
-    'js/components/resultsbrief.js',
+    'js/components/resultsBrief.js',
     output='gen/codp_search.%(version)s.js',
     npm={
         'angular': '~1.4.10',

--- a/cernopendata/static/js/components/resultsBrief.js
+++ b/cernopendata/static/js/components/resultsBrief.js
@@ -4,6 +4,7 @@ var defaultTemplate = "default.html";
 var templateMap = {
   "glossary-term-v1.0.0.json": 'terms.html',
   "article-v1.0.0.json": 'articles.html',
+  "record-v1.0.0.json": 'record.html',
   "datasets-v1.0.0.json": 'dataset.html',
   "software-v1.0.0.json": 'software.html'
 }

--- a/cernopendata/static/templates/search/briefs/record.html
+++ b/cernopendata/static/templates/search/briefs/record.html
@@ -2,7 +2,7 @@
 <div class="card">
   <div class="card-body">
     <h4>
-      <a target="_self" ng-href="/datasets/{{ record.metadata.control_number }}">{{ record.metadata.title }}</a>
+      <a target="_self" ng-href="/record/{{ record.metadata.control_number }}">{{ record.metadata.title }}</a>
     </h4>
     <p ng-if="record.metadata.abstract.description" ng-bind-html="record.metadata.abstract.description | limitTo : 200 | unsafe" class="mt-1"></p>
     <div class="tags-box-search-results">


### PR DESCRIPTION
* Fixes Internal Server Error of `/search` page and the empty search page
   results related to resultsBrief loweecasing.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>