### PR TITLE
CMS: new 2011 RAW dataset sample and rereco software records

### DIFF
--- a/cernopendata/modules/fixtures/data/records/atlas-tools.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-tools.json
@@ -69,6 +69,9 @@
   "date_created": "2016", 
   "date_published": "2016", 
   "distribution": {
+    "formats": [
+      "gz"
+    ], 
     "number_files": 1, 
     "size": 26914
   }, 

--- a/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2011A.json
@@ -1,0 +1,444 @@
+[
+{
+  "abstract": {
+    "description": "A sample from MinimumBias primary dataset in RAW format from RunA of 2011. Run period 160957."
+  },
+  "accelerator": "CERN-LHC",
+  "collaboration": {
+    "name": "CMS collaboration",
+    "recid": "451"
+  },
+  "collections": [
+    "CMS-Primary-Datasets"
+  ],
+  "collision_information": {
+    "energy": "7TeV",
+    "type": "pp"
+  },
+  "date_created": "2011",
+  "date_published": "2017",
+  "distribution": {
+    "formats": [
+      "root",
+      "raw"
+    ],
+    "number_events": 1913190,
+    "number_files": 72,
+    "size": 248789344017
+  },
+  "doi": "10.7483/OPENDATA.CMS.I8HN.DF32",
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3319670957,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/00CD8D3F-8053-E011-9C1F-001D09F290CE.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3372121415,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/02FD18E5-7753-E011-B91D-000423D9A2AE.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3359848126,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/0E402934-7E53-E011-868E-0030487CD77E.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3544816194,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/107A864F-6053-E011-8C67-001D09F2305C.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3787000453,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/1298B669-5553-E011-B3B5-0030487CD7E0.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3321370934,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/1A49C5A2-8153-E011-B455-0030487CD7E0.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3666020238,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/1A6C472C-5D53-E011-8E50-001D09F2512C.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3380141691,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/1CC0DC26-7C53-E011-B857-003048F0258C.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 4017437280,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/2094B7A4-6E53-E011-8059-000423D9890C.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3385123809,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/22ECE3B2-7A53-E011-AF5D-001617C3B6C6.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3559732432,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/22EEA058-6153-E011-BBEA-001617DBD5AC.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3385344320,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/263B8DF3-7953-E011-B3C0-001D09F251FE.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3798816619,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/2AB43E2F-5153-E011-8D32-001617C3B778.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3402184469,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/2AF00F7D-7853-E011-8100-0030487A195C.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3438179605,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/2C992C7F-6853-E011-A5CD-003048D2BB90.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3531015786,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/32666198-6553-E011-90F9-0030487CBD0A.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3805334959,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/3A106243-5353-E011-8776-000423D9890C.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3440276851,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/4838B123-6B53-E011-A4E7-003048CFB40C.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3426091215,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/5024634C-7453-E011-A15E-0030487A322E.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3303839766,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/52E47EBB-4F53-E011-A959-0030487CD178.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3312784131,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/54225188-7F53-E011-8550-001D09F24FEC.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3339812812,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/54ACC2FC-7D53-E011-ADEE-001D09F23A34.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3576988749,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/58A93E0F-6253-E011-900D-001617C3B77C.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 4096365459,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/5A9A51F9-8053-E011-861C-003048F11C5C.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3178626872,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/5EB03417-7053-E011-AE1D-000423D9890C.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3766853075,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/64DB6F7A-5553-E011-BFBC-0030487C635A.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3595110939,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/68658FC7-5F53-E011-B594-001D09F2512C.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3367910710,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/6A9F3C50-7A53-E011-8206-001D09F295FB.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3182553778,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/6CB22194-7353-E011-B627-003048F01E88.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3633858358,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/6E1B58EB-6653-E011-9A61-003048F024C2.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3176430506,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/7452F822-7053-E011-93A5-0019B9F730D2.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3672425382,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/767FFF01-5B53-E011-BA7D-001617E30D52.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3478982489,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/7A4E0BB7-6753-E011-B99C-0030487C7392.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3988846639,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/7AD3C3E1-7253-E011-A4CF-003048F11114.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 2175229386,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/7AEB2818-8353-E011-957B-003048F024DE.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3563762728,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/7ED2BB6D-5053-E011-AC80-001617C3B706.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3385008680,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/823DCFB1-7553-E011-8CBF-003048F11C58.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3672576840,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/8258004A-5A53-E011-BC73-0030487C778E.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3488161077,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/860C5B4E-6653-E011-B7E2-003048F024DC.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3333844074,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/88E3BDF7-8053-E011-B841-003048F11114.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3331246279,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/8E21AB3F-8053-E011-B575-001D09F25438.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 4092690271,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/96F94636-5453-E011-97CE-0030487A1FEC.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3397122414,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/9863E901-7553-E011-8E60-00304879EDEA.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3427112458,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/98F28E09-7553-E011-A218-0030487A3C92.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3367671657,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/9CBCADB2-7A53-E011-9BC2-001617C3B6FE.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3666132458,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/9E58A1A9-5B53-E011-A894-003048F117EA.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3318140041,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/A08F2BF8-8053-E011-80FC-0030487CAF5E.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3366197134,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/A405732F-7E53-E011-8E9C-001D09F23D1D.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3743205997,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/A604EBD9-6953-E011-9F08-0030487CAF5E.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3728588230,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/ACA00F52-5853-E011-9862-0030487C778E.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3423940969,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/AE4000E8-6B53-E011-97C9-001D09F282F5.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3557778085,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/B2B30A93-4E53-E011-B173-001D09F28F11.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3693870769,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/BA3888E2-5D53-E011-A1DB-001D09F2906A.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3714649481,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/BAA1CF7E-5753-E011-A3F5-003048F1C424.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3357722394,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/BC48F4B8-7C53-E011-8E36-0030487A1990.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3522307319,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/CA8B1AB6-6253-E011-8377-003048D2BB90.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3664450493,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/CC894567-6353-E011-9DDA-001617E30CC8.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3663076814,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/CEE4ECE0-5D53-E011-A593-0030487A18F2.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3394344703,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/D01FB7B2-7553-E011-8FB8-003048F110BE.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3400980471,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/D6F1F7DD-7753-E011-8DAD-000423D9997E.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3365353173,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/D6FE93B4-7A53-E011-AA04-001617DBD472.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3406742980,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/D8BCEC63-7653-E011-8C9E-0030487CD76A.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3747641240,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/D8E0EE91-5953-E011-8F10-0030487CD178.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 4030921468,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/DA5BFEFF-6D53-E011-AF3A-003048F01E88.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3339958248,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/E0130F8E-7F53-E011-8CB8-001D09F24EAC.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3455103685,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/E47141BF-6953-E011-8836-0030487CBD0A.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3165901252,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/E8AA4A7B-7153-E011-8A20-0030487CD7EE.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3801174925,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/F2D54691-5253-E011-BD09-001617C3B778.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3278200485,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/F83AEF93-7353-E011-962D-003048F024FA.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3386323884,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/F8AA8950-7A53-E011-9151-001D09F28EA3.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 3750294437,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/957/FE147EBF-5653-E011-9A35-001617C3B76A.root"
+    },
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "size": 8875,
+      "type": "index",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/file-indexes/CMS_Run2011A_MinimumBias_RAW_v1_000_160_957_file_index.txt"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": " <p>Events stored in this primary dataset were selected because of the presence of low-energy particles (soft-QCD events).</p>\n        <p><strong>Data taking / HLT</strong>\n        <br/>The collision data were assigned to different RAW datasets using the following <a href=\"/record/1700\">HLT configuration</a>.</p>\n        <p><strong>HLT trigger paths</strong>\n      <br/>The possible HLT trigger paths in this dataset are:\n      <br/><a href=\"/search?p=HLT_JetE30_NoBPTX\">HLT_JetE30_NoBPTX</a>\n      <br/><a href=\"/search?p=HLT_JetE30_NoBPTX3BX_NoHalo\">HLT_JetE30_NoBPTX3BX_NoHalo</a>\n      <br/><a href=\"/search?p=HLT_JetE30_NoBPTX_NoHalo\">HLT_JetE30_NoBPTX_NoHalo</a>\n      <br/><a href=\"/search?p=HLT_JetE50_NoBPTX3BX_NoHalo\">HLT_JetE50_NoBPTX3BX_NoHalo</a>\n      <br/><a href=\"/search?p=HLT_L1Tech_BSC_minBias_threshold1\">HLT_L1Tech_BSC_minBias_threshold1</a>\n      <br/><a href=\"/search?p=HLT_Physics\">HLT_Physics</a>\n      <br/><a href=\"/search?p=HLT_PixelTracks_Multiplicity100\">HLT_PixelTracks_Multiplicity100</a>\n      <br/><a href=\"/search?p=HLT_PixelTracks_Multiplicity110\">HLT_PixelTracks_Multiplicity110</a>\n      <br/><a href=\"/search?p=HLT_PixelTracks_Multiplicity125\">HLT_PixelTracks_Multiplicity125</a>\n      <br/><a href=\"/search?p=HLT_PixelTracks_Multiplicity80\">HLT_PixelTracks_Multiplicity80</a>\n      <br/><a href=\"/search?p=HLT_Random\">HLT_Random</a>\n      <br/><a href=\"/search?p=HLT_ZeroBias\">HLT_ZeroBias</a></p> "
+  },
+  "note": {
+    "description": "This dataset contains one run from 2011 RunA. The list of validated lumi sections, which must be applied to all analyses, can be found in",
+    "links": [
+      {
+        "recid": "1001"
+      }
+    ]
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "35",
+  "run_period": "Run2011A",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "Recommended release for reconstruction: CMSSW_5_3_32"
+  },
+  "title": "/MinimumBias/Run2011A-v1/RAW",
+  "title_additional": "MinimumBias primary dataset sample in RAW format from RunA of 2011 (from /MinimumBias/Run2011A-v1/RAW)",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Collision"
+    ]
+  },
+  "usage": {
+    "description": "<p> These data are in RAW format and not directly usable in analysis. The reconstructed data reprocessed from these RAW data are included in the data of <a href=\"/record/24\">this record</a>. \n      The reconstruction step can be repeated with the code available in <a href=\"/record/463\">Validation code for reprocessing AOD from 2011 MinimumBias RAW sample</a> and the resulting AOD has been confirmed to be identical with the original one with comparison code available in <a href=\"/record/464\">Validation code to plot basic physics objects from AOD</a></p> "
+  },
+  "validation": {
+    "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+    "links": [
+      {
+        "description": "CMS data quality monitoring: Systems and experiences",
+        "url": "http://iopscience.iop.org/1742-6596/219/7/072020/pdf/1742-6596_219_7_072020.pdf"
+      },
+      {
+        "description": "The CMS Data Quality Monitoring software experience and future improvements",
+        "url": "http://cds.cern.ch/record/1631039/files/CR2013_418.pdf"
+      },
+      {
+        "description": "The CMS data quality monitoring software: experience and future prospects",
+        "url": "http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf"
+      }
+    ]
+  }
+}
+]

--- a/cernopendata/modules/fixtures/data/records/cms-tools-reco.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-reco.json
@@ -1,0 +1,127 @@
+[
+{
+  "abstract": {
+    "description": " <p>This code for validation reproduces AOD format in <a href=\"/record/24\">this record</a> from the <a href=\"/record/35\">2011 MinimumBias RAW sample</a>. It only contains the configuration file to be run on <a href=\"/record/252\">2011 OpenData VM</a> using CMSSW_5_3_32. No compilation is required. The configuration file has been slightly modified from the <a href=\"/record/3610\">original one</a> to take into account the OpenData computing environment (global tag, input file, commenting out unnecessary steps). Note that the code in this category is not meant to be a pedagogical example but is a validation tool.</p> \n      "
+  }, 
+  "accelerator": "CERN-LHC", 
+  "authors": [
+    {
+      "name": "Lassila-Perini, Kati"
+    }
+  ], 
+  "collections": [
+    "CMS-Tools"
+  ], 
+  "date_created": "2017", 
+  "date_published": "2017", 
+  "distribution": {
+    "formats": [
+      "gz"
+    ], 
+    "number_files": 1, 
+    "size": 14566
+  }, 
+  "doi": "10.7483/OPENDATA.CMS.99IJ.BGV4", 
+  "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000", 
+      "size": 14566, 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/2011-minimumbias-raw-recotest/2011-minimumbias-raw-recotest-1.0.0.tar.gz"
+    }
+  ], 
+  "license": {
+    "attribution": "GNU General Public License (GPL) version 3"
+  }, 
+  "publisher": "CERN Open Data Portal", 
+  "recid": "463", 
+  "run_period": "Run2011A", 
+  "system_details": {
+    "description": "Use this code with the CMS Open Data VM environment for 2011 open data", 
+    "recid": "252", 
+    "release": "CMSSW_5_3_32"
+  }, 
+  "title": "Validation code for reprocessing AOD from 2011 MinimumBias RAW sample", 
+  "type": {
+    "primary": "Software", 
+    "secondary": []
+  }, 
+  "usage": {
+    "description": " <p>If you do not have the CERN Virtual Machine for 2011 CMS data installed, follow the instructions in step 1 and step 2 at <a href=\"/VM/CMS/2011\">How to install a CERN Virtual Machine</a>.\n      Then follow the instructions in <a href=\"https://github.com/cms-opendata-validation/2011-minimumbias-raw-recotest/blob/master/README.md\">GitHub</a>.</p> "
+  }, 
+  "use_with": {
+    "description": "Use this with the following dataset:", 
+    "links": [
+      {
+        "recid": "35"
+      }
+    ]
+  }, 
+  "validation": {
+    "description": " <p>The AOD produced by this code can be validated by comparing histograms produced with the <a href=\"/record/464\">Validation code to plot basic physics objects from AOD</a> from the reprocessed AOD and the original AOD, and the histograms, when run over the same event numbers, are found to be equal.</p> "
+  }
+}
+,
+{
+  "abstract": {
+    "description": "This is a simple comparison code to validate the reprocessing step on the Open Data VM by comparing the resulting file (newly rereconstructed from the RAW data sample available on the Open Data Portal) and the original AOD (also available on the Open Data portal). It loops over different physics objects (tracks, electrons, muons, photons, jets, taus and missing et) and fills histograms with P, pt, eta and phi of these objects."
+  }, 
+  "accelerator": "CERN-LHC", 
+  "authors": [
+    {
+      "name": "Lassila-Perini, Kati"
+    }
+  ], 
+  "collections": [
+    "CMS-Tools"
+  ], 
+  "date_created": "2017", 
+  "date_published": "2017", 
+  "distribution": {
+    "formats": [
+      "gz"
+    ], 
+    "number_files": 1, 
+    "size": 17076
+  }, 
+  "doi": "10.7483/OPENDATA.CMS.11RI.SDX7", 
+  "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0000000000000000000000000000000000000000", 
+      "size": 17076, 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/2011-minimumbias-compare-rereco/2011-minimumbias-compare-rereco-1.0.0.tar.gz"
+    }
+  ], 
+  "license": {
+    "attribution": "GNU General Public License (GPL) version 3"
+  }, 
+  "publisher": "CERN Open Data Portal", 
+  "recid": "464", 
+  "run_period": "Run2011A", 
+  "system_details": {
+    "description": "Use this code with the CMS Open Data VM environment for 2011 open data", 
+    "recid": "252", 
+    "release": "CMSSW_5_3_32"
+  }, 
+  "title": "Validation code to plot basic physics objects from AOD", 
+  "type": {
+    "primary": "Software", 
+    "secondary": []
+  }, 
+  "usage": {
+    "description": " <p>If you do not have the CERN Virtual Machine for 2011 CMS data installed, follow the instructions in step 1 and step 2 at <a href=\"/VM/CMS/2011\">How to install a CERN Virtual Machine</a>.\n      Then follow the instructions in <a href=\"https://github.com/cms-opendata-validation/2011-minimumbias-compare-rereco/blob/master/README.md\">GitHub</a>.</p> "
+  }, 
+  "use_with": {
+    "description": "Use this with the following datasets:", 
+    "links": [
+      {
+        "recid": "24"
+      }, 
+      {
+        "recid": "463"
+      }
+    ]
+  }
+}
+]


### PR DESCRIPTION
* Introduces new record for 2011 RAW data sample. (closes #1202)

* Introduces two new software records for the RAW data sample. (closes #1525)

* Note: PR prepared from COD2 PR #1546.

* Also fixes distribution.formats for other `tar.gz` files.

Co-authored-by: Tibor Simko <tibor.simko@cern.ch>
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>