### PR TITLE
scripts: populate small files first

### DIFF
--- a/scripts/populate-instance.sh
+++ b/scripts/populate-instance.sh
@@ -130,9 +130,9 @@ else
         ${INVENIO_WEB_INSTANCE} fixtures records --skip-files
     else
         # Prevent memory leak which happens when all fixtures are loaded at once
-        for record in $(ls cernopendata/modules/fixtures/data/records/*.json);
+        for recordfile in $(ls -Sr cernopendata/modules/fixtures/data/records/*.json);
         do
-            ${INVENIO_WEB_INSTANCE} fixtures records -f "$record" --verbose
+            ${INVENIO_WEB_INSTANCE} fixtures records -f "$recordfile" --verbose
         done
     fi
 fi


### PR DESCRIPTION
* Amends `populate-instance.sh` script in order to upload the small files first.
  This alleviates the symptoms of the "big file" loading issues until they are
  properly addressed. (see #1826)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>