### PR TITLE
templates: capitalisation fix for OPERA .json

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/opera-news-first-release/opera-news-first-release.json
+++ b/cernopendata/modules/fixtures/data/docs/opera-news-first-release/opera-news-first-release.json
@@ -2,10 +2,10 @@
   {
     "title": "Release of the first set of data samples by the OPERA Collaboration",
     "type": {"primary": "News"},
-    "experiment": "Opera",
+    "experiment": "OPERA",
     "collections": [
       {
-        "experiment": "Opera"
+        "experiment": "OPERA"
       },
       {
         "primary": "News"


### PR DESCRIPTION
* Changes the experiment name from Opera --> OPERA, so that it is not
displayed twice in the facet.

Signed-off-by: Artemis Lavasa <artemis.lavasa@cern.ch>