### PR TITLE
docs: about CMS simulated dataset names

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cms-simulated-dataset-names/cms-simulated-dataset-names.json
+++ b/cernopendata/modules/fixtures/data/docs/cms-simulated-dataset-names/cms-simulated-dataset-names.json
@@ -10,7 +10,7 @@
       }
     ],
     "body": {
-      "content": "cms-dataset-names.md",
+      "content": "cms-simulated-dataset-names.md",
       "format": "md"
     }
   }


### PR DESCRIPTION
* Fixes installation issue related to ABout CMS Simulated Dataset Names docs.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>