### PR TITLE
CMS: fixes for GitHub pattuples2011 link

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-ana-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-ana-Run2011A.json
@@ -63,7 +63,7 @@
     "links": [
       {
         "description": "GitHub", 
-        "url": "https://github.com/katilp/pattuples2011"
+        "url": "https://github.com/cms-opendata-analyses/pattuples2011"
       }
     ]
   }, 


### PR DESCRIPTION
* Fixes GitHub link for the pattuples2011 software record 233.
  (closes #1296) (PR #1302)

Co-authored-by: Tibor Simko <tibor.simko@cern.ch>
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>