### PR TITLE
records: CMS 2012 collision dataset RECO configuration files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-reco-configuration-files-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-reco-configuration-files-2012.json
@@ -1,0 +1,2446 @@
+[
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4598
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "a1109d2b609a6e01086ab312c6f94e409f4fb410",
+        "size": 4598,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_HTMHTParked.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7000",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_HTMHTParked",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4595
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "c94f43b43c644f7d6c26de550d53e11af8a7edd1",
+        "size": 4595,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_TauPlusX.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7001",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_TauPlusX",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6103
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "82c93e94be30241bce941fee71da051125a84a1b",
+        "size": 6103,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MuOniaParked.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7002",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_MuOniaParked",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4592
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "57405e705c0290478d5f9ad190179c51a1002edb",
+        "size": 4592,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_JetHT.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7003",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_JetHT",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4049
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "e8b783ab728a0fba965e7de3fe846e192a340017",
+        "size": 4049,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MuEG.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7004",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_MuEG",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4055
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "fa81e82d88b5642a1e247c518b994840a6354033",
+        "size": 4055,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_VBF1Parked.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7005",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_VBF1Parked",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5587
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "99777d13433970e29d0299c974950886f7580e98",
+        "size": 5587,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_Commissioning.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7006",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_Commissioning",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4050
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "84a1caed05488fbcac01638be70f8c929a612c39",
+        "size": 4050,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MuHad.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7007",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_MuHad",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8819
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "d726f30a9a4ab6c9b465a32afa1a11e9a9de0ca1",
+        "size": 8819,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_SingleMu.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7008",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_SingleMu",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4593
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "ecca56f6a90489539cae8400a1f842517b742e8a",
+        "size": 4593,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_JetMon.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7009",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_JetMon",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4050
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "c9e33404bc903c5a5debd45f9dd1e76a9c2a3ad3",
+        "size": 4050,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MuHad.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7010",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_MuHad",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4596
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "65d90d17c56f237cde126e00a47300252e615239",
+        "size": 4596,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_PhotonHad.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7011",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_PhotonHad",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4596
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "f27a9ccf775ef434b7c1138bd8c74c277c19344b",
+        "size": 4596,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_PhotonHad.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7012",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_PhotonHad",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4590
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "8cc6201017aeed94c9147b86192cc62b9f9b8485",
+        "size": 4590,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MET.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7013",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_MET",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4591
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "fa3b2aa94fb00082a432cbb2721a7da367ef6cee",
+        "size": 4591,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_BTag.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7014",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_BTag",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4057
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "7505ddab2d5cac66d6200794760667f488b4a374",
+        "size": 4057,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_DoublePhoton.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7015",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_DoublePhoton",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4054
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "108d1c316f5af363bd736841c15edaa79420f903",
+        "size": 4054,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_BJetPlusX.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7016",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_BJetPlusX",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7384
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "4c8ad74176458573c579b593a21899446e0e1d66",
+        "size": 7384,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MinimumBias.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7017",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_MinimumBias",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4063
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "fde5feeb8292c404a3a215d21274eedf7868e1ce",
+        "size": 4063,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_DoublePhotonHighPt.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7018",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_DoublePhotonHighPt",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6624
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "c3e22543f70842d779dedba38fef73bee13ace56",
+        "size": 6624,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_SingleElectron.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7019",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_SingleElectron",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6638
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "4acc9a56757ffa339e8eddcbfd65541c609939c0",
+        "size": 6638,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MuOnia.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7020",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_MuOnia",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4595
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "86ccf2172dd13c1c664bb2c1418dcbf71213a9a9",
+        "size": 4595,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_TauPlusX.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7021",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_TauPlusX",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5817
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "9eeba45f6067c4741dd2252211a1f4de16cec27c",
+        "size": 5817,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_HcalNZS.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7022",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_HcalNZS",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4056
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "0a790bd7a1aeff7218fedc851b0626e55a4a72d8",
+        "size": 4056,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_ElectronHad.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7023",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_ElectronHad",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6624
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "d2f48240e699582f7ae317484d2d6df495d6eb0f",
+        "size": 6624,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_DoubleElectron.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7024",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_DoubleElectron",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4599
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "1e1fca069177835f58a6cce2466f66f5939b3c4a",
+        "size": 4599,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_SinglePhoton.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7025",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_SinglePhoton",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7384
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "8e1e56d8a816e34b9fee7d0bd9e128e5020a63db",
+        "size": 7384,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MinimumBias.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7026",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_MinimumBias",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5587
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "41ed5c90cc26ceaacf363029eca7626f1f95cbf9",
+        "size": 5587,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_Commissioning.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7027",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_Commissioning",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4593
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "ee14fe7072f7cf935d82abae78141cef8c378609",
+        "size": 4593,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_NoBPTX.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7028",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_NoBPTX",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4591
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "1b50945fa95b576347bd193e0c9fdf98b0bab33e",
+        "size": 4591,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_BTag.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7029",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_BTag",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4598
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "f115cfe99882a447cefbca1a52019b6e3d52fa26",
+        "size": 4598,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_HTMHTParked.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7030",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_HTMHTParked",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6103
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "611adc60addc51f8ae74be55ef76591d6eea0b79",
+        "size": 6103,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MuOniaParked.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7031",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_MuOniaParked",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4055
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "d9d771771a9665bd76fb0f266267882c3055c1e6",
+        "size": 4055,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_VBF1Parked.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7032",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_VBF1Parked",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8768
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "1bc4e297f1c7a042e50d7ea0fccd31dc844f3b12",
+        "size": 8768,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_DoubleMuParked.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7033",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_DoubleMuParked",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4056
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "46a9be4470ae8f02de474b7f0e2f4c027a0055e7",
+        "size": 4056,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_ElectronHad.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7034",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_ElectronHad",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4593
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "06230305494acbd4c55b404ce2690e56cafa0f42",
+        "size": 4593,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_JetMon.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7035",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_JetMon",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4054
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "683849573316907e298d22e2bf5966558d5c2c48",
+        "size": 4054,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_TauParked.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7036",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_TauParked",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6638
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "bbcb175d68a761ade609076b1d4abab79958891d",
+        "size": 6638,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MuOnia.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7037",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_MuOnia",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8768
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "d2c4203f0523288b336a4fa296c8d1e97ddd2f96",
+        "size": 8768,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_DoubleMuParked.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7038",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_DoubleMuParked",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8819
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "ffea94dd64fb030cc38ba468c132e58d5f720c0a",
+        "size": 8819,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_SingleMu.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7039",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_SingleMu",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5817
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "95ce0078c37819187ddfb26986e44c480ba07262",
+        "size": 5817,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_HcalNZS.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7040",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_HcalNZS",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4593
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "1cd161c74cce9e0e2d943c5911e7731ed7a9edd8",
+        "size": 4593,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_NoBPTX.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7041",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_NoBPTX",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4057
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "ad2b37c194384d09190ab27b7a6e86d707c68d42",
+        "size": 4057,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_DoublePhoton.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7042",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_DoublePhoton",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6624
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "9f698b518a9595650b6af4c026c22dd75c6a8c88",
+        "size": 6624,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_DoubleElectron.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7043",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_DoubleElectron",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6624
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "ed03624aed0b4de7998415dae0937f2474367a5c",
+        "size": 6624,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_SingleElectron.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7044",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_SingleElectron",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4049
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "b0863f3b3273e26f432eb52b7c416e808d2204d0",
+        "size": 4049,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MuEG.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7045",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_MuEG",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4054
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "f8fc4b97601995dbcc0fc8721d591062b35548db",
+        "size": 4054,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_TauParked.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7046",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_TauParked",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4592
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "dd7d9604058b1d1ea8abe07e55167a0e8f83ff83",
+        "size": 4592,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_JetHT.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7047",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_JetHT",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4599
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "12cfe74631425f7ecfab2e333022128f0deafebb",
+        "size": 4599,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_SinglePhoton.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7048",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_SinglePhoton",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4054
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "dad3163f63ad52e68405abeca4be310b27a58f40",
+        "size": 4054,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_BJetPlusX.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7049",
+    "run_period": "Run2012B",
+    "title": "Configuration file for RECO step reco_2012B_BJetPlusX",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4590
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "5e9726c92536a9cecd1029f208e172844b3a12d7",
+        "size": 4590,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MET.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7050",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_MET",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in RECO data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4063
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "8955f09cc519d1079e08dc953971b2a845c539cb",
+        "size": 4063,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_DoublePhotonHighPt.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "7051",
+    "run_period": "Run2012C",
+    "title": "Configuration file for RECO step reco_2012C_DoublePhotonHighPt",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
* Adds RECO configuration files for CMS 2012 collision datasets.
  (closes #1988)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>