### PR TITLE
templates: CMS: updates to education guide

### DIFF
--- a/cernopendata/modules/fixtures/data/articles/cms-guide-for-education/education.md
+++ b/cernopendata/modules/fixtures/data/articles/cms-guide-for-education/education.md
@@ -46,8 +46,8 @@ You can get an overview of our education resources through [this search query](/
     - [A quick (completely online) hands-on demo](https://mybinder.org/v2/gh/cms-opendata-education/cms-online-notebooks-for-binder/master?filepath=quick-start-to-CMS-open-data.ipynb) to Jupyter and CMS Open Data (using python).
     - [Analysing CMS Open Data in Jupyter using **python**](/record/FIXME)
     - [Analysing CMS Open Data in Jupyter using **R**](/record/FIXME), with a brief intro to the R programming language
-- All applications mentioned above use open data insimplified csv (comma separated values) format. See [all available csv datasets](/search?page=1&size=20&q=&type=Dataset&experiment=CMS&subtype=Derived&file_type=csv), which have been extracted directly from the original collision datasets.
-    - If you are interested in producing your own selection of open data in csv format, see [example software ](/record/552) for the processing step.
+- All applications mentioned above use open data in simplified CSV (comma-separated values) format. See [all available CSV datasets](/search?page=1&size=20&q=&type=Dataset&experiment=CMS&subtype=Derived&file_type=csv), which have been extracted directly from the original collision datasets.
+    - If you are interested in producing your own selection of open data in CSV format, see [example software ](/record/552) for the processing step.
 ---
 
 #### Dive deeper into the data

--- a/cernopendata/modules/fixtures/data/articles/cms-guide-for-education/education.md
+++ b/cernopendata/modules/fixtures/data/articles/cms-guide-for-education/education.md
@@ -46,7 +46,8 @@ You can get an overview of our education resources through [this search query](/
     - [A quick (completely online) hands-on demo](https://mybinder.org/v2/gh/cms-opendata-education/cms-online-notebooks-for-binder/master?filepath=quick-start-to-CMS-open-data.ipynb) to Jupyter and CMS Open Data (using python).
     - [Analysing CMS Open Data in Jupyter using **python**](/record/FIXME)
     - [Analysing CMS Open Data in Jupyter using **R**](/record/FIXME), with a brief intro to the R programming language
-
+- All applications mentioned above use open data insimplified csv (comma separated values) format. See [all available csv datasets](/search?page=1&size=20&q=&type=Dataset&experiment=CMS&subtype=Derived&file_type=csv), which have been extracted directly from the original collision datasets.
+    - If you are interested in producing your own selection of open data in csv format, see [example software ](/record/552) for the processing step.
 ---
 
 #### Dive deeper into the data

--- a/cernopendata/modules/fixtures/data/articles/cms-guide-for-education/education.md
+++ b/cernopendata/modules/fixtures/data/articles/cms-guide-for-education/education.md
@@ -9,7 +9,7 @@ This page will guide you through contents of the CMS Open Data collections that 
 
 If you are new to particle physics, your time is limited, or you want to do something online fairly quickly, have a look at visual displays of real particle collisions. For example, here are collision events which contributed to the discovery of the Higgs boson in 2012:
 
-1. Go to the [CMS event display](/visualise/events/CMS),
+1. Go to the [CMS event display](/visualise/events/cms),
 1. wait for the tool to load, and click on the `Open file` button,
 1. choose `Open file(s) from web`,
 1. choose `Education/`,
@@ -23,15 +23,15 @@ Your collision event should now appear in the display.
 
 **Note**: If you have a VR viewer (even a simple one like [Google Cardboard](https://vr.google.com/cardboard/)), you can immerse yourself into the collision using your smartphone: click on the "Stereo View" button (shaped like binoculars), insert your phone into the viewer and have virtual tour in 3D of a real LHC collision!
 
-The first few events of all collision datasets from CMS served on the CERN Open Data portal are available in a format suitable for the event display. In addition, many other events have been selected in specially prepared collections. Find them all in [this search query](search?page=1&size=20&q=display&subtype=Derived&experiment=CMS).
+The first few events of all collision datasets from CMS served on the CERN Open Data portal are available in a format suitable for the event display. In addition, many other events have been selected in specially prepared collections. Find them all in [this search query](/search?page=1&size=20&q=display&subtype=Derived&experiment=CMS).
 Two examples of these specially prepared files are:
 
-- [Higgs candidate events for use in education and outreach](http://opendata.cern.ch/record/300), and
-- [Dimuon events with invariant mass range 2-5 GeV for public education and outreach](http://opendata.cern.ch/record/301) for J/&psi;&rarr;&mu;&mu; candidates.
+- [Higgs candidate events for use in education and outreach](/record/300), and
+- [Dimuon events with invariant mass range 2-5 GeV for public education and outreach](/record/301) for J/&psi;&rarr;&mu;&mu; candidates.
 
 You can also download these files directly from the records on this portal.
 
-To learn how to use the [CMS event display](/visualise/events/CMS), click on `Need help?` link on the top right side of the screen (FIXME: not visible in the current display). For suggestions for class room activities see FIXME: new record for https://github.com/cms-opendata-education/cms-event-display-materials-multiple-languages
+To learn how to use the [CMS event display](/visualise/events/cms), click on `Need help?` link on the top right side of the screen. For suggestions for class room activities see [instructions for use of CMS Open Data in spreadsheets for schools and education](/record/FIXME).
 
 ---
 
@@ -39,19 +39,19 @@ To learn how to use the [CMS event display](/visualise/events/CMS), click on `Ne
 
 You can get an overview of our education resources through [this search query](/search?page=1&size=20&q=learning%20school%20education&experiment=CMS) with your keyword of interest (you can change the pre-defined keywords here). Here are some highlights:
 
-- If you already know what the basic physics quantities measured in a particle collision are and want to **play online with histograms** from different samples of open data, check out the [CMS histogram visualiser](http://opendata.cern.ch/visualise/histograms/CMS). For instructions on how to use the visualiser, click on `Need help?`.
+- If you already know what the basic physics quantities measured in a particle collision are and want to **play online with histograms** from different samples of open data, check out the [CMS histogram visualiser](/visualise/histograms/cms). For instructions on how to use the visualiser, click on `Need help?`.
 - To learn some concepts of statistical analysis in a hands-on classroom activity, have a look at the material for an organised ["**Masterclass**" exercise](/record/53) based on CMS data and the online event display. A CMS Masterclass typically takes one day (including introductory lectures and post-analysis discussions), but the exercise itself can be done in approximately two hours. Learn more about organising your own Masterclass [on the CMS website](https://cms.cern/engage-with-cms/cms-physics-masterclass).
-- You can also use **spreadsheet programs** to make a further step in the direction of data analysis, using [a limited number of CMS events that are suitable for this type of exercise](FIXME). These exercises can be done in an hour or so.
+- You can also use **spreadsheet programs** to make a further step in the direction of data analysis, using a limited number of CMS events that are suitable for this type of exercise, see [instructions for use of CMS Open Data in spreadsheets for schools and education](/record/FIXME). These exercises can be done in an hour or so.
 - For a first taste of real programming using physics data, consider these resources that use [**Jupyter notebooks**](https://jupyter.org/) for a browser-based introduction to data analysis (time can vary from less than an hour to several hours, depending on the scope of your exercise):
     - [A quick (completely online) hands-on demo](https://mybinder.org/v2/gh/cms-opendata-education/cms-online-notebooks-for-binder/master?filepath=quick-start-to-CMS-open-data.ipynb) to Jupyter and CMS Open Data (using python).
-    - [Analysing CMS Open Data in Jupyter using **python**](FIXME)
-    - [Analysing CMS Open Data in Jupyter using **R**](FIXME), with a brief intro to the R programming language
+    - [Analysing CMS Open Data in Jupyter using **python**](/record/FIXME)
+    - [Analysing CMS Open Data in Jupyter using **R**](/record/FIXME), with a brief intro to the R programming language
 
 ---
 
 #### Dive deeper into the data
 
-If you want a more detailed understanding of particle physics or an introduction aimed at the university level, take a look at some of the other resources in [this search query](search?page=1&size=20&q=&keywords=education&experiment=CMS).
+If you want a more detailed understanding of particle physics or an introduction aimed at the university level, take a look at some of the other resources in [this search query](/search?page=1&size=20&q=&keywords=education&experiment=CMS).
 
 For example:
 - [Particle Physics Playground](/record/52) provides you with further hands-on activities with open data from CMS and other experiments.
@@ -60,8 +60,8 @@ For example:
 
 Of course, you can also undertake your own explorations with CMS Open Data:
 
-- If you want to "re-discover" the **Higgs boson** in the CMS Open Data from 2010, first install the Virtual Machine (VM) as instructed in ["CMS 2010 Virtual Machines: How to install"](/articles/cms-2010-virtual-machines-how-to-install) and look at [this Higgs analysis example](FIXME).
-- If you want to learn how data analysis is done by CMS scientists, install the Virtual Machine (VM) as instructed in ["CMS 2011 Virtual Machines: How to install"](/articles/cms-2011-virtual-machines-how-to-install), follow the instructions in ["Getting Started with CMS Open Data"](/articles/getting-started-with-cms-open-data), and then
+- If you want to "re-discover" the **Higgs boson** in the CMS Open Data from 2011-2012, first install the Virtual Machine (VM) as instructed in ["CMS 2011 Virtual Machines: How to install"](/articles/cms-2011-virtual-machines-how-to-install) and look at [this Higgs analysis example](/record/FIXME).
+- If you want to learn how data analysis is done by CMS scientists, install the Virtual Machine (VM) as instructed in ["CMS 2011 Virtual Machines: How to install"](/articles/cms-2011-virtual-machines-how-to-install), follow the instructions in ["Getting Started with CMS Open Data"](/articles/getting-started-with-cms-2011-open-data), and then
 check out our extensive overview of research activities under ["Guide for research use of CMS Open Data"](/articles/cms-guide-to-research-use-of-cms-open-data).
 
 Have fun!!


### PR DESCRIPTION
Fixes links and other points in https://github.com/cernopendata/opendata.cern.ch/issues/1518#issuecomment-347027796.
Needs records from #1789, #1760, #1761 and #1762 to fix rest of the links.

The title and the link has two times CMS : CMS Guide to education use of CMS Open Data . The first should be removed.