### PR TITLE
CMS: adds software record for event display files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-ispy-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-ispy-2012.json
@@ -1,0 +1,76 @@
+[
+{
+  "abstract": {
+    "description": "Software to create the data for the browser-based event display for the CMS Experiment from the Run2012 primary datasets"
+  }, 
+  "accelerator": "CERN-LHC", 
+  "authors": [
+    {
+      "name": "McCauley, Thomas"
+    }
+  ], 
+  "collections": [
+    "CMS-Tools"
+  ], 
+  "date_created": "2012", 
+  "date_published": "2017", 
+  "experiment": "CMS", 
+  "license": {
+    "attribution": "GNU General Public License (GPL) version 3"
+  }, 
+  "links": [
+    {
+      "description": "More information on the format can be found at", 
+      "url": "http://cms-outreach.github.io/ispy/#what-is-an-ig-file"
+    }, 
+    {
+      "url": "https://github.com/cms-outreach/ispy-analyzers/tree/Run2012"
+    }
+  ], 
+  "methodology": {
+    "description": "<P>The software produces the objects to be displayed. The configuration file <a href=\"https://github.com/cms-outreach/ispy-analyzers/blob/Run2012/produceIg.py\">https://github.com/cms-outreach/ispy-analyzers/blob/Run2012/produceIg.py</a> defines the objects to write out, which is done in the corresponding cc files in the src directory. No event selection, apart from accepting only the validated runs, is applied.</p>"
+  }, 
+  "publisher": "CERN Open Data Portal", 
+  "recid": "556", 
+  "relations": [
+    {
+      "description": "The output are files in json format such as", 
+      "recid": "7125", 
+      "type": "isRelatedTo"
+    }
+  ], 
+  "run_period": "Run2012B-Run2012C", 
+  "system_details": {
+    "description": "Use this code with the CMS Open Data VM environment", 
+    "recid": "221", 
+    "release": "CMSSW_5_3_32"
+  }, 
+  "title": "Software to extract the event display format from the CMS primary dataset from the Run2012", 
+  "type": {
+    "primary": "Software", 
+    "secondary": [
+      "Tool"
+    ]
+  }, 
+  "usage": {
+    "description": "See the run instructions in", 
+    "links": [
+      {
+        "description": "GitHub", 
+        "url": "https://github.com/cms-outreach/ispy-analyzers/blob/Run2012/README.md"
+      }
+    ]
+  }, 
+  "use_with": {
+    "description": "Use this with any of the CMS primary datasets"
+  }, 
+  "validation": {
+    "description": "Only the list of validated runs are accepted:", 
+    "links": [
+      {
+        "recid": "1002"
+      }
+    ]
+  }
+}
+]


### PR DESCRIPTION
* Adds one new software record for CMS 2012 event display files.
(closes #2025)

Signed-off-by: Artemis Lavasa <artemis.lavasa@cern.ch>