### PR TITLE
records: CMS VM records link fix

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
@@ -39,7 +39,7 @@
     "links": [
       {
         "title": "CMS Virtual Machines - Known Issues and Limitations", 
-        "url": "/VM/CMS#2011"
+        "url": "/VM/CMS/2011#issue"
       }
     ]
   }, 
@@ -58,7 +58,7 @@
     "links": [
       {
         "description": "CMS Virtual Machines: How to install", 
-        "url": "/VM/CMS#how"
+        "url": "/VM/CMS/2011"
       }
     ]
   }, 
@@ -67,7 +67,7 @@
     "links": [
       {
         "description": "Testing the CernVM", 
-        "url": "/VM/CMS/validation/report#2011"
+        "recid": "56"
       }
     ]
   }

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
@@ -39,7 +39,7 @@
     "links": [
       {
         "title": "CMS Virtual Machines - Known Issues and Limitations", 
-        "url": "/VM/CMS"
+        "url": "/VM/CMS/2010#issues2010"
       }
     ]
   }, 
@@ -58,7 +58,7 @@
     "links": [
       {
         "description": "CMS Virtual Machines: How to install", 
-        "url": "/VM/CMS"
+        "url": "/VM/CMS/2010"
       }
     ]
   }, 
@@ -67,7 +67,7 @@
     "links": [
       {
         "description": "Testing the CernVM", 
-        "url": "/VM/CMS/validation/report"
+        "recid": "56"
       }
     ]
   }


### PR DESCRIPTION
* Fixes links in the 2010 and 2011 CMS VM image records. (closes #1883)

Signed-off-by: Artemis Lavasa <artemis.lavasa@cern.ch>