### PR TITLE
CMS: Adds educational materials

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-open-data-instructions-2017.json
+++ b/cernopendata/modules/fixtures/data/records/cms-open-data-instructions-2017.json
@@ -1,0 +1,175 @@
+[
+{
+  "abstract": {
+    "description": " <p>CMS Open Data in the form of CSV files can be used in programming applications such as Jupyter notebooks, but they can also be read in and analysed with spreadsheet programs. This can be convenient in schools and in the general context of education if teachers and students are already familiar with spreadsheet programs. Note, however, that it can become cumbersome to work with large datasets in these applications. Instructions for use are provided for LibreOffice (in English and Spanish) and for Excel (in English). You can access the repository directly in <a href=\"https://github.com/cms-opendata-education/cms-spreadsheet-materials-multiple-languages/\">this Github repository</a> or download the contents from this record.</p> "
+  }, 
+  "accelerator": "CERN-LHC", 
+  "collaboration": {
+    "name": "CMS Collaboration", 
+    "recid": "451"
+  }, 
+  "collections": [
+    "CMS-Open-Data-Instructions"
+  ], 
+  "date_created": "2017", 
+  "date_published": "2017", 
+  "distribution": {
+    "formats": [
+      "gz"
+    ], 
+    "number_files": 1,
+    "size": 6328249
+  }, 
+  "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:673b32ebcfaa3369215de99fe382ae97f0f51292", 
+      "size": 6328249, 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/cms-spreadsheet-materials-multiple-languages/cms-spreadsheet-materials-multiple-languages-1.0.tar.gz"
+    }
+  ], 
+  "keywords": [
+    "education", 
+    "teaching"
+  ], 
+  "publisher": "CERN Open Data Portal", 
+  "recid": "5100", 
+  "title": "Instructions for use of CMS Open Data in spreadsheets", 
+  "type": {
+    "primary": "Documentation", 
+    "secondary": [
+      "Activities"
+    ]
+  }
+},
+{
+  "abstract": {
+    "description": " <p>CMS Open Data in the form of CSV files can be used in programming applications such as Jupyter notebooks. These example notebooks have been prepared as a tutorial to introduce Jupyter and CMS Open Data. You can access the example notebook repositories in different languages in <a href=\"https://github.com/cms-opendata-education/\">this Github organisation</a>, where you can choose cms-jupyter-materials-yourlanguage or download the contents of the version in English from this record. You can download the material and modify them for your own teaching purposes. We welcome translations into different languages and other contributions.</p> "
+  }, 
+  "accelerator": "CERN-LHC", 
+  "collaboration": {
+    "name": "CMS Collaboration", 
+    "recid": "451"
+  }, 
+  "collections": [
+    "CMS-Open-Data-Instructions"
+  ], 
+  "date_created": "2017", 
+  "date_published": "2017", 
+  "distribution": {
+    "formats": [
+      "gz"
+    ],
+    "number_files": 1,
+    "size": 85664941
+  }, 
+  "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:62c66b9e9880a4dc3bd974627ceb21869e41c8d4", 
+      "size": 85664941, 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/cms-jupyter-materials-english/cms-jupyter-materials-english-1.0.tar.gz"
+    }
+  ], 
+  "keywords": [
+    "education", 
+    "teaching"
+  ], 
+  "publisher": "CERN Open Data Portal", 
+  "recid": "5101", 
+  "title": "Jupyter notebooks using CMS Open Data", 
+  "type": {
+    "primary": "Documentation", 
+    "secondary": [
+      "Activities"
+    ]
+  }
+},
+{
+  "abstract": {
+    "description": " <p>CMS Open Data in the form of CSV files can be used in programming applications such as Jupyter notebooks or R. A tutorial is provided to introduce R and CMS Open Data. You can access the repository of instructions in different languages in <a href=\"https://github.com/cms-opendata-education/cms-rmaterial-multiple-languages\">this Github repository</a> or download the PDF file of the instructions in English from this record. We welcome translations into different languages and other contributions.</p> "
+  }, 
+  "accelerator": "CERN-LHC", 
+  "authors": [
+    {
+      "name": "Villegas Garcia, Edith Natalia"
+    }
+  ],  
+  "collections": [
+    "CMS-Open-Data-Instructions"
+  ], 
+  "date_created": "2017", 
+  "date_published": "2017", 
+  "distribution": {
+    "formats": [
+      "pdf"
+    ],
+    "number_files": 1,
+    "size": 614307
+  }, 
+  "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:34971230f14fd19b8af8f787d46f8fd4bef02c17", 
+      "size": 614307, 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/cms-rmaterial-multiple-languages/cms-rmaterial-multiple-languages-1.0.tar.gz"
+    }
+  ], 
+  "keywords": [
+    "education", 
+    "teaching"
+  ], 
+  "publisher": "CERN Open Data Portal", 
+  "recid": "5102", 
+  "title": "Instructions for use of CMS Open Data in R", 
+  "type": {
+    "primary": "Documentation", 
+    "secondary": [
+      "Activities"
+    ]
+  }
+},
+{
+  "abstract": {
+    "description": " <p>Tutorials and worksheets for classroom use of the <a href=\"http://opendata.cern.ch/visualise/events/cms/\">CMS Event Display</a>. You can access the material in different languages in <a href=\"https://github.com/cms-opendata-education/cms-event-display-materials-multiple-languages/\">this Github repository</a> or download the files from this record. You can download the material and modify them for your own teaching purposes. We welcome translations into different languages and other contributions.</p> "
+  }, 
+  "accelerator": "CERN-LHC", 
+  "collaboration": {
+    "name": "CMS Collaboration", 
+    "recid": "451"
+  }, 
+  "collections": [
+    "CMS-Open-Data-Instructions"
+  ], 
+  "date_created": "2017", 
+  "date_published": "2017", 
+  "distribution": {
+    "formats": [
+      "gz"
+    ],
+    "number_files": 1,
+    "size": 11361597
+  }, 
+  "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "sha1:0be37c4464d591e2024863624030a71199888765", 
+      "size": 11361597, 
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/cms-event-display-materials-multiple-languages/cms-event-display-materials-multiple-languages-1.0.tar.gz"
+    }
+  ], 
+  "keywords": [
+    "education", 
+    "teaching"
+  ], 
+  "publisher": "CERN Open Data Portal", 
+  "recid": "5103", 
+  "title": "Tutorials and worksheets for CMS Event Display", 
+  "type": {
+    "primary": "Documentation", 
+    "secondary": [
+      "Activities"
+    ]
+  }
+}
+]


### PR DESCRIPTION
* Adds four new records for 2017 CMS educational activities. (closes #1760) (closes #1761) (closes #1762) (closes #1789)

Signed-off-by: Artemis Lavasa <artemis.lavasa@cern.ch>