### PR TITLE
records: CMS 2011 MC isChildOf relation fix

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
@@ -71,12 +71,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1300", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-550_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -177,12 +171,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1301", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-550_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -290,12 +278,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1302", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -403,12 +385,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1303", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -509,12 +485,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1304", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -622,12 +592,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1305", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-600_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -735,12 +699,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1306", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-600_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -848,12 +806,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1307", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -953,12 +905,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1308", 
-  "relations": [
-    {
-      "title": "/ZZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -1065,12 +1011,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1309", 
-  "relations": [
-    {
-      "title": "/ZZJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -1178,12 +1118,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1310", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-650_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -1298,12 +1232,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1311", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-650_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -1404,12 +1332,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1312", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-700_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -1524,12 +1446,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1313", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-700_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -1637,12 +1553,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1314", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-750_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -1750,12 +1660,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1315", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-800_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -1863,12 +1767,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1316", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-800_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -1969,12 +1867,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1317", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-850_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -2089,12 +1981,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1318", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-900_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -2209,12 +2095,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1319", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-900_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -2315,12 +2195,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1320", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-950_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -2421,12 +2295,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1321", 
-  "relations": [
-    {
-      "title": "/Graviton2PH6ToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -2534,12 +2402,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1322", 
-  "relations": [
-    {
-      "title": "/Higgs0MToGGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -2640,12 +2502,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1323", 
-  "relations": [
-    {
-      "title": "/Higgs0MToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -2753,12 +2609,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1324", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -2866,12 +2716,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1325", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -2979,12 +2823,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1326", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -3092,12 +2930,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1327", 
-  "relations": [
-    {
-      "title": "/Higgs0Mf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -3198,12 +3030,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1328", 
-  "relations": [
-    {
-      "title": "/Higgs0PMToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -3311,12 +3137,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1329", 
-  "relations": [
-    {
-      "title": "/Higgs0PMToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -3417,12 +3237,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1330", 
-  "relations": [
-    {
-      "title": "/JJHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -3537,12 +3351,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1331", 
-  "relations": [
-    {
-      "title": "/JJHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -3643,12 +3451,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1332", 
-  "relations": [
-    {
-      "title": "/JJHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -3749,12 +3551,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1333", 
-  "relations": [
-    {
-      "title": "/JJHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -3869,12 +3665,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1334", 
-  "relations": [
-    {
-      "title": "/JJHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -3995,12 +3785,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1335", 
-  "relations": [
-    {
-      "title": "/JPsiToMuMu_2MuPEtaFilter_7TeV-pythia6-evtgen-v2/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -4108,12 +3892,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1336", 
-  "relations": [
-    {
-      "title": "/LambdaBToJPsiLambda_lambdaFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -4214,12 +3992,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1337", 
-  "relations": [
-    {
-      "title": "/LambdaBToLambdaJpsi_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -4320,12 +4092,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1338", 
-  "relations": [
-    {
-      "title": "/LambdaBToLambdaMuMu_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -4426,12 +4192,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1339", 
-  "relations": [
-    {
-      "title": "/LambdaBToLambdaPsi_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -4531,12 +4291,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1340", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-0to5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -4636,12 +4390,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1341", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -4741,12 +4489,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1342", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-1000to1400_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -4853,12 +4595,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1343", 
-  "relations": [
-    {
-      "title": "/ZZJetsTo4L_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -4966,12 +4702,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1344", 
-  "relations": [
-    {
-      "title": "/ZZTo2e2muJJ_Contin_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -5100,12 +4830,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1345", 
-  "relations": [
-    {
-      "title": "/ZZTo2e2mu_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -5213,12 +4937,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1346", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -5318,12 +5036,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1347", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-120to170_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -5423,12 +5135,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1348", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-120to170_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -5529,12 +5235,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1349", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -5635,12 +5335,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1350", 
-  "relations": [
-    {
-      "title": "/VBFHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -5748,12 +5442,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1351", 
-  "relations": [
-    {
-      "title": "/VBFHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -5854,12 +5542,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1352", 
-  "relations": [
-    {
-      "title": "/VBFHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -5960,12 +5642,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1353", 
-  "relations": [
-    {
-      "title": "/VBFHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -6065,12 +5741,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1354", 
-  "relations": [
-    {
-      "title": "/Tbar_TuneZ2_tW-channel-DS_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -6170,12 +5840,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1355", 
-  "relations": [
-    {
-      "title": "/Tbar_TuneZ2_tW-channel-DR_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -6276,12 +5940,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1356", 
-  "relations": [
-    {
-      "title": "/T_TuneZ2_tW-channel-DS_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -6382,12 +6040,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1357", 
-  "relations": [
-    {
-      "title": "/T_TuneZ2_t-channel_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -6487,12 +6139,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1358", 
-  "relations": [
-    {
-      "title": "/TTbarH_HToZZTo4L_M-130_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -6601,12 +6247,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1359", 
-  "relations": [
-    {
-      "title": "/TT_weights_CT10_TuneZ2_7TeV-powheg-pythia-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -6707,12 +6347,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1360", 
-  "relations": [
-    {
-      "title": "/TTTo2L2Nu2B_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -6829,12 +6463,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1361", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_matchingup_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -6935,12 +6563,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1362", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_matchingdown_mt172_5_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -7048,12 +6670,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1363", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -7153,12 +6769,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1364", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-1400to1800_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -7265,12 +6875,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1365", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-15to20_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -7419,12 +7023,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1366", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-15to30_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -7524,12 +7122,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1367", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-170to250_EMEnriched_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -7629,12 +7221,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1368", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-170to300_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -7734,12 +7320,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1369", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-170to300_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -7839,12 +7419,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1370", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-1800_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -7944,12 +7518,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1371", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-20_MuEnrichedPt-10_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -8049,12 +7617,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1372", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-20_MuEnrichedPt-15_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -8154,12 +7716,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1373", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-20to30_BCtoE_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -8259,12 +7815,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1374", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-20to30_EMEnriched_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -8364,12 +7914,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1375", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-20to30_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -8469,12 +8013,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1376", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-250to350_EMEnriched_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -8574,12 +8112,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1377", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-300to470_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -8680,12 +8212,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1378", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -8786,12 +8312,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1379", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -8899,12 +8419,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1380", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -9005,12 +8519,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1381", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -9125,12 +8633,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1382", 
-  "relations": [
-    {
-      "title": "/ZZTo2e2mu_mll4_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -9230,12 +8732,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1383", 
-  "relations": [
-    {
-      "title": "/Tbar_TuneZ2_t-channel_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -9343,12 +8839,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1384", 
-  "relations": [
-    {
-      "title": "/BuToKMuMu_BFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -9449,12 +8939,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1385", 
-  "relations": [
-    {
-      "title": "/BuToKstarJPsiV2_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -9562,12 +9046,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1386", 
-  "relations": [
-    {
-      "title": "/BuToKstarMuMuV2_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -9668,12 +9146,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1387", 
-  "relations": [
-    {
-      "title": "/BuToKstarPsi2SV2_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -9781,12 +9253,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1388", 
-  "relations": [
-    {
-      "title": "/BuToPsiK_KFilter_TuneZ2star_SVS_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -9907,12 +9373,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1389", 
-  "relations": [
-    {
-      "title": "/DY1JetToLL_M-10To50_TuneZ2_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -10068,12 +9528,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1390", 
-  "relations": [
-    {
-      "title": "/DY2Jets_M-10To50_TuneZ2_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -10194,12 +9648,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1391", 
-  "relations": [
-    {
-      "title": "/DY3Jets_M-10To50_TuneZ2_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -10306,12 +9754,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1392", 
-  "relations": [
-    {
-      "title": "/DY4Jets_M-10To50_TuneZ2_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -10411,12 +9853,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1393", 
-  "relations": [
-    {
-      "title": "/DYJetsToLL_M-10To50_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -10573,12 +10009,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1394", 
-  "relations": [
-    {
-      "title": "/DYJetsToLL_M-50_7TeV-madgraph-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -10790,12 +10220,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1395", 
-  "relations": [
-    {
-      "title": "/DYJetsToLL_TuneZ2_M-50_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -10895,12 +10319,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1396", 
-  "relations": [
-    {
-      "title": "/GJet_Pt-20_doubleEMEnriched_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -11000,12 +10418,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1397", 
-  "relations": [
-    {
-      "title": "/GJets_TuneZ2_100_HT_200_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v3/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -11112,12 +10524,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1398", 
-  "relations": [
-    {
-      "title": "/GJets_TuneZ2_200_HT_inf_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -11217,12 +10623,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1399", 
-  "relations": [
-    {
-      "title": "/GJets_TuneZ2_40_HT_100_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -11344,12 +10744,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1400", 
-  "relations": [
-    {
-      "title": "/GluGluTo2L2Lprime_Contin_7TeV-gg2vv315-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -11450,12 +10844,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1401", 
-  "relations": [
-    {
-      "title": "/GluGluTo2L2Lprime_H_M-125p6_7TeV-gg2vv315-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -11577,12 +10965,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1402", 
-  "relations": [
-    {
-      "title": "/GluGluTo2e2mu_Contin_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -11704,12 +11086,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1403", 
-  "relations": [
-    {
-      "title": "/GluGluTo2e2mu_SMH_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -11824,12 +11200,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1404", 
-  "relations": [
-    {
-      "title": "/GluGluTo4L_Contin_7TeV-gg2vv315-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -11930,12 +11300,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1405", 
-  "relations": [
-    {
-      "title": "/GluGluTo4L_H_M-125p6_7TeV-gg2vv315-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -12036,12 +11400,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1406", 
-  "relations": [
-    {
-      "title": "/GluGluTo4e_Contin_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -12142,12 +11500,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1407", 
-  "relations": [
-    {
-      "title": "/GluGluTo4e_SMH_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -12255,12 +11607,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1408", 
-  "relations": [
-    {
-      "title": "/GluGluTo4mu_Contin_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -12375,12 +11721,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1409", 
-  "relations": [
-    {
-      "title": "/GluGluTo4mu_SMH_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -12488,12 +11828,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1410", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -12601,12 +11935,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1411", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -12707,12 +12035,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1412", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -12820,12 +12142,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1413", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -12926,12 +12242,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1414", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -13039,12 +12349,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1415", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -13152,12 +12456,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1416", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -13265,12 +12563,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1417", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -13378,12 +12670,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1418", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -13484,12 +12770,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1419", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -13597,12 +12877,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1420", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -13710,12 +12984,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1421", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -13823,12 +13091,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1422", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -13936,12 +13198,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1423", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -14049,12 +13305,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1424", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -14162,12 +13412,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1425", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -14268,12 +13512,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1426", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -14374,12 +13612,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1427", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -14480,12 +13712,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1428", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -14586,12 +13812,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1429", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -14692,12 +13912,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1430", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -14798,12 +14012,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1431", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -14904,12 +14112,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1432", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -15010,12 +14212,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1433", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -15116,12 +14312,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1434", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -15222,12 +14412,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1435", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -15328,12 +14512,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1436", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -15434,12 +14612,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1437", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -15540,12 +14712,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1438", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -15646,12 +14812,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1439", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -15752,12 +14912,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1440", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -15858,12 +15012,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1441", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -15971,12 +15119,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1442", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-1000_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -16077,12 +15219,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1443", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-125_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -16183,12 +15319,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1444", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-125_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -16289,12 +15419,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1445", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-126_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -16402,12 +15526,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1446", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-126_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -16515,12 +15633,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1447", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-190_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -16635,12 +15747,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1448", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-200_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -16748,12 +15854,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1449", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-225_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -16854,12 +15954,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1450", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-250_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -16960,12 +16054,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1451", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-250_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -17073,12 +16161,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1452", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-275_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -17179,12 +16261,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1453", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-300_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -17292,12 +16368,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1454", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-300_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -17398,12 +16468,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1455", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-350_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -17504,12 +16568,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1456", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-350_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -17610,12 +16668,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1457", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-400_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -17716,12 +16768,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1458", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-400_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -17829,12 +16875,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1459", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-450_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -17949,12 +16989,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1460", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-450_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -18062,12 +17096,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1461", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-500_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -18167,12 +17195,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1462", 
-  "relations": [
-    {
-      "title": "/TTbarH_HToZZTo4L_M-180_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -18272,12 +17294,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1463", 
-  "relations": [
-    {
-      "title": "/TTbarH_HToZZTo4L_M-160_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -18377,12 +17393,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1464", 
-  "relations": [
-    {
-      "title": "/TTbarH_HToZZTo4L_M-115_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -18482,12 +17492,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1465", 
-  "relations": [
-    {
-      "title": "/TTbarH_HToZZTo4L_M-120_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -18587,12 +17591,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1466", 
-  "relations": [
-    {
-      "title": "/TTbarH_HToZZTo4L_M-125_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -18693,12 +17691,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1467", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -18799,12 +17791,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1468", 
-  "relations": [
-    {
-      "title": "/VBFHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -18904,12 +17890,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1469", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-300to470_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -19010,12 +17990,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1470", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -19116,12 +18090,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1471", 
-  "relations": [
-    {
-      "title": "/VBFHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -19222,12 +18190,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1472", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -19327,12 +18289,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1473", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-30to50_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -19433,12 +18389,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1474", 
-  "relations": [
-    {
-      "title": "/Bd2JpsiKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -19539,12 +18489,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1475", 
-  "relations": [
-    {
-      "title": "/Bd2KstarMuMu_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -19645,12 +18589,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1476", 
-  "relations": [
-    {
-      "title": "/Bd2Psi2SKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -19758,12 +18696,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1477", 
-  "relations": [
-    {
-      "title": "/BuToJPsiKV2_2MuPtEtaFilterKPtEtaFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -19892,12 +18824,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1478", 
-  "relations": [
-    {
-      "title": "/GluGluTo2L2Lprime_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -20026,12 +18952,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1479", 
-  "relations": [
-    {
-      "title": "/GluGluTo2e2mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -20146,12 +19066,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1480", 
-  "relations": [
-    {
-      "title": "/GluGluTo2e2mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -20252,12 +19166,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1481", 
-  "relations": [
-    {
-      "title": "/GluGluTo4L_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -20365,12 +19273,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1482", 
-  "relations": [
-    {
-      "title": "/GluGluTo4e_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -20485,12 +19387,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1483", 
-  "relations": [
-    {
-      "title": "/GluGluTo4e_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -20591,12 +19487,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1484", 
-  "relations": [
-    {
-      "title": "/GluGluTo4mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -20704,12 +19594,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1485", 
-  "relations": [
-    {
-      "title": "/GluGluTo4mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -20824,12 +19708,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1486", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-1000_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -20930,12 +19808,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1487", 
-  "relations": [
-    {
-      "title": "/Graviton2BPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -21050,12 +19922,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1488", 
-  "relations": [
-    {
-      "title": "/Graviton2HPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -21163,12 +20029,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1489", 
-  "relations": [
-    {
-      "title": "/Graviton2MH10qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -21269,12 +20129,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1490", 
-  "relations": [
-    {
-      "title": "/Graviton2PH2qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -21375,12 +20229,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1491", 
-  "relations": [
-    {
-      "title": "/Graviton2PH3qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -21488,12 +20336,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1492", 
-  "relations": [
-    {
-      "title": "/Higgs0L1f01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -21608,12 +20450,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1493", 
-  "relations": [
-    {
-      "title": "/Higgs0L1f05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -21714,12 +20550,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1494", 
-  "relations": [
-    {
-      "title": "/Higgs0PHf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -21820,12 +20650,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1495", 
-  "relations": [
-    {
-      "title": "/Higgs0PHf01ph90ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -21933,12 +20757,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1496", 
-  "relations": [
-    {
-      "title": "/Higgs0PHf033ph0Mf033ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -22053,12 +20871,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1497", 
-  "relations": [
-    {
-      "title": "/Higgs0PHf05ph0Mf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -22166,12 +20978,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1498", 
-  "relations": [
-    {
-      "title": "/Higgs0PHf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -22279,12 +21085,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1499", 
-  "relations": [
-    {
-      "title": "/Higgs0PHf05ph180ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -22406,12 +21206,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1500", 
-  "relations": [
-    {
-      "title": "/Higgs0PMToZZf05GGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -22512,12 +21306,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1501", 
-  "relations": [
-    {
-      "title": "/Higgs0PMToZZf05ZGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -22618,12 +21406,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1502", 
-  "relations": [
-    {
-      "title": "/Higgs0PMToZZfZGfGGfTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -22731,12 +21513,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1503", 
-  "relations": [
-    {
-      "title": "/JJHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -22837,12 +21613,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1504", 
-  "relations": [
-    {
-      "title": "/LambdaBToLambdaPsi_JpsiPiPiPPi_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -22950,12 +21720,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1505", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-115_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -23056,12 +21820,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1506", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-122_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -23162,12 +21920,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1507", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-125_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -23289,12 +22041,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1508", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-126_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -23416,12 +22162,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1509", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-130_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -23529,12 +22269,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1510", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-185_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -23644,12 +22378,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1511", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_dileptonic_central_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -23752,12 +22480,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1512", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -23860,12 +22582,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1513", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6_ext1-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -23975,12 +22691,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1514", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_dileptonic_matchingup_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -24083,12 +22793,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1515", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_dileptonic_mt166_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -24205,12 +22909,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1516", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_dileptonic_mt178_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -24313,12 +23011,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1517", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_dileptonic_scaledown_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v3/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -24428,12 +23120,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1518", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_dileptonic_scaleup_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -24557,12 +23243,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1519", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_scaledown_TuneZ2star_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -24686,12 +23366,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1520", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_scaledown_mt172_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -24815,12 +23489,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1521", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_scaleup_TuneZ2star_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -24927,12 +23595,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1522", 
-  "relations": [
-    {
-      "title": "/Upsilon1SToMuMu_2MuEtaFilter_tuneD6T_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -25033,12 +23695,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1523", 
-  "relations": [
-    {
-      "title": "/VBFHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -25146,12 +23802,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1524", 
-  "relations": [
-    {
-      "title": "/VBFHiggs0Mf05ph0ToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -25252,12 +23902,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1525", 
-  "relations": [
-    {
-      "title": "/VBFHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -25358,12 +24002,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1526", 
-  "relations": [
-    {
-      "title": "/VBFHiggs0PHToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -25464,12 +24102,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1527", 
-  "relations": [
-    {
-      "title": "/WHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -25577,12 +24209,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1528", 
-  "relations": [
-    {
-      "title": "/ZHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -25711,12 +24337,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1529", 
-  "relations": [
-    {
-      "title": "/ZZTo2e2muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -25831,12 +24451,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1530", 
-  "relations": [
-    {
-      "title": "/ZZTo2e2muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -25951,12 +24565,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1531", 
-  "relations": [
-    {
-      "title": "/ZZTo2e2muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -26057,12 +24665,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1532", 
-  "relations": [
-    {
-      "title": "/ZZTo4eJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -26170,12 +24772,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1533", 
-  "relations": [
-    {
-      "title": "/ZZTo4eJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -26297,12 +24893,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1534", 
-  "relations": [
-    {
-      "title": "/ZZTo4eJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -26417,12 +25007,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1535", 
-  "relations": [
-    {
-      "title": "/ZZTo4muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -26530,12 +25114,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1536", 
-  "relations": [
-    {
-      "title": "/ZZTo4muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -26650,12 +25228,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1537", 
-  "relations": [
-    {
-      "title": "/ZZTo4muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -26763,12 +25335,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1538", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -26868,12 +25434,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1539", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-30to50_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -26973,12 +25533,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1540", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-30to80_BCtoE_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -27085,12 +25639,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1541", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-30to80_EMEnriched_TuneZ2_7TeV-pythia/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -27191,12 +25739,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1542", 
-  "relations": [
-    {
-      "title": "/ZHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -27297,12 +25839,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1543", 
-  "relations": [
-    {
-      "title": "/ZHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -27438,12 +25974,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1544", 
-  "relations": [
-    {
-      "title": "/TTJets_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -27544,12 +26074,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1545", 
-  "relations": [
-    {
-      "title": "/GluGluToHToZZTo4L_M-500_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -27657,12 +26181,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1546", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -27763,12 +26281,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1547", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -27868,12 +26380,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1548", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-350_EMEnriched_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -27974,12 +26480,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1549", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -28079,12 +26579,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1550", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-470to600_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -28192,12 +26686,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1551", 
-  "relations": [
-    {
-      "title": "/ZZTo2e2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -28305,12 +26793,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1552", 
-  "relations": [
-    {
-      "title": "/ZZTo2e2tau_mll4_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -28410,12 +26892,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1553", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-470to600_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -28515,12 +26991,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1554", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-50to80_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -28620,12 +27090,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1555", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-50to80_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -28725,12 +27189,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1556", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-5to15_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -28830,12 +27288,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1557", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-600to800_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -28935,12 +27387,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1558", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-600to800_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -29040,12 +27486,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1559", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-800to1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -29145,12 +27585,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1560", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-800to1000_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -29250,12 +27684,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1561", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-80to120_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -29355,12 +27783,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1562", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-80to120_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -29460,12 +27882,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1563", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-80to170_BCtoE_TuneZ2_7TeV-pythia/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -29565,12 +27981,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1564", 
-  "relations": [
-    {
-      "title": "/QCD_Pt-80to170_EMEnriched_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -29671,12 +28081,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1565", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-120_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -29777,12 +28181,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1566", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-124_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -29883,12 +28281,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1567", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-128_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -29989,12 +28381,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1568", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-135_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -30102,12 +28488,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1569", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-140_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -30208,12 +28588,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1570", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-145_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -30328,12 +28702,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1571", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-150_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -30455,12 +28823,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1572", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-160_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -30561,12 +28923,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1573", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -30674,12 +29030,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1574", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -30780,12 +29130,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1575", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-170_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -30886,12 +29230,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1576", 
-  "relations": [
-    {
-      "title": "/ZZTo2mu2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -30999,12 +29337,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1577", 
-  "relations": [
-    {
-      "title": "/ZZTo2mu2tau_mll4_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -31105,12 +29437,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1578", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -31211,12 +29537,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1579", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -31317,12 +29637,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1580", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -31423,12 +29737,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1581", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -31543,12 +29851,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1582", 
-  "relations": [
-    {
-      "title": "/ZHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -31649,12 +29951,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1583", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -31762,12 +30058,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1584", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -31868,12 +30158,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1585", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -31974,12 +30258,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1586", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo4L_M-250_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -32080,12 +30358,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1587", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-175_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -32200,12 +30472,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1588", 
-  "relations": [
-    {
-      "title": "/ZZTo4eJJ_Contin_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -32312,12 +30578,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1589", 
-  "relations": [
-    {
-      "title": "/TTbarH_HToZZTo4L_M-200_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -32417,12 +30677,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1590", 
-  "relations": [
-    {
-      "title": "/TTbarH_HToZZTo4L_M-140_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -32537,12 +30791,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1591", 
-  "relations": [
-    {
-      "title": "/TT_weights_CT10_AUET2_7TeV-powheg-herwig/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -32650,12 +30898,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1592", 
-  "relations": [
-    {
-      "title": "/T_TuneZ2_s-channel_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -32756,12 +30998,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1593", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo4L_M-275_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -32869,12 +31105,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1594", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo4L_M-300_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -32982,12 +31212,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1595", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo4L_M-350_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -33095,12 +31319,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1596", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo4L_M-450_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -33201,12 +31419,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1597", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo4L_M-550_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -33307,12 +31519,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1598", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo4L_M-600_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -33420,12 +31626,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1599", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo4L_M-900_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -33526,12 +31726,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1600", 
-  "relations": [
-    {
-      "title": "/VBF_ToHToZZTo4L_M-115_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -33632,12 +31826,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1601", 
-  "relations": [
-    {
-      "title": "/VBF_ToHToZZTo4L_M-120_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -33738,12 +31926,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1602", 
-  "relations": [
-    {
-      "title": "/VBF_ToHToZZTo4L_M-125_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -33844,12 +32026,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1603", 
-  "relations": [
-    {
-      "title": "/VBF_ToHToZZTo4L_M-130_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -33950,12 +32126,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1604", 
-  "relations": [
-    {
-      "title": "/VBF_ToHToZZTo4L_M-140_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -34056,12 +32226,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1605", 
-  "relations": [
-    {
-      "title": "/VBF_ToHToZZTo4L_M-150_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -34162,12 +32326,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1606", 
-  "relations": [
-    {
-      "title": "/VBF_ToHToZZTo4L_M-160_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -34268,12 +32426,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1607", 
-  "relations": [
-    {
-      "title": "/VBF_ToHToZZTo4L_M-170_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -34374,12 +32526,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1608", 
-  "relations": [
-    {
-      "title": "/VBF_ToHToZZTo4L_M-180_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -34480,12 +32626,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1609", 
-  "relations": [
-    {
-      "title": "/VBF_ToHToZZTo4L_M-190_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -34586,12 +32726,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1610", 
-  "relations": [
-    {
-      "title": "/VBF_ToHToZZTo4L_M-200_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -34698,12 +32832,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1611", 
-  "relations": [
-    {
-      "title": "/W1Jet_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -34803,12 +32931,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1612", 
-  "relations": [
-    {
-      "title": "/W2Jets_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -34915,12 +33037,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1613", 
-  "relations": [
-    {
-      "title": "/W3Jets_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -35020,12 +33136,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1614", 
-  "relations": [
-    {
-      "title": "/W4Jets_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -35125,12 +33235,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1615", 
-  "relations": [
-    {
-      "title": "/WH_HToZZTo4L_M-110_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -35237,12 +33341,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1616", 
-  "relations": [
-    {
-      "title": "/WH_HToZZTo4L_M-115_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -35349,12 +33447,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1617", 
-  "relations": [
-    {
-      "title": "/WH_HToZZTo4L_M-120_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -35454,12 +33546,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1618", 
-  "relations": [
-    {
-      "title": "/WH_HToZZTo4L_M-125_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -35559,12 +33645,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1619", 
-  "relations": [
-    {
-      "title": "/WH_HToZZTo4L_M-126_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -35664,12 +33744,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1620", 
-  "relations": [
-    {
-      "title": "/WH_HToZZTo4L_M-130_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -35769,12 +33843,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1621", 
-  "relations": [
-    {
-      "title": "/WH_HToZZTo4L_M-140_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -35881,12 +33949,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1622", 
-  "relations": [
-    {
-      "title": "/WH_HToZZTo4L_M-150_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -35993,12 +34055,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1623", 
-  "relations": [
-    {
-      "title": "/WH_HToZZTo4L_M-160_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -36098,12 +34154,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1624", 
-  "relations": [
-    {
-      "title": "/WH_HToZZTo4L_M-180_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -36203,12 +34253,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1625", 
-  "relations": [
-    {
-      "title": "/WH_HToZZTo4L_M-200_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -36309,12 +34353,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1626", 
-  "relations": [
-    {
-      "title": "/WHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -36422,12 +34460,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1627", 
-  "relations": [
-    {
-      "title": "/WHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -36535,12 +34567,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1628", 
-  "relations": [
-    {
-      "title": "/WHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -36641,12 +34667,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1629", 
-  "relations": [
-    {
-      "title": "/WHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -36754,12 +34774,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1630", 
-  "relations": [
-    {
-      "title": "/WHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -36860,12 +34874,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1631", 
-  "relations": [
-    {
-      "title": "/WHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -36973,12 +34981,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1632", 
-  "relations": [
-    {
-      "title": "/WHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -37099,12 +35101,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1633", 
-  "relations": [
-    {
-      "title": "/WJetsToLNu_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -37204,12 +35200,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1634", 
-  "relations": [
-    {
-      "title": "/WWJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -37310,12 +35300,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1635", 
-  "relations": [
-    {
-      "title": "/WW_TuneZ2_7TeV_pythia6_tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -37422,12 +35406,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1636", 
-  "relations": [
-    {
-      "title": "/WZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -37528,12 +35506,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1637", 
-  "relations": [
-    {
-      "title": "/ZHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -37641,12 +35613,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1638", 
-  "relations": [
-    {
-      "title": "/T_TuneZ2_tW-channel-DR_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -37770,12 +35736,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1639", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_matchingdown_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -37875,12 +35835,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1640", 
-  "relations": [
-    {
-      "title": "/WZJetsTo3LNu_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -37981,12 +35935,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1641", 
-  "relations": [
-    {
-      "title": "/WZ_TuneZ2_7TeV_pythia6_tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -38086,12 +36034,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1642", 
-  "relations": [
-    {
-      "title": "/ZGToNuNuG_TuneZ2_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -38191,12 +36133,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1643", 
-  "relations": [
-    {
-      "title": "/ZH_HToZZTo4L_M-110_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -38297,12 +36233,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1644", 
-  "relations": [
-    {
-      "title": "/VBFHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -38409,12 +36339,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1645", 
-  "relations": [
-    {
-      "title": "/ZH_HToZZTo4L_M-115_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -38521,12 +36445,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1646", 
-  "relations": [
-    {
-      "title": "/ZH_HToZZTo4L_M-120_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -38627,12 +36545,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1647", 
-  "relations": [
-    {
-      "title": "/ZZTo4e_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -38768,12 +36680,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1648", 
-  "relations": [
-    {
-      "title": "/ZZTo4e_mll4_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -38874,12 +36780,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1649", 
-  "relations": [
-    {
-      "title": "/ZZTo4muJJ_Contin_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -38980,12 +36880,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1650", 
-  "relations": [
-    {
-      "title": "/ZZTo4mu_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -39093,12 +36987,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1651", 
-  "relations": [
-    {
-      "title": "/ZZTo4mu_mll4_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -39220,12 +37108,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1652", 
-  "relations": [
-    {
-      "title": "/ZZTo4tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -39333,12 +37215,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1653", 
-  "relations": [
-    {
-      "title": "/ZZTo4tau_mll4_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -39439,12 +37315,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1654", 
-  "relations": [
-    {
-      "title": "/ZZ_TuneZ2_7TeV_pythia6_tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -39544,12 +37414,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1655", 
-  "relations": [
-    {
-      "title": "/TTbarH_HToZZTo4L_M-150_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -39650,12 +37514,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1656", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-180_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -39756,12 +37614,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1657", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -39861,12 +37713,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1658", 
-  "relations": [
-    {
-      "title": "/ZH_HToZZTo4L_M-125_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -39974,12 +37820,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1659", 
-  "relations": [
-    {
-      "title": "/SMHiggsToZZTo4L_M-200_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -40087,12 +37927,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1660", 
-  "relations": [
-    {
-      "title": "/VBFToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -40192,12 +38026,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1661", 
-  "relations": [
-    {
-      "title": "/ZH_HToZZTo4L_M-126_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -40300,12 +38128,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1662", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_central_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -40429,12 +38251,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1663", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_mass169_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -40534,12 +38350,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1664", 
-  "relations": [
-    {
-      "title": "/ZH_HToZZTo4L_M-130_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -40639,12 +38449,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1665", 
-  "relations": [
-    {
-      "title": "/ZH_HToZZTo4L_M-140_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -40761,12 +38565,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1666", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_mass171_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -40866,12 +38664,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1667", 
-  "relations": [
-    {
-      "title": "/ZH_HToZZTo4L_M-150_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -40978,12 +38770,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1668", 
-  "relations": [
-    {
-      "title": "/ZH_HToZZTo4L_M-160_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -41083,12 +38869,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1669", 
-  "relations": [
-    {
-      "title": "/ZH_HToZZTo4L_M-180_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -41195,12 +38975,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1670", 
-  "relations": [
-    {
-      "title": "/ZH_HToZZTo4L_M-200_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -41301,12 +39075,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1671", 
-  "relations": [
-    {
-      "title": "/ZHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -41407,12 +39175,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1672", 
-  "relations": [
-    {
-      "title": "/ZHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -41513,12 +39275,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1673", 
-  "relations": [
-    {
-      "title": "/ZHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -41626,12 +39382,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1674", 
-  "relations": [
-    {
-      "title": "/Tbar_TuneZ2_s-channel_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -41755,12 +39505,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1675", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_mass173_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -41874,12 +39618,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1676", 
-  "relations": [
-    {
-      "title": "/TTbarH_HToZZTo4L_M-126_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -42010,12 +39748,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1677", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_mass175_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -42116,12 +39848,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1678", 
-  "relations": [
-    {
-      "title": "/VBFHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -42223,12 +39949,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1679", 
-  "relations": [
-    {
-      "title": "/Vector1MToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 
@@ -42338,12 +40058,6 @@
   }, 
   "publisher": "CERN Open Data Portal", 
   "recid": "1680", 
-  "relations": [
-    {
-      "title": "/TTJets_MSDecays_scaleup_mt172_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM", 
-      "type": "isChildOf"
-    }
-  ], 
   "run_period": "Run2011A", 
   "system_details": {
     "global_tag": "START53_LV6", 


### PR DESCRIPTION
* Remoes invalid `isChildOf` relations for CMS 2011 MC datasets.
  (addresses #2048)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>