### PR TITLE
records: sha1 checksum fix for files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012B.json
@@ -30,7 +30,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "25f583efc84fba23953501bbba90197e8f745fdb",
+      "checksum": "sha1:25f583efc84fba23953501bbba90197e8f745fdb",
       "size": 4657122,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/IG/22Jan2013-v1/BJetPlusX_Run2012B_0.ig"
     }
@@ -107,7 +107,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "981c3b0022b6ca9ce8c91d2d6d2e4811b3088370",
+      "checksum": "sha1:981c3b0022b6ca9ce8c91d2d6d2e4811b3088370",
       "size": 2855989,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BTag/IG/22Jan2013-v1/BTag_Run2012B_0.ig"
     }
@@ -184,7 +184,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "e6e3380fe96daa5d747077e41b0f83cf70aaf253",
+      "checksum": "sha1:e6e3380fe96daa5d747077e41b0f83cf70aaf253",
       "size": 1213583,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/Commissioning/IG/22Jan2013-v1/Commissioning_Run2012B_0.ig"
     }
@@ -261,7 +261,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "f0e937f78dbc432daf64b083d626b1bd853e58d8",
+      "checksum": "sha1:f0e937f78dbc432daf64b083d626b1bd853e58d8",
       "size": 2735536,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/IG/22Jan2013-v1/DoubleElectron_Run2012B_0.ig"
     }
@@ -338,7 +338,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "6315b113775e83c4cf9a4f1f7693feda1e661a21",
+      "checksum": "sha1:6315b113775e83c4cf9a4f1f7693feda1e661a21",
       "size": 2421331,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/IG/22Jan2013-v1/DoubleMuParked_Run2012B_0.ig"
     }
@@ -415,7 +415,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "6c647816fdb33d58e5f37339c1ff9b56f9292edf",
+      "checksum": "sha1:6c647816fdb33d58e5f37339c1ff9b56f9292edf",
       "size": 2290289,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/IG/22Jan2013-v1/DoublePhoton_Run2012B_0.ig"
     }
@@ -492,7 +492,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "6af732ef22c007cb5222113c9eddf29e6216aae0",
+      "checksum": "sha1:6af732ef22c007cb5222113c9eddf29e6216aae0",
       "size": 3483546,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhotonHighPt/IG/22Jan2013-v1/DoublePhotonHighPt_Run2012B_0.ig"
     }
@@ -569,7 +569,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "0009d197aa5bb3f42842e241a401ab9f78d9e89f",
+      "checksum": "sha1:0009d197aa5bb3f42842e241a401ab9f78d9e89f",
       "size": 3496785,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/IG/22Jan2013-v1/ElectronHad_Run2012B_0.ig"
     }
@@ -646,7 +646,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "7bd2fa50c5ad8a145d1770d4dee7d3e75952c645",
+      "checksum": "sha1:7bd2fa50c5ad8a145d1770d4dee7d3e75952c645",
       "size": 4297007,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/IG/22Jan2013-v1/HTMHTParked_Run2012B_0.ig"
     }
@@ -723,7 +723,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "af2ee47f08e04cb8c94949dc1663f4db47ca83de",
+      "checksum": "sha1:af2ee47f08e04cb8c94949dc1663f4db47ca83de",
       "size": 1635763,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HcalNZS/IG/22Jan2013-v1/HcalNZS_Run2012B_0.ig"
     }
@@ -800,7 +800,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "dbb29dde6081ff5ea1fbe4297c88035ea6cd9487",
+      "checksum": "sha1:dbb29dde6081ff5ea1fbe4297c88035ea6cd9487",
       "size": 5070266,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/IG/22Jan2013-v1/JetHT_Run2012B_0.ig"
     }
@@ -877,7 +877,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "fdb2c0c345438ee1728c982c360705257beac9d3",
+      "checksum": "sha1:fdb2c0c345438ee1728c982c360705257beac9d3",
       "size": 3320518,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetMon/IG/22Jan2013-v1/JetMon_Run2012B_0.ig"
     }
@@ -954,7 +954,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "2d8dec189915d8ceeeacb523921568d98f8d9887",
+      "checksum": "sha1:2d8dec189915d8ceeeacb523921568d98f8d9887",
       "size": 2525841,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/IG/22Jan2013-v1/MET_Run2012B_0.ig"
     }
@@ -1031,7 +1031,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "434957cc490332f746859edf1823b70753afb9fe",
+      "checksum": "sha1:434957cc490332f746859edf1823b70753afb9fe",
       "size": 1674785,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MinimumBias/IG/22Jan2013-v1/MinimumBias_Run2012B_0.ig"
     }
@@ -1108,7 +1108,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "676e4b265a379632be8ae57a036c9012afa9b296",
+      "checksum": "sha1:676e4b265a379632be8ae57a036c9012afa9b296",
       "size": 2767985,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/IG/22Jan2013-v1/MuEG_Run2012B_0.ig"
     }
@@ -1185,7 +1185,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "50405bc0086fa9c26b64a7a744b1b3b192d77023",
+      "checksum": "sha1:50405bc0086fa9c26b64a7a744b1b3b192d77023",
       "size": 4175894,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/IG/22Jan2013-v1/MuHad_Run2012B_0.ig"
     }
@@ -1262,7 +1262,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "b3745d6c9b7882867778511d48ade58d11dc30c5",
+      "checksum": "sha1:b3745d6c9b7882867778511d48ade58d11dc30c5",
       "size": 1903571,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/IG/22Jan2013-v1/MuOnia_Run2012B_0.ig"
     }
@@ -1339,7 +1339,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "c0451b2c875e16e7d6fb169b4ac3047dd1b32330",
+      "checksum": "sha1:c0451b2c875e16e7d6fb169b4ac3047dd1b32330",
       "size": 420370,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/NoBPTX/IG/22Jan2013-v1/NoBPTX_Run2012B_0.ig"
     }
@@ -1416,7 +1416,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "ab2923deb1046de8236d46a45d3de2a802e49cba",
+      "checksum": "sha1:ab2923deb1046de8236d46a45d3de2a802e49cba",
       "size": 3293511,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/IG/22Jan2013-v1/PhotonHad_Run2012B_0.ig"
     }
@@ -1493,7 +1493,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "6d09616b94253604f24cfe007fe9a4b33ab98e8e",
+      "checksum": "sha1:6d09616b94253604f24cfe007fe9a4b33ab98e8e",
       "size": 3115787,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/IG/22Jan2013-v1/SingleElectron_Run2012B_0.ig"
     }
@@ -1570,7 +1570,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "201c0cdf5946d2a2be30a6008050796c2bf915b8",
+      "checksum": "sha1:201c0cdf5946d2a2be30a6008050796c2bf915b8",
       "size": 1748615,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/IG/22Jan2013-v1/SingleMu_Run2012B_0.ig"
     }
@@ -1647,7 +1647,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "8b8188cfd4cdd33fa380090cf310b0b3187ca736",
+      "checksum": "sha1:8b8188cfd4cdd33fa380090cf310b0b3187ca736",
       "size": 2903012,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SinglePhoton/IG/22Jan2013-v1/SinglePhoton_Run2012B_0.ig"
     }
@@ -1724,7 +1724,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "f38b9ab08589a7e3ec847802279796bb33e5b1d6",
+      "checksum": "sha1:f38b9ab08589a7e3ec847802279796bb33e5b1d6",
       "size": 2884098,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/IG/22Jan2013-v1/TauParked_Run2012B_0.ig"
     }
@@ -1801,7 +1801,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "8ea52acbe86fa998447d1d4c5ad557ecb85c6a9b",
+      "checksum": "sha1:8ea52acbe86fa998447d1d4c5ad557ecb85c6a9b",
       "size": 2289465,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/IG/22Jan2013-v1/TauPlusX_Run2012B_0.ig"
     }
@@ -1878,7 +1878,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "48e50855f560aebfc0698133e73e4822aa9ef750",
+      "checksum": "sha1:48e50855f560aebfc0698133e73e4822aa9ef750",
       "size": 3176610,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/IG/22Jan2013-v1/VBF1Parked_Run2012B_0.ig"
     }

--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012C.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012C.json
@@ -30,7 +30,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "2b62f5b231ebcc5a097caa2df6e02622119837ee",
+      "checksum": "sha1:2b62f5b231ebcc5a097caa2df6e02622119837ee",
       "size": 3529192,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/IG/22Jan2013-v1/BJetPlusX_Run2012C_0.ig"
     }
@@ -107,7 +107,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "cf2f64ab67ebbb07f1209475b9b73b482197279a",
+      "checksum": "sha1:cf2f64ab67ebbb07f1209475b9b73b482197279a",
       "size": 3065876,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BTag/IG/22Jan2013-v1/BTag_Run2012C_0.ig"
     }
@@ -184,7 +184,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "88867ab7d42aaea3f40d6dd05344b36e140eb7a1",
+      "checksum": "sha1:88867ab7d42aaea3f40d6dd05344b36e140eb7a1",
       "size": 1543681,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/IG/22Jan2013-v1/Commissioning_Run2012C_0.ig"
     }
@@ -261,7 +261,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "e32873dfd23ac1b404170f0a9a729f91c95deeb1",
+      "checksum": "sha1:e32873dfd23ac1b404170f0a9a729f91c95deeb1",
       "size": 2257530,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/IG/22Jan2013-v1/DoubleElectron_Run2012C_0.ig"
     }
@@ -338,7 +338,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "4477ed2ea68f9b101c03fc1378aa8c72b5d8dc4c",
+      "checksum": "sha1:4477ed2ea68f9b101c03fc1378aa8c72b5d8dc4c",
       "size": 3012530,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/IG/22Jan2013-v1/DoubleMuParked_Run2012C_0.ig"
     }
@@ -415,7 +415,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "e7263d2e7b8d7148dbd6ba643ec0654a5c21dd8c",
+      "checksum": "sha1:e7263d2e7b8d7148dbd6ba643ec0654a5c21dd8c",
       "size": 2581960,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/IG/22Jan2013-v2/DoublePhoton_Run2012C_0.ig"
     }
@@ -492,7 +492,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "13c79fb786ff0fc0f1cf0113879e69d8b1cfe3a1",
+      "checksum": "sha1:13c79fb786ff0fc0f1cf0113879e69d8b1cfe3a1",
       "size": 3441201,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhotonHighPt/IG/22Jan2013-v1/DoublePhotonHighPt_Run2012C_0.ig"
     }
@@ -569,7 +569,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "4222c37e3aa79df758eedcfbd15d6bac55127e4f",
+      "checksum": "sha1:4222c37e3aa79df758eedcfbd15d6bac55127e4f",
       "size": 3698072,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/IG/22Jan2013-v1/ElectronHad_Run2012C_0.ig"
     }
@@ -646,7 +646,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "9ff633788501a8aa3613500ba5b3091262379abf",
+      "checksum": "sha1:9ff633788501a8aa3613500ba5b3091262379abf",
       "size": 4539126,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/IG/22Jan2013-v1/HTMHTParked_Run2012C_0.ig"
     }
@@ -723,7 +723,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "614e01589c497c3aabd577971138d226c92cb492",
+      "checksum": "sha1:614e01589c497c3aabd577971138d226c92cb492",
       "size": 2014385,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HcalNZS/IG/22Jan2013-v1/HcalNZS_Run2012C_0.ig"
     }
@@ -800,7 +800,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "0e26be3cf1a712908c636fb27ce84b4d556af368",
+      "checksum": "sha1:0e26be3cf1a712908c636fb27ce84b4d556af368",
       "size": 4834920,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/IG/22Jan2013-v1/JetHT_Run2012C_0.ig"
     }
@@ -877,7 +877,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "7b1184bae0ac1ed3467790241deb093dd3db7f09",
+      "checksum": "sha1:7b1184bae0ac1ed3467790241deb093dd3db7f09",
       "size": 3782469,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetMon/IG/22Jan2013-v1/JetMon_Run2012C_0.ig"
     }
@@ -954,7 +954,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "fa6c680c2b829cbd60ead541dd9a3946876f37a3",
+      "checksum": "sha1:fa6c680c2b829cbd60ead541dd9a3946876f37a3",
       "size": 3032299,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/IG/22Jan2013-v1/MET_Run2012C_0.ig"
     }
@@ -1031,7 +1031,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "781360c427490e96fb9049afb9ea114e216916e0",
+      "checksum": "sha1:781360c427490e96fb9049afb9ea114e216916e0",
       "size": 1129918,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MinimumBias/IG/22Jan2013-v1/MinimumBias_Run2012C_0.ig"
     }
@@ -1108,7 +1108,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "eb4d6aa4286e612d32a955d43d9e4486f2719aae",
+      "checksum": "sha1:eb4d6aa4286e612d32a955d43d9e4486f2719aae",
       "size": 2713188,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/IG/22Jan2013-v1/MuEG_Run2012C_0.ig"
     }
@@ -1185,7 +1185,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "8cb0f25da4575c3c441d7d3db6e04693982a9b6f",
+      "checksum": "sha1:8cb0f25da4575c3c441d7d3db6e04693982a9b6f",
       "size": 4368131,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/IG/22Jan2013-v1/MuHad_Run2012C_0.ig"
     }
@@ -1262,7 +1262,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "01dc54f1e07fee641e7bf86d63bcf982599fd6f2",
+      "checksum": "sha1:01dc54f1e07fee641e7bf86d63bcf982599fd6f2",
       "size": 2099934,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/IG/22Jan2013-v1/MuOnia_Run2012C_0.ig"
     }
@@ -1339,7 +1339,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "791b4b18cb79a6ea1e58e7e60cc860fe60eaeb0b",
+      "checksum": "sha1:791b4b18cb79a6ea1e58e7e60cc860fe60eaeb0b",
       "size": 481762,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/NoBPTX/IG/22Jan2013-v1/NoBPTX_Run2012C_0.ig"
     }
@@ -1416,7 +1416,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "b528387c215eda69cfa09cee10cf644aba4abbc7",
+      "checksum": "sha1:b528387c215eda69cfa09cee10cf644aba4abbc7",
       "size": 4210535,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/IG/22Jan2013-v1/PhotonHad_Run2012C_0.ig"
     }
@@ -1493,7 +1493,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "d812a70a0a9ce1115ba2660a822836fb1efa628f",
+      "checksum": "sha1:d812a70a0a9ce1115ba2660a822836fb1efa628f",
       "size": 3081204,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/IG/22Jan2013-v1/SingleElectron_Run2012C_0.ig"
     }
@@ -1570,7 +1570,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "5d9501f3d8f8a920ec3f62de9ab6a3c6b9309ceb",
+      "checksum": "sha1:5d9501f3d8f8a920ec3f62de9ab6a3c6b9309ceb",
       "size": 2212692,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/IG/22Jan2013-v1/SingleMu_Run2012C_0.ig"
     }
@@ -1647,7 +1647,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "b9550d0653802ec1b285a5e1777efbbde21013c8",
+      "checksum": "sha1:b9550d0653802ec1b285a5e1777efbbde21013c8",
       "size": 3435007,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/IG/22Jan2013-v1/SinglePhoton_Run2012C_0.ig"
     }
@@ -1724,7 +1724,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "ca249e14e06df5addc6895b3df800d9a845d9d11",
+      "checksum": "sha1:ca249e14e06df5addc6895b3df800d9a845d9d11",
       "size": 2760392,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/IG/22Jan2013-v1/TauParked_Run2012C_0.ig"
     }
@@ -1801,7 +1801,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "f868643fe9e4b5123d5225bf2df9a4183a5219fd",
+      "checksum": "sha1:f868643fe9e4b5123d5225bf2df9a4183a5219fd",
       "size": 2785003,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/IG/22Jan2013-v1/TauPlusX_Run2012C_0.ig"
     }
@@ -1878,7 +1878,7 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "e16296f7d65edf7523f7ff94a12cbd45856f2af7",
+      "checksum": "sha1:e16296f7d65edf7523f7ff94a12cbd45856f2af7",
       "size": 3077135,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/IG/22Jan2013-v1/VBF1Parked_Run2012C_0.ig"
     }

--- a/cernopendata/modules/fixtures/data/records/cms-hlt-configuration-files-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-hlt-configuration-files-2012.json
@@ -27,7 +27,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "cdb4eddb00282f5d01f6fcfce70b53a8410ef71e",
+        "checksum": "sha1:cdb4eddb00282f5d01f6fcfce70b53a8410ef71e",
         "size": 2084149,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v4.2_HLT_V1.py"
       }
@@ -74,7 +74,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "dd0fb4642fbf6fa9ed681d299b19f37f86a8ca5e",
+        "checksum": "sha1:dd0fb4642fbf6fa9ed681d299b19f37f86a8ca5e",
         "size": 2308868,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.0_HLT_V2.py"
       }
@@ -121,7 +121,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "514c0d3a5e223741a477456e838f35d31a3281dc",
+        "checksum": "sha1:514c0d3a5e223741a477456e838f35d31a3281dc",
         "size": 2192031,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v1.1_HLT_V1.py"
       }
@@ -168,7 +168,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "55f328f1ab4706e49897cdcfb0533f2710821250",
+        "checksum": "sha1:55f328f1ab4706e49897cdcfb0533f2710821250",
         "size": 2071786,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.3_HLT_V1.py"
       }
@@ -215,7 +215,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "deea4854dd80a1a721c9a2ff10e4a342963f26e0",
+        "checksum": "sha1:deea4854dd80a1a721c9a2ff10e4a342963f26e0",
         "size": 2067575,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.2_HLT_V3.py"
       }
@@ -262,7 +262,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "2925ecd5e85deba962c64adab1eaa7e5c5357123",
+        "checksum": "sha1:2925ecd5e85deba962c64adab1eaa7e5c5357123",
         "size": 2321436,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.1_HLT_V6.py"
       }
@@ -309,7 +309,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "2d3aca75a9d79dbb26988e5a0ffde45551eb1126",
+        "checksum": "sha1:2d3aca75a9d79dbb26988e5a0ffde45551eb1126",
         "size": 2064310,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.0_HLT_V4.py"
       }
@@ -356,7 +356,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "895cd479f1f1d4ecb8b27bd0cef692eda36b1b5e",
+        "checksum": "sha1:895cd479f1f1d4ecb8b27bd0cef692eda36b1b5e",
         "size": 2064311,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.1_HLT_V1.py"
       }
@@ -403,7 +403,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "861be4b8249ce4bc51d593e05a8492501132e18c",
+        "checksum": "sha1:861be4b8249ce4bc51d593e05a8492501132e18c",
         "size": 2059043,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.1_HLT_V11.py"
       }
@@ -450,7 +450,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "206a2afca55edd95fa5e826f81af3234c6b08b8d",
+        "checksum": "sha1:206a2afca55edd95fa5e826f81af3234c6b08b8d",
         "size": 2079227,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V21.py"
       }
@@ -497,7 +497,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "7bfe201c4f3dd0514ecc5597361e682e2cdae97a",
+        "checksum": "sha1:7bfe201c4f3dd0514ecc5597361e682e2cdae97a",
         "size": 2064311,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.0_HLT_V5.py"
       }
@@ -544,7 +544,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "91dd867b4f4555216dc0fe675c085188dc593b9f",
+        "checksum": "sha1:91dd867b4f4555216dc0fe675c085188dc593b9f",
         "size": 2064310,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.0_HLT_V3.py"
       }
@@ -591,7 +591,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "5510f163b0133a9f21eeecb13e1166824b22c894",
+        "checksum": "sha1:5510f163b0133a9f21eeecb13e1166824b22c894",
         "size": 2042796,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.6_HLT_V5.py"
       }
@@ -638,7 +638,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "c6d162c46f4cab1d06e5a377bae6b27813fb2242",
+        "checksum": "sha1:c6d162c46f4cab1d06e5a377bae6b27813fb2242",
         "size": 2042914,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.8_HLT_V1.py"
       }
@@ -685,7 +685,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "4c59efa2d18ee42bba58db60814d180e55a1edde",
+        "checksum": "sha1:4c59efa2d18ee42bba58db60814d180e55a1edde",
         "size": 2064310,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.0_HLT_V2.py"
       }
@@ -732,7 +732,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "6b18acb5027d7d812cdf338db4cd2eaa717cd8a5",
+        "checksum": "sha1:6b18acb5027d7d812cdf338db4cd2eaa717cd8a5",
         "size": 2078704,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V3.py"
       }
@@ -779,7 +779,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "f501d6c28d6443c018d48a8db76b81853430739a",
+        "checksum": "sha1:f501d6c28d6443c018d48a8db76b81853430739a",
         "size": 2079765,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V15.py"
       }
@@ -826,7 +826,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "ca7f1beb7cdbccf8b25343b81173395adac93c09",
+        "checksum": "sha1:ca7f1beb7cdbccf8b25343b81173395adac93c09",
         "size": 2071454,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.3_HLT_V3.py"
       }
@@ -873,7 +873,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "60b0cd36a9d6c7962eec6778c2c8d1a7b1213fa6",
+        "checksum": "sha1:60b0cd36a9d6c7962eec6778c2c8d1a7b1213fa6",
         "size": 2193391,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v1.2_HLT_V1.py"
       }
@@ -920,7 +920,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "07b400eb709484019aa7c70a9c5f88249f672197",
+        "checksum": "sha1:07b400eb709484019aa7c70a9c5f88249f672197",
         "size": 2045673,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.10_HLT_V1.py"
       }
@@ -967,7 +967,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "634d28aa49d3751f8a518189fa6c6d84b0ee80ac",
+        "checksum": "sha1:634d28aa49d3751f8a518189fa6c6d84b0ee80ac",
         "size": 2071455,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.3_HLT_V2.py"
       }
@@ -1014,7 +1014,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "036c97a41aeef6f7086c595765a3d879664f1d8d",
+        "checksum": "sha1:036c97a41aeef6f7086c595765a3d879664f1d8d",
         "size": 2051896,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v4.0_HLT_V1.py"
       }
@@ -1061,7 +1061,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "9f00e57cbae6d8fa90ba8bfa493b2db152862e33",
+        "checksum": "sha1:9f00e57cbae6d8fa90ba8bfa493b2db152862e33",
         "size": 2059590,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.1_HLT_V13.py"
       }
@@ -1108,7 +1108,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "1a10f3dda40a9490d60f37fe5e688dc8ce2d88ff",
+        "checksum": "sha1:1a10f3dda40a9490d60f37fe5e688dc8ce2d88ff",
         "size": 2052178,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.4_HLT_V5.py"
       }
@@ -1155,7 +1155,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "74a30e1a465ea306e69e40a7140f8d8712f1c769",
+        "checksum": "sha1:74a30e1a465ea306e69e40a7140f8d8712f1c769",
         "size": 2078889,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.14_HLT_V1.py"
       }
@@ -1202,7 +1202,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "049c43cdf66071b66c1d438f06369c65991c1d07",
+        "checksum": "sha1:049c43cdf66071b66c1d438f06369c65991c1d07",
         "size": 2078704,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V2.py"
       }
@@ -1249,7 +1249,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "10ef3796de5a0651a1ae7ae822ced602ac469a0f",
+        "checksum": "sha1:10ef3796de5a0651a1ae7ae822ced602ac469a0f",
         "size": 2321436,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.1_HLT_V7.py"
       }
@@ -1296,7 +1296,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "fba62722ab75f483056e038e952d7f2446779120",
+        "checksum": "sha1:fba62722ab75f483056e038e952d7f2446779120",
         "size": 2078401,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.13_HLT_V1.py"
       }
@@ -1343,7 +1343,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "87333f29f12c409a973f2489bf57b0e3cfb1b97d",
+        "checksum": "sha1:87333f29f12c409a973f2489bf57b0e3cfb1b97d",
         "size": 2189925,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v1.0_HLT_V2.py"
       }
@@ -1390,7 +1390,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "a0a852fd1f96981c3e0ec7138cfdfc7c1decf348",
+        "checksum": "sha1:a0a852fd1f96981c3e0ec7138cfdfc7c1decf348",
         "size": 383104,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012PI_PilotRun_PIHLT_V2.py"
       }
@@ -1437,7 +1437,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "30510f4d5aac1fe0ae20e8e8e74da2d13d2bd93f",
+        "checksum": "sha1:30510f4d5aac1fe0ae20e8e8e74da2d13d2bd93f",
         "size": 2047845,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.5_HLT_V1.py"
       }
@@ -1484,7 +1484,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "e7474a2801fbcfbc8e05559aaf0104be5da26635",
+        "checksum": "sha1:e7474a2801fbcfbc8e05559aaf0104be5da26635",
         "size": 2078617,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.12_HLT_V1.py"
       }
@@ -1531,7 +1531,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "5274b68a3192610d713b3734217dc55337069388",
+        "checksum": "sha1:5274b68a3192610d713b3734217dc55337069388",
         "size": 383184,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012PI_PilotRun_PIHLT_V4.py"
       }
@@ -1578,7 +1578,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "400ea11eaad2749d4e601f38efd1145ae16a47a4",
+        "checksum": "sha1:400ea11eaad2749d4e601f38efd1145ae16a47a4",
         "size": 2046545,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.11_HLT_V2.py"
       }
@@ -1625,7 +1625,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "7adcd41559a1ee991a62c7f0ea819561d6fbb0d3",
+        "checksum": "sha1:7adcd41559a1ee991a62c7f0ea819561d6fbb0d3",
         "size": 2049751,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.4_HLT_V7.py"
       }
@@ -1672,7 +1672,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "385353e55b0cb023f2ab2ea8b933e07e31e7db6e",
+        "checksum": "sha1:385353e55b0cb023f2ab2ea8b933e07e31e7db6e",
         "size": 2043235,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.7_HLT_V1.py"
       }
@@ -1719,7 +1719,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "76d2687d324f9da8b0b849ba9b08719b41546061",
+        "checksum": "sha1:76d2687d324f9da8b0b849ba9b08719b41546061",
         "size": 2067597,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.2_HLT_V2.py"
       }
@@ -1766,7 +1766,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "0d11aed4691f881ddfa7a93482527ab450288f58",
+        "checksum": "sha1:0d11aed4691f881ddfa7a93482527ab450288f58",
         "size": 2103381,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.4_HLT_V1.py"
       }
@@ -1813,7 +1813,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "bb0f380abeedaa5a422b90a359b96503f3c1e7b5",
+        "checksum": "sha1:bb0f380abeedaa5a422b90a359b96503f3c1e7b5",
         "size": 2079765,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V18.py"
       }
@@ -1860,7 +1860,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "2a911e70e005b2516526993e8b6c86036da9e82d",
+        "checksum": "sha1:2a911e70e005b2516526993e8b6c86036da9e82d",
         "size": 2059046,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.1_HLT_V12.py"
       }
@@ -1907,7 +1907,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "9780b020f07adbc26b0d420393b068e75f7c1fb3",
+        "checksum": "sha1:9780b020f07adbc26b0d420393b068e75f7c1fb3",
         "size": 2048137,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.5_HLT_V3.py"
       }
@@ -1954,7 +1954,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "cb76fe27a5bbe43b379f12be6640db474fa13234",
+        "checksum": "sha1:cb76fe27a5bbe43b379f12be6640db474fa13234",
         "size": 2308871,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.0_HLT_V3.py"
       }
@@ -2001,7 +2001,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "aff3583172e19e875e1ff001bce83fe6094524ee",
+        "checksum": "sha1:aff3583172e19e875e1ff001bce83fe6094524ee",
         "size": 2051070,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v4.0_HLT_V4.py"
       }
@@ -2048,7 +2048,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "57493dd5ac2764e20fc1f93cc4618507d8671562",
+        "checksum": "sha1:57493dd5ac2764e20fc1f93cc4618507d8671562",
         "size": 2321428,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.1_HLT_V5.py"
       }
@@ -2095,7 +2095,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "0b18658b7ab191fc217c4e1a5aaf96f090bf4024",
+        "checksum": "sha1:0b18658b7ab191fc217c4e1a5aaf96f090bf4024",
         "size": 2079718,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V14.py"
       }
@@ -2142,7 +2142,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "efb5a412cb51fd86db461b4292a43e0b74f0762e",
+        "checksum": "sha1:efb5a412cb51fd86db461b4292a43e0b74f0762e",
         "size": 2064311,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.1_HLT_V2.py"
       }
@@ -2189,7 +2189,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "1091157c7d15d2699f0ad4802b563adb58b08ef3",
+        "checksum": "sha1:1091157c7d15d2699f0ad4802b563adb58b08ef3",
         "size": 2051652,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v4.1_HLT_V1.py"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-reco-configuration-files-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-reco-configuration-files-2012.json
@@ -27,7 +27,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "a1109d2b609a6e01086ab312c6f94e409f4fb410",
+        "checksum": "sha1:a1109d2b609a6e01086ab312c6f94e409f4fb410",
         "size": 4598,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_HTMHTParked.py"
       }
@@ -74,7 +74,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "c94f43b43c644f7d6c26de550d53e11af8a7edd1",
+        "checksum": "sha1:c94f43b43c644f7d6c26de550d53e11af8a7edd1",
         "size": 4595,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_TauPlusX.py"
       }
@@ -121,7 +121,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "82c93e94be30241bce941fee71da051125a84a1b",
+        "checksum": "sha1:82c93e94be30241bce941fee71da051125a84a1b",
         "size": 6103,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MuOniaParked.py"
       }
@@ -168,7 +168,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "57405e705c0290478d5f9ad190179c51a1002edb",
+        "checksum": "sha1:57405e705c0290478d5f9ad190179c51a1002edb",
         "size": 4592,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_JetHT.py"
       }
@@ -215,7 +215,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "e8b783ab728a0fba965e7de3fe846e192a340017",
+        "checksum": "sha1:e8b783ab728a0fba965e7de3fe846e192a340017",
         "size": 4049,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MuEG.py"
       }
@@ -262,7 +262,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "fa81e82d88b5642a1e247c518b994840a6354033",
+        "checksum": "sha1:fa81e82d88b5642a1e247c518b994840a6354033",
         "size": 4055,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_VBF1Parked.py"
       }
@@ -309,7 +309,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "99777d13433970e29d0299c974950886f7580e98",
+        "checksum": "sha1:99777d13433970e29d0299c974950886f7580e98",
         "size": 5587,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_Commissioning.py"
       }
@@ -356,7 +356,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "84a1caed05488fbcac01638be70f8c929a612c39",
+        "checksum": "sha1:84a1caed05488fbcac01638be70f8c929a612c39",
         "size": 4050,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MuHad.py"
       }
@@ -403,7 +403,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "d726f30a9a4ab6c9b465a32afa1a11e9a9de0ca1",
+        "checksum": "sha1:d726f30a9a4ab6c9b465a32afa1a11e9a9de0ca1",
         "size": 8819,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_SingleMu.py"
       }
@@ -450,7 +450,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "ecca56f6a90489539cae8400a1f842517b742e8a",
+        "checksum": "sha1:ecca56f6a90489539cae8400a1f842517b742e8a",
         "size": 4593,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_JetMon.py"
       }
@@ -497,7 +497,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "c9e33404bc903c5a5debd45f9dd1e76a9c2a3ad3",
+        "checksum": "sha1:c9e33404bc903c5a5debd45f9dd1e76a9c2a3ad3",
         "size": 4050,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MuHad.py"
       }
@@ -544,7 +544,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "65d90d17c56f237cde126e00a47300252e615239",
+        "checksum": "sha1:65d90d17c56f237cde126e00a47300252e615239",
         "size": 4596,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_PhotonHad.py"
       }
@@ -591,7 +591,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "f27a9ccf775ef434b7c1138bd8c74c277c19344b",
+        "checksum": "sha1:f27a9ccf775ef434b7c1138bd8c74c277c19344b",
         "size": 4596,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_PhotonHad.py"
       }
@@ -638,7 +638,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "8cc6201017aeed94c9147b86192cc62b9f9b8485",
+        "checksum": "sha1:8cc6201017aeed94c9147b86192cc62b9f9b8485",
         "size": 4590,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MET.py"
       }
@@ -685,7 +685,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "fa3b2aa94fb00082a432cbb2721a7da367ef6cee",
+        "checksum": "sha1:fa3b2aa94fb00082a432cbb2721a7da367ef6cee",
         "size": 4591,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_BTag.py"
       }
@@ -732,7 +732,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "7505ddab2d5cac66d6200794760667f488b4a374",
+        "checksum": "sha1:7505ddab2d5cac66d6200794760667f488b4a374",
         "size": 4057,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_DoublePhoton.py"
       }
@@ -779,7 +779,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "108d1c316f5af363bd736841c15edaa79420f903",
+        "checksum": "sha1:108d1c316f5af363bd736841c15edaa79420f903",
         "size": 4054,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_BJetPlusX.py"
       }
@@ -826,7 +826,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "4c8ad74176458573c579b593a21899446e0e1d66",
+        "checksum": "sha1:4c8ad74176458573c579b593a21899446e0e1d66",
         "size": 7384,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MinimumBias.py"
       }
@@ -873,7 +873,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "fde5feeb8292c404a3a215d21274eedf7868e1ce",
+        "checksum": "sha1:fde5feeb8292c404a3a215d21274eedf7868e1ce",
         "size": 4063,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_DoublePhotonHighPt.py"
       }
@@ -920,7 +920,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "c3e22543f70842d779dedba38fef73bee13ace56",
+        "checksum": "sha1:c3e22543f70842d779dedba38fef73bee13ace56",
         "size": 6624,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_SingleElectron.py"
       }
@@ -967,7 +967,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "4acc9a56757ffa339e8eddcbfd65541c609939c0",
+        "checksum": "sha1:4acc9a56757ffa339e8eddcbfd65541c609939c0",
         "size": 6638,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MuOnia.py"
       }
@@ -1014,7 +1014,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "86ccf2172dd13c1c664bb2c1418dcbf71213a9a9",
+        "checksum": "sha1:86ccf2172dd13c1c664bb2c1418dcbf71213a9a9",
         "size": 4595,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_TauPlusX.py"
       }
@@ -1061,7 +1061,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "9eeba45f6067c4741dd2252211a1f4de16cec27c",
+        "checksum": "sha1:9eeba45f6067c4741dd2252211a1f4de16cec27c",
         "size": 5817,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_HcalNZS.py"
       }
@@ -1108,7 +1108,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "0a790bd7a1aeff7218fedc851b0626e55a4a72d8",
+        "checksum": "sha1:0a790bd7a1aeff7218fedc851b0626e55a4a72d8",
         "size": 4056,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_ElectronHad.py"
       }
@@ -1155,7 +1155,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "d2f48240e699582f7ae317484d2d6df495d6eb0f",
+        "checksum": "sha1:d2f48240e699582f7ae317484d2d6df495d6eb0f",
         "size": 6624,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_DoubleElectron.py"
       }
@@ -1202,7 +1202,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "1e1fca069177835f58a6cce2466f66f5939b3c4a",
+        "checksum": "sha1:1e1fca069177835f58a6cce2466f66f5939b3c4a",
         "size": 4599,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_SinglePhoton.py"
       }
@@ -1249,7 +1249,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "8e1e56d8a816e34b9fee7d0bd9e128e5020a63db",
+        "checksum": "sha1:8e1e56d8a816e34b9fee7d0bd9e128e5020a63db",
         "size": 7384,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MinimumBias.py"
       }
@@ -1296,7 +1296,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "41ed5c90cc26ceaacf363029eca7626f1f95cbf9",
+        "checksum": "sha1:41ed5c90cc26ceaacf363029eca7626f1f95cbf9",
         "size": 5587,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_Commissioning.py"
       }
@@ -1343,7 +1343,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "ee14fe7072f7cf935d82abae78141cef8c378609",
+        "checksum": "sha1:ee14fe7072f7cf935d82abae78141cef8c378609",
         "size": 4593,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_NoBPTX.py"
       }
@@ -1390,7 +1390,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "1b50945fa95b576347bd193e0c9fdf98b0bab33e",
+        "checksum": "sha1:1b50945fa95b576347bd193e0c9fdf98b0bab33e",
         "size": 4591,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_BTag.py"
       }
@@ -1437,7 +1437,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "f115cfe99882a447cefbca1a52019b6e3d52fa26",
+        "checksum": "sha1:f115cfe99882a447cefbca1a52019b6e3d52fa26",
         "size": 4598,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_HTMHTParked.py"
       }
@@ -1484,7 +1484,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "611adc60addc51f8ae74be55ef76591d6eea0b79",
+        "checksum": "sha1:611adc60addc51f8ae74be55ef76591d6eea0b79",
         "size": 6103,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MuOniaParked.py"
       }
@@ -1531,7 +1531,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "d9d771771a9665bd76fb0f266267882c3055c1e6",
+        "checksum": "sha1:d9d771771a9665bd76fb0f266267882c3055c1e6",
         "size": 4055,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_VBF1Parked.py"
       }
@@ -1578,7 +1578,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "1bc4e297f1c7a042e50d7ea0fccd31dc844f3b12",
+        "checksum": "sha1:1bc4e297f1c7a042e50d7ea0fccd31dc844f3b12",
         "size": 8768,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_DoubleMuParked.py"
       }
@@ -1625,7 +1625,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "46a9be4470ae8f02de474b7f0e2f4c027a0055e7",
+        "checksum": "sha1:46a9be4470ae8f02de474b7f0e2f4c027a0055e7",
         "size": 4056,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_ElectronHad.py"
       }
@@ -1672,7 +1672,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "06230305494acbd4c55b404ce2690e56cafa0f42",
+        "checksum": "sha1:06230305494acbd4c55b404ce2690e56cafa0f42",
         "size": 4593,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_JetMon.py"
       }
@@ -1719,7 +1719,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "683849573316907e298d22e2bf5966558d5c2c48",
+        "checksum": "sha1:683849573316907e298d22e2bf5966558d5c2c48",
         "size": 4054,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_TauParked.py"
       }
@@ -1766,7 +1766,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "bbcb175d68a761ade609076b1d4abab79958891d",
+        "checksum": "sha1:bbcb175d68a761ade609076b1d4abab79958891d",
         "size": 6638,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MuOnia.py"
       }
@@ -1813,7 +1813,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "d2c4203f0523288b336a4fa296c8d1e97ddd2f96",
+        "checksum": "sha1:d2c4203f0523288b336a4fa296c8d1e97ddd2f96",
         "size": 8768,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_DoubleMuParked.py"
       }
@@ -1860,7 +1860,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "ffea94dd64fb030cc38ba468c132e58d5f720c0a",
+        "checksum": "sha1:ffea94dd64fb030cc38ba468c132e58d5f720c0a",
         "size": 8819,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_SingleMu.py"
       }
@@ -1907,7 +1907,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "95ce0078c37819187ddfb26986e44c480ba07262",
+        "checksum": "sha1:95ce0078c37819187ddfb26986e44c480ba07262",
         "size": 5817,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_HcalNZS.py"
       }
@@ -1954,7 +1954,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "1cd161c74cce9e0e2d943c5911e7731ed7a9edd8",
+        "checksum": "sha1:1cd161c74cce9e0e2d943c5911e7731ed7a9edd8",
         "size": 4593,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_NoBPTX.py"
       }
@@ -2001,7 +2001,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "ad2b37c194384d09190ab27b7a6e86d707c68d42",
+        "checksum": "sha1:ad2b37c194384d09190ab27b7a6e86d707c68d42",
         "size": 4057,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_DoublePhoton.py"
       }
@@ -2048,7 +2048,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "9f698b518a9595650b6af4c026c22dd75c6a8c88",
+        "checksum": "sha1:9f698b518a9595650b6af4c026c22dd75c6a8c88",
         "size": 6624,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_DoubleElectron.py"
       }
@@ -2095,7 +2095,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "ed03624aed0b4de7998415dae0937f2474367a5c",
+        "checksum": "sha1:ed03624aed0b4de7998415dae0937f2474367a5c",
         "size": 6624,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_SingleElectron.py"
       }
@@ -2142,7 +2142,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "b0863f3b3273e26f432eb52b7c416e808d2204d0",
+        "checksum": "sha1:b0863f3b3273e26f432eb52b7c416e808d2204d0",
         "size": 4049,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MuEG.py"
       }
@@ -2189,7 +2189,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "f8fc4b97601995dbcc0fc8721d591062b35548db",
+        "checksum": "sha1:f8fc4b97601995dbcc0fc8721d591062b35548db",
         "size": 4054,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_TauParked.py"
       }
@@ -2236,7 +2236,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "dd7d9604058b1d1ea8abe07e55167a0e8f83ff83",
+        "checksum": "sha1:dd7d9604058b1d1ea8abe07e55167a0e8f83ff83",
         "size": 4592,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_JetHT.py"
       }
@@ -2283,7 +2283,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "12cfe74631425f7ecfab2e333022128f0deafebb",
+        "checksum": "sha1:12cfe74631425f7ecfab2e333022128f0deafebb",
         "size": 4599,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_SinglePhoton.py"
       }
@@ -2330,7 +2330,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "dad3163f63ad52e68405abeca4be310b27a58f40",
+        "checksum": "sha1:dad3163f63ad52e68405abeca4be310b27a58f40",
         "size": 4054,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_BJetPlusX.py"
       }
@@ -2377,7 +2377,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "5e9726c92536a9cecd1029f208e172844b3a12d7",
+        "checksum": "sha1:5e9726c92536a9cecd1029f208e172844b3a12d7",
         "size": 4590,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MET.py"
       }
@@ -2424,7 +2424,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "8955f09cc519d1079e08dc953971b2a845c539cb",
+        "checksum": "sha1:8955f09cc519d1079e08dc953971b2a845c539cb",
         "size": 4063,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_DoublePhotonHighPt.py"
       }


### PR DESCRIPTION
* Fixes checksum information for several CMS files. (closes #2064)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>