### PR TITLE
records: CMS trigger examples VM link fixes

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-trigger-examples.json
+++ b/cernopendata/modules/fixtures/data/records/cms-trigger-examples.json
@@ -2,18 +2,18 @@
 {
   "abstract": {
     "description": " <p>This is an example of the C++ code (and its configuration in Python) needed to extract the trigger information from CMS Open/Legacy data. These instructions are valid to work with 2010 data. Snippets of this software can be used for physics analysis.</p>"
-  }, 
-  "accelerator": "CERN-LHC", 
+  },
+  "accelerator": "CERN-LHC",
   "authors": [
     {
       "name": "Carrera, Edgar"
     }
-  ], 
+  ],
   "collections": [
     "CMS-Tools"
-  ], 
-  "date_created": "2010", 
-  "date_published": "2017", 
+  ],
+  "date_created": "2010",
+  "date_published": "2017",
   "distribution": {
     "formats": [
       "gz"
@@ -21,39 +21,39 @@
     "number_files": 1,
     "size": 8759
   },
-  "doi": "10.7483/OPENDATA.CMS.TE10.IIC8", 
-  "experiment": "CMS", 
+  "doi": "10.7483/OPENDATA.CMS.TE10.IIC8",
+  "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:3164b6530e1a90fecbe0d742baec61114555b378", 
-      "size": 8759, 
+      "checksum": "sha1:3164b6530e1a90fecbe0d742baec61114555b378",
+      "size": 8759,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/trigger_examples/trigger_examples-10.0.0.tar.gz"
     }
-  ], 
+  ],
   "license": {
     "attribution": "GNU General Public License (GPL) version 3"
-  }, 
+  },
   "note": {
     "description": "<p>The examples, within the code, have plenty of in-line comments to make it more understandable and to point potential users to the original information sources. It has been put together compiling the most important pieces of already-available <a href=\"https://github.com/cms-sw/cmssw\">CMSSW software</a>.</p> "
-  }, 
-  "publisher": "CERN Open Data Portal", 
-  "recid": "5003", 
-  "run_period": "Run2010B", 
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "5003",
+  "run_period": "Run2010B",
   "system_details": {
-    "description": "Use this code with the CMS Open Data VM environment", 
-    "recid": "249", 
+    "description": "Use this code with the CMS Open Data VM environment",
+    "recid": "250",
     "release": "CMSSW_4_2_8"
-  }, 
-  "title": "Analysis code for extracting the trigger information from the CMS 2010 data", 
+  },
+  "title": "Analysis code for extracting the trigger information from the CMS 2010 data",
   "type": {
-    "primary": "Software", 
+    "primary": "Software",
     "secondary": [
       "Analysis"
     ]
-  }, 
+  },
   "usage": {
     "description": " <p>If you do not have the CERN Virtual Machine for 2010 CMS data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2010\">How to install a CERN Virtual Machine</a>.</p>\n\t\t\t<p>To run the analysis, follow the instructions at <a href=\"https://github.com/cms-opendata-analyses/trigger_examples/tree/2010/TriggerInfo/TriggerInfoAnalyzer\">https://github.com/cms-opendata-analyses/trigger_examples/tree/2010/TriggerInfo/TriggerInfoAnalyzer</a>.</p> "
-  }, 
+  },
   "use_with": {
     "description": "Use this with any CMS 2010 primary dataset and/or Monte Carlo datasets."
   }
@@ -61,18 +61,18 @@
 {
   "abstract": {
     "description": " <p>This is an example of the C++ code (and its configuration in Python) needed to extract the trigger information from CMS Open/Legacy data. These instructions are valid to work with 2011 data. Snippets of this software can be used for physics analysis.</p>"
-  }, 
-  "accelerator": "CERN-LHC", 
+  },
+  "accelerator": "CERN-LHC",
   "authors": [
     {
       "name": "Carrera, Edgar"
     }
-  ], 
+  ],
   "collections": [
     "CMS-Tools"
-  ], 
-  "date_created": "2011", 
-  "date_published": "2017", 
+  ],
+  "date_created": "2011",
+  "date_published": "2017",
   "distribution": {
     "formats": [
       "gz"
@@ -80,39 +80,39 @@
     "number_files": 1,
     "size": 9102
   },
-  "doi": "10.7483/OPENDATA.CMS.TE11.L03E", 
-  "experiment": "CMS", 
+  "doi": "10.7483/OPENDATA.CMS.TE11.L03E",
+  "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:6ebac43316112666a9a3eac8a44f4f43b6d9c638", 
-      "size": 9102, 
+      "checksum": "sha1:6ebac43316112666a9a3eac8a44f4f43b6d9c638",
+      "size": 9102,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/trigger_examples/trigger_examples-11.0.0.tar.gz"
     }
-  ], 
+  ],
   "license": {
     "attribution": "GNU General Public License (GPL) version 3"
-  }, 
+  },
   "note": {
     "description": "<p>The examples, within the code, have plenty of in-line comments to make it more understandable and to point potential users to the original information sources. It has been put together compiling the most important pieces of already-available <a href=\"https://github.com/cms-sw/cmssw\">CMSSW software</a>.</p> "
-  }, 
-  "publisher": "CERN Open Data Portal", 
-  "recid": "5004", 
-  "run_period": "Run2011A", 
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "5004",
+  "run_period": "Run2011A",
   "system_details": {
-    "description": "Use this code with the CMS Open Data VM environment", 
-    "recid": "251", 
+    "description": "Use this code with the CMS Open Data VM environment",
+    "recid": "252",
     "release": "CMSSW_5_3_32"
-  }, 
-  "title": "Analysis code for extracting the trigger information from the CMS 2011 data", 
+  },
+  "title": "Analysis code for extracting the trigger information from the CMS 2011 data",
   "type": {
-    "primary": "Software", 
+    "primary": "Software",
     "secondary": [
       "Analysis"
     ]
-  }, 
+  },
   "usage": {
     "description": " <p>If you do not have the CERN Virtual Machine for 2011 CMS data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2011\">How to install a CERN Virtual Machine</a>.</p>\n\t\t\t<p>To run the analysis, follow the instructions at <a href=\"https://github.com/cms-opendata-analyses/trigger_examples/tree/2011/TriggerInfo/TriggerInfoAnalyzer\">https://github.com/cms-opendata-analyses/trigger_examples/tree/2011/TriggerInfo/TriggerInfoAnalyzer</a>.</p> "
-  }, 
+  },
   "use_with": {
     "description": "Use this with any CMS 2011 primary dataset and/or Monte Carlo datasets."
   }


### PR DESCRIPTION
* Fixes links to VM records for CMS trigger examples records. (closes #1984)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>