### PR TITLE
global: removes ui-bootstrap from cdn

### DIFF
--- a/cernopendata/modules/theme/bundles.py
+++ b/cernopendata/modules/theme/bundles.py
@@ -34,12 +34,14 @@ js = NpmBundle(
     'node_modules/jquery/jquery.js',
     'node_modules/popper.js/dist/umd/popper.js',
     'node_modules/bootstrap/dist/js/bootstrap.js',
+    'node_modules/angular-ui-bootstrap/ui-bootstrap-tpls.js',
     output='gen/cernopendata.theme.%(version)s.js',
     npm={
         'angular': '~1.4.9',
         'jquery': '~1.9.1',
         'popper.js': '~1.11.0',
         'bootstrap': '~4.0.0-beta',
+        'angular-ui-bootstrap': '~0.12.1'
     },
 )
 

--- a/cernopendata/templates/cernopendata_theme/page.html
+++ b/cernopendata/templates/cernopendata_theme/page.html
@@ -43,7 +43,6 @@
 
 {%- block javascript %}
   {% assets "cernopendata_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
-  <script src="//angular-ui.github.io/bootstrap/ui-bootstrap-tpls-0.11.0.js"></script>
   {{super()}}
   {% assets "cernopendata_glossary_js" %}<script src="{{ ASSET_URL }}"></script>{% endassets %}
   {%- block javascript_glossary %}


### PR DESCRIPTION
 * Closes #1837.

Signed-off-by: Ioannis Tsanaktsidis <ioannis.tsanaktsidis@cern.ch>