### PR TITLE
records: CMS 2012 HLT configuration files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-hlt-configuration-files-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-hlt-configuration-files-2012.json
@@ -1,0 +1,2211 @@
+[
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 202970 - 203002, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_6_onlpatch3\">CMSSW_5_2_6_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2084149
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "cdb4eddb00282f5d01f6fcfce70b53a8410ef71e",
+        "size": 2084149,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v4.2_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6100",
+    "run_period": "Run2012C",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v4.2/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 206744 - 206745, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_7_onlpatch2\">CMSSW_5_2_7_onlpatch2</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2308868
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "dd0fb4642fbf6fa9ed681d299b19f37f86a8ca5e",
+        "size": 2308868,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.0_HLT_V2.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6101",
+    "run_period": "Run2012D",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/8e33/v2.0/HLT/V2",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 204100 - 205238, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_7\">CMSSW_5_2_7</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2192031
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "514c0d3a5e223741a477456e838f35d31a3281dc",
+        "size": 2192031,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v1.1_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6102",
+    "run_period": "Run2012D",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/8e33/v1.1/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 194735 - 194778, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch3\">CMSSW_5_2_4_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2071786
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "55f328f1ab4706e49897cdcfb0533f2710821250",
+        "size": 2071786,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.3_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6103",
+    "run_period": "Run2012B",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v2.3/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 194424 - 194712, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch3\">CMSSW_5_2_4_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2067575
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "deea4854dd80a1a721c9a2ff10e4a342963f26e0",
+        "size": 2067575,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.2_HLT_V3.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6104",
+    "run_period": "Run2012B",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v2.2/HLT/V3",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 207779 - 207886, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_7_onlpatch3\">CMSSW_5_2_7_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2321436
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "2925ecd5e85deba962c64adab1eaa7e5c5357123",
+        "size": 2321436,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.1_HLT_V6.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6105",
+    "run_period": "Run2012D",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/8e33/v2.1/HLT/V6",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 198050 - 198063, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch5\">CMSSW_5_2_4_onlpatch5</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2064310
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "2d3aca75a9d79dbb26988e5a0ffde45551eb1126",
+        "size": 2064310,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.0_HLT_V4.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6106",
+    "run_period": "Run2012C",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v3.0/HLT/V4",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 198249 - 199021, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch5\">CMSSW_5_2_4_onlpatch5</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2064311
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "895cd479f1f1d4ecb8b27bd0cef692eda36b1b5e",
+        "size": 2064311,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.1_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6107",
+    "run_period": "Run2012C",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v3.1/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 193834 - 193836, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch3\">CMSSW_5_2_4_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2059043
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "861be4b8249ce4bc51d593e05a8492501132e18c",
+        "size": 2059043,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.1_HLT_V11.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6108",
+    "run_period": "Run2012B",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v2.1/HLT/V11",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 193541 - 193621, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch1\">CMSSW_5_2_4_onlpatch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2079227
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "206a2afca55edd95fa5e826f81af3234c6b08b8d",
+        "size": 2079227,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V21.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6109",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.16/HLT/V21",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 198116 - 198230, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch5\">CMSSW_5_2_4_onlpatch5</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2064311
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "7bfe201c4f3dd0514ecc5597361e682e2cdae97a",
+        "size": 2064311,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.0_HLT_V5.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6110",
+    "run_period": "Run2012C",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v3.0/HLT/V5",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 198023 - 198049, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch5\">CMSSW_5_2_4_onlpatch5</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2064310
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "91dd867b4f4555216dc0fe675c085188dc593b9f",
+        "size": 2064310,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.0_HLT_V3.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6111",
+    "run_period": "Run2012C",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v3.0/HLT/V3",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 190645 - 190659, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_3_patch1\">CMSSW_5_2_3_patch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2042796
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "5510f163b0133a9f21eeecb13e1166824b22c894",
+        "size": 2042796,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.6_HLT_V5.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6112",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.6/HLT/V5",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 190688 - 190738, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_3_patch1\">CMSSW_5_2_3_patch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2042914
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "c6d162c46f4cab1d06e5a377bae6b27813fb2242",
+        "size": 2042914,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.8_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6113",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.8/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 198022, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch5\">CMSSW_5_2_4_onlpatch5</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2064310
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "4c59efa2d18ee42bba58db60814d180e55a1edde",
+        "size": 2064310,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.0_HLT_V2.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6114",
+    "run_period": "Run2012C",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v3.0/HLT/V2",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 191800 - 191859, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch1\">CMSSW_5_2_4_onlpatch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2078704
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "6b18acb5027d7d812cdf338db4cd2eaa717cd8a5",
+        "size": 2078704,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V3.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6115",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.16/HLT/V3",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 193192 - 193207, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch1\">CMSSW_5_2_4_onlpatch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2079765
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "f501d6c28d6443c018d48a8db76b81853430739a",
+        "size": 2079765,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V15.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6116",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.16/HLT/V15",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 194896 - 195970, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch3\">CMSSW_5_2_4_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2071454
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "ca7f1beb7cdbccf8b25343b81173395adac93c09",
+        "size": 2071454,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.3_HLT_V3.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6117",
+    "run_period": "Run2012B",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v2.3/HLT/V3",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 205303 - 205834, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_7_onlpatch1\">CMSSW_5_2_7_onlpatch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2193391
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "60b0cd36a9d6c7962eec6778c2c8d1a7b1213fa6",
+        "size": 2193391,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v1.2_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6118",
+    "run_period": "Run2012D",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/8e33/v1.2/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 190782, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_3_patch1\">CMSSW_5_2_3_patch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2045673
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "07b400eb709484019aa7c70a9c5f88249f672197",
+        "size": 2045673,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.10_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6119",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.10/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 194788 - 194825, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch3\">CMSSW_5_2_4_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2071455
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "634d28aa49d3751f8a518189fa6c6d84b0ee80ac",
+        "size": 2071455,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.3_HLT_V2.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6120",
+    "run_period": "Run2012B",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v2.3/HLT/V2",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 199698 - 199877, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_6_onlpatch2\">CMSSW_5_2_6_onlpatch2</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2051896
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "036c97a41aeef6f7086c595765a3d879664f1d8d",
+        "size": 2051896,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v4.0_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6121",
+    "run_period": "Run2012C",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v4.0/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 194223 - 194225, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch3\">CMSSW_5_2_4_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2059590
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "9f00e57cbae6d8fa90ba8bfa493b2db152862e33",
+        "size": 2059590,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.1_HLT_V13.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6122",
+    "run_period": "Run2012B",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v2.1/HLT/V13",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 190456 - 190465, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_3_patch1\">CMSSW_5_2_3_patch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2052178
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "1a10f3dda40a9490d60f37fe5e688dc8ce2d88ff",
+        "size": 2052178,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.4_HLT_V5.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6123",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.4/HLT/V5",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 191201 - 191411, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_3_patch4\">CMSSW_5_2_3_patch4</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2078889
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "74a30e1a465ea306e69e40a7140f8d8712f1c769",
+        "size": 2078889,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.14_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6124",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.14/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 191691 - 191726, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch1\">CMSSW_5_2_4_onlpatch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2078704
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "049c43cdf66071b66c1d438f06369c65991c1d07",
+        "size": 2078704,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V2.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6125",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.16/HLT/V2",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 207887 - 208686, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_7_onlpatch3\">CMSSW_5_2_7_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2321436
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "10ef3796de5a0651a1ae7ae822ced602ac469a0f",
+        "size": 2321436,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.1_HLT_V7.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6126",
+    "run_period": "Run2012D",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/8e33/v2.1/HLT/V7",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 191043 - 191090, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_3_patch4\">CMSSW_5_2_3_patch4</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2078401
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "fba62722ab75f483056e038e952d7f2446779120",
+        "size": 2078401,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.13_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6127",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.13/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 203777 - 203994, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_7\">CMSSW_5_2_7</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2189925
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "87333f29f12c409a973f2489bf57b0e3cfb1b97d",
+        "size": 2189925,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v1.0_HLT_V2.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6128",
+    "run_period": "Run2012D",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/8e33/v1.0/HLT/V2",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 202792, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_6_onlpatch3\">CMSSW_5_2_6_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 383104
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "a0a852fd1f96981c3e0ec7138cfdfc7c1decf348",
+        "size": 383104,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012PI_PilotRun_PIHLT_V2.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6129",
+    "run_period": "Run2012C",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012PI/PilotRun/PIHLT/V2",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 196046 - 196531, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch4\">CMSSW_5_2_4_onlpatch4</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2047845
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "30510f4d5aac1fe0ae20e8e8e74da2d13d2bd93f",
+        "size": 2047845,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.5_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6130",
+    "run_period": "Run2012B",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v2.5/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 190945 - 190949, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_3_patch4\">CMSSW_5_2_3_patch4</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2078617
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "e7474a2801fbcfbc8e05559aaf0104be5da26635",
+        "size": 2078617,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.12_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6131",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.12/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 202793 - 202794, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_6_onlpatch3\">CMSSW_5_2_6_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 383184
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "5274b68a3192610d713b3734217dc55337069388",
+        "size": 383184,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012PI_PilotRun_PIHLT_V4.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6132",
+    "run_period": "Run2012C",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012PI/PilotRun/PIHLT/V4",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 190895 - 190906, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_3_patch1\">CMSSW_5_2_3_patch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2046545
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "400ea11eaad2749d4e601f38efd1145ae16a47a4",
+        "size": 2046545,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.11_HLT_V2.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6133",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.11/HLT/V2",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 190482 - 190539, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_3_patch1\">CMSSW_5_2_3_patch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2049751
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "7adcd41559a1ee991a62c7f0ea819561d6fbb0d3",
+        "size": 2049751,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.4_HLT_V7.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6134",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.4/HLT/V7",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 190661 - 190679, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_3_patch1\">CMSSW_5_2_3_patch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2043235
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "385353e55b0cb023f2ab2ea8b933e07e31e7db6e",
+        "size": 2043235,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.7_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6135",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.7/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 194270 - 194317, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch3\">CMSSW_5_2_4_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2067597
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "76d2687d324f9da8b0b849ba9b08719b41546061",
+        "size": 2067597,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.2_HLT_V2.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6136",
+    "run_period": "Run2012B",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v2.2/HLT/V2",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 195868 - 195950, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch3\">CMSSW_5_2_4_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2103381
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "0d11aed4691f881ddfa7a93482527ab450288f58",
+        "size": 2103381,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.4_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6137",
+    "run_period": "Run2012B",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v2.4/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 193334 - 193336, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch1\">CMSSW_5_2_4_onlpatch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2079765
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "bb0f380abeedaa5a422b90a359b96503f3c1e7b5",
+        "size": 2079765,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V18.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6138",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.16/HLT/V18",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 193998 - 194210, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch3\">CMSSW_5_2_4_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2059046
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "2a911e70e005b2516526993e8b6c86036da9e82d",
+        "size": 2059046,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.1_HLT_V12.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6139",
+    "run_period": "Run2012B",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v2.1/HLT/V12",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 190591 - 190595, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_3_patch1\">CMSSW_5_2_3_patch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2048137
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "9780b020f07adbc26b0d420393b068e75f7c1fb3",
+        "size": 2048137,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.5_HLT_V3.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6140",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.5/HLT/V3",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 206859 - 207100, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_7_onlpatch2\">CMSSW_5_2_7_onlpatch2</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2308871
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "cb76fe27a5bbe43b379f12be6640db474fa13234",
+        "size": 2308871,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.0_HLT_V3.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6141",
+    "run_period": "Run2012D",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/8e33/v2.0/HLT/V3",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 199960 - 200381, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_6_onlpatch2\">CMSSW_5_2_6_onlpatch2</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2051070
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "aff3583172e19e875e1ff001bce83fe6094524ee",
+        "size": 2051070,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v4.0_HLT_V4.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6142",
+    "run_period": "Run2012C",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v4.0/HLT/V4",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 207214 - 207518, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_7_onlpatch3\">CMSSW_5_2_7_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2321428
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "57493dd5ac2764e20fc1f93cc4618507d8671562",
+        "size": 2321428,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.1_HLT_V5.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6143",
+    "run_period": "Run2012D",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/8e33/v2.1/HLT/V5",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 193093 - 193124, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch1\">CMSSW_5_2_4_onlpatch1</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2079718
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "0b18658b7ab191fc217c4e1a5aaf96f090bf4024",
+        "size": 2079718,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V14.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6144",
+    "run_period": "Run2012A",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/5e33/v4.16/HLT/V14",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 199318 - 199608, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_4_onlpatch5\">CMSSW_5_2_4_onlpatch5</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2064311
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "efb5a412cb51fd86db461b4292a43e0b74f0762e",
+        "size": 2064311,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.1_HLT_V2.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6145",
+    "run_period": "Run2012C",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v3.1/HLT/V2",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": " The configuration file used in data taking and HLT data processing step.<p>Run number 200466 - 202504, software version <a href=\"https://github.com/cms-sw/cmssw-cvs/tree/CMSSW_5_2_6_onlpatch3\">CMSSW_5_2_6_onlpatch3</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 2051652
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "1091157c7d15d2699f0ad4802b563adb58b08ef3",
+        "size": 2051652,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v4.1_HLT_V1.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "6146",
+    "run_period": "Run2012C",
+    "title": "Configuration file for HLT step /cdaq/physics/Run2012/7e33/v4.1/HLT/V1",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
* Adds CMS HLT configuration files for 2012. (closes #1961)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>