### PR TITLE
CMS: docs: fix list formatting

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cms-about/cms-about.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-about/cms-about.md
@@ -1,8 +1,8 @@
 The Compact Muon Solenoid (CMS) Experiment is one of the large particle detectors at CERN's Large Hadron Collider. The CMS Collaboration consists of more than 3000 scientists, engineers, technicians and students from 180+ institutes and universities from 40+ countries. You can find more information about the CMS [detector design](https://cms.cern/news/cms-detector-design) and [overview](https://cms.cern/news/detector-overview) on the official [CMS website](https://cms.cern).
 
 You can find usage instructions and suggestions of CMS Open Data in two detailed guides:
-- [Guide to education use of CMS Open Data](/docs/cms-guide-for-education)
-- [Guide to research use of CMS Open Data](/docs/cms-guide-for-research).
+* [Guide to education use of CMS Open Data](/docs/cms-guide-for-education)
+* [Guide to research use of CMS Open Data](/docs/cms-guide-for-research).
 
 This page gives a brief overview of CMS Open Data contents:
 

--- a/cernopendata/modules/fixtures/data/docs/cms-about/cms-about.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-about/cms-about.md
@@ -42,7 +42,7 @@ The following are provided through this portal:
     * Definition of same objects is different in each analysis.
 
 * The files can be read in [ROOT](http://root.cern.ch/), but they cannot be opened (and understood) as simple data tables.
-* Only the runs that are validated by data quality monitoring should be used in any analysis. The [list of the validated runs](/search?page=1&size=20&q="CMS%20list%20of%20validated%20runs") is provided.
+* Only the runs that are validated by data quality monitoring should be used in any analysis. The [list of the validated runs](/search?page=1&size=20&q=&type=Environment&subtype=Validation) is provided.
 * A small sample of [raw data](/search?page=1&size=20&q=&experiment=CMS&file_type=raw) is also provided.
 
 ## <a name="disclaimer">Disclaimer</a>

--- a/cernopendata/modules/fixtures/data/docs/cms-guide-for-conddb/cms-guide-for-conddb.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-for-conddb/cms-guide-for-conddb.md
@@ -6,10 +6,11 @@ These records are stored in the condition database. Condition data include non-e
 
 Most [physics objects](/docs/cms-physics-objects-2011) in the CMS Open Data are already calibrated and ready-to-use, and no additional corrections are needed other than selection and identification criteria, which will be applied in the analysis code. Therefore simple analyses do not need to access the condition database. Examples of such analysis are [the di-muon spectrum example](/record/5001) or [the Higgs analysis example](/record/5500).
 
-However, the access to the condition database is necessary, for example, for jet energy corrections and trigger configuration information. Examples of such analysis are [the PAT object production example](/record/233) or [the top quark par production analysis example](/record/5000).
+However, the access to the condition database is necessary, for example, for jet energy corrections and trigger configuration information. Examples of such analysis are [the PAT object production example](/record/233) or [the top quark pair production analysis example](/record/5000).
 
 Note that when you need to access the condition database, the first time you run the job on the CMS Open Data VM, it will download the condition data from the `/cvmfs` area. It will take time (an example run of a 10 Mbps line took 45 mins), but it will only happen once as the files will be cached on your VM. The job will not produce any output during this time, but you can check the ongoing processes with the command 'top' and you can monitor the progress of reading the condition data to the local cache with the command 'df'.
 
+---
 
 **For 2011 collision data**, the global tag is FT_53_LV5_AN1. To access the condition database, first, set the symbolic links:
 
@@ -33,10 +34,12 @@ process.GlobalTag.globaltag = 'FT_53_LV5_AN1::All'
 ```
 
 Note that two sets of condition data for 2011 data are provided:
-- FT_53_LV5_AN1 valid for the full range of 2011 data taking
-- FT_53_LV5_AN1_RUNA valid for the run range of 2011 RunA (public data)
+* FT_53_LV5_AN1 valid for the full range of 2011 data taking
+* FT_53_LV5_AN1_RUNA valid for the run range of 2011 RunA (public data)
 
 It is convenient to use FT_53_LV5_AN1_RUNA as instructed above, it makes the starting time of the first job somewhat faster.
+
+---
 
 **For 2011 Montecarlo data**, the global tag is START53_LV6A1. To access the condition database, first, set the symbolic links:
 
@@ -59,6 +62,7 @@ process.GlobalTag.connect = cms.string('sqlite_file:/cvmfs/cms-opendata-conddb.c
 process.GlobalTag.globaltag = 'START53_LV6A1::All'
 ```
 
+---
 
 **For 2012 collision data**, the global tag is FT53_V21A_AN6. To access the condition database, first, set the symbolic links:
 
@@ -83,11 +87,13 @@ process.GlobalTag.globaltag = 'FT53_V21A_AN6::All'
 ```
 
 Note that three sets of condition data for 2011 data are provided:
-- FT53_V21A_AN6_FULL valid for the full range of 2012 data taking
-- FT53_V21A_AN6 valid for the run range of 2012 RunB (public data)
-- FT53_V21A_AN6_RUNC valid for the run range of 2012 RunC (public data)
+* FT53_V21A_AN6_FULL valid for the full range of 2012 data taking
+* FT53_V21A_AN6 valid for the run range of 2012 RunB (public data)
+* FT53_V21A_AN6_RUNC valid for the run range of 2012 RunC (public data)
 
 It is convenient to use FT53_V21A_AN6_FULL as instructed above, as you will not need to load RunB and RunC condition data separately. You should use the CMS Open Data VM version CMS-Open-Data-1.3.0.ova with a large enough cache area.
+
+---
 
 **For 2012 Montecarlo data**, the global tag is START53_V27. To access the condition database, first, set the symbolic links:
 

--- a/cernopendata/modules/fixtures/data/docs/cms-guide-for-conddb/cms-guide-for-conddb.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-for-conddb/cms-guide-for-conddb.md
@@ -6,7 +6,7 @@ These records are stored in the condition database. Condition data include non-e
 
 Most [physics objects](/docs/cms-physics-objects-2011) in the CMS Open Data are already calibrated and ready-to-use, and no additional corrections are needed other than selection and identification criteria, which will be applied in the analysis code. Therefore simple analyses do not need to access the condition database. Examples of such analysis are [the di-muon spectrum example](/record/5001) or [the Higgs analysis example](/record/5500).
 
-However, the access to the condition database is necessary, for example, for jet energy corrections and trigger configuration information. Examples of such analysis are [the PAT object production example](/record/233) or [the top quark pair production analysis example](/record/5000).
+However, the access to the condition database is necessary, for example, for jet energy corrections and trigger configuration information. Examples of such analysis are for [the PAT object production](/record/233) or [the top quark pair production analysis](/record/5000).
 
 Note that when you need to access the condition database, the first time you run the job on the CMS Open Data VM, it will download the condition data from the `/cvmfs` area. It will take time (an example run of a 10 Mbps line took 45 mins), but it will only happen once as the files will be cached on your VM. The job will not produce any output during this time, but you can check the ongoing processes with the command 'top' and you can monitor the progress of reading the condition data to the local cache with the command 'df'.
 

--- a/cernopendata/modules/fixtures/data/docs/cms-guide-for-conddb/cms-guide-for-conddb.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-for-conddb/cms-guide-for-conddb.md
@@ -6,7 +6,7 @@ These records are stored in the condition database. Condition data include non-e
 
 Most [physics objects](/docs/cms-physics-objects-2011) in the CMS Open Data are already calibrated and ready-to-use, and no additional corrections are needed other than selection and identification criteria, which will be applied in the analysis code. Therefore simple analyses do not need to access the condition database. Examples of such analysis are [the di-muon spectrum example](/record/5001) or [the Higgs analysis example](/record/5500).
 
-However, the access to the condition database is necessary, for example, for jet energy corrections and trigger configuration information. Examples of such analysis are for [the PAT object production](/record/233) or [the top quark pair production analysis](/record/5000).
+However, the access to the condition database is necessary, for example, for jet energy corrections and trigger configuration information. Examples of such analysis are for [the PAT object production](/record/233) or [the top quark pair production](/record/5000).
 
 Note that when you need to access the condition database, the first time you run the job on the CMS Open Data VM, it will download the condition data from the `/cvmfs` area. It will take time (an example run of a 10 Mbps line took 45 mins), but it will only happen once as the files will be cached on your VM. The job will not produce any output during this time, but you can check the ongoing processes with the command 'top' and you can monitor the progress of reading the condition data to the local cache with the command 'df'.
 

--- a/cernopendata/modules/fixtures/data/docs/cms-guide-for-education/cms-guide-for-education.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-for-education/cms-guide-for-education.md
@@ -1,7 +1,7 @@
 This page will guide you through contents of the CMS Open Data collections that are meant for educational use (or for physics enthusiasts!). It is roughly broken down into three levels of difficulty:
-- Beginner: *Visualise collisions*
-- Intermediate: *Make histograms with collision data*
-- Advanced: *Dive deeper into the data*
+* Beginner: *Visualise collisions*
+* Intermediate: *Make histograms with collision data*
+* Advanced: *Dive deeper into the data*
 
 ---
 
@@ -18,16 +18,15 @@ If you are new to particle physics, your time is limited, or you want to do some
 
 Your collision event should now appear in the display.
 
-- If you chose the `4lepton.ig` set and you want to see electrons, check `Electrons` under `Physics` and uncheck `Tracks (reco)` under `Tracking` in the menu to the left  (the choice is only visible if electrons are present in the collision).
-- If you chose the `diphoton.ig` set, check `Photons` under `Physics` in the menu to the left (the choice is only visible if photons are present in the collision).
+* If you chose the `4lepton.ig` set and you want to see electrons, check `Electrons` under `Physics` and uncheck `Tracks (reco)` under `Tracking` in the menu to the left  (the choice is only visible if electrons are present in the collision).
+* If you chose the `diphoton.ig` set, check `Photons` under `Physics` in the menu to the left (the choice is only visible if photons are present in the collision).
 
 **Note**: If you have a VR viewer (even a simple one like [Google Cardboard](https://vr.google.com/cardboard/)), you can immerse yourself into the collision using your smartphone: click on the "Stereo View" button (shaped like binoculars), insert your phone into the viewer and have virtual tour in 3D of a real LHC collision!
 
 The first few events of all collision datasets from CMS served on the CERN Open Data portal are available in a format suitable for the event display. In addition, many other events have been selected in specially prepared collections. Find them all in [this search query](/search?page=1&size=20&q=display&subtype=Derived&experiment=CMS).
 Two examples of these specially prepared files are:
-
-- [Higgs candidate events for use in education and outreach](/record/300), and
-- [Dimuon events with invariant mass range 2-5 GeV for public education and outreach](/record/301) for J/&psi;&rarr;&mu;&mu; candidates.
+* [Higgs candidate events for use in education and outreach](/record/300), and
+* [Dimuon events with invariant mass range 2-5 GeV for public education and outreach](/record/301) for J/&psi;&rarr;&mu;&mu; candidates.
 
 You can also download these files directly from the records on this portal.
 
@@ -39,15 +38,15 @@ To learn how to use the [CMS event display](/visualise/events/cms), click on `Ne
 
 You can get an overview of our education resources through [this search query](/search?page=1&size=20&q=learning%20school%20education&experiment=CMS) with your keyword of interest (you can change the pre-defined keywords here). Here are some highlights:
 
-- If you already know what the basic physics quantities measured in a particle collision are and want to **play online with histograms** from different samples of open data, check out the [CMS histogram visualiser](/visualise/histograms/cms). For instructions on how to use the visualiser, click on `Need help?`.
-- To learn some concepts of statistical analysis in a hands-on classroom activity, have a look at the material for an organised ["**Masterclass**" exercise](/record/53) based on CMS data and the online event display. A CMS Masterclass typically takes one day (including introductory lectures and post-analysis discussions), but the exercise itself can be done in approximately two hours. Learn more about organising your own Masterclass [on the CMS website](https://cms.cern/engage-with-cms/cms-physics-masterclass).
-- You can also use **spreadsheet programs** to make a further step in the direction of data analysis, using a limited number of CMS events that are suitable for this type of exercise, see [instructions for use of CMS Open Data in spreadsheets for schools and education](/record/5100). These exercises can be done in an hour or so.
-- For a first taste of real programming using physics data, consider these resources that use [**Jupyter notebooks**](https://jupyter.org/) for a browser-based introduction to data analysis (time can vary from less than an hour to several hours, depending on the scope of your exercise):
-    - [A quick (completely online) hands-on demo](https://mybinder.org/v2/gh/cms-opendata-education/cms-online-notebooks-for-binder/master?filepath=quick-start-to-CMS-open-data.ipynb) to Jupyter and CMS Open Data (using python).
-    - [Analysing CMS Open Data in Jupyter using **python**](/record/5101)
-    - [Analysing CMS Open Data in Jupyter using **R**](/record/5102), with a brief intro to the R programming language
-- All applications mentioned above use open data in simplified CSV (comma-separated values) format. See [all available CSV datasets](/search?page=1&size=20&q=&type=Dataset&experiment=CMS&subtype=Derived&file_type=csv), which have been extracted directly from the original collision datasets.
-    - If you are interested in producing your own selection of open data in CSV format, see [example software ](/record/552) for the processing step.
+* If you already know what the basic physics quantities measured in a particle collision are and want to **play online with histograms** from different samples of open data, check out the [CMS histogram visualiser](/visualise/histograms/cms). For instructions on how to use the visualiser, click on `Need help?`.
+* To learn some concepts of statistical analysis in a hands-on classroom activity, have a look at the material for an organised ["**Masterclass**" exercise](/record/53) based on CMS data and the online event display. A CMS Masterclass typically takes one day (including introductory lectures and post-analysis discussions), but the exercise itself can be done in approximately two hours. Learn more about organising your own Masterclass [on the CMS website](https://cms.cern/engage-with-cms/cms-physics-masterclass).
+* You can also use **spreadsheet programs** to make a further step in the direction of data analysis, using a limited number of CMS events that are suitable for this type of exercise, see [instructions for use of CMS Open Data in spreadsheets for schools and education](/record/5100). These exercises can be done in an hour or so.
+* For a first taste of real programming using physics data, consider these resources that use [**Jupyter notebooks**](https://jupyter.org/) for a browser-based introduction to data analysis (time can vary from less than an hour to several hours, depending on the scope of your exercise):
+    * [A quick (completely online) hands-on demo](https://mybinder.org/v2/gh/cms-opendata-education/cms-online-notebooks-for-binder/master?filepath=quick-start-to-CMS-open-data.ipynb) to Jupyter and CMS Open Data (using python).
+    * [Analysing CMS Open Data in Jupyter using **python**](/record/5101)
+    * [Analysing CMS Open Data in Jupyter using **R**](/record/5102), with a brief intro to the R programming language
+* All applications mentioned above use open data in simplified CSV (comma-separated values) format. See [all available CSV datasets](/search?page=1&size=20&q=&type=Dataset&experiment=CMS&subtype=Derived&file_type=csv), which have been extracted directly from the original collision datasets.
+    * If you are interested in producing your own selection of open data in CSV format, see [example software ](/record/552) for the processing step.
 ---
 
 #### Dive deeper into the data
@@ -55,14 +54,13 @@ You can get an overview of our education resources through [this search query](/
 If you want a more detailed understanding of particle physics or an introduction aimed at the university level, take a look at some of the other resources in [this search query](/search?page=1&size=20&q=&keywords=education&experiment=CMS).
 
 For example:
-- [Particle Physics Playground](/record/52) provides you with further hands-on activities with open data from CMS and other experiments.
-- [Computing Methods in High-Energy Physics](/record/61) is an introductory course on computing in high-energy physics.
-- [CMS HEP Tutorial](/record/50) is a one-week course with a basic introduction to fundamental concepts of data analysis in HEP experiments using CMS Open Data.
+* [Particle Physics Playground](/record/52) provides you with further hands-on activities with open data from CMS and other experiments.
+* [Computing Methods in High-Energy Physics](/record/61) is an introductory course on computing in high-energy physics.
+* [CMS HEP Tutorial](/record/50) is a one-week course with a basic introduction to fundamental concepts of data analysis in HEP experiments using CMS Open Data.
 
 Of course, you can also undertake your own explorations with CMS Open Data:
-
-- If you want to "re-discover" the **Higgs boson** in the CMS Open Data from 2011-2012, first install the Virtual Machine (VM) as instructed in ["CMS 2011 Virtual Machines: How to install"](/docs/cms-virtual-machine-2011) and look at [this Higgs analysis example](/record/5500).
-- If you want to learn how data analysis is done by CMS scientists, install the Virtual Machine (VM) as instructed in ["CMS 2011 Virtual Machines: How to install"](/docs/cms-virtual-machine-2011), follow the instructions in ["Getting Started with CMS Open Data"](/docs/cms-getting-started-2011), and then
+* If you want to "re-discover" the **Higgs boson** in the CMS Open Data from 2011-2012, first install the Virtual Machine (VM) as instructed in ["CMS 2011 Virtual Machines: How to install"](/docs/cms-virtual-machine-2011) and look at [this Higgs analysis example](/record/5500).
+* If you want to learn how data analysis is done by CMS scientists, install the Virtual Machine (VM) as instructed in ["CMS 2011 Virtual Machines: How to install"](/docs/cms-virtual-machine-2011), follow the instructions in ["Getting Started with CMS Open Data"](/docs/cms-getting-started-2011), and then
 check out our extensive overview of research activities under ["Guide for research use of CMS Open Data"](/docs/cms-guide-for-research).
 
 Have fun!!

--- a/cernopendata/modules/fixtures/data/docs/cms-guide-for-research/cms-guide-for-research.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-for-research/cms-guide-for-research.md
@@ -102,7 +102,7 @@ or, alternatively:
 <center>–––</center>
 
 **I want to find out which 2011 dataset and/or analysis/validation example is most useful for my purpose.**
-* Dedicated examples for 2011 beyond those available in "Getting Started" can be found in [software](/search?page=1&size=20&q=&type=Software&subtype=Analysis&experiment=CMS&year=2011), including jet tuple production and top cross-sections. Alternatively, start from a 2010 example and adjust to run on 2011 data (see [the CMS troubleshooting guide](/docs/cms-guide-troubleshooting) for instructions.
+* Dedicated examples for 2011 beyond those available in "Getting Started" can be found in [software](/search?page=1&size=20&q=&type=Software&subtype=Analysis&experiment=CMS&year=2011), including jet tuple production and top cross-sections. Alternatively, start from a 2010 example and adjust to run on 2011 data (see [the CMS troubleshooting guide](/docs/cms-guide-troubleshooting) for instructions).
 
 <center>–––</center>
 

--- a/cernopendata/modules/fixtures/data/docs/cms-guide-for-research/cms-guide-for-research.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-for-research/cms-guide-for-research.md
@@ -7,228 +7,195 @@ However, if you are interested in finding hints, tips and guidance for conductin
 
 ---
 
-#### Quick introduction
+### Quick introduction
 
-> "I want to get a general introduction into HEP and CMS software and terminology, with a simplified event format."
-
-- Read the instructions related to [educational content](/docs/cms-guide-for-education) and follow the corresponding exercises.
-
-<center>–––</center>
-
-> "I want to learn about the terms under which I can access and use the CMS Open Data, and publish results obtained from them."
-
-- Go to ["Data preservation and open access policy"](/record/411) (if you are a CMS member, also see the internal document ["Rules for use of open access CMS data by individual members of CMS"](https://cms-docdb.cern.ch/cgi-bin/DocDB/ShowDocument?docid=12242)).
+**I want to get a general introduction into HEP and CMS software and terminology, with a simplified event format.**
+* Read the instructions related to [educational content](/docs/cms-guide-for-education) and follow the corresponding exercises.
 
 <center>–––</center>
 
-> "I want to get inspiration for some potential physics topics."
-
-- A link with examples of potentially interesting physics topics and their relation to CMS Open Data might be added here soon.
+**I want to learn about the terms under which I can access and use the CMS Open Data, and publish results obtained from them.**
+* Go to ["Data preservation and open access policy"](/record/411) (if you are a CMS member, also see the internal document ["Rules for use of open access CMS data by individual members of CMS"](https://cms-docdb.cern.ch/cgi-bin/DocDB/ShowDocument?docid=12242)).
 
 <center>–––</center>
 
-> "I want to learn about the nature of the CMS physics objects and the corresponding variables and terminology."
+**I want to get inspiration for some potential physics topics.**
+* A link with examples of potentially interesting physics topics and their relation to CMS Open Data might be added here soon.
 
-- Go to ["CMS Physics Objects"](/docs/cms-physics-objects-2011).
+<center>–––</center>
+
+**I want to learn about the nature of the CMS physics objects and the corresponding variables and terminology.**
+* Go to ["CMS Physics Objects"](/docs/cms-physics-objects-2011).
 
 ---
 
-#### Deciding which datasets to explore
+### Deciding which datasets to explore
 
-> "I want to find out whether I should go for data from 2010 or 2011 (both are pp data at 7 TeV) or from 2012 (pp data at 8 TeV)."
-
-- The 2010 data have been released first; have fewer, smaller datasets with better low-p<sub>T</sub> tracking, low trigger thresholds, low pile-up and more/simpler analysis/validation examples; but have no MC. If you do not need MC or maximal statistics, you might want to try 2010 data first (simpler).
-- The 2011/2012 data have more statistics, more diverse datasets, many associated MC sets, and a slightly more advanced VM environment. If you are immediately interested in maximal statistics and/or MC acceptance corrections you should go for 2011/2012 data (more sophisticated).
-- Information on the respective luminosities and pile-up rates vs time can be found in [public CMS luminosity information](https://twiki.cern.ch/twiki/bin/view/CMSPublic/LumiPublicResults#Multi_year_Collisions_Plots).
-- If you want to try both datasets, you will need to use [the appropriate VMs](/search?page=1&size=20&tags=VM&experiment=CMS).
+**I want to find out whether I should go for data from 2010 or 2011 (both are pp data at 7 TeV) or from 2012 (pp data at 8 TeV).**
+* The 2010 data have been released first; have fewer, smaller datasets with better low-p<sub>T</sub> tracking, low trigger thresholds, low pile-up and more/simpler analysis/validation examples; but have no MC. If you do not need MC or maximal statistics, you might want to try 2010 data first.
+* The 2011/2012 data have more statistics, more diverse datasets, many associated MC sets, and a slightly more advanced VM environment. If you are immediately interested in maximal statistics and/or MC acceptance corrections you should go for 2011/2012 data.
+* Information on the respective luminosities and pile-up rates vs time can be found in [public CMS luminosity information](https://twiki.cern.ch/twiki/bin/view/CMSPublic/LumiPublicResults#Multi_year_Collisions_Plots).
+* If you want to try both datasets, you will need to use [the appropriate VMs](/search?page=1&size=20&tags=VM&experiment=CMS).
 
 <center>–––</center>
 
-> "I want to install the CMS software environment needed for access to and analysis of CMS Research level data."
-
-- Install the appropriate virtual machine, [2010 VM](/record/250) for 2010 data, and [2011 VM](/record/252) for 2011/2012 data.
-- Go to ["Getting started with CMS 2010 open data"](/docs/cms-getting-started-2010) for 2010 or ["Getting started with CMS 2011 open data"](/docs/cms-getting-started-2011) for 2011/2012 data.
+**I want to install the CMS software environment needed for access to and analysis of CMS Research level data.**
+* Install the appropriate virtual machine, [2010 VM](/record/250) for 2010 data, and [2011 VM](/record/252) for 2011/2012 data.
+* Go to ["Getting started with CMS 2010 open data"](/docs/cms-getting-started-2010) for 2010 or ["Getting started with CMS 2011 open data"](/docs/cms-getting-started-2011) for 2011/2012 data.
 
 **Note**: The 2010 (SL5) virtual machine will only work on 2010 data with CMSSW 4-2-8 (and other SLC5-based CMSSW releases). The 2011 (SL6) virtual machine will only work on 2011/2012 data and MC with CMSSW 5-3-32 (and other SLC6-based CMSSW releases).
 
 <center>–––</center>
 
-> "I want to produce some example physics distributions (e.g. inclusive di-muon spectrum analysis example directly from AOD or two-/four-lepton analysis example with intermediate ntuples)."
-
-- Install the CMS software as in the previous item (for 2010 or 2011).
-
-- Follow options A (inclusive di-muon spectrum analysis example directly from AOD) or B (two-/four-lepton analysis example with intermediate ntuples) in ["Getting started with CMS 2010 open data"](/docs/cms-getting-started-2010) or ["Getting started with CMS 2011 open data"](/docs/cms-getting-started-2011).
+**I want to produce some example physics distributions.**
+* Install the CMS software as in the previous item (for 2010 or 2011).
+* Follow options A (inclusive di-muon spectrum analysis example directly from AOD) or B (two-/four-lepton analysis example with intermediate ntuples) in ["Getting started with CMS 2010 open data"](/docs/cms-getting-started-2010) or ["Getting started with CMS 2011 open data"](/docs/cms-getting-started-2011).
 
 ---
 
-#### Exploring the 2010 datasets
+### Exploring the 2010 datasets
 
-> "I want to find out which 2010 datasets exist, and how to get a feel for their content."
-
-- Go to [2010 CMS primary datasets](/search?page=1&size=20&q=&type=Dataset&subtype=Collision&experiment=CMS&year=2010),
-- choose a dataset, and read the comments.
-
-<center>–––</center>
-
-> "I also want to view some corresponding event displays."
-
-- Go to [2010 CMS derived datasets of event display ("ig") type](/search?page=1&size=20&q=&type=Dataset&subtype=Derived&experiment=CMS&year=2010&file_type=ig),
-- choose `Event display file derived from`… + the name of the CMS primary dataset you want (ZeroBias is known to be essentially empty).
-
-> or, alternatively:
-
-- Load the [CMS event display](/visualise/events/cms),
-- choose `Open File` &rarr; `Open Files from Web` &rarr; `2010`, and
-- choose your dataset.
+**I want to find out which 2010 datasets exist, and how to get a feel for their content.**
+* Go to [2010 CMS primary datasets](/search?page=1&size=20&q=&type=Dataset&subtype=Collision&experiment=CMS&year=2010),
+* choose a dataset, and read the comments.
 
 <center>–––</center>
 
-> "I want to find out which 2010 dataset and/or analysis/validation example is most useful for my purpose."
+**I also want to view some corresponding event displays.**
+* Go to [2010 CMS derived datasets of event display ("ig") type](/search?page=1&size=20&q=&type=Dataset&subtype=Derived&experiment=CMS&year=2010&file_type=ig),
+* choose `Event display file derived from`… + the name of the CMS primary dataset you want (ZeroBias is known to be essentially empty).
 
-- To learn how to do a muon analysis, follow "*I want to produce some example physics distributions*," (above) with either option A (recommended) or B, or try one of the relevant "*I want to (re)validate the 2010 datasets examples*," (further below).
+or, alternatively:
+* Load the [CMS event display](/visualise/events/cms),
+* choose `Open File` &rarr; `Open Files from Web` &rarr; `2010`, and
+* choose your dataset.
+
+<center>–––</center>
+
+**I want to find out which 2010 dataset and/or analysis/validation example is most useful for my purpose.**
+* To learn how to do a muon analysis, follow "*I want to produce some example physics distributions*," (above) with either option A (recommended) or B, or try one of the relevant "*I want to (re)validate the 2010 datasets examples*," (further below).
 - To learn how to do an electron analysis, follow "*I want to produce some first physics distributions*," (above) with option B, or try one of the relevant "*I want to (re)validate the 2010 datasets examples*," (below).
 - To learn how to do a minimum-bias track analysis, try the MinimumBias example on "*I want to (re)validate the 2010 datasets*," (below).
 - [More to come…]
 
 ---
 
-#### Exploring the 2011 datasets
+### Exploring the 2011-2012 datasets
 
-> "I want to find out which 2011 data and MC sets exist, and how to get a feel for their content."
-
-- Go to [2011 CMS primary datasets](/search?page=1&size=20&q=&subtype=Collision&experiment=CMS&year=2011) or [2011 CMS simulated datasets](/search?page=1&size=20&q=&subtype=Simulated&experiment=CMS&year=2011),
-- choose a dataset, read the comments, and read also about [simulated dataset names](/docs/cms-simulated-dataset-names).
-
-<center>–––</center>
-
-> "I also want to  to view some corresponding event displays."
-
-- These are available for data only for the time being.
-- Go to [2011 CMS derived datasets of event display ("ig") type](/search?page=1&size=20&q=&subtype=Derived&experiment=CMS&year=2011&file_type=ig),
-- choose `Event display file derived from`… + the name of the CMS primary dataset you want (ZeroBias is known to be essentially empty).
-
-> or, alternatively:
-
-- Load the [CMS event display](/visualise/events/cms),
-- choose `Open File` &rarr; `Open Files from Web` &rarr; `2011`, and
-- choose your dataset.
+**I want to find out which 2011-2012 data and MC sets exist, and how to get a feel for their content.**
+* For collision data, go to [2011 CMS primary datasets](/search?page=1&size=20&q=&subtype=Collision&experiment=CMS&year=2011) or [2011 CMS primary datasets](/search?page=1&size=20&q=&subtype=Collision&experiment=CMS&year=2012)
+* For MC, go to [2011 CMS simulated datasets](/search?page=1&size=20&q=&subtype=Simulated&experiment=CMS&year=2011) or [2012 CMS simulated datasets](/search?page=1&size=20&q=&subtype=Simulated&experiment=CMS&year=2012)
+* choose a dataset, read the comments, and read also about [simulated dataset names](/docs/cms-simulated-dataset-names).
 
 <center>–––</center>
 
-> "I want to find out which 2011 dataset and/or analysis/validation example is most useful for my purpose."
+**I also want to  to view some corresponding event displays.**
+* These are available for data only for the time being.
+* Go to CMS derived datasets of event display ("ig") type for the [2011 data](/search?page=1&size=20&q=&subtype=Derived&experiment=CMS&year=2011&file_type=ig) or the [2012 data](/search?page=1&size=20&q=&subtype=Derived&experiment=CMS&year=2012&file_type=ig) ,
+* choose `Event display file derived from`… + the name of the CMS primary dataset you want (ZeroBias is known to be essentially empty).
 
-- Dedicated examples for 2011 beyond those available in "Getting Started" can be found in [software](/search?page=1&size=20&q=&type=Software&subtype=Analysis&experiment=CMS&year=2011), including jet tuple production and top cross-sections. Alternatively, start from a 2010 example and adjust to run on 2011 data.
+or, alternatively:
+* Load the [CMS event display](/visualise/events/cms),
+* choose `Open File` &rarr; `Open Files from Web` &rarr; `2011` or `2012`, and
+* choose your dataset.
 
 <center>–––</center>
 
-- For more information on Monte Carlo, see below.
+**I want to find out which 2011 dataset and/or analysis/validation example is most useful for my purpose.**
+* Dedicated examples for 2011 beyond those available in "Getting Started" can be found in [software](/search?page=1&size=20&q=&type=Software&subtype=Analysis&experiment=CMS&year=2011), including jet tuple production and top cross-sections. Alternatively, start from a 2010 example and adjust to run on 2011 data (see [the CMS troubleshooting guide](/docs/cms-guide-troubleshooting) for instructions.
+
+<center>–––</center>
+
+* For more information on Monte Carlo, see below.
 
 ---
 
-#### Trigger information, condition data, luminosity
+### Trigger information, condition data, luminosity
 
-> "I want to find out how to use the trigger and trigger prescale information in the dataset I am interested in."
-
-- Go to [the guide to CMS trigger system](/docs/cms-guide-trigger-system).
-
-<center>–––</center>
-
-> "I want to find out how to access the luminosity information for the dataset I am interested in and how to select "good data" only."
-
-- Check the [CMS luminosity information](/search?page=1&size=20&q=luminosity&type=Supplementaries&subtype=Luminosity), and
-- check the [list of validated runs](/search?page=1&size=20&q=%22CMS%20list%20of%20validated%20runs%22).
+**I want to find out how to use the trigger and trigger prescale information in the dataset I am interested in.**
+* Go to [the guide to CMS trigger system](/docs/cms-guide-trigger-system).
 
 <center>–––</center>
 
-> "I want to find out whether I need condition data base information, and if so, how to access it."
-
-- Condition data are needed on examples using e.g. jet energy corrections and trigger configuration information, many of the simpler analysis/validation examples do not need any additional corrections from condition database.
-- Using condition data slows down data access, so use them only if really needed. If so:
-    - see the instructions in ["The Guide to the CMS condition database"](/docs/cms-guide-to-the-cms-condition-database).
+**I want to find out how to access the luminosity information for the dataset I am interested in and how to select "good data" only.**
+* Check the [CMS luminosity information](/search?page=1&size=20&q=luminosity&type=Supplementaries&subtype=Luminosity), and
+* check the [list of validated runs](/search?page=1&size=20&q=%22CMS%20list%20of%20validated%20runs%22).
 
 <center>–––</center>
 
-> "I want to find the luminosity of my dataset, possibly constrained by using specific triggers."
+**I want to find out whether I need condition data base information, and if so, how to access it.**
+* Condition data are needed on examples using e.g. jet energy corrections and trigger configuration information, many of the simpler analysis/validation examples do not need any additional corrections from condition database.
+* Using condition data slows down data access, so use them only if really needed. If so:
+    * see the instructions in ["The Guide to the CMS condition database"](/docs/cms-guide-to-the-cms-condition-database).
 
-- Please check [CMS luminosity information](/search?page=1&size=20&q=luminosity&type=Supplementaries&subtype=Luminosity),
-- decide on the triggers you want to use,
-- find out the runs/lumi sections in which these triggers were active and whether they were prescaled,
-- overlap with the available CMS Open Data samples (run range) and with the selection in the list of validated runs.
-    - If not prescaled, sum up the luminosity for the surviving runs/lumi sections.
-    - If prescaled, life is more complicated. Find the prescales as in [the trigger example code](/record/5004)
+<center>–––</center>
+
+**I want to find the luminosity of my dataset, possibly constrained by using specific triggers.**
+* Please check [CMS luminosity information](/search?page=1&size=20&q=luminosity&type=Supplementaries&subtype=Luminosity),
+* decide on the triggers you want to use,
+* find out the runs/lumi sections in which these triggers were active and whether they were prescaled,
+* overlap with the available CMS Open Data samples (run range) and with the selection in the list of validated runs.
+    * If not prescaled, sum up the luminosity for the surviving runs/lumi sections.
+    * If prescaled, life is more complicated. Find the prescales as in [the trigger example code](/record/5004)
 
 ---
 
-#### Performing an analysis
+### Performing an analysis
 
-> "I want to find more CMS software and data format documentation from public sources."
-
-- This is strongly recommended for serious analysis, but is hard to navigate!
-- Check the [CMS public Twiki](https://twiki.cern.ch/twiki/bin/view/CMSPublic/WebHome) or the CMS Fermilab website or use your favourite web-search engine.
-
-<center>–––</center>
-
-> "I want to learn about the published jet-analysis papers by the MIT group."
-
-- See *Jet Substructure Studies with CMS Open Data*, A. Tripathee et al., Apr 19, 2017, MIT-CTP-4890, [arXiv:1704.05842](https://inspirehep.net/record/1593756),
-- and *Exposing the QCD Splitting Function with CMS Open Data*, A. Larkoski et al., Apr 17, 2017, MIT-CTP-4891, [arXiv:1704.05066](https://inspirehep.net/record/1591972).
+**I want to find more CMS software and data format documentation from public sources.**
+* This is strongly recommended for serious analysis, but is hard to navigate!
+* Check the [CMS public Twiki](https://twiki.cern.ch/twiki/bin/view/CMSPublic/WebHome) or the CMS Fermilab website or use your favourite web-search engine.
 
 <center>–––</center>
 
-> "I want to run the examples used for validation of the 2010 datasets within my setup…"
+**I want to learn about the published jet-analysis papers by the MIT group.**
+* See *Jet Substructure Studies with CMS Open Data*, A. Tripathee et al., Apr 19, 2017, MIT-CTP-4890, [arXiv:1704.05842](https://inspirehep.net/record/1593756),
+* and *Exposing the QCD Splitting Function with CMS Open Data*, A. Larkoski et al., Apr 17, 2017, MIT-CTP-4891, [arXiv:1704.05066](https://inspirehep.net/record/1591972).
 
-- … for the MinimumBias, Commissioning, Mu or MuMonitor datasets:
-    - Go to [Validation software](/search?page=1&size=20&q=&subtype=Validation&type=Software&year=2010)
-    - choose and execute the corresponding Validation code.
+<center>–––</center>
 
-
-- … for the Multijet dataset (see also [here](http://hep.caltech.edu/cms/opendata/)):
-    - choose and execute ["Razor filter and analyzer for SUSY searches"](/record/553).
-
-- … for the Electron (or Mu) dataset:
-    - choose and execute ["Software to preprocess the CMS 2010 Muon and Electron datasets for the two-lepton/four-lepton analysis example of CMS open data"](/record/200), then
-    - choose ["Two-lepton/four-lepton analysis example of CMS 2010 open data"](/record/101) and compare PAT-tuples from the previous to those linked therein, or execute it on your new PAT tuples.
-
-- … for the ZeroBias dataset:
-    - Not useful, no validation needed.
-
-- … for the Jet, MuOnia, BTau, Photon, JetMETTaumonitor, METFwd datasets:
+**I want to run the examples used for validation of the 2010 datasets within my setup…**
+* … for the MinimumBias, Commissioning, Mu or MuMonitor datasets:
+    * Go to [Validation software](/search?page=1&size=20&q=&subtype=Validation&type=Software&year=2010)
+    * choose and execute the corresponding Validation code.
+* … for the Multijet dataset (see also [here](http://hep.caltech.edu/cms/opendata/)):
+    * choose and execute ["Razor filter and analyzer for SUSY searches"](/record/553).
+* … for the Electron (or Mu) dataset:
+    * choose and execute ["Software to preprocess the CMS 2010 Muon and Electron datasets for the two-lepton/four-lepton analysis example of CMS open data"](/record/200), then
+    * choose ["Two-lepton/four-lepton analysis example of CMS 2010 open data"](/record/101) and compare PAT-tuples from the previous to those linked therein, or execute it on your new PAT tuples.
+* … for the ZeroBias dataset:
+    * Not useful, no validation needed.
+* … for the Jet, MuOnia, BTau, Photon, JetMETTaumonitor, METFwd datasets:
     - Validation not yet available (partially in preparation).
 
 <center>–––</center>
 
-> "I want to backup my code, or import some external code."
-
-- We recommend you use `scp` from and to your host from within the VM.
+**I want to backup my code, or import some external code.**
+* We recommend you use `scp` from and to your host from within the VM.
 
 ---
 
-#### Monte Carlo
+### Monte Carlo
 
-> "How do I interpret the MC set names?"
-
-- Check [CMS Simulated Dataset Names](/docs/cms-simulated-dataset-names).
+**How do I interpret the MC set names?**
+* Check [CMS Simulated Dataset Names](/docs/cms-simulated-dataset-names).
 
 <center>–––</center>
 
-> "I want to find the effective luminosity of my MC set."
+**I want to find the effective luminosity of my MC set.**
+* Information will be added to the portal.
+* Generically: divide MC cross-section (next item) times matching efficiency times filter efficiency by the number of events.
 
-- To be documented.
-- Generically: divide MC cross-section (next item) times matching efficiency times filter efficiency by the number of events.
-
-> "I want to find the generator cross section of a particular MC set."
-
-- To be documented.
-- On some MC sets, the following might work (reliability of information not guaranteed): open the ROOT file, create TBrowser and navigate to `Runs` &rarr; `GenRunInfoProduct_generator__SIM.` &rarr; `GenRunInfoProduct_generator__SIM.obj` &rarr; `InternalXSec` &rarr; `value_`.
+**I want to find the generator cross section of a particular MC set.**
+* To be documented.
+* On some MC sets, the following might work (reliability of information not guaranteed): open the ROOT file, create TBrowser and navigate to `Runs` &rarr; `GenRunInfoProduct_generator__SIM.` &rarr; `GenRunInfoProduct_generator__SIM.obj` &rarr; `InternalXSec` &rarr; `value_`.
 
 ---
 
 ### Further information / Contact us
 
-> I want information that is not documented here and elsewhere on the [CERN Open Data portal](http://opendata.cern.ch/).
+**I want information that is not documented here and elsewhere on the [CERN Open Data portal](http://opendata.cern.ch/).""
+* Kindly contact &lt;[opendata-support@cern.ch](mailto:opendata-support@cern.ch)&gt;
 
-- Kindly contact &lt;[opendata-support@cern.ch](mailto:opendata-support@cern.ch)&gt;
-
-> "I ran into a problem and need help!"
-
-- Please check our page related to known errors.
+**I ran into a problem and need help!**
+* Please check [our page related to known errors](/docs/cms-guide-troubleshooting).

--- a/cernopendata/modules/fixtures/data/docs/cms-guide-for-research/cms-guide-for-research.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-for-research/cms-guide-for-research.md
@@ -126,7 +126,7 @@ or, alternatively:
 **I want to find out whether I need condition data base information, and if so, how to access it.**
 * Condition data are needed on examples using e.g. jet energy corrections and trigger configuration information, many of the simpler analysis/validation examples do not need any additional corrections from condition database.
 * Using condition data slows down data access, so use them only if really needed. If so:
-    * see the instructions in ["The Guide to the CMS condition database"](/docs/cms-guide-to-the-cms-condition-database).
+    * see the instructions in ["The Guide to the CMS condition database"](/docs/cms-guide-for-condition-database).
 
 <center>–––</center>
 

--- a/cernopendata/modules/fixtures/data/docs/cms-guide-troubleshooting/cms-guide-troubleshooting.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-troubleshooting/cms-guide-troubleshooting.md
@@ -3,66 +3,66 @@ This page lists possible solutions to frequently encountered issues with CMS Ope
 ### Virtual machine
 
 **I have trouble installing VirtualBox**
-- Read the FAQs in [the VM installation guide](/docs/cms-2011-virtual-machines-how-to-install#issue). If it still fails, please contact your local system administrator.
+* Read the FAQs in [the VM installation guide](/docs/cms-2011-virtual-machines-how-to-install#issue). If it still fails, please contact your local system administrator.
 
 **What is the root password for the CMS Open Data VM?**
-- The root password for the CMS Open Data VM is `password`.
+* The root password for the CMS Open Data VM is `password`.
 
 **The CMS Open Data VM does not open correctly**
-- In some versions of VirtualBox, it has happened that the CMS Open Data VM does not open correctly. This was the case for example for VirtulBox 5.0.32, but more recent versions from [the VirtualBox website](https://www.virtualbox.org/wiki/Downloads) have been tested and are working properly. Note that it can take a while to launch the CMS Open Data VM for the first time.
+* In some versions of VirtualBox, it has happened that the CMS Open Data VM does not open correctly. This was the case for example for VirtulBox 5.0.32, but more recent versions from [the VirtualBox website](https://www.virtualbox.org/wiki/Downloads) have been tested and are working properly. Note that it can take a while to launch the CMS Open Data VM for the first time.
 
 **When/after installing CERN VM, I get a message that my VM uses too much memory**
-- Reduce the memory allocated to VirtualBox by clicking on System in the VirtualBox graphical user interface and adjust the base memory with the sliding bar.
+* Reduce the memory allocated to VirtualBox by clicking on System in the VirtualBox graphical user interface and adjust the base memory with the sliding bar.
 
 #### File download
 
 **xml files do not download correctly by clicking on "Download"** 
-- Note that all files can be downloaded directly from the CMS Open Data VM terminal with wget e.g. you download the file `http://opendata.cern.ch/record/560/files/BuildFile.xml` in [record 560](/record/560) with
+* Note that all files can be downloaded directly from the CMS Open Data VM terminal with wget e.g. you download the file `http://opendata.cern.ch/record/560/files/BuildFile.xml` in [record 560](/record/560) with
 `$ wget http://opendata.cern.ch/record/560/files/BuildFile.xml`
 
 ### CMSSW software and open data examples
 
 **When I start the CMS job, nothing happens**
-- If you access the condition data (see the details in [the guide to the CMS condition database](/doc/cms-guide-to-the-cms-condition-database)), the download of condition data to the local cache of your VM starts at the beginning of the job. The job will produce no output during that time. This may take up to one hour for the first time, but the next time you run the job, it will start fast as the data is already in the cache. If you observe that the cvmfs cache gets filled (see the output of `df` command) and the job also stops after the first time you run it, you should use [the CMS Open Data VM](/record/252) version with a larger cache size (CMS-OpenData-1.3.0.ova).
+* If you access the condition data (see the details in [the guide to the CMS condition database](/doc/cms-guide-to-the-cms-condition-database)), the download of condition data to the local cache of your VM starts at the beginning of the job. The job will produce no output during that time. This may take up to one hour for the first time, but the next time you run the job, it will start fast as the data is already in the cache. If you observe that the cvmfs cache gets filled (see the output of `df` command) and the job also stops after the first time you run it, you should use [the CMS Open Data VM](/record/252) version with a larger cache size (CMS-OpenData-1.3.0.ova).
 
 **While running on AOD data, my job gets "killed" by the VM without any further explanation**
-- You might have exceeded the VMs available memory (use the VMs monitoring tools to check whether memory is marginal). Try one of the following:
-  - do not run anything else using a lot of memory (e.g. a web browser) on the VM in parallel
-  - reduce memory usage of the job (and/or check for potential memory leak)
-  - increase the memory allocated to the VM by clicking on System in the VirtualBox graphical user interface and adjust the base memory with the sliding bar.
+* You might have exceeded the VMs available memory (use the VMs monitoring tools to check whether memory is marginal). Try one of the following:
+    * do not run anything else using a lot of memory (e.g. a web browser) on the VM in parallel
+    * reduce memory usage of the job (and/or check for potential memory leak)
+    * increase the memory allocated to the VM by clicking on System in the VirtualBox graphical user interface and adjust the base memory with the sliding bar.
  
- **I've done the demo example from the getting started instructions and I want to change the class name**
- - Change the name of src/DemoAnalyzer.cc to the name of your choice, and replace all occurrences of `DemoAnalyzer` with the name of your choice in it and in `demoanalyzer_cfg.py`, `python/demoanalyzer_cfi`.
+**I've done the demo example from the getting started instructions and I want to change the class name**
+* Change the name of src/DemoAnalyzer.cc to the name of your choice, and replace all occurrences of `DemoAnalyzer` with the name of your choice in it and in `demoanalyzer_cfg.py`, `python/demoanalyzer_cfi`.
  
 **After having compiled my code, I get a runtime error `An exception of category 'PluginNotFound'...`**
- - It may be that your code directory is not two directories deep from `CMSSW_5_3_32/src`. If the instructions ask you to make an intermediate directory, you should do so, otherwise the CMSSW framework does not find your code even if it compiles.
+* It may be that your code directory is not two directories deep from `CMSSW_5_3_32/src`. If the instructions ask you to make an intermediate directory, you should do so, otherwise the CMSSW framework does not find your code even if it compiles.
  
 **I think I've messed up my working area, how can I clean it?**
- - You can clean up your working area with `scram b clean`.
+* You can clean up your working area with `scram b clean`.
  
 **I have an example running on the 2010 data, what do I need to modify to run it on the 2011-2012 data?**
-- Download [the CMS Open Data VM for 2011-2012 data](/record/252).
-- Change all instances of CMSSW to the correct version (CMSSW_5_3_32 for 2011 and 2012 datasets).
-- In your configuration file replace `PhysicsTools.PythonAnalysis.LumiList` with `FWCore.PythonUtilities.LumiList`.
-- Download the list of validated runs for your data of interest ([2011](/record/1001) or [2012](/record/1002)) and change it in your configuration file.
-- If your example accesses the condition database, set the logical links in your working directory and change the global tag definition in your configuration file as described in [the guide to the CMS condition database](/doc/cms-guide-to-the-cms-condition-database)
-- Change the input files to those of 2011 or 2012.
-- Other changes may be needed depending on the complexity of your code, due to the change of the CMSSW version and to the type of the data.
+* Download [the CMS Open Data VM for 2011-2012 data](/record/252).
+* Change all instances of CMSSW to the correct version (CMSSW_5_3_32 for 2011 and 2012 datasets).
+* In your configuration file replace `PhysicsTools.PythonAnalysis.LumiList` with `FWCore.PythonUtilities.LumiList`.
+* Download the list of validated runs for your data of interest ([2011](/record/1001) or [2012](/record/1002)) and change it in your configuration file.
+* If your example accesses the condition database, set the logical links in your working directory and change the global tag definition in your configuration file as described in [the guide to the CMS condition database](/doc/cms-guide-to-the-cms-condition-database)
+* Change the input files to those of 2011 or 2012.
+* Other changes may be needed depending on the complexity of your code, due to the change of the CMSSW version and to the type of the data.
 
 **I have an example running on the 2011 data, what do I need to modify to run it on the 2012 data?**
-- You can use the same CMS Open Data VM and the same CMSSW version (CMSSW_5_3_32).
-- Download the the list of validated runs for ([2012](/record/1002) and change it in your configuration file.
-- If your example accesses the condition database, set the logical links in your working directory and change the global tag definition in your configuration file as described in [the guide to the CMS condition database](/doc/cms-guide-to-the-cms-condition-database).
-- Change the input files to those of 2012.
+* You can use the same CMS Open Data VM and the same CMSSW version (CMSSW_5_3_32).
+* Download the the list of validated runs for ([2012](/record/1002) and change it in your configuration file.
+* If your example accesses the condition database, set the logical links in your working directory and change the global tag definition in your configuration file as described in [the guide to the CMS condition database](/doc/cms-guide-to-the-cms-condition-database).
+* Change the input files to those of 2012.
 
 
 ### File access runtime
 
 **When reading AOD data, I get write access warnings from eospublic on every file**
-- This was a temporary 'feature' of a change in the eos software which has meanwhile been fixed. It does not affect the results.
+* This was a temporary 'feature' of a change in the eos software which has meanwhile been fixed. It does not affect the results.
 
 **When reading AOD data,I get runtime Xrd error messages for some of the runs**
-- Messages such as 
+* Messages such as 
 ```
 170724 19:39:13 4988 Xrd: XrdClientMessage::ReadRaw: Failed to read header (8 bytes).
 170724 19:40:06 5113 Xrd: CheckErrorStatus: Server [188.184.50.150:1094] declared: session not found(error code: 3011)
@@ -70,7 +70,7 @@ This page lists possible solutions to frequently encountered issues with CMS Ope
 can be safely ignored, they do not affect the results.
 
 **When reading AOD data, I get fatal access error messages from eospublic on specific files**
-- According to the CERN eos-admin team, disk access problems to eospublic may occur occasionally and are automatically corrected within a few hours. If the access problem to a particular file lasts longer than about a day send a mail to [eos-admins@cern.ch](mailto://eos-admins@cern.ch), providing the file name and a log of the error message.
+* According to the CERN eos-admin team, disk access problems to eospublic may occur occasionally and are automatically corrected within a few hours. If the access problem to a particular file lasts longer than about a day send a mail to [eos-admins@cern.ch](mailto://eos-admins@cern.ch), providing the file name and a log of the error message.
 
 
 **Any other problem you cannot solve yourself or with the help of your local administrator(s), not related to your local setup**

--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2010/cms-virtual-machine-2010.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2010/cms-virtual-machine-2010.md
@@ -1,4 +1,4 @@
-The CMS-specific VM includes the [ROOT framework](http://root.cern.ch/) and [CMSSW](http://cms-sw.github.io/). Follow the instructions below to setup a CERN Virtual Machine on your computer for 2010 CMS open data. Then, go to [Getting Started with CMS data](/docs/cms-getting-started-2010)
+The CMS-specific VM includes the [ROOT framework](http://root.cern.ch/) and [CMSSW](http://cms-sw.github.io/). Follow the instructions below to setup a CERN Virtual Machine on your computer for 2010 CMS Open Data. Then, go to [Getting Started with CMS data](/docs/cms-getting-started-2010)
 
 1.  [How to install a CERN VM](#install2010)
 2.  [How to Test & Validate?](#testvalidate2010)
@@ -18,7 +18,7 @@ Note: the latest tested version of VirtualBox working with this CMS-specific Cer
 
 **Important**: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see [Issues and Limitations](#issues2010) if you encounter any problems with booting the VM.
 
-Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2010 CMS open data](/record/250).
+Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2010 CMS Open Data](/record/250).
 
 By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings: in case of any problems with booting with these default settings, see [Issues and Limitations](#issues2010). Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment.
 

--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2010/cms-virtual-machine-2010.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2010/cms-virtual-machine-2010.md
@@ -1,4 +1,4 @@
-The CMS-specific VM includes the [ROOT framework](http://root.cern.ch/) and [CMSSW](http://cms-sw.github.io/). Follow the instructions below to setup a CERN Virtual Machine on your computer. Then, go to [Getting Started with CMS data](/docs/cms-getting-started-2010)
+The CMS-specific VM includes the [ROOT framework](http://root.cern.ch/) and [CMSSW](http://cms-sw.github.io/). Follow the instructions below to setup a CERN Virtual Machine on your computer for 2010 CMS open data. Then, go to [Getting Started with CMS data](/docs/cms-getting-started-2010)
 
 1.  [How to install a CERN VM](#install2010)
 2.  [How to Test & Validate?](#testvalidate2010)

--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2010/cms-virtual-machine-2010.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2010/cms-virtual-machine-2010.md
@@ -12,7 +12,7 @@ VirtualBox is a free, open source and multiplatform application to run virtual m
 
 You will need administrative ("root") privileges on every platform to perform the installation of VirtualBox.
 
-Note: the latest tested version of VirtualBox working with this CMS-specific CernVM image is 4.3.14\. If you have troubles with the latest version of VirtualBox, pick that one: the full history of VirtualBox versions is available [on a different page.](https://www.VirtualBox.org/wiki/Download_Old_Builds)
+Note: the latest tested version of VirtualBox working with this CMS-specific CernVM image is 5.2.2\. If you have troubles with the latest version of VirtualBox, pick that one: the full history of VirtualBox versions is available [on a different page.](https://www.VirtualBox.org/wiki/Download_Old_Builds)
 
 ### Step 2: Downloading and Creating a Virtual Machine
 

--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
@@ -17,11 +17,11 @@ Note: the latest tested version of VirtualBox working with this CMS-specific Cer
 
 ### Step 2: Downloading and Creating a Virtual Machine
 
-**Important**: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see [Issues and Limitations][issue] if you encounter any problems with booting the VM.
+**Important**: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see [Issues and Limitations](#issue) if you encounter any problems with booting the VM.
 
 Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2011 CMS Open Data][cmsvmimage2011].
 
-By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings: in case of any problems with booting with these default settings, see [Issues and Limitations][issues]. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment
+By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings: in case of any problems with booting with these default settings, see [Issues and Limitations](#issue). Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment
 
 
 ## <a name="test">How to Test & Validate?</a>
@@ -169,6 +169,5 @@ Question: Resizing the VM window doesn't resize its contents.
 
 [installVB]: <https://www.virtualbox.org/wiki/Downloads>
 [installVB2]: <https://www.virtualbox.org/wiki/Download_Old_Builds>
-[issues]: </VM/CMS#issues>
 [cmsvmimage2011]: </record/252>
 [getstartedcms]: </docs/cms-getting-started-2011>

--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
@@ -12,7 +12,7 @@ VirtualBox is a free, open source and multiplatform application to run virtual m
 
 You will need administrative ("root") privileges on every platform to perform the installation of VirtualBox.
 
-Note: the latest tested version of VirtualBox working with this CMS-specific CernVM image is 5.0.14. If you have troubles with the latest version of VirtualBox, pick that one: the full history of VirtualBox versions is available [on a different page][installVB2].
+Note: the latest tested version of VirtualBox working with this CMS-specific CernVM image is 5.2.2. If you have troubles with the latest version of VirtualBox, pick that one: the full history of VirtualBox versions is available [on a different page][installVB2].
 
 
 ### Step 2: Downloading and Creating a Virtual Machine

--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
@@ -1,4 +1,4 @@
-The CMS-specific VM includes the [ROOT framework](http://root.cern.ch/) and [CMSSW](http://cms-sw.github.io/). Follow the instructions below to setup a CERN Virtual Machine on your computer. Then, go to [Getting Started with CMS data][getstartedcms]
+The CMS-specific VM includes the [ROOT framework](http://root.cern.ch/) and [CMSSW](http://cms-sw.github.io/). Follow the instructions below to setup a CERN Virtual Machine on your computer for 2011-2012 CMS open data. Then, go to [Getting Started with CMS data][getstartedcms]
 
 1. [How to install a CERN VM](#vbox)
 2. [How to Test & Validate?](#test)

--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
@@ -1,4 +1,4 @@
-The CMS-specific VM includes the [ROOT framework](http://root.cern.ch/) and [CMSSW](http://cms-sw.github.io/). Follow the instructions below to setup a CERN Virtual Machine on your computer for 2011-2012 CMS open data. Then, go to [Getting Started with CMS data][getstartedcms]
+The CMS-specific VM includes the [ROOT framework](http://root.cern.ch/) and [CMSSW](http://cms-sw.github.io/). Follow the instructions below to setup a CERN Virtual Machine on your computer for 2011-2012 CMS Open Data. Then, go to [Getting Started with CMS data][getstartedcms]
 
 1. [How to install a CERN VM](#vbox)
 2. [How to Test & Validate?](#test)
@@ -17,9 +17,9 @@ Note: the latest tested version of VirtualBox working with this CMS-specific Cer
 
 ### Step 2: Downloading and Creating a Virtual Machine
 
-**Important**: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see [Issues and Limitations](#issue) if you encounter any problems with booting the VM.
+**Important**: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see [Issues and Limitations][issue] if you encounter any problems with booting the VM.
 
-Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2011 CMS open data][cmsvmimage2011].
+Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2011 CMS Open Data][cmsvmimage2011].
 
 By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings: in case of any problems with booting with these default settings, see [Issues and Limitations][issues]. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment
 

--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
@@ -17,7 +17,7 @@ Note: the latest tested version of VirtualBox working with this CMS-specific Cer
 
 ### Step 2: Downloading and Creating a Virtual Machine
 
-**Important**: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see [Issues and Limitations][issues] if you encounter any problems with booting the VM.
+**Important**: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see [Issues and Limitations](#issue) if you encounter any problems with booting the VM.
 
 Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2011 CMS open data][cmsvmimage2011].
 


### PR DESCRIPTION
Fixes the lists in CMS docs which do not display properly on the portal, closes #2069 and #2063