### PR TITLE
CMS: adds luminosity information

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-luminosity-information-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-luminosity-information-Run2012B.json
@@ -1,0 +1,62 @@
+[
+{
+  "abstract": {
+    "description": " <p>The integrated luminosity for validated runs and luminosity sections of the 2012 public data (RunB and RunC) is available in the tables <a href=\"/record/5003/files/2012RunBlumi.txt\">2012RunBlumi.txt</a> and <a href=\"/record/5003/files/2012RunClumi.txt\">2012RunClumi.txt</a>. (The integrated luminosity for validated runs and luminosity sections of all 2012 p-p data taking is available in <a href=\"/record/5003/files/2012lumi.txt\">2012lumi.txt</a>.)</p>\n<p>In your estimate for the integrated luminosity, check for which runs the trigger you have selected is active and sum the values for those runs. The uncertainty in the luminosity measurement of 2012 data should be considered as 2.6% (reference <a href=\"https://cds.cern.ch/record/1598864\">CMS PAS LUM-13-001</a>).</p>\n<p>If you are using prescaled triggers, you can find the HLT trigger prescale factors for different run ranges in trigger configuration files listed in <a href=\"/record/1701\">this record</a> (under \"PrescaleService\"). Note that these factors may change during a run, and the change of prescales (run, lumi section, index of prescales) is recorded in\n<a href=\"/record/5003/files/prescale2012.txt\">prescale2012.txt</a>. In this case you may also need detailed list of luminosity by lumi section in <a href=\"/record/5003/files/2012lumibyls.csv\">2012lumibyls.csv</a> for the <a href=\"/record/1002\">list of validated runs</a> and lumi sections.</p> "
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+      "recid": "451",
+      "name": "CMS Collaboration"
+  },
+  "collections": [
+      "CMS-Luminosity-Information"
+  ],
+  "date_created": "2012",
+  "date_published": "2017",
+  "distribution": {
+      "formats": [
+          "txt",
+          "csv"
+      ]
+  },
+  "doi": "10.7483/OPENDATA.CMS.LJ89.MM3I",
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "sha1:fda50848945c709b3fba2dda30c9712c86beabc2",
+      "size": 48284,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2012/2012lumi.txt"
+    },
+    {
+      "checksum": "sha1:0c63092d2b815e7c6510679b176c007bc1a1f30b",
+      "size": 12916,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2012/2012RunBlumi.txt"
+    },
+    {
+      "checksum": "sha1:47dcef3072b17f76734bc053f3c4c7bda1078cc9",
+      "size": 16070,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2012/2012RunClumi.txt"
+    },
+    {
+      "checksum": "sha1:ea8837412e962faaf1ca452c9f7f4da678d648f2",
+      "size": 19463607,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2012/2012lumibyls.csv"
+    },
+    {
+      "checksum": "sha1:14ca08d74f697e106944c1e173ba909915a0f567",
+      "size": 49680,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2012/prescale2012.txt"
+    }
+  ],
+  "publisher": "CERN Open Data Portal",
+  "recid": "1052",
+  "run_period": "Run2012B-Run2012C",
+  "title": "CMS luminosity information, for 2012 CMS open data",
+  "type": {
+    "primary": "Supplementaries",
+    "secondary": [
+      "Luminosity"
+    ]
+  }
+}
+]

--- a/cernopendata/modules/fixtures/data/records/cms-luminosity-information.json
+++ b/cernopendata/modules/fixtures/data/records/cms-luminosity-information.json
@@ -2,42 +2,42 @@
 {
   "abstract": {
     "description": " <p>The integrated luminosity for validated runs and luminosity sections of the 2010 public data (RunB) is available in the table <a href=\"/record/1050/files/2010RunBlumi.txt\">2010RunBlumi.txt</a>. (The integrated luminosity for validated runs and luminosity sections of all 2010 p-p data taking is available in <a href=\"/record/1050/files/2010lumi.txt\">2010lumi.txt</a>.)</p> <p>In your estimate for the integrated luminosity, check for which runs the trigger you have selected is active and sum the values for those runs. The uncertainty in the luminosity measurement of 2010 data should be considered as 11% (reference <a href=\"https://cds.cern.ch/record/1279145/files/EWK-10-004-pas.pdf\">CMS PAS EWK-10-004</a>).</p> "
-  }, 
-  "accelerator": "CERN-LHC", 
+  },
+  "accelerator": "CERN-LHC",
   "collaboration": {
-    "name": "CMS Collaboration", 
+    "name": "CMS Collaboration",
     "recid": "451"
-  }, 
+  },
   "collections": [
     "CMS-Luminosity-Information"
-  ], 
-  "date_created": "2010", 
-  "date_published": "2017", 
+  ],
+  "date_created": "2010",
+  "date_published": "2017",
   "distribution": {
     "formats": [
       "txt"
     ]
-  }, 
-  "doi": "10.7483/OPENDATA.CMS.WTXQ.PCF8", 
-  "experiment": "CMS", 
+  },
+  "doi": "10.7483/OPENDATA.CMS.WTXQ.PCF8",
+  "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:c101dbd1bea6c4a0f4e0b02344693ff3c5d0272f", 
-      "size": 63840, 
+      "checksum": "sha1:c101dbd1bea6c4a0f4e0b02344693ff3c5d0272f",
+      "size": 63840,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2010/2010lumi.txt"
-    }, 
+    },
     {
-      "checksum": "sha1:47372391f417cec0e886fd912fccd37131530b1a", 
-      "size": 21429, 
+      "checksum": "sha1:47372391f417cec0e886fd912fccd37131530b1a",
+      "size": 21429,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2010/2010RunBlumi.txt"
     }
-  ], 
-  "publisher": "CERN Open Data Portal", 
-  "recid": "1050", 
-  "run_period": "Run2010B", 
-  "title": "CMS luminosity information, for 2010 CMS open data", 
+  ],
+  "publisher": "CERN Open Data Portal",
+  "recid": "1050",
+  "run_period": "Run2010B",
+  "title": "CMS luminosity information, for 2010 CMS open data",
   "type": {
-    "primary": "Supplementaries", 
+    "primary": "Supplementaries",
     "secondary": [
       "Luminosity"
     ]
@@ -47,53 +47,53 @@
 {
   "abstract": {
     "description": " <p>The integrated luminosity for validated runs and luminosity sections of the 2011 public data (RunA) is available in the table <a href=\"/record/1051/files/2011RunAlumi.txt\">2011RunAlumi.txt</a>. (The integrated luminosity for validated runs and luminosity sections of all 2011 p-p data taking is available in <a href=\"/record/1051/files/2011lumi.txt\">2011lumi.txt</a>.)</p>\n<p>In your estimate for the integrated luminosity, check for which runs the trigger you have selected is active and sum the values for those runs. The uncertainty in the luminosity measurement of 2011 data should be considered as 2.2% (reference <a href=\"https://cds.cern.ch/record/1434360/files/SMP-12-008-pas.pdf\">CMS PAS SMP-12-008</a>).</p>\n<p>If you are using prescaled triggers, you can find the HLT trigger prescale factors for different run ranges in trigger configuration files listed in <a href=\"http://opendata.cern.ch/record/1700\">this record</a> (under \"PrescaleService\"). Note that these factors may change during a run, and the change of prescales (run, lumi section, index of prescales) is recorded in\n<a href=\"/record/1051/files/prescale2011.txt\">prescale2011.txt</a>. In this case you may also need detailed list of luminosity by lumi section in <a href=\"/record/1051/files/2011lumibyls.csv\">2011lumibyls.csv</a> for the <a href=\"/record/1001\">list of validated runs</a> and lumi sections.</p> "
-  }, 
-  "accelerator": "CERN-LHC", 
+  },
+  "accelerator": "CERN-LHC",
   "collaboration": {
-    "name": "CMS Collaboration", 
+    "name": "CMS Collaboration",
     "recid": "451"
-  }, 
+  },
   "collections": [
     "CMS-Luminosity-Information"
-  ], 
-  "date_created": "2011", 
-  "date_published": "2017", 
+  ],
+  "date_created": "2011",
+  "date_published": "2017",
   "distribution": {
     "formats": [
-      "txt", 
+      "txt",
       "csv"
     ]
-  }, 
-  "doi": "10.7483/OPENDATA.CMS.FPPH.Q7S2", 
-  "experiment": "CMS", 
+  },
+  "doi": "10.7483/OPENDATA.CMS.FPPH.Q7S2",
+  "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:57e6f5c4d46ac496ac1536f39e9a2b8e07d2d527", 
-      "size": 49349, 
+      "checksum": "sha1:57e6f5c4d46ac496ac1536f39e9a2b8e07d2d527",
+      "size": 49349,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2011/2011lumi.txt"
-    }, 
+    },
     {
-      "checksum": "sha1:64a5b4e899a1d25166d62d58c17444144e18fea7", 
-      "size": 33867, 
+      "checksum": "sha1:64a5b4e899a1d25166d62d58c17444144e18fea7",
+      "size": 33867,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2011/2011RunAlumi.txt"
-    }, 
+    },
     {
-      "checksum": "sha1:eff396954645741f78e8cfa6e2d2b875aac8e3c5", 
-      "size": 13708129, 
+      "checksum": "sha1:eff396954645741f78e8cfa6e2d2b875aac8e3c5",
+      "size": 13708129,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2011/2011lumibyls.csv"
-    }, 
+    },
     {
-      "checksum": "sha1:7e144b4b568a336d22f2915b9fac22fc4c3cc1e2", 
-      "size": 41460, 
+      "checksum": "sha1:7e144b4b568a336d22f2915b9fac22fc4c3cc1e2",
+      "size": 41460,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2011/prescale2011.txt"
     }
-  ], 
-  "publisher": "CERN Open Data Portal", 
-  "recid": "1051", 
-  "run_period": "Run2011A", 
-  "title": "CMS luminosity information, for 2011 CMS open data", 
+  ],
+  "publisher": "CERN Open Data Portal",
+  "recid": "1051",
+  "run_period": "Run2011A",
+  "title": "CMS luminosity information, for 2011 CMS open data",
   "type": {
-    "primary": "Supplementaries", 
+    "primary": "Supplementaries",
     "secondary": [
       "Luminosity"
     ]


### PR DESCRIPTION
* Adds one new record for 2012 luminosity information. (closes #1827)

Signed-off-by: Artemis Lavasa <artemis.lavasa@cern.ch>