### PR TITLE
CMS: adds contextualization script, fixes for VMs

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-2012.json
@@ -1,0 +1,63 @@
+[
+{
+  "abstract": {
+      "description": "The scripts provided create the CMS virtual machine image based on <a href=\"https://cernvm.cern.ch\">CernVM</a>, with Scientific Linux CERN 6 (slc6)."
+  }, 
+  "accelerator": "CERN-LHC", 
+  "authors": [
+      {
+          "name": "Blomer, Jakob"
+      }
+  ], 
+  "collections": [
+      "CMS-Tools"
+  ], 
+  "date_created": "2012", 
+  "date_published": "2017", 
+  "distribution": {
+      "formats": [
+          "txt"
+      ],
+      "number_files": 3,
+      "size": 3401
+  }, 
+  "experiment": "CMS", 
+  "files": [
+    {
+      "checksum": "adler32:234a36f3",
+      "size": 178,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2012/cernvm-script.txt"
+    },
+    {
+      "checksum": "adler32:f223d6d8",
+      "size": 3071,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2012/cms-user-data.txt"
+    },
+    {
+      "checksum": "adler32:786f33c7",
+      "size": 152,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2012/opendata-desktop-settings"
+    }
+  ],
+  "publisher": "CERN Open Data Portal", 
+  "recid": "253", 
+  "relations": [
+      {
+          "type": "isRelatedTo", 
+          "recid": "252", 
+          "description": "The final CERN VM image can be found here:"
+      }
+  ], 
+  "run_period": "Run2012A-Run2012D", 
+  "title": "Contextualisation scripts to create the CMS VM Image version 1.3.0, for 2012 data release", 
+  "type": {
+      "primary": "Environment", 
+      "secondary": [
+          "VM"
+      ]
+  },
+  "usage": {
+    "description": " <p> First, you need to run a normal Micro-CernVM, using your own context so you can login. Copy the attached files to the running VM and then   login.</p>\n <p>Inside the VM, you first need a copy of the latest Micro-CernVM release as a template for the Open Data image. Download it, inside the running VM, from: <a href=\"http://cernvm.cern.ch/releases/production/cernvm3-micro-2.8-6.hdd\">    http://cernvm.cern.ch/releases/production/cernvm3-micro-2.8-6.hdd </a>  placing it in the same directory as the other files. </p>\n <p> Run the script:<code>./cernvm-script </code>which will produce some output on the terminal, and then finish. </p>\n      <p>The result should be a file with the title coming from the -n field in the script. In this case, the file we're interested in is: <code>CMS-OpenData-1.3.0.ova </code>which can be copied from the running VM to elsewhere. </p> "
+  }
+}
+]

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
@@ -1,7 +1,7 @@
 [
 {
   "abstract": {
-    "description": "The virtual machine image is based on CernVM (cernvm.cern.ch), with Scientific Linux CERN 6 (slc6), which is the environment needed for the CMSSW release\n      to be used with the 2011 CMS open data. It gets the CMS software (CMSSW) from /cvmfs/cms.cern.ch and the jobs running on the CMS open data VM read the condition data from /cvmfs/cms-opendata-conddb.cern.ch. Access to the data is through XRootD."
+    "description": " <p>The virtual machine image is based on CernVM (cernvm.cern.ch), with Scientific Linux CERN 6 (slc6), which is the environment needed for the CMSSW release\n      to be used with the 2011 and 2012 CMS open data. It gets the CMS software (CMSSW) from /cvmfs/cms.cern.ch and the jobs running on the CMS open data VM read the condition data from /cvmfs/cms-opendata-conddb.cern.ch. Access to the data is through XRootD.</p> <p>CMS-Open-Data-1.2.0.ova has a 20G virtual hard disk and a 10G cvmfs cache. CMS-Open-Data-1.3.0.ova has a 40G virtual hard disk and a 20G cvmfs cache. Use CMS-Open-Data-1.3.0.ova if you access the condition data for full event range for 2012 data (see <a href=\"/docs/cms-guide-for-condition-database\">the CMS guide to the condition database</a> for further details.</p> "
   }, 
   "accelerator": "CERN-LHC", 
   "collaboration": {
@@ -16,7 +16,9 @@
   "distribution": {
     "formats": [
       "ova"
-    ]
+    ],
+    "number_files": 2,
+    "size": 36874240
   }, 
   "experiment": "CMS", 
   "files": [
@@ -24,6 +26,11 @@
       "checksum": "sha1:7ea617ce250cb3794c6e3b57a0eff38c15fa5938", 
       "size": 18145280, 
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2011/CMS-Open-Data-1.2.0.ova"
+    },
+    {
+      "checksum": "adler32:4a0b475e",
+      "size": 18728960,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2012/CMS-Open-Data-1.3.0.ova"
     }
   ], 
   "methodology": {
@@ -31,6 +38,9 @@
     "links": [
       {
         "recid": "251"
+      },
+      {
+        "recid": "253"
       }
     ]
   }, 
@@ -46,7 +56,7 @@
   "publisher": "CERN Open Data Portal", 
   "recid": "252", 
   "run_period": "Run2011A", 
-  "title": "CMS VM Image, for 2011 CMS open data", 
+  "title": "CMS VM Image, for 2011 and 2012 CMS open data", 
   "type": {
     "primary": "Environment", 
     "secondary": [
@@ -75,7 +85,7 @@
 ,
 {
   "abstract": {
-    "description": "The scripts provided create the CMS virtual machine image based on CernVM (cernvm.cern.ch), with Scientific Linux CERN 6 (slc6)."
+    "description": " <p>The scripts provided create the CMS virtual machine image based on <a href=\"https://cernvm.cern.ch\">CernVM</a>, with Scientific Linux CERN 6 (slc6)</p> ."
   }, 
   "accelerator": "CERN-LHC", 
   "authors": [
@@ -91,7 +101,9 @@
   "distribution": {
     "formats": [
       "txt"
-    ]
+    ],
+    "number_files": 3,
+    "size": 4091
   }, 
   "experiment": "CMS", 
   "files": [
@@ -121,10 +133,6 @@
     }
   ], 
   "run_period": "Run2011A", 
-  "system_details": {
-    "release": "Use this with a Micro-CernVM available at", 
-    "url": "http://cernvm.cern.ch/portal/downloads"
-  }, 
   "title": "Contextualisation scripts to create the CMS VM Image, for 2011 data release", 
   "type": {
     "primary": "Environment", 

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
@@ -16,7 +16,9 @@
   "distribution": {
     "formats": [
       "ova"
-    ]
+    ],
+    "number_files": 1,
+    "size": 915956
   }, 
   "experiment": "CMS", 
   "files": [
@@ -75,7 +77,7 @@
 ,
 {
   "abstract": {
-    "description": "The scripts provided create the CMS virtual machine image based on CernVM (cernvm.cern.ch), with Scientific Linux CERN 5 (slc5)."
+    "description": " <p>The scripts provided create the CMS virtual machine image based on <a href=\"https://cernvm.cern.ch\">CernVM</a>, with Scientific Linux CERN 6 (slc5)</p> "
   }, 
   "accelerator": "CERN-LHC", 
   "authors": [
@@ -91,8 +93,10 @@
   "distribution": {
     "formats": [
       "txt"
-    ]
-  }, 
+    ],
+    "number_files": 3,
+    "size": 4091
+}, 
   "experiment": "CMS", 
   "files": [
     {
@@ -121,10 +125,6 @@
     }
   ], 
   "run_period": "Run2010B", 
-  "system_details": {
-    "release": "Use this with a Micro-CernVM available at", 
-    "url": "http://cernvm.cern.ch/portal/downloads"
-  }, 
   "title": "Contextualisation scripts to create the CMS VM Image, for 2010 CMS open data", 
   "type": {
     "primary": "Environment", 


### PR DESCRIPTION
* Adds one record for the new contextualization script and makes
modifications to the previous contextualization script records. (closes #2045)

* Updates the 2011 VM record, so that it is appropriate for 2012 data as well. (closes #2044)

Signed-off-by: Artemis Lavasa <artemis.lavasa@cern.ch>