### PR TITLE
records: CMS 2012 event display files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012B.json
@@ -1,0 +1,1926 @@
+[
+{
+  "abstract": {
+    "description": "Sample event set from /BJetPlusX/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 4657122
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "25f583efc84fba23953501bbba90197e8f745fdb",
+      "size": 4657122,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/IG/22Jan2013-v1/BJetPlusX_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7100",
+  "relations": [
+    {
+      "recid": "6000",
+      "title": "/BJetPlusX/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /BJetPlusX/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /BTag/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2855989
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "981c3b0022b6ca9ce8c91d2d6d2e4811b3088370",
+      "size": 2855989,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BTag/IG/22Jan2013-v1/BTag_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7101",
+  "relations": [
+    {
+      "recid": "6001",
+      "title": "/BTag/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /BTag/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /Commissioning/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 1213583
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "e6e3380fe96daa5d747077e41b0f83cf70aaf253",
+      "size": 1213583,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/Commissioning/IG/22Jan2013-v1/Commissioning_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7102",
+  "relations": [
+    {
+      "recid": "6002",
+      "title": "/Commissioning/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /Commissioning/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /DoubleElectron/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2735536
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "f0e937f78dbc432daf64b083d626b1bd853e58d8",
+      "size": 2735536,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/IG/22Jan2013-v1/DoubleElectron_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7103",
+  "relations": [
+    {
+      "recid": "6003",
+      "title": "/DoubleElectron/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /DoubleElectron/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /DoubleMuParked/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2421331
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "6315b113775e83c4cf9a4f1f7693feda1e661a21",
+      "size": 2421331,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/IG/22Jan2013-v1/DoubleMuParked_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7104",
+  "relations": [
+    {
+      "recid": "6004",
+      "title": "/DoubleMuParked/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /DoubleMuParked/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /DoublePhoton/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2290289
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "6c647816fdb33d58e5f37339c1ff9b56f9292edf",
+      "size": 2290289,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/IG/22Jan2013-v1/DoublePhoton_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7105",
+  "relations": [
+    {
+      "recid": "6005",
+      "title": "/DoublePhoton/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /DoublePhoton/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /DoublePhotonHighPt/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3483546
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "6af732ef22c007cb5222113c9eddf29e6216aae0",
+      "size": 3483546,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhotonHighPt/IG/22Jan2013-v1/DoublePhotonHighPt_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7106",
+  "relations": [
+    {
+      "recid": "6006",
+      "title": "/DoublePhotonHighPt/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /DoublePhotonHighPt/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /ElectronHad/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3496785
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "0009d197aa5bb3f42842e241a401ab9f78d9e89f",
+      "size": 3496785,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/IG/22Jan2013-v1/ElectronHad_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7107",
+  "relations": [
+    {
+      "recid": "6007",
+      "title": "/ElectronHad/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /ElectronHad/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /HTMHTParked/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 4297007
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "7bd2fa50c5ad8a145d1770d4dee7d3e75952c645",
+      "size": 4297007,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/IG/22Jan2013-v1/HTMHTParked_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7108",
+  "relations": [
+    {
+      "recid": "6008",
+      "title": "/HTMHTParked/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /HTMHTParked/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /HcalNZS/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 1635763
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "af2ee47f08e04cb8c94949dc1663f4db47ca83de",
+      "size": 1635763,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HcalNZS/IG/22Jan2013-v1/HcalNZS_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7109",
+  "relations": [
+    {
+      "recid": "6009",
+      "title": "/HcalNZS/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /HcalNZS/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /JetHT/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 5070266
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "dbb29dde6081ff5ea1fbe4297c88035ea6cd9487",
+      "size": 5070266,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/IG/22Jan2013-v1/JetHT_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7110",
+  "relations": [
+    {
+      "recid": "6010",
+      "title": "/JetHT/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /JetHT/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /JetMon/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3320518
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "fdb2c0c345438ee1728c982c360705257beac9d3",
+      "size": 3320518,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetMon/IG/22Jan2013-v1/JetMon_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7111",
+  "relations": [
+    {
+      "recid": "6011",
+      "title": "/JetMon/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /JetMon/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /MET/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2525841
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "2d8dec189915d8ceeeacb523921568d98f8d9887",
+      "size": 2525841,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/IG/22Jan2013-v1/MET_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7112",
+  "relations": [
+    {
+      "recid": "6012",
+      "title": "/MET/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /MET/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /MinimumBias/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 1674785
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "434957cc490332f746859edf1823b70753afb9fe",
+      "size": 1674785,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MinimumBias/IG/22Jan2013-v1/MinimumBias_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7113",
+  "relations": [
+    {
+      "recid": "6013",
+      "title": "/MinimumBias/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /MinimumBias/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /MuEG/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2767985
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "676e4b265a379632be8ae57a036c9012afa9b296",
+      "size": 2767985,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/IG/22Jan2013-v1/MuEG_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7114",
+  "relations": [
+    {
+      "recid": "6014",
+      "title": "/MuEG/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /MuEG/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /MuHad/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 4175894
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "50405bc0086fa9c26b64a7a744b1b3b192d77023",
+      "size": 4175894,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/IG/22Jan2013-v1/MuHad_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7115",
+  "relations": [
+    {
+      "recid": "6015",
+      "title": "/MuHad/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /MuHad/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /MuOnia/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 1903571
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "b3745d6c9b7882867778511d48ade58d11dc30c5",
+      "size": 1903571,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/IG/22Jan2013-v1/MuOnia_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7116",
+  "relations": [
+    {
+      "recid": "6016",
+      "title": "/MuOnia/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /MuOnia/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /NoBPTX/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 420370
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "c0451b2c875e16e7d6fb169b4ac3047dd1b32330",
+      "size": 420370,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/NoBPTX/IG/22Jan2013-v1/NoBPTX_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7117",
+  "relations": [
+    {
+      "recid": "6018",
+      "title": "/NoBPTX/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /NoBPTX/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /PhotonHad/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3293511
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "ab2923deb1046de8236d46a45d3de2a802e49cba",
+      "size": 3293511,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/IG/22Jan2013-v1/PhotonHad_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7118",
+  "relations": [
+    {
+      "recid": "6019",
+      "title": "/PhotonHad/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /PhotonHad/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /SingleElectron/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3115787
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "6d09616b94253604f24cfe007fe9a4b33ab98e8e",
+      "size": 3115787,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/IG/22Jan2013-v1/SingleElectron_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7119",
+  "relations": [
+    {
+      "recid": "6020",
+      "title": "/SingleElectron/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /SingleElectron/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /SingleMu/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 1748615
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "201c0cdf5946d2a2be30a6008050796c2bf915b8",
+      "size": 1748615,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/IG/22Jan2013-v1/SingleMu_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7120",
+  "relations": [
+    {
+      "recid": "6021",
+      "title": "/SingleMu/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /SingleMu/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /SinglePhoton/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2903012
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "8b8188cfd4cdd33fa380090cf310b0b3187ca736",
+      "size": 2903012,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SinglePhoton/IG/22Jan2013-v1/SinglePhoton_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7121",
+  "relations": [
+    {
+      "recid": "6022",
+      "title": "/SinglePhoton/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /SinglePhoton/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /TauParked/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2884098
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "f38b9ab08589a7e3ec847802279796bb33e5b1d6",
+      "size": 2884098,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/IG/22Jan2013-v1/TauParked_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7122",
+  "relations": [
+    {
+      "recid": "6023",
+      "title": "/TauParked/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /TauParked/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /TauPlusX/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2289465
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "8ea52acbe86fa998447d1d4c5ad557ecb85c6a9b",
+      "size": 2289465,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/IG/22Jan2013-v1/TauPlusX_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7123",
+  "relations": [
+    {
+      "recid": "6024",
+      "title": "/TauPlusX/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /TauPlusX/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /VBF1Parked/Run2012B-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3176610
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "48e50855f560aebfc0698133e73e4822aa9ef750",
+      "size": 3176610,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/IG/22Jan2013-v1/VBF1Parked_Run2012B_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7124",
+  "relations": [
+    {
+      "recid": "6025",
+      "title": "/VBF1Parked/Run2012B-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012B",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /VBF1Parked/Run2012B-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+]

--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012C.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012C.json
@@ -1,0 +1,1926 @@
+[
+{
+  "abstract": {
+    "description": "Sample event set from /BJetPlusX/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3529192
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "2b62f5b231ebcc5a097caa2df6e02622119837ee",
+      "size": 3529192,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/IG/22Jan2013-v1/BJetPlusX_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7125",
+  "relations": [
+    {
+      "recid": "6026",
+      "title": "/BJetPlusX/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /BJetPlusX/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /BTag/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3065876
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "cf2f64ab67ebbb07f1209475b9b73b482197279a",
+      "size": 3065876,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BTag/IG/22Jan2013-v1/BTag_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7126",
+  "relations": [
+    {
+      "recid": "6027",
+      "title": "/BTag/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /BTag/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /Commissioning/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 1543681
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "88867ab7d42aaea3f40d6dd05344b36e140eb7a1",
+      "size": 1543681,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/IG/22Jan2013-v1/Commissioning_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7127",
+  "relations": [
+    {
+      "recid": "6028",
+      "title": "/Commissioning/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /Commissioning/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /DoubleElectron/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2257530
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "e32873dfd23ac1b404170f0a9a729f91c95deeb1",
+      "size": 2257530,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/IG/22Jan2013-v1/DoubleElectron_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7128",
+  "relations": [
+    {
+      "recid": "6029",
+      "title": "/DoubleElectron/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /DoubleElectron/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /DoubleMuParked/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3012530
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "4477ed2ea68f9b101c03fc1378aa8c72b5d8dc4c",
+      "size": 3012530,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/IG/22Jan2013-v1/DoubleMuParked_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7129",
+  "relations": [
+    {
+      "recid": "6030",
+      "title": "/DoubleMuParked/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /DoubleMuParked/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /DoublePhoton/Run2012C-22Jan2013-v2/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2581960
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "e7263d2e7b8d7148dbd6ba643ec0654a5c21dd8c",
+      "size": 2581960,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/IG/22Jan2013-v2/DoublePhoton_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7130",
+  "relations": [
+    {
+      "recid": "6031",
+      "title": "/DoublePhoton/Run2012C-22Jan2013-v2/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /DoublePhoton/Run2012C-22Jan2013-v2/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /DoublePhotonHighPt/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3441201
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "13c79fb786ff0fc0f1cf0113879e69d8b1cfe3a1",
+      "size": 3441201,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhotonHighPt/IG/22Jan2013-v1/DoublePhotonHighPt_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7131",
+  "relations": [
+    {
+      "recid": "6032",
+      "title": "/DoublePhotonHighPt/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /DoublePhotonHighPt/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /ElectronHad/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3698072
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "4222c37e3aa79df758eedcfbd15d6bac55127e4f",
+      "size": 3698072,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/IG/22Jan2013-v1/ElectronHad_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7132",
+  "relations": [
+    {
+      "recid": "6033",
+      "title": "/ElectronHad/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /ElectronHad/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /HTMHTParked/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 4539126
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "9ff633788501a8aa3613500ba5b3091262379abf",
+      "size": 4539126,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/IG/22Jan2013-v1/HTMHTParked_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7133",
+  "relations": [
+    {
+      "recid": "6034",
+      "title": "/HTMHTParked/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /HTMHTParked/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /HcalNZS/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2014385
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "614e01589c497c3aabd577971138d226c92cb492",
+      "size": 2014385,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HcalNZS/IG/22Jan2013-v1/HcalNZS_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7134",
+  "relations": [
+    {
+      "recid": "6035",
+      "title": "/HcalNZS/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /HcalNZS/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /JetHT/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 4834920
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "0e26be3cf1a712908c636fb27ce84b4d556af368",
+      "size": 4834920,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/IG/22Jan2013-v1/JetHT_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7135",
+  "relations": [
+    {
+      "recid": "6036",
+      "title": "/JetHT/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /JetHT/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /JetMon/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3782469
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "7b1184bae0ac1ed3467790241deb093dd3db7f09",
+      "size": 3782469,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetMon/IG/22Jan2013-v1/JetMon_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7136",
+  "relations": [
+    {
+      "recid": "6037",
+      "title": "/JetMon/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /JetMon/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /MET/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3032299
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "fa6c680c2b829cbd60ead541dd9a3946876f37a3",
+      "size": 3032299,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/IG/22Jan2013-v1/MET_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7137",
+  "relations": [
+    {
+      "recid": "6038",
+      "title": "/MET/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /MET/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /MinimumBias/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 1129918
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "781360c427490e96fb9049afb9ea114e216916e0",
+      "size": 1129918,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MinimumBias/IG/22Jan2013-v1/MinimumBias_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7138",
+  "relations": [
+    {
+      "recid": "6039",
+      "title": "/MinimumBias/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /MinimumBias/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /MuEG/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2713188
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "eb4d6aa4286e612d32a955d43d9e4486f2719aae",
+      "size": 2713188,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/IG/22Jan2013-v1/MuEG_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7139",
+  "relations": [
+    {
+      "recid": "6040",
+      "title": "/MuEG/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /MuEG/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /MuHad/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 4368131
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "8cb0f25da4575c3c441d7d3db6e04693982a9b6f",
+      "size": 4368131,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/IG/22Jan2013-v1/MuHad_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7140",
+  "relations": [
+    {
+      "recid": "6041",
+      "title": "/MuHad/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /MuHad/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /MuOnia/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2099934
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "01dc54f1e07fee641e7bf86d63bcf982599fd6f2",
+      "size": 2099934,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/IG/22Jan2013-v1/MuOnia_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7141",
+  "relations": [
+    {
+      "recid": "6042",
+      "title": "/MuOnia/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /MuOnia/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /NoBPTX/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 481762
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "791b4b18cb79a6ea1e58e7e60cc860fe60eaeb0b",
+      "size": 481762,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/NoBPTX/IG/22Jan2013-v1/NoBPTX_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7142",
+  "relations": [
+    {
+      "recid": "6044",
+      "title": "/NoBPTX/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /NoBPTX/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /PhotonHad/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 4210535
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "b528387c215eda69cfa09cee10cf644aba4abbc7",
+      "size": 4210535,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/IG/22Jan2013-v1/PhotonHad_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7143",
+  "relations": [
+    {
+      "recid": "6045",
+      "title": "/PhotonHad/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /PhotonHad/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /SingleElectron/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3081204
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "d812a70a0a9ce1115ba2660a822836fb1efa628f",
+      "size": 3081204,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/IG/22Jan2013-v1/SingleElectron_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7144",
+  "relations": [
+    {
+      "recid": "6046",
+      "title": "/SingleElectron/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /SingleElectron/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /SingleMu/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2212692
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "5d9501f3d8f8a920ec3f62de9ab6a3c6b9309ceb",
+      "size": 2212692,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/IG/22Jan2013-v1/SingleMu_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7145",
+  "relations": [
+    {
+      "recid": "6047",
+      "title": "/SingleMu/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /SingleMu/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /SinglePhoton/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3435007
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "b9550d0653802ec1b285a5e1777efbbde21013c8",
+      "size": 3435007,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/IG/22Jan2013-v1/SinglePhoton_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7146",
+  "relations": [
+    {
+      "recid": "6048",
+      "title": "/SinglePhoton/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /SinglePhoton/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /TauParked/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2760392
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "ca249e14e06df5addc6895b3df800d9a845d9d11",
+      "size": 2760392,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/IG/22Jan2013-v1/TauParked_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7147",
+  "relations": [
+    {
+      "recid": "6049",
+      "title": "/TauParked/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /TauParked/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /TauPlusX/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 2785003
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "f868643fe9e4b5123d5225bf2df9a4183a5219fd",
+      "size": 2785003,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/IG/22Jan2013-v1/TauPlusX_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7148",
+  "relations": [
+    {
+      "recid": "6050",
+      "title": "/TauPlusX/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /TauPlusX/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+,
+{
+  "abstract": {
+    "description": "Sample event set from /VBF1Parked/Run2012C-22Jan2013-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+  },
+  "accelerator": "CERN-LHC",
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ],
+  "collections": [
+    "CMS-Derived-Datasets"
+  ],
+  "collision_information": {
+    "energy": "8TeV",
+    "type": "pp"
+  },
+  "date_created": "2012",
+  "date_published": "2017",
+  "date_reprocessed": "2012",
+  "distribution": {
+    "formats": [
+      "ig"
+    ],
+    "number_events": 25,
+    "number_files": 1,
+    "size": 3077135
+  },
+  "experiment": "CMS",
+  "files": [
+    {
+      "checksum": "e16296f7d65edf7523f7ff94a12cbd45856f2af7",
+      "size": 3077135,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/IG/22Jan2013-v1/VBF1Parked_Run2012C_0.ig"
+    }
+  ],
+  "license": {
+    "attribution": "CC0"
+  },
+  "methodology": {
+    "description": "These files contain the objects to be displayed with the online event display. No event selection, apart accepting only the validated runs, is applied."
+  },
+  "note": {
+    "description": "No selection or quality criteria have been applied on the individual physics objects, apart from accepting only the validated runs."
+  },
+  "publisher": "CERN Open Data Portal",
+  "recid": "7149",
+  "relations": [
+    {
+      "recid": "6051",
+      "title": "/VBF1Parked/Run2012C-22Jan2013-v1/AOD",
+      "type": "isChildOf"
+    }
+  ],
+  "run_period": "Run2012C",
+  "system_details": {
+    "global_tag": "FT_53_LV5_AN1",
+    "release": "CMSSW_5_3_32"
+  },
+  "title": "Event display file derived from /VBF1Parked/Run2012C-22Jan2013-v1/AOD",
+  "type": {
+    "primary": "Dataset",
+    "secondary": [
+      "Derived"
+    ]
+  },
+  "usage": {
+    "description": "The data can be accessed from the file menu of the online event display",
+    "links": [
+      {
+        "description": "Explore and visualise events",
+        "url": "/visualise/events/CMS"
+      }
+    ]
+  }
+}
+]


### PR DESCRIPTION
* Adds CMS 2012 event display files. (closes #1404)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>