### PR TITLE
CMS: adds 2012 condition data

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-2012.json
@@ -1,0 +1,97 @@
+[
+{
+  "abstract": {
+    "description": "<p>Condition database includes non-event-related\n      information (Alignment, Calibration, Temperature, etc) and parameters for\n      simulation/reconstruction/analysis software.</p>\n      <p> These files are needed when running a CMSSW job on the Open Data VM. They are automatically read from\n      the /cvmfs/cms-opendata-conddb.cern.ch runtime, you do not need to download these files from here separately.</p>\n      <p>FT53_V21A_AN6 is to be used with the collision data of RunB 2012 and FT53_V21A_AN6_RUNC with the collision data of RunC 2012 (with the event range of the open data, the file for the full event range for 2012 are also stored\n      under FIXME on /cvmfs/cms-opendata-conddb.cern.ch)</p> \n      <p>For 2012 CMS Simulated Datasets see:</p>", 
+    "links": [
+      {
+        "recid": "1804"
+      }
+    ]
+  }, 
+  "accelerator": "CERN-LHC", 
+  "collaboration": {
+    "recid": "451", 
+    "name": "CMS collaboration"
+  },
+  "collections": [
+    "CMS-Condition-Data"
+  ], 
+  "date_created": "2012", 
+  "date_published": "2017", 
+  "distribution": {
+    "formats": [
+      "db"
+    ], 
+    "number_files": 2, 
+    "size": 240640
+  }, 
+  "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:9f6b79104ed3562232849454dd6cb6b5039e9238", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/db/FT53_V21A_AN6.db", 
+      "size": 119808
+    }, 
+    {
+      "checksum": "sha1:4fa656cdfe9efd4bae55d776b16e144b40fb2706", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/db/FT53_V21A_AN6_RUNC.db", 
+      "size": 120832
+    }
+  ], 
+  "publisher": "CERN Open Data Portal", 
+  "recid": "1803", 
+  "run_period": "Run2012B-Run2012C", 
+  "title": "Condition data for 2012 CMS collision data", 
+  "type": {
+    "primary": "Environment", 
+    "secondary": [
+      "Condition"
+    ]
+  }
+},
+{
+  "abstract": {
+    "description": "<p>Condition database includes non-event-related\n      information (Alignment, Calibration, Temperature, etc) and parameters for\n      simulation/reconstruction/analysis software.</p>\n      <p> These files are needed when running a CMSSW job on the Open Data VM. They are automatically read from\n      the /cvmfs/cms-opendata-conddb.cern.ch runtime, you do not need to download these files from here separately.</p>\n      <p>START53_LVA1 is to be used with the simulated data</p>\n      <p>For 2012 CMS collision data see</p>",
+    "links": [
+      {
+        "recid": "1803"
+      }
+    ]
+  }, 
+  "accelerator": "CERN-LHC", 
+  "collaboration": {
+    "recid": "451", 
+    "name": "CMS collaboration"
+  },
+  "collections": [
+    "CMS-Condition-Data"
+  ], 
+  "date_created": "2012", 
+  "date_published": "2017", 
+  "distribution": {
+    "formats": [
+      "db"
+    ], 
+    "number_files": 1, 
+    "size": 130048
+  }, 
+  "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:6f0f12509c70baddb99380da8859d879e3f5b58f", 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/db/START53_V27.db", 
+      "size": 130048
+    }
+  ], 
+  "publisher": "CERN Open Data Portal", 
+  "recid": "1804", 
+  "run_period": "Run2012B-Run2012C", 
+  "title": "Condition data for 2012 CMS Simulated Datasets", 
+  "type": {
+      "primary": "Environment", 
+      "secondary": [
+          "Condition"
+      ]
+  }
+}
+]


### PR DESCRIPTION
* Adds two new records for 2012 CMS condition data for
collision and simulated data from RunB and RunC. (closes #1263)

Signed-off-by: Artemis Lavasa <artemis.lavasa@cern.ch>