### PR TITLE
records: dates in date_created -> data-taking year

### DIFF
--- a/cernopendata/modules/fixtures/data/records/atlas-tools.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-tools.json
@@ -68,7 +68,7 @@
   "collections": [
     "ATLAS-Tools"
   ], 
-  "date_created": "2016", 
+  "date_created": "2012", 
   "date_published": "2016", 
   "distribution": {
     "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-author-list-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-author-list-Run2011A.json
@@ -19847,7 +19847,7 @@
   "collections": [
     "Author-Lists"
   ], 
-  "date_created": "2016", 
+  "date_created": "2011", 
   "date_published": "2016", 
   "distribution": {
     "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-author-list.json
+++ b/cernopendata/modules/fixtures/data/records/cms-author-list.json
@@ -19022,7 +19022,7 @@
   "collections": [
     "Author-Lists"
   ], 
-  "date_created": "2014", 
+  "date_created": "2010", 
   "date_published": "2014", 
   "distribution": {
     "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-open-data-instructions-2017.json
+++ b/cernopendata/modules/fixtures/data/records/cms-open-data-instructions-2017.json
@@ -11,7 +11,7 @@
   "collections": [
     "CMS-Open-Data-Instructions"
   ],
-  "date_created": "2017",
+  "date_created": "2010-2012",
   "date_published": "2017",
   "distribution": {
     "formats": [
@@ -54,7 +54,7 @@
   "collections": [
     "CMS-Open-Data-Instructions"
   ],
-  "date_created": "2017",
+  "date_created": "2010-2012",
   "date_published": "2017",
   "distribution": {
     "formats": [
@@ -98,7 +98,7 @@
   "collections": [
     "CMS-Open-Data-Instructions"
   ],
-  "date_created": "2017",
+  "date_created": "2010-2012",
   "date_published": "2017",
   "distribution": {
     "formats": [
@@ -141,7 +141,7 @@
   "collections": [
     "CMS-Open-Data-Instructions"
   ],
-  "date_created": "2017",
+  "date_created": "2010-2012",
   "date_published": "2017",
   "distribution": {
     "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-open-data-instructions.json
+++ b/cernopendata/modules/fixtures/data/records/cms-open-data-instructions.json
@@ -161,7 +161,7 @@
   "collections": [
     "CMS-Open-Data-Instructions"
   ], 
-  "date_created": "2016", 
+  "date_created": "2010", 
   "date_published": "2016", 
   "experiment": "CMS", 
   "publisher": "CERN Open Data Portal", 
@@ -191,7 +191,7 @@
   "collections": [
     "CMS-Open-Data-Instructions"
   ], 
-  "date_created": "2016", 
+  "date_created": "2010", 
   "date_published": "2016", 
   "experiment": "CMS", 
   "publisher": "CERN Open Data Portal", 
@@ -216,7 +216,7 @@
   "collections": [
     "CMS-Open-Data-Instructions"
   ], 
-  "date_created": "2016", 
+  "date_created": "2010-2012", 
   "date_published": "2017", 
   "distribution": {
     "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-tools-ana-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-ana-Run2011A.json
@@ -15,7 +15,7 @@
   "collections": [
     "CMS-Tools"
   ], 
-  "date_created": "2016", 
+  "date_created": "2011", 
   "date_published": "2016", 
   "distribution": {
     "number_files": 1
@@ -104,7 +104,7 @@
   "collections": [
     "CMS-Tools"
   ], 
-  "date_created": "2016", 
+  "date_created": "2011", 
   "date_published": "2016", 
   "distribution": {
     "number_files": 1

--- a/cernopendata/modules/fixtures/data/records/cms-tools-cmssw-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-cmssw-Run2011A.json
@@ -11,7 +11,7 @@
   "collections": [
     "CMS-Tools"
   ], 
-  "date_created": "2011", 
+  "date_created": "2011-2012", 
   "date_published": "2016", 
   "doi": "10.7483/OPENDATA.CMS.WYJG.FYK9", 
   "experiment": "CMS", 

--- a/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-filter.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-filter.json
@@ -12,6 +12,7 @@
   "collections": [
     "CMS-Tools"
   ], 
+  "date_created": "2010", 
   "date_published": "2015", 
   "distribution": {
     "formats": [
@@ -91,6 +92,7 @@
   "collections": [
     "CMS-Tools"
   ], 
+  "date_created": "2010", 
   "date_published": "2014", 
   "distribution": {
     "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-spectrum-2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-spectrum-2010.json
@@ -21,7 +21,7 @@
   "collections": [
     "CMS-Tools"
   ], 
-  "date_created": "2016", 
+  "date_created": "2010", 
   "date_published": "2016", 
   "distribution": {
     "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-tools-ispy-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-ispy-Run2011A.json
@@ -12,7 +12,7 @@
   "collections": [
     "CMS-Tools"
   ], 
-  "date_created": "2016", 
+  "date_created": "2011", 
   "date_published": "2016", 
   "experiment": "CMS", 
   "license": {

--- a/cernopendata/modules/fixtures/data/records/cms-tools-reco.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-reco.json
@@ -12,7 +12,7 @@
   "collections": [
     "CMS-Tools"
   ], 
-  "date_created": "2017", 
+  "date_created": "2011", 
   "date_published": "2017", 
   "distribution": {
     "formats": [
@@ -75,7 +75,7 @@
   "collections": [
     "CMS-Tools"
   ], 
-  "date_created": "2017", 
+  "date_created": "2011", 
   "date_published": "2017", 
   "distribution": {
     "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-validation-code-Run2010B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validation-code-Run2010B.json
@@ -21,7 +21,7 @@
   "collections": [
     "CMS-Validation-Utilities"
   ], 
-  "date_created": "2016", 
+  "date_created": "2010", 
   "date_published": "2016", 
   "distribution": {
     "formats": [
@@ -169,7 +169,7 @@
   "collections": [
     "CMS-Validation-Utilities"
   ], 
-  "date_created": "2016", 
+  "date_created": "2010", 
   "date_published": "2016", 
   "distribution": {
     "formats": [
@@ -299,7 +299,7 @@
   "collections": [
     "CMS-Validation-Utilities"
   ], 
-  "date_created": "2016", 
+  "date_created": "2010", 
   "date_published": "2016", 
   "distribution": {
     "formats": [

--- a/cernopendata/modules/fixtures/data/records/opera-author-list.json
+++ b/cernopendata/modules/fixtures/data/records/opera-author-list.json
@@ -524,7 +524,7 @@
   "collections": [
     "Author-Lists"
   ], 
-  "date_created": "2017", 
+  "date_created": "2010-2012", 
   "date_published": "2017", 
   "distribution": {
     "formats": [


### PR DESCRIPTION
* Fixes dates in records where the `date_created` property did not indicate the
data-taking year and introduces dates where this property was missing
completely. (closes #1891) (addresses #1944)

Signed-off-by: Artemis Lavasa <artemis.lavasa@cern.ch>