### PR TITLE
templates: HTML in record validation description

### DIFF
--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -288,7 +288,7 @@
                   {% else %}
                   <h3>How were these data validated?</h3>
                   {% endif %}
-                  <p>{{record.validation.description}}</p>
+                  <p>{{record.validation.description | safe}}</p>
                   {% if record.validation.links %}
                   {% for link in record.validation.links %}
                   <p><a href="{{link.url}}">{{link.description}}</a></p>


### PR DESCRIPTION
* Interpret HTML in record validation descriptions. (closes #1932)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>