### PR TITLE
templates: fix traceback for author list records

### DIFF
--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail_Author-Lists.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail_Author-Lists.html
@@ -111,7 +111,7 @@
                 {% endif %}
               {% endblock metadata_block %}
 
-              {% block files_block %} {{ files_box(record) }} {% endblock files_block %}
+              {% block files_block %} {{ files_box() }} {% endblock files_block %}
               {% block disclaimer %} {{super()}} {% endblock disclaimer %}
             </div>
           </div>


### PR DESCRIPTION
* Fixes traceback when displaying author lists records.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>