### PR TITLE
docker: add elasticsearch 5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,12 @@ sudo: false
 
 language: python
 
+env:
+  # Latest available version of Docker-Compose at the time of commit.
+  # To download latest available version, one needs to do some (JSON) parsing
+  # as Github doesn't provide an easy way to download the latest release.
+  - DOCKER_COMPOSE_VERSION=1.17.1
+
 matrix:
   fast_finish: true
 
@@ -47,12 +53,20 @@ addons:
     packages:
     - nodejs
     - jq
+    - docker-ce # Use latest available Docker-CE from official repo
 
 before_install:
+  # Docker-Compose update
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
   - npm install -g jsonlint
   - ./run-tests.sh --check-fixtures-only
 
 install:
+  - "docker version"
+  - "docker-compose version"
   - "docker-compose build"
 
 script:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,116 +22,122 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-web:
-  restart: "always"
-  build: .
-  command: "cernopendata run -h 0.0.0.0"
-  environment:
-    - PATH=/home/invenio/.virtualenvs/cernopendata/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - VIRTUALENVWRAPPER_PYTHON=/usr/bin/python
-    - APP_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://cernopendata:dbpass123@postgresql:5432/cernopendata
-    - APP_CACHE_REDIS_HOST=redis
-    - APP_CACHE_REDIS_URL=redis://redis:6379/0
-    - APP_ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/1
-    - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 3
-    - APP_CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 4
-    - APP_CELERY_RESULT_BACKEND=redis://redis:6379/2
-    - APP_SEARCH_ELASTIC_HOSTS=elasticsearch
-    - APP_PIDSTORE_DATACITE_TESTMODE=False
-    - APP_PIDSTORE_DATACITE_DOI_PREFIX=10.5072
-    - APP_PIDSTORE_DATACITE_USERNAME=CERN.OPENDATA
-    - APP_PIDSTORE_DATACITE_PASSWORD=CHANGE_ME
-    - APP_PIDSTORE_LANDING_BASE_URL=http://opendata.cern.ch/record/
-    - APP_FILES_REST_FILE_URI_MAX_LEN=512  # Allow URI's longer than 255 chars.
-  volumes:
-    - ../devmodules:/devmodules
-    - ./cernopendata:/code/cernopendata
-    - ./scripts:/code/scripts
-  volumes_from:
-    - static
-  links:
-    - postgresql
-    - redis
-    - elasticsearch
-    - rabbitmq
-  ports:
-    - "5000:5000"
+version: "2"
 
-worker:
-  build: .
-  restart: "always"
-  command: "celery worker -A cernopendata.celery --loglevel=INFO"
-  environment:
-    - PATH=/home/invenio/.virtualenvs/cernopendata/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-    - VIRTUALENVWRAPPER_PYTHON=/usr/bin/python
-    - APP_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://cernopendata:dbpass123@postgresql:5432/cernopendata
-    - APP_CACHE_REDIS_HOST=redis
-    - APP_CACHE_REDIS_URL=redis://redis:6379/0
-    - APP_ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/1
-    - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 3
-    - APP_CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 4
-    - APP_CELERY_RESULT_BACKEND=redis://redis:6379/2
-    - APP_SEARCH_ELASTIC_HOSTS=elasticsearch
-  volumes:
-    - ../devmodules:/devmodules
-    - ./cernopendata:/code/cernopendata
-    - ./scripts:/code/scripts
-  volumes_from:
-    - static
-  links:
-    - postgresql
-    - redis
-    - elasticsearch
-    - rabbitmq
+services:
 
-postgresql:
-  restart: "always"
-  image: postgres
-  environment:
-    - POSTGRES_USER=cernopendata
-    - POSTGRES_DB=cernopendata
-    - POSTGRES_PASSWORD=dbpass123
-  ports:
-    - "5432"
+  web:
+    restart: "always"
+    build: .
+    command: "cernopendata run -h 0.0.0.0"
+    environment:
+      - PATH=/home/invenio/.virtualenvs/cernopendata/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - VIRTUALENVWRAPPER_PYTHON=/usr/bin/python
+      - APP_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://cernopendata:dbpass123@postgresql:5432/cernopendata
+      - APP_CACHE_REDIS_HOST=redis
+      - APP_CACHE_REDIS_URL=redis://redis:6379/0
+      - APP_ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/1
+      - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 3
+      - APP_CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 4
+      - APP_CELERY_RESULT_BACKEND=redis://redis:6379/2
+      - APP_SEARCH_ELASTIC_HOSTS=elasticsearch
+      - APP_PIDSTORE_DATACITE_TESTMODE=False
+      - APP_PIDSTORE_DATACITE_DOI_PREFIX=10.5072
+      - APP_PIDSTORE_DATACITE_USERNAME=CERN.OPENDATA
+      - APP_PIDSTORE_DATACITE_PASSWORD=CHANGE_ME
+      - APP_PIDSTORE_LANDING_BASE_URL=http://opendata.cern.ch/record/
+      - APP_FILES_REST_FILE_URI_MAX_LEN=512  # Allow URI's longer than 255 chars.
+    volumes:
+      - "./cernopendata:/code/cernopendata"
+      - "./scripts:/code/scripts"
+    volumes_from:
+      - static
+    links:
+      - postgresql
+      - redis
+      - elasticsearch
+      - rabbitmq
+    ports:
+      - "5000:5000"
 
-redis:
-  restart: "always"
-  image: redis
-  ports:
-    - "6379"
+  worker:
+    build: .
+    restart: "always"
+    command: "celery worker -A cernopendata.celery --loglevel=INFO"
+    environment:
+      - PATH=/home/invenio/.virtualenvs/cernopendata/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+      - VIRTUALENVWRAPPER_PYTHON=/usr/bin/python
+      - APP_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://cernopendata:dbpass123@postgresql:5432/cernopendata
+      - APP_CACHE_REDIS_HOST=redis
+      - APP_CACHE_REDIS_URL=redis://redis:6379/0
+      - APP_ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/1
+      - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 3
+      - APP_CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 4
+      - APP_CELERY_RESULT_BACKEND=redis://redis:6379/2
+      - APP_SEARCH_ELASTIC_HOSTS=elasticsearch
+    volumes:
+      - "./cernopendata:/code/cernopendata"
+      - "./scripts:/code/scripts"
+    volumes_from:
+      - static
+    links:
+      - postgresql
+      - redis
+      - elasticsearch
+      - rabbitmq
 
-elasticsearch:
-  restart: "always"
-  build: .
-  dockerfile: ./elasticsearch/Dockerfile
-  ports:
-    - "9200:9200"
-    - "9300:9300"
+  postgresql:
+    restart: "always"
+    image: postgres
+    environment:
+      - POSTGRES_USER=cernopendata
+      - POSTGRES_DB=cernopendata
+      - POSTGRES_PASSWORD=dbpass123
+    ports:
+      - "5432"
 
-rabbitmq:
-  restart: "always"
-  image: rabbitmq
-  ports:
-    - "4369"
-    - "5672"
+  redis:
+    restart: "always"
+    image: redis
+    ports:
+      - "6379"
 
-nginx:
-  restart: "always"
-  build: ./nginx
-  ports:
-    - "80:80"
-  volumes:
-    - ../devmodules:/devmodules
-    - ./cernopendata:/code/cernopendata
-    - ./scripts:/code/scripts
-  volumes_from:
-    - static
-  links:
-    - web
+  elasticsearch:
+    restart: "always"
+    build:
+      context: .
+      dockerfile: ./elasticsearch/Dockerfile
+      args:
+        - ES_VERSION=2
+    ports:
+      - "9200:9200"
+      - "9300:9300"
 
-static:
-  restart: "no"
-  build: .
-  volumes:
-    - /usr/local/var/cernopendata/var/cernopendata-instance/static
-  user: invenio
+  rabbitmq:
+    restart: "always"
+    image: rabbitmq
+    ports:
+      - "4369"
+      - "5672"
+
+  nginx:
+    restart: "always"
+    build: ./nginx
+    ports:
+      - "80:80"
+    volumes:
+      - "./cernopendata:/code/cernopendata"
+      - "./scripts:/code/scripts"
+    depends_on:
+     - static
+    volumes_from:
+      - static
+    links:
+      - web
+
+  static:
+    restart: "no"
+    build: .
+    volumes:
+      - /usr/local/var/cernopendata/var/cernopendata-instance/static
+    user: invenio

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -22,8 +22,24 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-# Use Elasticsearch 2.
-FROM elasticsearch:2
+# By default use Elasticsearch 2.
+ARG ES_VERSION=2
+
+# Select base image based on ES_VERSION BUILD ARGUMENT
+# ('--build-arg', not '-e')
+FROM elasticsearch:$ES_VERSION
+
+# Because of Docker's multi-staged build ARGs defined before FROM will be
+# in some sense "flushed" to empty or default values, so ARG ES_VERSION
+# needs to be set again. (for info see https://github.com/docker/cli/pull/333)
+
+ARG ES_VERSION=2
+
+# Build arguments are not available in shell started with RUN.
+# We need to set it to ENV_VAR.
+ENV ES_VERSION=${ES_VERSION:-2}
+
 COPY scripts/provision-elasticsearch.sh /tmp/
+
 # Install Elasticsarch plugins:
 RUN /tmp/provision-elasticsearch.sh

--- a/scripts/provision-elasticsearch.sh
+++ b/scripts/provision-elasticsearch.sh
@@ -129,7 +129,15 @@ enabled=1" | \
 
 install_plugins () {
     # sphinxdoc-install-elasticsearch-plugins-begin
-    $sudo /usr/share/elasticsearch/bin/plugin install -b mapper-attachments
+    if [ "$ES_VERSION" = "2" ]; then
+        $sudo /usr/share/elasticsearch/bin/plugin install -b mapper-attachments
+    else
+        # FIXME: mapper-attachments -plugin is deprecated in ES5.
+        #        Replaced by ingest-attachment -plugin which probably isn't
+        #        API compatible with mapper-attachments.
+        # $sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install -b ingest-attachment
+        $sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install -b mapper-attachments
+    fi
     # sphinxdoc-install-elasticsearch-plugins-end
 }
 


### PR DESCRIPTION
* Add necessary build argument (ES_VERSION) to specify which
  major version of Elasticsearch should be used.
  Tested with ES_VERSION=2 and ES_VERSION=5
  (closes #2001)

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>