### PR TITLE
records: rich index files for CMS 2012 collision datasets

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012B.json
@@ -30,80 +30,157 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:6afa99f1cf3c632534c765b4e55ec76ec7372a82",
+      "description": "BJetPlusX AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
+      "size": 276741,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:c137911dbe005bd648e9b1242c77801a5b8e2957",
+      "description": "BJetPlusX AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
+      "size": 57816,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:be27d96b1ad759e2431f1a22e7be36a1058d2937",
+      "description": "BJetPlusX AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:e97aa5d647e4fbc9ea55476a6aa95b36f477afe0",
+      "description": "BJetPlusX AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:4cade2b5af0a1ea87a8060ee821c54e64dacad02",
+      "description": "BJetPlusX AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20004_file_index.json"
+    },
+    {
+      "checksum": "sha1:5195fb12cddf63b6d1b2c764f4a09b0d6c1e7e8e",
+      "description": "BJetPlusX AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20009_file_index.json"
+    },
+    {
+      "checksum": "sha1:51221d04493e019285283b6aa4ae4917653adae4",
+      "description": "BJetPlusX AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
+      "size": 278386,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:8ac8d824d6887dcda154081cfdb01cd3d167078f",
+      "description": "BJetPlusX AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
+      "size": 12058,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:5cfda283e650bf6c1b4159a1bd5fc2c941d159d0",
+      "description": "BJetPlusX AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
+      "size": 550,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30003_file_index.json"
+    },
+    {
+      "checksum": "sha1:dc1d278d2f548ec16644dc27ddedbe48a4258451",
+      "description": "BJetPlusX AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30005_file_index.json"
+    },
+    {
+      "checksum": "sha1:a6776fd2137d683e414cf3cc610beb129dd0bc68",
+      "description": "BJetPlusX AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30008_file_index.json"
+    },
+    {
+      "checksum": "sha1:2cf98231686b93f599b8c6f27d028139d4c135c5",
       "description": "BJetPlusX AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
       "size": 128270,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:15c15a07339d26dc453a2e4182d139a738eb1c78",
       "description": "BJetPlusX AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
       "size": 26797,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9c74a19d6d5efe5a85fca50cb693393c9204ce69",
       "description": "BJetPlusX AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9c7d7adff55f41f97bdfdb0ac40a9316a51089f2",
       "description": "BJetPlusX AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b6acf2ab8c8a431d7af505a98274b95ed82b4f09",
       "description": "BJetPlusX AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e7c58ff9c1cbf4da6042b1869521ce07832d3ac3",
       "description": "BJetPlusX AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8497e0551ba67539df20c1feb9abae68d163c96d",
       "description": "BJetPlusX AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
       "size": 129032,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e858bb122351217c28be5baa52098ba7fd2abcfb",
       "description": "BJetPlusX AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
       "size": 5588,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8411a735341fea1075018ba4c37aeda18fdf69c0",
       "description": "BJetPlusX AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
       "size": 254,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f31cbd7ce065ca6d3ff5b308d9f3ef4382b8903d",
       "description": "BJetPlusX AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:219c10eb8b1ce665ae6e205ef0f001b34f7d0fd1",
       "description": "BJetPlusX AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30008_file_index.txt"
     }
   ],
@@ -199,17 +276,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3f2cd1af4938bc61f85b9783ba5efe3a59547c87",
+      "description": "BTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 95497,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BTag_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:3824e7ccdfa2c40e6da4497e306cdb8da8be0885",
+      "description": "BTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 62141,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BTag_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:56262403ea272ca03d01a5ad3d39f88b4fae3024",
       "description": "BTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 43310,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BTag_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1fe77fe302d88289d91dd49b8f59aabf3f370db6",
       "description": "BTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 28182,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BTag_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -305,10 +396,17 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4e1b57dd71dbfcbbc5fff8430e9930e3f515ae97",
+      "description": "Commissioning AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
+      "size": 141504,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_Commissioning_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:f99b078c8a2ac74fb56e93e92a6f6a439541e960",
       "description": "Commissioning AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
       "size": 66679,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_Commissioning_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -404,24 +502,45 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f09ede99ea5354397a155cce8ed2e0adfc959d23",
+      "description": "DoubleElectron AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
+      "size": 278723,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleElectron_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:7433f5ee98bb31c27a09bfd6bd4cd5c767e9004b",
+      "description": "DoubleElectron AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
+      "size": 173261,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleElectron_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:34d860a1c1181627bce0541d3c1c1c704cd9d0d0",
+      "description": "DoubleElectron AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
+      "size": 6418,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleElectron_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:a06400477058b6b2ec20cc808c3fc4a652afb747",
       "description": "DoubleElectron AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
       "size": 131868,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleElectron_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:130f9c2d413f58837bed7c6b1e2ad34b2d878f73",
       "description": "DoubleElectron AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
       "size": 81972,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleElectron_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f75c3a3cc6dcb3f8c2517f631f8aec3f6b636492",
       "description": "DoubleElectron AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
       "size": 3036,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleElectron_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -517,52 +636,101 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b960f884d4086aad32ff349ffcd4137c95e61d4c",
+      "description": "DoubleMuParked AOD dataset file index (1 of 7) for access to data via CMS virtual machine",
+      "size": 839,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "sha1:d5350460a4cfa2f034d1ee719f936f5c03e21413",
+      "description": "DoubleMuParked AOD dataset file index (2 of 7) for access to data via CMS virtual machine",
+      "size": 238826,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:1093b23663b2473a4c0d282ed2fe26e6bef69845",
+      "description": "DoubleMuParked AOD dataset file index (3 of 7) for access to data via CMS virtual machine",
+      "size": 278723,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:f60bf7690af51a8995dd9d24c914a7a97a81f43d",
+      "description": "DoubleMuParked AOD dataset file index (4 of 7) for access to data via CMS virtual machine",
+      "size": 69473,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:ce80ead2ba9006989d326fa06e4d1552df22aa29",
+      "description": "DoubleMuParked AOD dataset file index (5 of 7) for access to data via CMS virtual machine",
+      "size": 19042,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_210000_file_index.json"
+    },
+    {
+      "checksum": "sha1:3c983721ff7f3bf909c2dc7a7cef4ad0f3fad555",
+      "description": "DoubleMuParked AOD dataset file index (6 of 7) for access to data via CMS virtual machine",
+      "size": 12277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:52e797085084a1992c9e98bfe0559c45cbe9a0a9",
+      "description": "DoubleMuParked AOD dataset file index (7 of 7) for access to data via CMS virtual machine",
+      "size": 16802,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_310000_file_index.json"
+    },
+    {
+      "checksum": "sha1:5798f08d8a598fafe8902e7be3babe2edc2ddbca",
       "description": "DoubleMuParked AOD dataset file index (1 of 7) for access to data via CMS virtual machine",
       "size": 396,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a6fd67522a8653ec66286dc67a8253225be11b7d",
       "description": "DoubleMuParked AOD dataset file index (2 of 7) for access to data via CMS virtual machine",
       "size": 112992,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:39934bc27705f78ba9bd956afd0ae8324632d3ca",
       "description": "DoubleMuParked AOD dataset file index (3 of 7) for access to data via CMS virtual machine",
       "size": 131868,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3d7af9b643d25e5faa87ea3e0db33bbde6fd84de",
       "description": "DoubleMuParked AOD dataset file index (4 of 7) for access to data via CMS virtual machine",
       "size": 32868,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:808134c8008c31d39586c0ad342e8f5fb0411a63",
       "description": "DoubleMuParked AOD dataset file index (5 of 7) for access to data via CMS virtual machine",
       "size": 9044,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_210000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b9bba796ad6ec32e3020bc705ffb9fcf55fa75ad",
       "description": "DoubleMuParked AOD dataset file index (6 of 7) for access to data via CMS virtual machine",
       "size": 5808,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:075ce6b5f82114b86f3a257b3641b0de2e763902",
       "description": "DoubleMuParked AOD dataset file index (7 of 7) for access to data via CMS virtual machine",
       "size": 7980,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_310000_file_index.txt"
     }
   ],
@@ -658,38 +826,73 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f79f8d74f75e54427f69e70c4b4079bb32ba5ddd",
+      "description": "DoublePhoton AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
+      "size": 276725,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:729271c32ceb91a1a22580513e1c8bd39d878665",
+      "description": "DoublePhoton AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
+      "size": 168972,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:26409984dfc39f769f5d743ec93d55c56680720e",
+      "description": "DoublePhoton AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20006_file_index.json"
+    },
+    {
+      "checksum": "sha1:4bd770832dc920256db3bec6c20100654bca62c0",
+      "description": "DoublePhoton AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20010_file_index.json"
+    },
+    {
+      "checksum": "sha1:d533ea92cad6ec93316fabc48cf579cefef7db30",
+      "description": "DoublePhoton AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20015_file_index.json"
+    },
+    {
+      "checksum": "sha1:4b51174ee43611e0762bea0252ed1a4b811eb70c",
       "description": "DoublePhoton AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
       "size": 129870,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:29e468ea786226f78dc88675ca9ca36a7f11b065",
       "description": "DoublePhoton AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
       "size": 79300,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:093532a72d9f0f71f2bf6932c117b5b3c2699f8b",
       "description": "DoublePhoton AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:90ffe721c7b1dce0137ba3ae3e58f7abb44fabd7",
       "description": "DoublePhoton AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20010_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:783eb36c29c1ad86eb4d60e07a24b87e6a64b005",
       "description": "DoublePhoton AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20015_file_index.txt"
     }
   ],
@@ -785,17 +988,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:bf179507a8dec7378c963c837a5121cbb50e07d0",
+      "description": "DoublePhotonHighPt AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 149143,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhotonHighPt_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:4e18998d768b43c862cb5159ec32ec0566749dd8",
+      "description": "DoublePhotonHighPt AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 136125,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhotonHighPt_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:12fc9fa802af51e8cc9dd5a3b8a58bf91ebf2f87",
       "description": "DoublePhotonHighPt AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 71672,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhotonHighPt_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:588cfc17ea7bde79872b0d474052df21ff902ea5",
       "description": "DoublePhotonHighPt AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 65416,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhotonHighPt_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -891,31 +1108,59 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:638e36394a8e3b2bf3c6ad30ee5bc6ed2816e49d",
+      "description": "ElectronHad AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
+      "size": 81698,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:5fbbca5f7df9e8662aaea864687ec5c8adfb0fe4",
+      "description": "ElectronHad AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:fd44b1ef8637c4c5dbeed9d2a2e10129e1a6eff2",
+      "description": "ElectronHad AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
+      "size": 243432,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:44fea1d7c53df1baf83705a131992d7127a4aa6d",
+      "description": "ElectronHad AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:3e12a333f5a2e59157a6bc7dfebe8105c5954674",
       "description": "ElectronHad AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
       "size": 38184,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:683313c9cb22a3ecb0cc0d07e10d404297d3c1e6",
       "description": "ElectronHad AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4a73a691dc22e0d3a132b96a1a90d1d842e332a5",
       "description": "ElectronHad AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
       "size": 113778,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:77f16dd76fe60be5b4ed7bc4f1ccd0df3f727d42",
       "description": "ElectronHad AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_30001_file_index.txt"
     }
   ],
@@ -1011,108 +1256,213 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8a641359e9eeae772610b77aa2496c255192464d",
+      "description": "HTMHTParked AOD dataset file index (1 of 15) for access to data via CMS virtual machine",
+      "size": 280692,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:61330fc56d5dbe9d7aaa1780f332bef1bfacf586",
+      "description": "HTMHTParked AOD dataset file index (2 of 15) for access to data via CMS virtual machine",
+      "size": 35605,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:67f418f61c67d059c2d5caac48d41887a762607d",
+      "description": "HTMHTParked AOD dataset file index (3 of 15) for access to data via CMS virtual machine",
+      "size": 554,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:7accd93b1944cefcd044ca9cfe48b7db6c1a5361",
+      "description": "HTMHTParked AOD dataset file index (4 of 15) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20004_file_index.json"
+    },
+    {
+      "checksum": "sha1:2e7b014360b54bc3237d1fab8ffcd1b85e0bb353",
+      "description": "HTMHTParked AOD dataset file index (5 of 15) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20005_file_index.json"
+    },
+    {
+      "checksum": "sha1:e72c9f878f15977d3d9aea461f7fb64838993a1d",
+      "description": "HTMHTParked AOD dataset file index (6 of 15) for access to data via CMS virtual machine",
+      "size": 276002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:89843cadb32f0d493112c5196338ef8e901aacb3",
+      "description": "HTMHTParked AOD dataset file index (7 of 15) for access to data via CMS virtual machine",
+      "size": 276002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:e1a21601a2b58d306503cc98b2cd703532eca7a6",
+      "description": "HTMHTParked AOD dataset file index (8 of 15) for access to data via CMS virtual machine",
+      "size": 40297,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:48c89a6641116c34ae930aea764084bfedb08922",
+      "description": "HTMHTParked AOD dataset file index (9 of 15) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30005_file_index.json"
+    },
+    {
+      "checksum": "sha1:d1f96f99f87f7f7a5e0ce12c8e232847d85264cb",
+      "description": "HTMHTParked AOD dataset file index (10 of 15) for access to data via CMS virtual machine",
+      "size": 554,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30006_file_index.json"
+    },
+    {
+      "checksum": "sha1:427caefb305814c18e9c1252905619ae211646fc",
+      "description": "HTMHTParked AOD dataset file index (11 of 15) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30009_file_index.json"
+    },
+    {
+      "checksum": "sha1:782b617731c01c655b096f4a52fc9ceb56aaced6",
+      "description": "HTMHTParked AOD dataset file index (12 of 15) for access to data via CMS virtual machine",
+      "size": 554,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30010_file_index.json"
+    },
+    {
+      "checksum": "sha1:62e58e5dd2e9b3ed6dc0702e1e3e13e804b6cd61",
+      "description": "HTMHTParked AOD dataset file index (13 of 15) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30012_file_index.json"
+    },
+    {
+      "checksum": "sha1:3726d57bd3cd71447b09b216c54f49ea0becda0a",
+      "description": "HTMHTParked AOD dataset file index (14 of 15) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30015_file_index.json"
+    },
+    {
+      "checksum": "sha1:247f311461dc01b1e1268de039b97a6b592508b2",
+      "description": "HTMHTParked AOD dataset file index (15 of 15) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30019_file_index.json"
+    },
+    {
+      "checksum": "sha1:d3d74205a8a5a08e71f60336375d64cf9ce75923",
       "description": "HTMHTParked AOD dataset file index (1 of 15) for access to data via CMS virtual machine",
       "size": 131193,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d1bc12900eb78e3f8293b94871a6d78c80155f2a",
       "description": "HTMHTParked AOD dataset file index (2 of 15) for access to data via CMS virtual machine",
       "size": 16641,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:32937956e20848948a27f4f81e4d9529abcc77b8",
       "description": "HTMHTParked AOD dataset file index (3 of 15) for access to data via CMS virtual machine",
       "size": 258,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:04d068d690c8187b64178c156dffc6b8d1d1cf01",
       "description": "HTMHTParked AOD dataset file index (4 of 15) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:61a5d1036b2161c6bf78efd6da469eb4a4b16a19",
       "description": "HTMHTParked AOD dataset file index (5 of 15) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:adbd59514312050b3bddf9234838c0409dad812a",
       "description": "HTMHTParked AOD dataset file index (6 of 15) for access to data via CMS virtual machine",
       "size": 129000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ba81ad2e77c1fd8993800085d2c33b424936a7ec",
       "description": "HTMHTParked AOD dataset file index (7 of 15) for access to data via CMS virtual machine",
       "size": 129000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e3c3aa86a8eecd796593234776984d873053f5b2",
       "description": "HTMHTParked AOD dataset file index (8 of 15) for access to data via CMS virtual machine",
       "size": 18834,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7fdb723b5e4938197c114a0dcfbd787947d4d3b9",
       "description": "HTMHTParked AOD dataset file index (9 of 15) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:bf19a0513aa9037fb2429e735cb982d8a2b5ec92",
       "description": "HTMHTParked AOD dataset file index (10 of 15) for access to data via CMS virtual machine",
       "size": 258,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d6698c2a0336baad331119df32320ad80c352f87",
       "description": "HTMHTParked AOD dataset file index (11 of 15) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e1f7c8bd1070ae2275d106eb233e6d5480330eea",
       "description": "HTMHTParked AOD dataset file index (12 of 15) for access to data via CMS virtual machine",
       "size": 258,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30010_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2275af32d5a8eed33a8a52ad8e27f7eaa9c94576",
       "description": "HTMHTParked AOD dataset file index (13 of 15) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30012_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:35586a7f40e763bd03fe5cb53c9729114eb161d2",
       "description": "HTMHTParked AOD dataset file index (14 of 15) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30015_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9f0ca29b8b6414e764d7981feb9d851153af34f8",
       "description": "HTMHTParked AOD dataset file index (15 of 15) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30019_file_index.txt"
     }
   ],
@@ -1208,10 +1558,17 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:14f287c4c8b58e60441d9097b94aca2b23a66afb",
+      "description": "HcalNZS AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
+      "size": 20129,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HcalNZS/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HcalNZS_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:fd8525d5a65b327f97bfc52fbf083ccb1ecef764",
       "description": "HcalNZS AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
       "size": 9250,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HcalNZS/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HcalNZS_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -1307,59 +1664,115 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:106f296883c7fdc70f9394d1aab78da4de55476b",
+      "description": "JetHT AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
+      "size": 106382,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:75a1ffdd23bbe2c0e25fed73a6d0a2840a0e2576",
+      "description": "JetHT AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
+      "size": 268652,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:fc6ec9904eb9295461f1a9625038e5950729e914",
+      "description": "JetHT AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
+      "size": 1082,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:420a16b9da91821abb6a754c99a87e06d0eae339",
+      "description": "JetHT AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
+      "size": 272,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:360f93f0696862d9599191e91d307a8562bca29a",
+      "description": "JetHT AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
+      "size": 272,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:0911caec915033b1831391ec9bc5cc422c8094d3",
+      "description": "JetHT AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
+      "size": 542,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30005_file_index.json"
+    },
+    {
+      "checksum": "sha1:899828ddcfa26cdc07262c316f71bc0e0c2f1eba",
+      "description": "JetHT AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
+      "size": 812,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30006_file_index.json"
+    },
+    {
+      "checksum": "sha1:7334f874fa96412d3ee7cc3fbd900f19b488fbc1",
+      "description": "JetHT AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
+      "size": 1082,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30007_file_index.json"
+    },
+    {
+      "checksum": "sha1:772b95bd7943eee3bf892c6674568a4b49eef527",
       "description": "JetHT AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
       "size": 48462,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:835f179e61bc51ef5999261f81265ff2872e77f6",
       "description": "JetHT AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
       "size": 122385,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7e8580b48cbc33ace96cf498540cab5985917b65",
       "description": "JetHT AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
       "size": 492,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:edc424ccf873a5f13e56851206de6b606a944757",
       "description": "JetHT AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
       "size": 123,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3b466f91e8b7ec6c9521e729e71fae1ddbc2bc08",
       "description": "JetHT AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
       "size": 123,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1e654842a727ccdc93ead1f240850e86667e944d",
       "description": "JetHT AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
       "size": 246,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1203eb6ad1125e6761deaaabc35ec30aaa1c5abb",
       "description": "JetHT AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
       "size": 369,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:863f615e7b5c3cf324735e2bfa01224de236c90d",
       "description": "JetHT AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
       "size": 492,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30007_file_index.txt"
     }
   ],
@@ -1455,17 +1868,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2597f91621a520553b06f1cdf56100573095b828",
+      "description": "JetMon AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 129540,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetMon_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:29d1dcc4f1aa2ca1e0e543b9ab39ad509f73a862",
+      "description": "JetMon AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 92142,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetMon_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:2faafd1903cd48ce9fcd2eeb602456482e08f35a",
       "description": "JetMon AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 59272,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetMon_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e83b31659e46dcb4aa93e2ebb2edbe9802cd0f39",
       "description": "JetMon AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 42160,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetMon_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -1561,59 +1988,115 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:cb1baae037e575d881e11c288f0b5826d9e2719c",
+      "description": "MET AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
+      "size": 1609,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "sha1:b1122f4f96868b8a6e5702e019e6f7d5ef61f912",
+      "description": "MET AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
+      "size": 55746,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:76f920604183f13ec54146954f65bb6f1487e483",
+      "description": "MET AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
+      "size": 269609,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:05ba824a7f17d78197dc45525c2b1de0fcc0e86f",
+      "description": "MET AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
+      "size": 45562,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:16c0bda86965bae7511737bd974ed072feeba468",
+      "description": "MET AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
+      "size": 270,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30003_file_index.json"
+    },
+    {
+      "checksum": "sha1:a36dff9739c817c5d0fbb5d7638e2c0e6dc2c4e8",
+      "description": "MET AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
+      "size": 538,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:3c3d777ee8089d14de86be1ff3ead666a99c0da0",
+      "description": "MET AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
+      "size": 270,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30005_file_index.json"
+    },
+    {
+      "checksum": "sha1:2873da547fb403ff3699e792f6f11da6b6d43e12",
+      "description": "MET AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
+      "size": 271,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_310000_file_index.json"
+    },
+    {
+      "checksum": "sha1:f863f8af44bf2bb1fc56c68e0d9c33ca17f6b71c",
       "description": "MET AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
       "size": 726,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:994d47935a636211dea7cb5a1c10ab7860ccb8e6",
       "description": "MET AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
       "size": 25168,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:fabe568df755e139b1628385a96404725414124e",
       "description": "MET AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
       "size": 121726,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4c548134108c49bc3e3df1a1d49d8231c09c0f5b",
       "description": "MET AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
       "size": 20570,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4a172c12dcc7762a11eb5024b39fed4d3a32a5e2",
       "description": "MET AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
       "size": 121,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:fe0c7582c0547944dd331efed5e66b6550848835",
       "description": "MET AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
       "size": 242,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c894a24c568cd026d67b57fd4401c9e29c136ae0",
       "description": "MET AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
       "size": 121,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:aa7c93534dce0a4abb2d8fa76c23920bf1627771",
       "description": "MET AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
       "size": 122,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_310000_file_index.txt"
     }
   ],
@@ -1709,17 +2192,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:30682825abf733f57c65b9f1af7e08097edcdf3d",
+      "description": "MinimumBias AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 104882,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MinimumBias_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:383878e75badc78751a0839a36f9f02c2a00f2a7",
+      "description": "MinimumBias AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 276000,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MinimumBias_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:e94f34af9efc9173f6bd4324d701355076a1274b",
       "description": "MinimumBias AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 49020,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MinimumBias_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2e79c24a67771f4393bd2a717a924fce3a9c8fe8",
       "description": "MinimumBias AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 129000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MinimumBias_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -1815,52 +2312,101 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:343804bc3ee45ee5ab8e7b288addddf19360c875",
+      "description": "MuEG AOD dataset file index (1 of 7) for access to data via CMS virtual machine",
+      "size": 268733,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:863b22108e19b4ab00011a9ecaa2f90af1ca6eb3",
+      "description": "MuEG AOD dataset file index (2 of 7) for access to data via CMS virtual machine",
+      "size": 50574,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:953bd90b9402ee5c3fa0c9bfd72bebd3c7d21628",
+      "description": "MuEG AOD dataset file index (3 of 7) for access to data via CMS virtual machine",
+      "size": 809,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:ff52f4cdf1fbadac56cd45158c059ab8cd39a007",
+      "description": "MuEG AOD dataset file index (4 of 7) for access to data via CMS virtual machine",
+      "size": 540,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20004_file_index.json"
+    },
+    {
+      "checksum": "sha1:3be4407d1a1df9d4ac54b8a4dd863cc0c4488659",
+      "description": "MuEG AOD dataset file index (5 of 7) for access to data via CMS virtual machine",
+      "size": 540,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20007_file_index.json"
+    },
+    {
+      "checksum": "sha1:89129231be753b0ef4543a09897950b35b124196",
+      "description": "MuEG AOD dataset file index (6 of 7) for access to data via CMS virtual machine",
+      "size": 809,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20009_file_index.json"
+    },
+    {
+      "checksum": "sha1:ef929852416a2be8853e60c2b0e33f2f2ce1e5d8",
+      "description": "MuEG AOD dataset file index (7 of 7) for access to data via CMS virtual machine",
+      "size": 1077,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:8719c0ddabf21029decc614d4e46eaa78715ee4e",
       "description": "MuEG AOD dataset file index (1 of 7) for access to data via CMS virtual machine",
       "size": 121878,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a42dce1d57240ef7145e71da2e885ac9a899f4dd",
       "description": "MuEG AOD dataset file index (2 of 7) for access to data via CMS virtual machine",
       "size": 22936,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a95076cdec5e935354b9dc44b3524963320c530d",
       "description": "MuEG AOD dataset file index (3 of 7) for access to data via CMS virtual machine",
       "size": 366,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:cfb73c04e8d82acf0a0104c278248da2e8dcea49",
       "description": "MuEG AOD dataset file index (4 of 7) for access to data via CMS virtual machine",
       "size": 244,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:149bd239b1d641383becfd20a6ad44881533f98c",
       "description": "MuEG AOD dataset file index (5 of 7) for access to data via CMS virtual machine",
       "size": 244,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:365ed882b7b45204d45052581d023ddd298d5e2a",
       "description": "MuEG AOD dataset file index (6 of 7) for access to data via CMS virtual machine",
       "size": 366,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:30a08ea8897f5c6c66418de905886e3bb7975847",
       "description": "MuEG AOD dataset file index (7 of 7) for access to data via CMS virtual machine",
       "size": 488,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -1956,45 +2502,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3ee281d3b94af932ac19f7458f208e070e482327",
+      "description": "MuHad AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 178742,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:40101fbed68c9bb611d6115d515c50fffdaca389",
+      "description": "MuHad AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 272,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:837781357754c2be4688d0b88eb0557ff400296a",
+      "description": "MuHad AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 272,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_20004_file_index.json"
+    },
+    {
+      "checksum": "sha1:a3669efaca7e92d93d5a8ea9fec68d33566823b5",
+      "description": "MuHad AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 191161,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:bbade8b1bd566a87927ed1a42a523126fc184089",
+      "description": "MuHad AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 272,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:ddb0b40406afb5a61f4db3008c733c296845fa0e",
+      "description": "MuHad AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 542,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:add076122cf26baa9157cffb98c9fabca615c8c4",
       "description": "MuHad AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 81426,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:20895b84e804a7ef3b4d0c1a11fda50da7ffd827",
       "description": "MuHad AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 123,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:896bd0cfb054e34f2ab73ad27a47ff7296ae465b",
       "description": "MuHad AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 123,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_20004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1dc2ecf82181e79c64651d36586b86eaa8c061a5",
       "description": "MuHad AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 87084,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:20f81caadbcee55aa6289d5ca09e00868b87d3fd",
       "description": "MuHad AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 123,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:238cb46355d89abd125266c4af646f6e40a61130",
       "description": "MuHad AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 246,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_30002_file_index.txt"
     }
   ],
@@ -2090,80 +2678,157 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:87ae0aecc43f7e3af3c1d374e3861511487ef5c6",
+      "description": "MuOnia AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
+      "size": 270731,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:c9554a864f64226e9d0b78a9dda114b6f68ee9fe",
+      "description": "MuOnia AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
+      "size": 152032,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:e8ed736302d81c507f56521e6fca8c654a07296d",
+      "description": "MuOnia AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
+      "size": 544,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20006_file_index.json"
+    },
+    {
+      "checksum": "sha1:33cfa0bb3083bb9d3d7fa3f546898ebb298f3d2b",
+      "description": "MuOnia AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20007_file_index.json"
+    },
+    {
+      "checksum": "sha1:2ec8ccbe251d2a9f308f19a9aeb06b4dfd2ed86c",
+      "description": "MuOnia AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
+      "size": 544,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20009_file_index.json"
+    },
+    {
+      "checksum": "sha1:dab8b48d4fcb73c4590db4105e7417107a09d147",
+      "description": "MuOnia AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20016_file_index.json"
+    },
+    {
+      "checksum": "sha1:d0ffaa704306a47e9c801c95c73d428aa7f9ab11",
+      "description": "MuOnia AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20018_file_index.json"
+    },
+    {
+      "checksum": "sha1:7f85fe7773d8f38fa54faa2a94c117419eef4361",
+      "description": "MuOnia AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20020_file_index.json"
+    },
+    {
+      "checksum": "sha1:0a292dcaa889c43aae60bdce3ac5f05e5cce11b6",
+      "description": "MuOnia AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
+      "size": 265852,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:9a17912a762573187b79d727e9f163db8184b470",
+      "description": "MuOnia AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
+      "size": 544,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_30003_file_index.json"
+    },
+    {
+      "checksum": "sha1:ce782e19cf8c7556d26a234d1c2b080a5b22fc70",
+      "description": "MuOnia AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_30007_file_index.json"
+    },
+    {
+      "checksum": "sha1:8ad716067eac5224141b6f646936a72a33e7dd0b",
       "description": "MuOnia AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
       "size": 123876,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e66f1d5aba6027c5ac665abd34fe399b01957877",
       "description": "MuOnia AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
       "size": 69564,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:175283a5e47f818c2be4b5647ea95dc5a04f5b7c",
       "description": "MuOnia AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
       "size": 248,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:57f26e7dfc255d87ab57b594a16652432cf26163",
       "description": "MuOnia AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d00490db2fb4adc2fa6d4d15df32c47a737ae1ea",
       "description": "MuOnia AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
       "size": 248,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ab3dfcd9163980cbcdfafd9c64848698c3dfad58",
       "description": "MuOnia AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20016_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2b83464f2e9456a27695801be209da3f75bb90f1",
       "description": "MuOnia AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20018_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:36b9bdf035b8ad09ad0e0b74d4109dc6116f4f95",
       "description": "MuOnia AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20020_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:24a655550adbcf1dc029d15e7bdc39fe3be63fb0",
       "description": "MuOnia AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
       "size": 121644,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e15437fe3066e64041abda0316a2050ba6676d98",
       "description": "MuOnia AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
       "size": 248,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_30003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:65a76e33b47f5e5dcb6d7209cf11c755a05b7d47",
       "description": "MuOnia AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_30007_file_index.txt"
     }
   ],
@@ -2259,108 +2924,213 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:19a29715507065e84cae443ff251ac597475226a",
+      "description": "MuOniaParked AOD dataset file index (1 of 15) for access to data via CMS virtual machine",
+      "size": 277278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:5c120290c17c9d9da0099947ab3bf114066a4ef2",
+      "description": "MuOniaParked AOD dataset file index (2 of 15) for access to data via CMS virtual machine",
+      "size": 276725,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:f8a2db519a82ed4db16d37c3f9c37c4c4929d077",
+      "description": "MuOniaParked AOD dataset file index (3 of 15) for access to data via CMS virtual machine",
+      "size": 268138,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:002970ed841711b56c2ab6f46fcfdc3069e32065",
+      "description": "MuOniaParked AOD dataset file index (4 of 15) for access to data via CMS virtual machine",
+      "size": 256781,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:a5b607a56da556080709179926989245cbe6e57e",
+      "description": "MuOniaParked AOD dataset file index (5 of 15) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20013_file_index.json"
+    },
+    {
+      "checksum": "sha1:041dddc77afe2aba716b89124212c8e6c9d4fa89",
+      "description": "MuOniaParked AOD dataset file index (6 of 15) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20014_file_index.json"
+    },
+    {
+      "checksum": "sha1:60be7da83d3bc18940a894c0830aceafa6772944",
+      "description": "MuOniaParked AOD dataset file index (7 of 15) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20020_file_index.json"
+    },
+    {
+      "checksum": "sha1:810ad83f02f32c0c6206af7280c376661dde4823",
+      "description": "MuOniaParked AOD dataset file index (8 of 15) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20025_file_index.json"
+    },
+    {
+      "checksum": "sha1:506c0b9deeab88392cc4a10a193e2a70738a71c0",
+      "description": "MuOniaParked AOD dataset file index (9 of 15) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20030_file_index.json"
+    },
+    {
+      "checksum": "sha1:0d976041e5ed924c9f2278e62274b7955fedf1dc",
+      "description": "MuOniaParked AOD dataset file index (10 of 15) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20034_file_index.json"
+    },
+    {
+      "checksum": "sha1:85b2d95b8d26fa93e13b1dfbccd1be22fc628c51",
+      "description": "MuOniaParked AOD dataset file index (11 of 15) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20035_file_index.json"
+    },
+    {
+      "checksum": "sha1:f6d0e673e8be9735a57ecde0802fd525ec5837cf",
+      "description": "MuOniaParked AOD dataset file index (12 of 15) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20040_file_index.json"
+    },
+    {
+      "checksum": "sha1:f9cdc40b384925e10e5b277993a07b84f0e467a8",
+      "description": "MuOniaParked AOD dataset file index (13 of 15) for access to data via CMS virtual machine",
+      "size": 7786,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_210000_file_index.json"
+    },
+    {
+      "checksum": "sha1:7e4bec2f39f11bcb91aae52fcab81c8525b7614b",
+      "description": "MuOniaParked AOD dataset file index (14 of 15) for access to data via CMS virtual machine",
+      "size": 111633,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:9e29512722b182eec82db2a14278fa53a2963cd2",
+      "description": "MuOniaParked AOD dataset file index (15 of 15) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:e0347a096cd573e7e16788760d1769db5ae3605b",
       "description": "MuOniaParked AOD dataset file index (1 of 15) for access to data via CMS virtual machine",
       "size": 130130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d1b3fb3dabcc82fa5cdbff86308c98da9c3cf516",
       "description": "MuOniaParked AOD dataset file index (2 of 15) for access to data via CMS virtual machine",
       "size": 129870,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d26920eb43d0df749a5e47d0867f14bfdc939f7e",
       "description": "MuOniaParked AOD dataset file index (3 of 15) for access to data via CMS virtual machine",
       "size": 125840,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:24e00fa24ceadcbf18bc703541b3a3a58c4948d5",
       "description": "MuOniaParked AOD dataset file index (4 of 15) for access to data via CMS virtual machine",
       "size": 120510,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:41b126d6a88a34887e113494a4a49e5ca8f7b28e",
       "description": "MuOniaParked AOD dataset file index (5 of 15) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20013_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9d58b138e27255c90bcfa1dd39ffb4d05b58cba3",
       "description": "MuOniaParked AOD dataset file index (6 of 15) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20014_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:45ea4e18af45966801c715c54e7e610c9f88939b",
       "description": "MuOniaParked AOD dataset file index (7 of 15) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20020_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2924973e0875c0971dcd55e8cea6b0701a34047d",
       "description": "MuOniaParked AOD dataset file index (8 of 15) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20025_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c9eb329049d766ff4531a135ed5546f24021dd02",
       "description": "MuOniaParked AOD dataset file index (9 of 15) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20030_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a06b3169d82ac95ee83a2af6ebaa06bb74d280fe",
       "description": "MuOniaParked AOD dataset file index (10 of 15) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20034_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ea6495fa7c17e9637be7795e030b699852b8a972",
       "description": "MuOniaParked AOD dataset file index (11 of 15) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20035_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:060b703173916b2956d369b951b3587d56729afb",
       "description": "MuOniaParked AOD dataset file index (12 of 15) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20040_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a75390c906b726c425080d882b4bb45a04883f4f",
       "description": "MuOniaParked AOD dataset file index (13 of 15) for access to data via CMS virtual machine",
       "size": 3668,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_210000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:648adea111e5fb139212e414de1f9daf6c177699",
       "description": "MuOniaParked AOD dataset file index (14 of 15) for access to data via CMS virtual machine",
       "size": 52390,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:820348081e337f4d0e54db13cf23fe2a0bff916a",
       "description": "MuOniaParked AOD dataset file index (15 of 15) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_30001_file_index.txt"
     }
   ],
@@ -2456,17 +3226,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e1865621ef2d8aff1bd474ff471cb3a9f143d7c4",
+      "description": "NoBPTX AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 68808,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_NoBPTX_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:4e1e1c99a561aa82837579e63627a66a6e2724b1",
+      "description": "NoBPTX AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 274,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_NoBPTX_AOD_22Jan2013-v1_310000_file_index.json"
+    },
+    {
+      "checksum": "sha1:088e3226261dace3c63c7de4c3532aae9990fa11",
       "description": "NoBPTX AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 31496,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_NoBPTX_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:335b7d836e852be4cd23751e24a4ff3bab97b6a8",
       "description": "NoBPTX AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 125,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_NoBPTX_AOD_22Jan2013-v1_310000_file_index.txt"
     }
   ],
@@ -2562,31 +3346,59 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e3ed59f5ce9ad66c6a1f7d60dfa88956ba7a6232",
+      "description": "PhotonHad AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
+      "size": 212352,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:d85daee389f142466e75c6d1428e9f64f750c56b",
+      "description": "PhotonHad AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:b9d718ad95fb7d87c8fe5080fd0827d625fc9a40",
+      "description": "PhotonHad AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
+      "size": 104944,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:f6cee9a9d6bcee5448b10d23dec70d9472cc5e3d",
+      "description": "PhotonHad AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:a2fa2a04e9ca1308d4d793b8f29620894063f715",
       "description": "PhotonHad AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
       "size": 98425,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:76ba3b4b0372c7279d77e7efe6b2f63baa23592a",
       "description": "PhotonHad AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c852480a9e211708443ebb7b44601034aaf01669",
       "description": "PhotonHad AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
       "size": 48641,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:6ae44f390092058846c7c35e32f99fb1cad0dc76",
       "description": "PhotonHad AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_30002_file_index.txt"
     }
   ],
@@ -2682,66 +3494,129 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:73587523907e27bfd889a02d6f3138180f40f38a",
+      "description": "SingleElectron AOD dataset file index (1 of 9) for access to data via CMS virtual machine",
+      "size": 279002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:fd4411ce71a550089e8e753017c66df756dcdd17",
+      "description": "SingleElectron AOD dataset file index (2 of 9) for access to data via CMS virtual machine",
+      "size": 279002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:6ca9c01dd8bc39c1048a864d63de0a1cb21baf6d",
+      "description": "SingleElectron AOD dataset file index (3 of 9) for access to data via CMS virtual machine",
+      "size": 236314,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:26e6966f2a2ffcf698ec9d7ca9275123ad51f062",
+      "description": "SingleElectron AOD dataset file index (4 of 9) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20012_file_index.json"
+    },
+    {
+      "checksum": "sha1:094c35333bc279aa254d31c71d559f5a36e840eb",
+      "description": "SingleElectron AOD dataset file index (5 of 9) for access to data via CMS virtual machine",
+      "size": 294068,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:d09f22bdfdac745f1e8a67b0321d545a354a36e5",
+      "description": "SingleElectron AOD dataset file index (6 of 9) for access to data via CMS virtual machine",
+      "size": 277328,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:82ec2d3404be9314c53805d7f97c5f061d17c21d",
+      "description": "SingleElectron AOD dataset file index (7 of 9) for access to data via CMS virtual machine",
+      "size": 111602,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:57ea77134c959298936e861c5cf6e78522f73a5a",
+      "description": "SingleElectron AOD dataset file index (8 of 9) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30005_file_index.json"
+    },
+    {
+      "checksum": "sha1:a62c9b900c9fc1f35bda4dbd51c57e5f90eca7a4",
+      "description": "SingleElectron AOD dataset file index (9 of 9) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30015_file_index.json"
+    },
+    {
+      "checksum": "sha1:3ceca2ac0abce9329bdbe111c3c55cb29de75e32",
       "description": "SingleElectron AOD dataset file index (1 of 9) for access to data via CMS virtual machine",
       "size": 132000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:06ef260173094be3248c980a70dc4900b81f096c",
       "description": "SingleElectron AOD dataset file index (2 of 9) for access to data via CMS virtual machine",
       "size": 132000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a3df40506b514b7b7e953b7c392e9b3b0e65cdd4",
       "description": "SingleElectron AOD dataset file index (3 of 9) for access to data via CMS virtual machine",
       "size": 111804,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f2084e8f44f1c2f6b26af0b58e7379d80c3d63cc",
       "description": "SingleElectron AOD dataset file index (4 of 9) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20012_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ec775d6485504d8f4ee761674674360d97bbcfe8",
       "description": "SingleElectron AOD dataset file index (5 of 9) for access to data via CMS virtual machine",
       "size": 139128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ed2a547986b3cc59391a8e86ddee6c752f93b4f3",
       "description": "SingleElectron AOD dataset file index (6 of 9) for access to data via CMS virtual machine",
       "size": 131208,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:81111b99606b07e6b59db0860bb894a3aa313bcc",
       "description": "SingleElectron AOD dataset file index (7 of 9) for access to data via CMS virtual machine",
       "size": 52800,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1dada3bc59c2de5a9f437a50a95efadd46e20eb2",
       "description": "SingleElectron AOD dataset file index (8 of 9) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1f83c55ca9beaa6614c91ff49537e9b2a0a64161",
       "description": "SingleElectron AOD dataset file index (9 of 9) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30015_file_index.txt"
     }
   ],
@@ -2837,150 +3712,297 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:6591002d75ee47e53596d8331adb06bc9e1349bf",
+      "description": "SingleMu AOD dataset file index (1 of 21) for access to data via CMS virtual machine",
+      "size": 13379,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_110000_file_index.json"
+    },
+    {
+      "checksum": "sha1:0101ea17080b8f165cfad6fa8e1fd806fb5d001c",
+      "description": "SingleMu AOD dataset file index (2 of 21) for access to data via CMS virtual machine",
+      "size": 279826,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:d7d57b8816ba548daa11895bb2b00ec1bddaea61",
+      "description": "SingleMu AOD dataset file index (3 of 21) for access to data via CMS virtual machine",
+      "size": 272456,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:b8576e7c36278036e9d8a6b185804633a0d55953",
+      "description": "SingleMu AOD dataset file index (4 of 21) for access to data via CMS virtual machine",
+      "size": 273002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:2533db18fba60295619c484adf559d873db4b6d3",
+      "description": "SingleMu AOD dataset file index (5 of 21) for access to data via CMS virtual machine",
+      "size": 171445,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:a0e226ece1bc87350b2dcfa3455bc7dacc9e3f7b",
+      "description": "SingleMu AOD dataset file index (6 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20008_file_index.json"
+    },
+    {
+      "checksum": "sha1:e1820f4630063647a77193935990304ea9bddf88",
+      "description": "SingleMu AOD dataset file index (7 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20009_file_index.json"
+    },
+    {
+      "checksum": "sha1:5a8c610b96eaddf1837ac2af6c1b2688ee3be24d",
+      "description": "SingleMu AOD dataset file index (8 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20011_file_index.json"
+    },
+    {
+      "checksum": "sha1:03fd289489298e146d6d08f3e188e4af8bcc33ea",
+      "description": "SingleMu AOD dataset file index (9 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20012_file_index.json"
+    },
+    {
+      "checksum": "sha1:3be9b5a96eb215fed5ee05273568444a7dfe9e56",
+      "description": "SingleMu AOD dataset file index (10 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20014_file_index.json"
+    },
+    {
+      "checksum": "sha1:7ca16de483e20e878aae5b4648fc6bf65de74366",
+      "description": "SingleMu AOD dataset file index (11 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20016_file_index.json"
+    },
+    {
+      "checksum": "sha1:eb81ac44faafc5532edf3db15ca386b9da389f7a",
+      "description": "SingleMu AOD dataset file index (12 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20020_file_index.json"
+    },
+    {
+      "checksum": "sha1:482bcf283c9a68131466ad65e73fc5a995638ea9",
+      "description": "SingleMu AOD dataset file index (13 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20023_file_index.json"
+    },
+    {
+      "checksum": "sha1:eb95b4f616b0792f0cc40ae4c3a1486944336041",
+      "description": "SingleMu AOD dataset file index (14 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20025_file_index.json"
+    },
+    {
+      "checksum": "sha1:400a8a6c1707bf671bce461f96b625fd94dfc57b",
+      "description": "SingleMu AOD dataset file index (15 of 21) for access to data via CMS virtual machine",
+      "size": 821,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20033_file_index.json"
+    },
+    {
+      "checksum": "sha1:50444d4c0e3e73f86b8b621100f752e30c4d0bc6",
+      "description": "SingleMu AOD dataset file index (16 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20036_file_index.json"
+    },
+    {
+      "checksum": "sha1:d8b8c2ef9d262c29ca867afd56dec70a0883b44b",
+      "description": "SingleMu AOD dataset file index (17 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20040_file_index.json"
+    },
+    {
+      "checksum": "sha1:9440b8bc1ad47be2d9331e317676a6527bd86c31",
+      "description": "SingleMu AOD dataset file index (18 of 21) for access to data via CMS virtual machine",
+      "size": 145784,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:6bdba34bc275bd91aaf32106823e1cd7e918a393",
+      "description": "SingleMu AOD dataset file index (19 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:d8409a0e6f15aa035543b375899c59dee2a94aa1",
+      "description": "SingleMu AOD dataset file index (20 of 21) for access to data via CMS virtual machine",
+      "size": 548,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30003_file_index.json"
+    },
+    {
+      "checksum": "sha1:8a32b482864125f6aab77096e5f9293ba70c3372",
+      "description": "SingleMu AOD dataset file index (21 of 21) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:53e6c8b388710f9cfe5ec03932245b55c3cc13bc",
       "description": "SingleMu AOD dataset file index (1 of 21) for access to data via CMS virtual machine",
       "size": 6223,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_110000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f6d3293108e46a345740f6be620b317499d71e6e",
       "description": "SingleMu AOD dataset file index (2 of 21) for access to data via CMS virtual machine",
       "size": 129150,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ca249484e8cead60cde45fec8cfb8ea89dd7ed2c",
       "description": "SingleMu AOD dataset file index (3 of 21) for access to data via CMS virtual machine",
       "size": 125748,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9b2e90d24be1a44627e4278b8ace23273f60d32d",
       "description": "SingleMu AOD dataset file index (4 of 21) for access to data via CMS virtual machine",
       "size": 126000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7a9ad52e03885a38a8578163eb56f748808a3bc1",
       "description": "SingleMu AOD dataset file index (5 of 21) for access to data via CMS virtual machine",
       "size": 79128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8b9c92d236f4f07429582015c32d32d53b9e2354",
       "description": "SingleMu AOD dataset file index (6 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ee2740fe7bec98006ab692f3bd4e1b428eb5ecda",
       "description": "SingleMu AOD dataset file index (7 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ebb9787c7cbffb199596fc09fe83fffd3560ff5c",
       "description": "SingleMu AOD dataset file index (8 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f4e4e0c55a81c85ba495bcbbf8aea639a5009b30",
       "description": "SingleMu AOD dataset file index (9 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20012_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7181f531e2b068a5b640127a36331f80d7100765",
       "description": "SingleMu AOD dataset file index (10 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20014_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:29f4d5c150f49edbddda3fbc592d58b820db0912",
       "description": "SingleMu AOD dataset file index (11 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20016_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4ae0bef6324d860539b500a366018ad7783456da",
       "description": "SingleMu AOD dataset file index (12 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20020_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0080e4188622dc900e5872b15356558b575cbc63",
       "description": "SingleMu AOD dataset file index (13 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20023_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c0e0e312a251ced755cc2b5dd886c059037b4b7c",
       "description": "SingleMu AOD dataset file index (14 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20025_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:fe44b6b571704eae4d77c8675e0f07ee938ee5b5",
       "description": "SingleMu AOD dataset file index (15 of 21) for access to data via CMS virtual machine",
       "size": 378,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20033_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:bdecb6cae31b0bc4c9d38d54d7bab8bf4de9f713",
       "description": "SingleMu AOD dataset file index (16 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20036_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:23e02c76ae7670fe7917b6739a95999df28f3df8",
       "description": "SingleMu AOD dataset file index (17 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20040_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9c2f1e53feac7dbf7e81d65c378d93888bd151b0",
       "description": "SingleMu AOD dataset file index (18 of 21) for access to data via CMS virtual machine",
       "size": 67284,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d59199b14aae289bff0aba044c19d0b2de50733f",
       "description": "SingleMu AOD dataset file index (19 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c64b2fea01a44de4f7a15a89fd6f365a0a9d488a",
       "description": "SingleMu AOD dataset file index (20 of 21) for access to data via CMS virtual machine",
       "size": 252,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:97a284d47ed5a73a7a7d84171853c338ee5b468a",
       "description": "SingleMu AOD dataset file index (21 of 21) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30004_file_index.txt"
     }
   ],
@@ -3076,17 +4098,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e2a27781df4aec85c22227a65e880a04c5284ce5",
+      "description": "SinglePhoton AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 128529,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SinglePhoton_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:1e5a97167b85e0993b60e8fde4ca62928304c05e",
+      "description": "SinglePhoton AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 120774,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SinglePhoton_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:293ded8082a6baae2418062b1a05b087b9824649",
       "description": "SinglePhoton AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 60320,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SinglePhoton_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ca07d1b5a0235d78e16acf67d46eca9c3e1aeaa8",
       "description": "SinglePhoton AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 56680,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SinglePhoton_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -3182,157 +4218,311 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d42acacf92197d8599174b09b2e6ee5bacd86c80",
+      "description": "TauParked AOD dataset file index (1 of 22) for access to data via CMS virtual machine",
+      "size": 273728,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:a10819eb5615bb72f53dbf44f08bb9692112f368",
+      "description": "TauParked AOD dataset file index (2 of 22) for access to data via CMS virtual machine",
+      "size": 230710,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:b45b3d8fadd4d91e298d357d1a58cb55b2d67d03",
+      "description": "TauParked AOD dataset file index (3 of 22) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:7fc03760498cf1bb98af61cfb66f358a0586481e",
+      "description": "TauParked AOD dataset file index (4 of 22) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20005_file_index.json"
+    },
+    {
+      "checksum": "sha1:865441b675d789d5e9cb1923bf393dfc6f135ac0",
+      "description": "TauParked AOD dataset file index (5 of 22) for access to data via CMS virtual machine",
+      "size": 824,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20009_file_index.json"
+    },
+    {
+      "checksum": "sha1:d8f7a0e7a63ae7464d71eca5c81199c119df560a",
+      "description": "TauParked AOD dataset file index (6 of 22) for access to data via CMS virtual machine",
+      "size": 824,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20010_file_index.json"
+    },
+    {
+      "checksum": "sha1:b6b49f2975ed535f6d3bbed8a65c347e556ae17a",
+      "description": "TauParked AOD dataset file index (7 of 22) for access to data via CMS virtual machine",
+      "size": 550,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20011_file_index.json"
+    },
+    {
+      "checksum": "sha1:006d45238e8771790e14d0e0b74483e87e3dfa9e",
+      "description": "TauParked AOD dataset file index (8 of 22) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20013_file_index.json"
+    },
+    {
+      "checksum": "sha1:96b4f20c0db97648b29f1c62aa5588d8faeeeb5d",
+      "description": "TauParked AOD dataset file index (9 of 22) for access to data via CMS virtual machine",
+      "size": 550,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20014_file_index.json"
+    },
+    {
+      "checksum": "sha1:dabc85920dd0a2f31274bfafb950777f0a4e0630",
+      "description": "TauParked AOD dataset file index (10 of 22) for access to data via CMS virtual machine",
+      "size": 550,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20015_file_index.json"
+    },
+    {
+      "checksum": "sha1:485e7504c657ed372b8ae19b3c7f415589503d75",
+      "description": "TauParked AOD dataset file index (11 of 22) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20016_file_index.json"
+    },
+    {
+      "checksum": "sha1:42dc67f1d85bea95286166325d046a4b5ff1dfde",
+      "description": "TauParked AOD dataset file index (12 of 22) for access to data via CMS virtual machine",
+      "size": 550,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20017_file_index.json"
+    },
+    {
+      "checksum": "sha1:f1a411f43f347fcde2319201f1508291e1047754",
+      "description": "TauParked AOD dataset file index (13 of 22) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20018_file_index.json"
+    },
+    {
+      "checksum": "sha1:21694b783774f0508aa5ee189b710cb182f20260",
+      "description": "TauParked AOD dataset file index (14 of 22) for access to data via CMS virtual machine",
+      "size": 275372,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:636c94f953699647f92b59ece6f4ac42d155ad69",
+      "description": "TauParked AOD dataset file index (15 of 22) for access to data via CMS virtual machine",
+      "size": 149058,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:b34fe6b6c00124362bfa34645114cc6a2ecae508",
+      "description": "TauParked AOD dataset file index (16 of 22) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:133de43850580cab2462ac206ef324c48d46dc1c",
+      "description": "TauParked AOD dataset file index (17 of 22) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30006_file_index.json"
+    },
+    {
+      "checksum": "sha1:6e07620e6c0a2eb6c47dbbfb73703a433c802b0d",
+      "description": "TauParked AOD dataset file index (18 of 22) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30008_file_index.json"
+    },
+    {
+      "checksum": "sha1:4cbc25faf38a9943a5aad24820627fb98b51ce2f",
+      "description": "TauParked AOD dataset file index (19 of 22) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30010_file_index.json"
+    },
+    {
+      "checksum": "sha1:70f290cad0dd31ea72424e8477aa2054acb1c918",
+      "description": "TauParked AOD dataset file index (20 of 22) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30011_file_index.json"
+    },
+    {
+      "checksum": "sha1:ad6a04115f31377a838ab3e81c2e17482a9f1740",
+      "description": "TauParked AOD dataset file index (21 of 22) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30012_file_index.json"
+    },
+    {
+      "checksum": "sha1:571bf6c74b532a8b5089ed1140da69de53c16494",
+      "description": "TauParked AOD dataset file index (22 of 22) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30016_file_index.json"
+    },
+    {
+      "checksum": "sha1:4f3dc7fe07e1023942d6ca72081b945a3e7d9235",
       "description": "TauParked AOD dataset file index (1 of 22) for access to data via CMS virtual machine",
       "size": 126873,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:bf29d30fd83b0ca97faaf09532482b2879adeafd",
       "description": "TauParked AOD dataset file index (2 of 22) for access to data via CMS virtual machine",
       "size": 106934,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b244dfc7adf157896c795b3a87a1846a86e75903",
       "description": "TauParked AOD dataset file index (3 of 22) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b3f42873d02a645774a7c6579d8a580f4a65131c",
       "description": "TauParked AOD dataset file index (4 of 22) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:5c8585d9230cb9a33a3469fe1a111a1af88cc56f",
       "description": "TauParked AOD dataset file index (5 of 22) for access to data via CMS virtual machine",
       "size": 381,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b5520aeb15bd205a09a9ff4edd8415488d8f7421",
       "description": "TauParked AOD dataset file index (6 of 22) for access to data via CMS virtual machine",
       "size": 381,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20010_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a9455f3caddea5cc1cad7ca7d9529c5d5ad9a33c",
       "description": "TauParked AOD dataset file index (7 of 22) for access to data via CMS virtual machine",
       "size": 254,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:352153c465abec7e5f13990290cf49cde529c988",
       "description": "TauParked AOD dataset file index (8 of 22) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20013_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2c89dd4eabad86600abd13985595ba327abb144e",
       "description": "TauParked AOD dataset file index (9 of 22) for access to data via CMS virtual machine",
       "size": 254,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20014_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:127259361a80afea0b9b1de2c0ce7cbb87a2b4ba",
       "description": "TauParked AOD dataset file index (10 of 22) for access to data via CMS virtual machine",
       "size": 254,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20015_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0124c12fe236319db8c4435ddbb23a641309375e",
       "description": "TauParked AOD dataset file index (11 of 22) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20016_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:135eb1599d79441ec1f5475dc2a6543dd286cc3e",
       "description": "TauParked AOD dataset file index (12 of 22) for access to data via CMS virtual machine",
       "size": 254,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20017_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:001458709ec6bd15ae97f1c1fea2bb2a32dd8ea7",
       "description": "TauParked AOD dataset file index (13 of 22) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20018_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9d76d1807da07fdfe3f906c710a5ed239d1851d9",
       "description": "TauParked AOD dataset file index (14 of 22) for access to data via CMS virtual machine",
       "size": 127635,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7399b9ab61d1941a96afb405332658e9209fa51d",
       "description": "TauParked AOD dataset file index (15 of 22) for access to data via CMS virtual machine",
       "size": 69088,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:dbeb6a77dbb41d1bfb17ac093dd629265c66f3d2",
       "description": "TauParked AOD dataset file index (16 of 22) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9671dc43d4c884ee60264104dc44682db7e26fed",
       "description": "TauParked AOD dataset file index (17 of 22) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:da78353273157af4d87a33992bb0057e763cbfd0",
       "description": "TauParked AOD dataset file index (18 of 22) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a4b90d5b9928fbbc1754dab1f9fe29254c978ff7",
       "description": "TauParked AOD dataset file index (19 of 22) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30010_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7708a8c401d172e84a07527de4d918969eacc694",
       "description": "TauParked AOD dataset file index (20 of 22) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4209d4537d8b5ac6f9d68baf198ea5e226513821",
       "description": "TauParked AOD dataset file index (21 of 22) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30012_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0643088498c8ab193de28f49bbb278e892afa72a",
       "description": "TauParked AOD dataset file index (22 of 22) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30016_file_index.txt"
     }
   ],
@@ -3428,59 +4618,115 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b7524e8f3fc268894bd4a688bc2a9191f46737f2",
+      "description": "TauPlusX AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
+      "size": 246247,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:4eb9a6ad832dd99c635658a69b6778d0b4783439",
+      "description": "TauPlusX AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
+      "size": 280918,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:31ce374db1454b1fb507f2c1f0c6a8d532f98c53",
+      "description": "TauPlusX AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
+      "size": 273002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:647b38a2882d003a13223c7fa3f24a029592a0c5",
+      "description": "TauPlusX AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
+      "size": 18839,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:3304415bf45e222618603437403652f9e691a4fc",
+      "description": "TauPlusX AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:c77f6083d533cc7e2ecc61d84f0c9bea03fdf602",
+      "description": "TauPlusX AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30005_file_index.json"
+    },
+    {
+      "checksum": "sha1:300fcab11967ae4a2d05a582a8e9460469e6a446",
+      "description": "TauPlusX AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
+      "size": 548,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30010_file_index.json"
+    },
+    {
+      "checksum": "sha1:3155b7a518e95ac79e132122b2a1e469d37cc6eb",
+      "description": "TauPlusX AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
+      "size": 548,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30020_file_index.json"
+    },
+    {
+      "checksum": "sha1:987d21595a1aeb03a6f7bd308bd44381fa7e8faa",
       "description": "TauPlusX AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
       "size": 113652,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:89ea1cc8c2ae0c061759248f684deaecd2986e91",
       "description": "TauPlusX AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
       "size": 129654,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:cb937bb2f44b0a69d0a423a6a39156742756679b",
       "description": "TauPlusX AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
       "size": 126000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:eafb077608612f9d2ca264552912f664dc790b17",
       "description": "TauPlusX AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
       "size": 8694,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:660dfcffc8fbdb94d0245b2b0f47f02eaca27258",
       "description": "TauPlusX AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:512ed9a05d0f8a91d5da8ec82f6860a610e7ea06",
       "description": "TauPlusX AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9be4fd681a7360e9043f6945a0b3c46ace6cc473",
       "description": "TauPlusX AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
       "size": 252,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30010_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f9c1b15e4a569c7a90d8b1449d300615fdb83bb2",
       "description": "TauPlusX AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
       "size": 252,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30020_file_index.txt"
     }
   ],
@@ -3576,199 +4822,395 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:724d4d3ec257e407711d3fbdfd5da863efefb28e",
+      "description": "VBF1Parked AOD dataset file index (1 of 28) for access to data via CMS virtual machine",
+      "size": 277477,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:cce2833e9ac6b6c08363633182d34ac5f6fec16b",
+      "description": "VBF1Parked AOD dataset file index (2 of 28) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:b3fc3657db2c07975747f89ce32a26560ccc5b47",
+      "description": "VBF1Parked AOD dataset file index (3 of 28) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:d0fe455c060ac045bbfb8b1dc66cdfbd404bc134",
+      "description": "VBF1Parked AOD dataset file index (4 of 28) for access to data via CMS virtual machine",
+      "size": 275552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:47c7104d0f4a40b3fe41ec3116a07ab3499e833b",
+      "description": "VBF1Parked AOD dataset file index (5 of 28) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20004_file_index.json"
+    },
+    {
+      "checksum": "sha1:b8cc5a1a66ac820b9d8d8a85188ef843be77f172",
+      "description": "VBF1Parked AOD dataset file index (6 of 28) for access to data via CMS virtual machine",
+      "size": 25852,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20005_file_index.json"
+    },
+    {
+      "checksum": "sha1:25dbd81e1538f764434042d439c14a67cc4a2c92",
+      "description": "VBF1Parked AOD dataset file index (7 of 28) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20006_file_index.json"
+    },
+    {
+      "checksum": "sha1:343d8a79b04f4553065b475cd2d610e341f9e71a",
+      "description": "VBF1Parked AOD dataset file index (8 of 28) for access to data via CMS virtual machine",
+      "size": 1102,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20007_file_index.json"
+    },
+    {
+      "checksum": "sha1:d886ff69a5b447cca18d1dfad9834576666ed782",
+      "description": "VBF1Parked AOD dataset file index (9 of 28) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20008_file_index.json"
+    },
+    {
+      "checksum": "sha1:ca8dc5f3f0f5492e84caa0b03d9fd1723cceb4a3",
+      "description": "VBF1Parked AOD dataset file index (10 of 28) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20009_file_index.json"
+    },
+    {
+      "checksum": "sha1:b93c897cfb4cba5a175fa58334cfa056893c5448",
+      "description": "VBF1Parked AOD dataset file index (11 of 28) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20010_file_index.json"
+    },
+    {
+      "checksum": "sha1:93578cef4612a2f6af4bc44430652079c20c2246",
+      "description": "VBF1Parked AOD dataset file index (12 of 28) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20011_file_index.json"
+    },
+    {
+      "checksum": "sha1:4af708dc8d31a5eba1f9c54bd7a41a2b97643285",
+      "description": "VBF1Parked AOD dataset file index (13 of 28) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20012_file_index.json"
+    },
+    {
+      "checksum": "sha1:178ddd964b0f89c8a0e56cc7de73629d2c3bda04",
+      "description": "VBF1Parked AOD dataset file index (14 of 28) for access to data via CMS virtual machine",
+      "size": 827,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20013_file_index.json"
+    },
+    {
+      "checksum": "sha1:35196c005e7bfab1c24833caf76a8f3b3ad39845",
+      "description": "VBF1Parked AOD dataset file index (15 of 28) for access to data via CMS virtual machine",
+      "size": 827,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20015_file_index.json"
+    },
+    {
+      "checksum": "sha1:e1a78d792b99598efc175f738b3dc84c768a75e1",
+      "description": "VBF1Parked AOD dataset file index (16 of 28) for access to data via CMS virtual machine",
+      "size": 827,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20016_file_index.json"
+    },
+    {
+      "checksum": "sha1:bf16f1ba204870c546911ce3716c040a7efb6b2d",
+      "description": "VBF1Parked AOD dataset file index (17 of 28) for access to data via CMS virtual machine",
+      "size": 275277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:a4b848aaf4d8a4c33415272b1283caeccebaef77",
+      "description": "VBF1Parked AOD dataset file index (18 of 28) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:70480b5716b30da27f8f532df497349ec607a3fd",
+      "description": "VBF1Parked AOD dataset file index (19 of 28) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:6e3ed6271c1a885f392e38decdf61bf5f3f517a5",
+      "description": "VBF1Parked AOD dataset file index (20 of 28) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30003_file_index.json"
+    },
+    {
+      "checksum": "sha1:5a9c9c284b6f7e4a06d9da1d5646351035fa81a3",
+      "description": "VBF1Parked AOD dataset file index (21 of 28) for access to data via CMS virtual machine",
+      "size": 275277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:8d438cd63f154ba086d07dfdb8cb03d8b1398fde",
+      "description": "VBF1Parked AOD dataset file index (22 of 28) for access to data via CMS virtual machine",
+      "size": 275277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30005_file_index.json"
+    },
+    {
+      "checksum": "sha1:e7be6d623cc00a95d9dc079df259aae470de12ba",
+      "description": "VBF1Parked AOD dataset file index (23 of 28) for access to data via CMS virtual machine",
+      "size": 204877,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30006_file_index.json"
+    },
+    {
+      "checksum": "sha1:42079e4c9130978d7c66438d40a8990f9e919e21",
+      "description": "VBF1Parked AOD dataset file index (24 of 28) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30013_file_index.json"
+    },
+    {
+      "checksum": "sha1:3cdea6969331a75162d4bd61aec77ce01ae7064c",
+      "description": "VBF1Parked AOD dataset file index (25 of 28) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30015_file_index.json"
+    },
+    {
+      "checksum": "sha1:b19d016f93812f7da69fc4d51f84f46d48bd8ce1",
+      "description": "VBF1Parked AOD dataset file index (26 of 28) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30017_file_index.json"
+    },
+    {
+      "checksum": "sha1:20247a41e1c7a5b4b103b9e122b8f7ce85c2a36c",
+      "description": "VBF1Parked AOD dataset file index (27 of 28) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30025_file_index.json"
+    },
+    {
+      "checksum": "sha1:205ccef6d4a09e41640fe74697aa6674689d0495",
+      "description": "VBF1Parked AOD dataset file index (28 of 28) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30026_file_index.json"
+    },
+    {
+      "checksum": "sha1:c9b7e531ba6f5461e87cad038e4bff2da5edfec9",
       "description": "VBF1Parked AOD dataset file index (1 of 28) for access to data via CMS virtual machine",
       "size": 129152,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a372380854d8a5e813853549058888ae95eaad7e",
       "description": "VBF1Parked AOD dataset file index (2 of 28) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3a4ecba11af8b89e90d5930cfad3a832f0da2a7f",
       "description": "VBF1Parked AOD dataset file index (3 of 28) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:48d705695d9f1f4635d933928989ef01d0e3dce0",
       "description": "VBF1Parked AOD dataset file index (4 of 28) for access to data via CMS virtual machine",
       "size": 128256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:cb9a10fb1f18a524179125ed0a1e08e954074573",
       "description": "VBF1Parked AOD dataset file index (5 of 28) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:df641352fe5f98d6b61e11b4153b1fdf9affbb74",
       "description": "VBF1Parked AOD dataset file index (6 of 28) for access to data via CMS virtual machine",
       "size": 12032,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9d865fb117b844e0b06fb55920297744ba12618a",
       "description": "VBF1Parked AOD dataset file index (7 of 28) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:358ce91a4e2689639a7a3c58c9ad79ed02f3b596",
       "description": "VBF1Parked AOD dataset file index (8 of 28) for access to data via CMS virtual machine",
       "size": 512,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:324d984fc43ebe62521f24aa0e9b942096b3d413",
       "description": "VBF1Parked AOD dataset file index (9 of 28) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:daeaa0e4d8393ef880e1d0c8dce3337d154701bc",
       "description": "VBF1Parked AOD dataset file index (10 of 28) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:64d53fdfe58cbbc47baf9fe6c3f23d7b3ad88aa0",
       "description": "VBF1Parked AOD dataset file index (11 of 28) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20010_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:927fe64a3a1980e850b03e3fbe0a1cae255b7b15",
       "description": "VBF1Parked AOD dataset file index (12 of 28) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e427f49d25013f6b348d4137da286dfb7adcaf67",
       "description": "VBF1Parked AOD dataset file index (13 of 28) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20012_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:48b7ab5195c758e24c72d5dac507f2f967c2b5f5",
       "description": "VBF1Parked AOD dataset file index (14 of 28) for access to data via CMS virtual machine",
       "size": 384,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20013_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0b4c0d577b8f6ebc2abaaef40d0af45ab17e910f",
       "description": "VBF1Parked AOD dataset file index (15 of 28) for access to data via CMS virtual machine",
       "size": 384,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20015_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:44b203beb8d4d3fb67421b2ae66a304a45ff1995",
       "description": "VBF1Parked AOD dataset file index (16 of 28) for access to data via CMS virtual machine",
       "size": 384,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20016_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:778dd66bb84526d2dd4227a921af1f9f49950fee",
       "description": "VBF1Parked AOD dataset file index (17 of 28) for access to data via CMS virtual machine",
       "size": 128128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:79ebbcf98e50e48beb151a6e207d331e0a2d908d",
       "description": "VBF1Parked AOD dataset file index (18 of 28) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2c7b9e9a5a4489e7c97a7672f3e259bcf343e01c",
       "description": "VBF1Parked AOD dataset file index (19 of 28) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ab9490c60be96547c30e057a6f8775882dcb2021",
       "description": "VBF1Parked AOD dataset file index (20 of 28) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:54e48f1d27a0dcd6bed9e515359d777323c87058",
       "description": "VBF1Parked AOD dataset file index (21 of 28) for access to data via CMS virtual machine",
       "size": 128128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e3bd8eb380684a83586b1a3daea843106b6c652e",
       "description": "VBF1Parked AOD dataset file index (22 of 28) for access to data via CMS virtual machine",
       "size": 128128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1c2f6214672a7eeecaf028c89e36b3ebb65242e6",
       "description": "VBF1Parked AOD dataset file index (23 of 28) for access to data via CMS virtual machine",
       "size": 95360,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9bf6c5515bdba1ff783198986575eba627007cf7",
       "description": "VBF1Parked AOD dataset file index (24 of 28) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30013_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:17b9526598de4cbb32abca13c0fbe1e7c076ea6e",
       "description": "VBF1Parked AOD dataset file index (25 of 28) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30015_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ba0dbaf167f0a858735ffd665ccc3905126f3d19",
       "description": "VBF1Parked AOD dataset file index (26 of 28) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30017_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c010837f7280d1cbe2c12bca99e948d0723232f2",
       "description": "VBF1Parked AOD dataset file index (27 of 28) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30025_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:004e684e2deda83cfd5b931220125d1f70bb2ea1",
       "description": "VBF1Parked AOD dataset file index (28 of 28) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30026_file_index.txt"
     }
   ],

--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012C.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012C.json
@@ -30,101 +30,199 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:6abe6079b80213c4020c1af4cebf9f0a5a5601b2",
+      "description": "BJetPlusX AOD dataset file index (1 of 14) for access to data via CMS virtual machine",
+      "size": 274002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:67bb00e6fa8b621cca1d351faf64ee896b572948",
+      "description": "BJetPlusX AOD dataset file index (2 of 14) for access to data via CMS virtual machine",
+      "size": 82202,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:b043f35132f9f67428f54f4797303d6e35f99b54",
+      "description": "BJetPlusX AOD dataset file index (3 of 14) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20008_file_index.json"
+    },
+    {
+      "checksum": "sha1:025de0e359324a512133151a8da72db303b237d5",
+      "description": "BJetPlusX AOD dataset file index (4 of 14) for access to data via CMS virtual machine",
+      "size": 550,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20011_file_index.json"
+    },
+    {
+      "checksum": "sha1:3118251b8ca6fd7b38a85543dc816136b0b3bba9",
+      "description": "BJetPlusX AOD dataset file index (5 of 14) for access to data via CMS virtual machine",
+      "size": 285784,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:27a787abf11ebf44b9c5a1298d0e701635aa5a50",
+      "description": "BJetPlusX AOD dataset file index (6 of 14) for access to data via CMS virtual machine",
+      "size": 200022,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:ec9beb865e5633c889e95204cef956cea4b4082c",
+      "description": "BJetPlusX AOD dataset file index (7 of 14) for access to data via CMS virtual machine",
+      "size": 1098,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30003_file_index.json"
+    },
+    {
+      "checksum": "sha1:842010021dfefa7f1fff1614eccc7f735bb65e19",
+      "description": "BJetPlusX AOD dataset file index (8 of 14) for access to data via CMS virtual machine",
+      "size": 550,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30006_file_index.json"
+    },
+    {
+      "checksum": "sha1:2c5c8fc123c52a69f8416b4f4b610d8eb8844f46",
+      "description": "BJetPlusX AOD dataset file index (9 of 14) for access to data via CMS virtual machine",
+      "size": 550,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30007_file_index.json"
+    },
+    {
+      "checksum": "sha1:13a8753b537b1f3cc77c6a5c014e0ce3c9febf50",
+      "description": "BJetPlusX AOD dataset file index (10 of 14) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30009_file_index.json"
+    },
+    {
+      "checksum": "sha1:ff46c2cf19b6ef71100b0d36542179ba8f7d1bb6",
+      "description": "BJetPlusX AOD dataset file index (11 of 14) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30011_file_index.json"
+    },
+    {
+      "checksum": "sha1:da7c2c856403290feda3cd355ca1418e4f0b7de5",
+      "description": "BJetPlusX AOD dataset file index (12 of 14) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30012_file_index.json"
+    },
+    {
+      "checksum": "sha1:bc106b37c951f1b2f4c2a5502db5e871a5e2fdbf",
+      "description": "BJetPlusX AOD dataset file index (13 of 14) for access to data via CMS virtual machine",
+      "size": 824,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30013_file_index.json"
+    },
+    {
+      "checksum": "sha1:67f8133a205c0e042418eeaef83d0913bf882c3b",
+      "description": "BJetPlusX AOD dataset file index (14 of 14) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30015_file_index.json"
+    },
+    {
+      "checksum": "sha1:c17cea88ae2eadf0ac4d009a7262f48e67406bba",
       "description": "BJetPlusX AOD dataset file index (1 of 14) for access to data via CMS virtual machine",
       "size": 127000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:5a36e161a243d64991c19f3cd76a866bd63873c7",
       "description": "BJetPlusX AOD dataset file index (2 of 14) for access to data via CMS virtual machine",
       "size": 38100,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:63f190b942327e247fda2913a7b06b21960610ef",
       "description": "BJetPlusX AOD dataset file index (3 of 14) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7f23e34ca5f2ffe964a9bf26f1b106c539da2b6c",
       "description": "BJetPlusX AOD dataset file index (4 of 14) for access to data via CMS virtual machine",
       "size": 254,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:aae00fa57e451b4349d4cc803cf6eba7b25ef976",
       "description": "BJetPlusX AOD dataset file index (5 of 14) for access to data via CMS virtual machine",
       "size": 132461,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:21d9708db012eb3e26c58a3249cbc269f1a29c5a",
       "description": "BJetPlusX AOD dataset file index (6 of 14) for access to data via CMS virtual machine",
       "size": 92710,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d3d0245659a79af3b1144be62226141cf962c5fd",
       "description": "BJetPlusX AOD dataset file index (7 of 14) for access to data via CMS virtual machine",
       "size": 508,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:481168c509e863522ab64a14d8799730e7704a5b",
       "description": "BJetPlusX AOD dataset file index (8 of 14) for access to data via CMS virtual machine",
       "size": 254,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7793711ff35307d1ea9025c62383ba4a56d3da20",
       "description": "BJetPlusX AOD dataset file index (9 of 14) for access to data via CMS virtual machine",
       "size": 254,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:857533795309d33a03de67bf8d427e0efebc5703",
       "description": "BJetPlusX AOD dataset file index (10 of 14) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:674996383820b75013c860fa9eadbdb3c03666e2",
       "description": "BJetPlusX AOD dataset file index (11 of 14) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e345f66f588a784b225eab7c196e4be107cb17f2",
       "description": "BJetPlusX AOD dataset file index (12 of 14) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30012_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:5d8f92b46affd3096e6967af987c3d0ed3171f78",
       "description": "BJetPlusX AOD dataset file index (13 of 14) for access to data via CMS virtual machine",
       "size": 381,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30013_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:6f9970294d621093a9893854d9aab460aa8d73e8",
       "description": "BJetPlusX AOD dataset file index (14 of 14) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30015_file_index.txt"
     }
   ],
@@ -220,17 +318,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3aec41aa9172deae9676bd5aa6833d4135e407a0",
+      "description": "BTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 134502,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BTag_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:1a6a0858ae17ead608170a38dac40f0da288e105",
+      "description": "BTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 76398,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BTag_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:4491698cb2a68e478fd9bc6e7adb066327e88f14",
       "description": "BTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 61000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BTag_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:bca5a01932e34868bbbd8719a25a40eecf6cf2bc",
       "description": "BTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 34648,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BTag_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -326,45 +438,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0f94f05816da2ccc5b53a7b8ea454491805915a9",
+      "description": "Commissioning AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 190707,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:fb3947446c444f881054f3354ce4c9cb5020857a",
+      "description": "Commissioning AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 557,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:af34e061c07e744ec3e12bc64ea98fc4629e2dd2",
+      "description": "Commissioning AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 22276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_210000_file_index.json"
+    },
+    {
+      "checksum": "sha1:070ff55543771e966067be186ce9dc2e08c220eb",
+      "description": "Commissioning AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 128716,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:35750ef2fe839abcbff3e28d3b7c97bf525fac3c",
+      "description": "Commissioning AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 1664,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_30006_file_index.json"
+    },
+    {
+      "checksum": "sha1:f62d051db48707c5cb759fe25bc9be73e8cf0cd8",
+      "description": "Commissioning AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 21485,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_310000_file_index.json"
+    },
+    {
+      "checksum": "sha1:54a72844651a1ed391e4c1c19e1692b444cf35de",
       "description": "Commissioning AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 89866,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:600487ac8afddb3e9ffbf7567e0c7cdd531a3598",
       "description": "Commissioning AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 262,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d3784ba9420c878547d683448ea55750e07eda69",
       "description": "Commissioning AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 10560,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_210000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c3bdd25e68f332c7cf4ea187dbefb03d1f6cc643",
       "description": "Commissioning AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 60653,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:33f6640e7349852bfc1b6483109d515327c115bf",
       "description": "Commissioning AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 786,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_30006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8b06ac253a2818ffa61fdd6aa40023c6cc0cf01f",
       "description": "Commissioning AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 10164,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_310000_file_index.txt"
     }
   ],
@@ -460,38 +614,73 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:accb9721ab6d12d85d4f936aea824bbe9bf74f34",
+      "description": "DoubleElectron AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
+      "size": 293510,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:bfe8098ed82d2374a8de7c22be74d3dc6804c4b9",
+      "description": "DoubleElectron AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
+      "size": 279002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:39cbc007f3c42a61cac43ddebec8ffc06b672162",
+      "description": "DoubleElectron AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
+      "size": 93467,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:a640209a8cd935e65b1f9f600e77fabbbe514d4f",
+      "description": "DoubleElectron AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:defa30235dc08279b500e638556e5d83f962360a",
+      "description": "DoubleElectron AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20011_file_index.json"
+    },
+    {
+      "checksum": "sha1:9a4dcb65e4a4063befad780e69c4cbc2994f6561",
       "description": "DoubleElectron AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
       "size": 138864,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7d7e89b65575a93a92a1df9e451c1956d58a9c55",
       "description": "DoubleElectron AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
       "size": 132000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4228c1ee18182171a2c1217e201dfe9f3663533e",
       "description": "DoubleElectron AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
       "size": 44220,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:aa85e51c32e8ac8c0703211e0d4922502335f075",
       "description": "DoubleElectron AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:357b2a5c0c423ad29e478299fc339f84925ab593",
       "description": "DoubleElectron AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20011_file_index.txt"
     }
   ],
@@ -587,94 +776,185 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:70412c223a8d3637876a499fc483624349a54a37",
+      "description": "DoubleMuParked AOD dataset file index (1 of 13) for access to data via CMS virtual machine",
+      "size": 279560,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "sha1:9af8f6396a78d3829f5d0fef76fde459d910aa3f",
+      "description": "DoubleMuParked AOD dataset file index (2 of 13) for access to data via CMS virtual machine",
+      "size": 279002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10001_file_index.json"
+    },
+    {
+      "checksum": "sha1:f750b5d52c7e19b3a596bf361a96e80564f74b43",
+      "description": "DoubleMuParked AOD dataset file index (3 of 13) for access to data via CMS virtual machine",
+      "size": 144245,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10002_file_index.json"
+    },
+    {
+      "checksum": "sha1:79617391212de40148d8324f4436a90974c87d26",
+      "description": "DoubleMuParked AOD dataset file index (4 of 13) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10003_file_index.json"
+    },
+    {
+      "checksum": "sha1:35e93f6289cf113e8814ee50948dc5a45908c499",
+      "description": "DoubleMuParked AOD dataset file index (5 of 13) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10010_file_index.json"
+    },
+    {
+      "checksum": "sha1:894d3e82c3a880c942d6d598e178fc17c5b64ceb",
+      "description": "DoubleMuParked AOD dataset file index (6 of 13) for access to data via CMS virtual machine",
+      "size": 839,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10011_file_index.json"
+    },
+    {
+      "checksum": "sha1:927e2dd5d5e2b14faac07024a68eaf87f2cf161b",
+      "description": "DoubleMuParked AOD dataset file index (7 of 13) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10013_file_index.json"
+    },
+    {
+      "checksum": "sha1:0684d38e32d976f65934a6d125db4519c1d89688",
+      "description": "DoubleMuParked AOD dataset file index (8 of 13) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10016_file_index.json"
+    },
+    {
+      "checksum": "sha1:6b70aa3198220734c9ad0bed3c6e22d27621f905",
+      "description": "DoubleMuParked AOD dataset file index (9 of 13) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10018_file_index.json"
+    },
+    {
+      "checksum": "sha1:55166b3f0ec26941f04d651ad7c88faa25ecf86c",
+      "description": "DoubleMuParked AOD dataset file index (10 of 13) for access to data via CMS virtual machine",
+      "size": 1118,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10021_file_index.json"
+    },
+    {
+      "checksum": "sha1:289765662ee80460a3eba4a7ca71ceba03941d24",
+      "description": "DoubleMuParked AOD dataset file index (11 of 13) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10022_file_index.json"
+    },
+    {
+      "checksum": "sha1:1aeae857858ae9b76cc432b6058af429f6eb984f",
+      "description": "DoubleMuParked AOD dataset file index (12 of 13) for access to data via CMS virtual machine",
+      "size": 560,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10024_file_index.json"
+    },
+    {
+      "checksum": "sha1:fac31f021db539ff78a385fe17c16c9d857baab8",
+      "description": "DoubleMuParked AOD dataset file index (13 of 13) for access to data via CMS virtual machine",
+      "size": 107696,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:dc808c84f1b0e417834e42bb76ca9d327e05e76c",
       "description": "DoubleMuParked AOD dataset file index (1 of 13) for access to data via CMS virtual machine",
       "size": 132264,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:faf4ca78be099646de16afe6f2b925d46080f792",
       "description": "DoubleMuParked AOD dataset file index (2 of 13) for access to data via CMS virtual machine",
       "size": 132000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:90064eae55becae580ad806e09f4d224ad7b076a",
       "description": "DoubleMuParked AOD dataset file index (3 of 13) for access to data via CMS virtual machine",
       "size": 68244,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:cf02465b253f47775dd6faf9e3ea258aaaf5b087",
       "description": "DoubleMuParked AOD dataset file index (4 of 13) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:56581c2499251b326c6e777dba7a3984692f9263",
       "description": "DoubleMuParked AOD dataset file index (5 of 13) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10010_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a16ff0d1efc12526afa6562413e8db109e2e2b72",
       "description": "DoubleMuParked AOD dataset file index (6 of 13) for access to data via CMS virtual machine",
       "size": 396,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b90bd07cf361427847b97a5ab295bec882a0dd78",
       "description": "DoubleMuParked AOD dataset file index (7 of 13) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10013_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:bee7b9c3f39dc502a4c1f91bbf27600a6e973036",
       "description": "DoubleMuParked AOD dataset file index (8 of 13) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10016_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:391341f9ca2ed863abb6ad9b34d65761a5780445",
       "description": "DoubleMuParked AOD dataset file index (9 of 13) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10018_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:de32f67bfe6d38347590e325ded83cad393327b4",
       "description": "DoubleMuParked AOD dataset file index (10 of 13) for access to data via CMS virtual machine",
       "size": 528,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10021_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2eb230cb5df042dbc7a326d1fb12f4a5196ac9c1",
       "description": "DoubleMuParked AOD dataset file index (11 of 13) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10022_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:6ffba6148e86fc5d05bcdc50a8e3e4b00368494a",
       "description": "DoubleMuParked AOD dataset file index (12 of 13) for access to data via CMS virtual machine",
       "size": 264,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10024_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:14e062c5dbd239423d2eaf1cfbfb780d1868a967",
       "description": "DoubleMuParked AOD dataset file index (13 of 13) for access to data via CMS virtual machine",
       "size": 50952,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_20000_file_index.txt"
     }
   ],
@@ -770,80 +1050,157 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c6e3a8ea7c5f01620cf0d104521f35f4c863f008",
+      "description": "DoublePhoton AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
+      "size": 97783,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:9e554b95798b7df955cc70c1ed2d87920a253897",
+      "description": "DoublePhoton AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
+      "size": 277278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:c19a08c97f4d188d747bff0289b89d703c06d173",
+      "description": "DoublePhoton AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
+      "size": 277002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:f87949dafc731a9789f7f7bac2e3429211fded28",
+      "description": "DoublePhoton AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
+      "size": 98891,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:c43370701d3bde6ebccf0b57ee51834f5a040246",
+      "description": "DoublePhoton AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:55759b6a0a620098883fc617afe557400921787e",
+      "description": "DoublePhoton AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30007_file_index.json"
+    },
+    {
+      "checksum": "sha1:9af8e43beff5d76083878a9e2901f76673008896",
+      "description": "DoublePhoton AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30009_file_index.json"
+    },
+    {
+      "checksum": "sha1:72eed27b170348089d66df9a86849f59fda06663",
+      "description": "DoublePhoton AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
+      "size": 556,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30019_file_index.json"
+    },
+    {
+      "checksum": "sha1:1398e24cc7f7e28a29ed1f5054af5e8827423b75",
+      "description": "DoublePhoton AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30020_file_index.json"
+    },
+    {
+      "checksum": "sha1:b0a4f176491ad0861ff2887b7b1d0258f6c8cd3b",
+      "description": "DoublePhoton AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30023_file_index.json"
+    },
+    {
+      "checksum": "sha1:e2b2f137caedc6cf500e32a19c2c1c5a52dc39ce",
+      "description": "DoublePhoton AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30028_file_index.json"
+    },
+    {
+      "checksum": "sha1:f4823cf61827444369d6351276e47244ef9319ac",
       "description": "DoublePhoton AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
       "size": 45890,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ff81f2a3a960cb1c03027f80d3386ec1358d981a",
       "description": "DoublePhoton AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
       "size": 130130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:613c11ced65e41b1bbac6c510f76c14eeaa08d59",
       "description": "DoublePhoton AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
       "size": 130000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:bed214546b366291d30a25ccc2fd282ec48e12dd",
       "description": "DoublePhoton AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
       "size": 46410,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:5caea083c7394073c22a0b79cc025cced9b2500d",
       "description": "DoublePhoton AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:465b5279972158eda0a9a91b9ca0ec4d0ff4ba24",
       "description": "DoublePhoton AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:fc3fa562f94bba17822778e2ca9d1fc8be4ce7ad",
       "description": "DoublePhoton AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:678e874363e45743d9e4038b432172af5d07bfb3",
       "description": "DoublePhoton AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
       "size": 260,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30019_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ac5474a0b3beaa15d9deb952cf56fcef9ad62dc5",
       "description": "DoublePhoton AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30020_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f2dbdc1e08fc0a2333ca4cf753b8ac51c264a3af",
       "description": "DoublePhoton AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30023_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:03292fde22b9c590f2c8b8e03ccf997d035c69a3",
       "description": "DoublePhoton AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30028_file_index.txt"
     }
   ],
@@ -939,17 +1296,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:53fb661eb8e1bd575995974bf876921faae75d5f",
+      "description": "DoublePhotonHighPt AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 153105,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoublePhotonHighPt_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:010cadedd848b0553f5b94ce1f1586cc341dda8b",
+      "description": "DoublePhotonHighPt AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 269984,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoublePhotonHighPt_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:cdda5039ad473d79cf1e6a13a3f565f1e497b5e0",
       "description": "DoublePhotonHighPt AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 73576,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoublePhotonHighPt_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:92822cdeea5b632b02422e66d312d1e2af1d2fd4",
       "description": "DoublePhotonHighPt AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 129744,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoublePhotonHighPt_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -1045,45 +1416,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9483079d4b9705c8339e77c6cc8dbcd81aeac3d5",
+      "description": "ElectronHad AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 283454,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "sha1:0b43505d59ecbb913982a7528e0f1e21123b4a2f",
+      "description": "ElectronHad AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 162290,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10001_file_index.json"
+    },
+    {
+      "checksum": "sha1:b0430c9c1166cd2325855384a0615a1a84a340c3",
+      "description": "ElectronHad AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10002_file_index.json"
+    },
+    {
+      "checksum": "sha1:c4021dc0440336f8f7dd34bfda8630dc360baee2",
+      "description": "ElectronHad AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10004_file_index.json"
+    },
+    {
+      "checksum": "sha1:b64929e55abe0d1109a57554f7fb067f561eab40",
+      "description": "ElectronHad AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10011_file_index.json"
+    },
+    {
+      "checksum": "sha1:7a7c7670fd3434174da529803550a163354e95ed",
+      "description": "ElectronHad AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10014_file_index.json"
+    },
+    {
+      "checksum": "sha1:d1dce61fa4023eae86e0253335882d264d03fba3",
       "description": "ElectronHad AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 132483,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:5f219d68b30389eec2666f261d31e0556a57e731",
       "description": "ElectronHad AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 75852,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:29d5d847ebc3e2a7fe0653f56c8cb1f9445935e7",
       "description": "ElectronHad AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:36fc95175fe58588db9841dab53ef126f48d5f1e",
       "description": "ElectronHad AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e6c6273fc7c3703f93a9bd0613515f5eef6408bb",
       "description": "ElectronHad AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:81b76b6135f1cc3734079a42d1f73cb8d29e9ed7",
       "description": "ElectronHad AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10014_file_index.txt"
     }
   ],
@@ -1179,192 +1592,381 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1086c34d1376bd7867dae12e35bd2a394ef5be1c",
+      "description": "HTMHTParked AOD dataset file index (1 of 27) for access to data via CMS virtual machine",
+      "size": 288145,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:dfd8f2012dc1c296694422c07d9adfaf9e9e7a1a",
+      "description": "HTMHTParked AOD dataset file index (2 of 27) for access to data via CMS virtual machine",
+      "size": 274898,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:e73dcfc53ec9491a97ca9c01f09c6a99617710c0",
+      "description": "HTMHTParked AOD dataset file index (3 of 27) for access to data via CMS virtual machine",
+      "size": 125306,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:517fc6391f44c7c8d72f83ced81332ffe7b6b70c",
+      "description": "HTMHTParked AOD dataset file index (4 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:3ed05521cfe93acc2d3c69680ad24fa7452c2114",
+      "description": "HTMHTParked AOD dataset file index (5 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20004_file_index.json"
+    },
+    {
+      "checksum": "sha1:f6292a596f4040c6bf1c3c5b5298db7a647ce8cf",
+      "description": "HTMHTParked AOD dataset file index (6 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20005_file_index.json"
+    },
+    {
+      "checksum": "sha1:626ec6b546c13335ec855dede57a09c08d7277cc",
+      "description": "HTMHTParked AOD dataset file index (7 of 27) for access to data via CMS virtual machine",
+      "size": 830,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20008_file_index.json"
+    },
+    {
+      "checksum": "sha1:031b57715379c93e4d87a85ac3881aecaa63bb74",
+      "description": "HTMHTParked AOD dataset file index (8 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20009_file_index.json"
+    },
+    {
+      "checksum": "sha1:53b8671b943ba3d1e7ebe973d1527ebdd902ef22",
+      "description": "HTMHTParked AOD dataset file index (9 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20011_file_index.json"
+    },
+    {
+      "checksum": "sha1:6e8f120be6a617f05abdc3e9238b60e04265fc96",
+      "description": "HTMHTParked AOD dataset file index (10 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20016_file_index.json"
+    },
+    {
+      "checksum": "sha1:d3d3185ded3580ae72b933f251c60da0170771dd",
+      "description": "HTMHTParked AOD dataset file index (11 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20019_file_index.json"
+    },
+    {
+      "checksum": "sha1:75d80d16425576217bf65d4830f951d951fe5717",
+      "description": "HTMHTParked AOD dataset file index (12 of 27) for access to data via CMS virtual machine",
+      "size": 554,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20020_file_index.json"
+    },
+    {
+      "checksum": "sha1:6530da1914a17ec62adacd20a2066b3c2831aff9",
+      "description": "HTMHTParked AOD dataset file index (13 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20021_file_index.json"
+    },
+    {
+      "checksum": "sha1:f2abf5fc441167e95e6af37b180008b6c44a6983",
+      "description": "HTMHTParked AOD dataset file index (14 of 27) for access to data via CMS virtual machine",
+      "size": 4970,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20022_file_index.json"
+    },
+    {
+      "checksum": "sha1:36952388af1d84ca16bea2e170c7e5e696c2ab1c",
+      "description": "HTMHTParked AOD dataset file index (15 of 27) for access to data via CMS virtual machine",
+      "size": 3603,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_210000_file_index.json"
+    },
+    {
+      "checksum": "sha1:794d77c72fc35271ad57c44e5f9fb7b3e0b01758",
+      "description": "HTMHTParked AOD dataset file index (16 of 27) for access to data via CMS virtual machine",
+      "size": 275174,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:ac23acce2e43d4fc03ee1cffc47b34d9eaff41c0",
+      "description": "HTMHTParked AOD dataset file index (17 of 27) for access to data via CMS virtual machine",
+      "size": 276002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:12872a4079ae92613e8bc255a55cf62a20348b9f",
+      "description": "HTMHTParked AOD dataset file index (18 of 27) for access to data via CMS virtual machine",
+      "size": 224390,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:964348477fa067a24f03d216548cdb54b6fd2849",
+      "description": "HTMHTParked AOD dataset file index (19 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30003_file_index.json"
+    },
+    {
+      "checksum": "sha1:bc7f1cdf660f8a84b030dd80450c74ef450dbbff",
+      "description": "HTMHTParked AOD dataset file index (20 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30007_file_index.json"
+    },
+    {
+      "checksum": "sha1:de9bbf8db796a19070b89521e24c0ea9ba8f6eb3",
+      "description": "HTMHTParked AOD dataset file index (21 of 27) for access to data via CMS virtual machine",
+      "size": 554,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30009_file_index.json"
+    },
+    {
+      "checksum": "sha1:945f619917daefb730f4667e0f6c4db9405c8474",
+      "description": "HTMHTParked AOD dataset file index (22 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30010_file_index.json"
+    },
+    {
+      "checksum": "sha1:71db905fbe862f70097e909446b7d9c9e1872c1d",
+      "description": "HTMHTParked AOD dataset file index (23 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30013_file_index.json"
+    },
+    {
+      "checksum": "sha1:eefd3d161ea6bfee82490719700b46f584184004",
+      "description": "HTMHTParked AOD dataset file index (24 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30015_file_index.json"
+    },
+    {
+      "checksum": "sha1:21ce98cd2df3cbeaba25b82ac169bec074a1ff9f",
+      "description": "HTMHTParked AOD dataset file index (25 of 27) for access to data via CMS virtual machine",
+      "size": 554,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30018_file_index.json"
+    },
+    {
+      "checksum": "sha1:2b2a561e4c58e5dc345f30d7f0581b4bb6467f56",
+      "description": "HTMHTParked AOD dataset file index (26 of 27) for access to data via CMS virtual machine",
+      "size": 554,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30019_file_index.json"
+    },
+    {
+      "checksum": "sha1:2be6d329dfef344efc06ec874c37b1da1b6b0066",
+      "description": "HTMHTParked AOD dataset file index (27 of 27) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30028_file_index.json"
+    },
+    {
+      "checksum": "sha1:7e5907eb6b005d5ed31d31f35b5f2a44c54d680a",
       "description": "HTMHTParked AOD dataset file index (1 of 27) for access to data via CMS virtual machine",
       "size": 134676,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1d0be6b91d814e245cf490d85a2746d5b568d676",
       "description": "HTMHTParked AOD dataset file index (2 of 27) for access to data via CMS virtual machine",
       "size": 128484,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b2c18282d8d5b394200a89c4f7d14c114cad33a3",
       "description": "HTMHTParked AOD dataset file index (3 of 27) for access to data via CMS virtual machine",
       "size": 58566,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8852020b281ff8ef9e04f4e4aa38feb0e925d995",
       "description": "HTMHTParked AOD dataset file index (4 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f6e1e0c8dfb9c82b9ebe6aedd758d5190194c46a",
       "description": "HTMHTParked AOD dataset file index (5 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:fab60be7606640fb4f6f33a0921ae0f802010405",
       "description": "HTMHTParked AOD dataset file index (6 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:71522690b918ea5352d0ae7d187cd9a78b69f772",
       "description": "HTMHTParked AOD dataset file index (7 of 27) for access to data via CMS virtual machine",
       "size": 387,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c79f704c6b00e7a59d4cc07d0007bf6fc96ba075",
       "description": "HTMHTParked AOD dataset file index (8 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:bf7f663b196cfc150f3848368ce805ab7944309e",
       "description": "HTMHTParked AOD dataset file index (9 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:40569b0715d6f2124c451bccde94c03f744411f6",
       "description": "HTMHTParked AOD dataset file index (10 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20016_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ec858de2ae3a84fcd915c16c38a8939652448c60",
       "description": "HTMHTParked AOD dataset file index (11 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20019_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:817bc2aefb1caebb27d3cc56cec3e6df83f269be",
       "description": "HTMHTParked AOD dataset file index (12 of 27) for access to data via CMS virtual machine",
       "size": 258,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20020_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b5c01b4560eab91ecda781dc22f9f74dfde81b69",
       "description": "HTMHTParked AOD dataset file index (13 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20021_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:cd579d75184fce23e618b6f7b3332042997be2f2",
       "description": "HTMHTParked AOD dataset file index (14 of 27) for access to data via CMS virtual machine",
       "size": 2322,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20022_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1091ad8278045245154a841126b50a6f06192e39",
       "description": "HTMHTParked AOD dataset file index (15 of 27) for access to data via CMS virtual machine",
       "size": 1690,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_210000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e99b3317f390756af187eb44b84359fd24e07eb8",
       "description": "HTMHTParked AOD dataset file index (16 of 27) for access to data via CMS virtual machine",
       "size": 128613,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3ba6d2f9ee60347fdd5645e042aa99bf8dbaf46b",
       "description": "HTMHTParked AOD dataset file index (17 of 27) for access to data via CMS virtual machine",
       "size": 129000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ef8d6424442955e82cc909601bb3bc6087220e41",
       "description": "HTMHTParked AOD dataset file index (18 of 27) for access to data via CMS virtual machine",
       "size": 104877,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d169500414bdfbe24535393dc513f159b656ee2d",
       "description": "HTMHTParked AOD dataset file index (19 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:5f1ebfc92ff67a543393ecce4163cb1362269885",
       "description": "HTMHTParked AOD dataset file index (20 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:edac3316a4af3c92aa8931ece9a9f164e57db49e",
       "description": "HTMHTParked AOD dataset file index (21 of 27) for access to data via CMS virtual machine",
       "size": 258,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8c2eb2c6e960c3eeac189c951945f889a6b2d560",
       "description": "HTMHTParked AOD dataset file index (22 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30010_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:450c4b565afa79f341ba3f6e945dcfb43b648ab3",
       "description": "HTMHTParked AOD dataset file index (23 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30013_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3b47fe4476248f9bab62bb676c50f0770d1b9fd2",
       "description": "HTMHTParked AOD dataset file index (24 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30015_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0d2261ce5a675f32f98ca0e08300d32000aa0a02",
       "description": "HTMHTParked AOD dataset file index (25 of 27) for access to data via CMS virtual machine",
       "size": 258,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30018_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a0c5f878e4da1837c622d1a5d898b0a891551e78",
       "description": "HTMHTParked AOD dataset file index (26 of 27) for access to data via CMS virtual machine",
       "size": 258,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30019_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ff511c50080cf42a47225f0521b64ed127b265be",
       "description": "HTMHTParked AOD dataset file index (27 of 27) for access to data via CMS virtual machine",
       "size": 129,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30028_file_index.txt"
     }
   ],
@@ -1460,10 +2062,17 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:db9006837969a88bf06462df5d26a1945d3e23eb",
+      "description": "HcalNZS AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
+      "size": 30738,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HcalNZS/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HcalNZS_AOD_22Jan2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "sha1:0101fbd40dc58b24bf761a9564cf17ba51c0f1e7",
       "description": "HcalNZS AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
       "size": 14125,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HcalNZS/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HcalNZS_AOD_22Jan2013-v1_10000_file_index.txt"
     }
   ],
@@ -1559,87 +2168,171 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:cefa1412f85f423d4b569cb0630fb5174a320988",
+      "description": "JetHT AOD dataset file index (1 of 12) for access to data via CMS virtual machine",
+      "size": 269462,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:aaaba812349c0e561081b4603155c34987148246",
+      "description": "JetHT AOD dataset file index (2 of 12) for access to data via CMS virtual machine",
+      "size": 269732,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:2aae691d5f3fef3a0d3edc2568f9b16c7d83efd3",
+      "description": "JetHT AOD dataset file index (3 of 12) for access to data via CMS virtual machine",
+      "size": 48062,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:2b195896c48d92933448673103c9496d2f2147b9",
+      "description": "JetHT AOD dataset file index (4 of 12) for access to data via CMS virtual machine",
+      "size": 542,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20005_file_index.json"
+    },
+    {
+      "checksum": "sha1:1c33db5c50a328fe871d0e6a0bab774246a7652b",
+      "description": "JetHT AOD dataset file index (5 of 12) for access to data via CMS virtual machine",
+      "size": 272,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20007_file_index.json"
+    },
+    {
+      "checksum": "sha1:557c29102d9b2b0d5dfe45539a72a812d78362c1",
+      "description": "JetHT AOD dataset file index (6 of 12) for access to data via CMS virtual machine",
+      "size": 1622,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20008_file_index.json"
+    },
+    {
+      "checksum": "sha1:6263dc74edb3b42315ed29555af42b6ab3f2972b",
+      "description": "JetHT AOD dataset file index (7 of 12) for access to data via CMS virtual machine",
+      "size": 542,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20010_file_index.json"
+    },
+    {
+      "checksum": "sha1:384e427af92ed4568a41aab3c98b8c16c442f895",
+      "description": "JetHT AOD dataset file index (8 of 12) for access to data via CMS virtual machine",
+      "size": 542,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20014_file_index.json"
+    },
+    {
+      "checksum": "sha1:df1084d0dfc9211c48ba7f9a18a209ebe0a0cc51",
+      "description": "JetHT AOD dataset file index (9 of 12) for access to data via CMS virtual machine",
+      "size": 272,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20015_file_index.json"
+    },
+    {
+      "checksum": "sha1:3f9fe5dc1b27d8b085ed4f75d27eedcc53e87962",
+      "description": "JetHT AOD dataset file index (10 of 12) for access to data via CMS virtual machine",
+      "size": 272,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20016_file_index.json"
+    },
+    {
+      "checksum": "sha1:1ca805b44cc8bb17202fe472839bdcc0682dffe2",
+      "description": "JetHT AOD dataset file index (11 of 12) for access to data via CMS virtual machine",
+      "size": 272,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20018_file_index.json"
+    },
+    {
+      "checksum": "sha1:b88eb2cbab86234f02800434af11969b545674c8",
+      "description": "JetHT AOD dataset file index (12 of 12) for access to data via CMS virtual machine",
+      "size": 5132,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:97c8b1f79c57aa69469b8046c4f7b33705d264c8",
       "description": "JetHT AOD dataset file index (1 of 12) for access to data via CMS virtual machine",
       "size": 122754,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:45982a5bf09e302b9c8757a0ffeb8601050eae9b",
       "description": "JetHT AOD dataset file index (2 of 12) for access to data via CMS virtual machine",
       "size": 122877,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3c34fcd1f75a76d49177562199a3f71c587f3ee9",
       "description": "JetHT AOD dataset file index (3 of 12) for access to data via CMS virtual machine",
       "size": 21894,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1604a857ea33ee7d9be670913084b369f4c0c7c3",
       "description": "JetHT AOD dataset file index (4 of 12) for access to data via CMS virtual machine",
       "size": 246,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8fea91ed74eca1cfde13f3fe705108ca7870d1ea",
       "description": "JetHT AOD dataset file index (5 of 12) for access to data via CMS virtual machine",
       "size": 123,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:acce68027389354cf7ea3d31f0cf5149d499fa1a",
       "description": "JetHT AOD dataset file index (6 of 12) for access to data via CMS virtual machine",
       "size": 738,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e07d39ac875a056466e694ccc4325f5dedd5b14a",
       "description": "JetHT AOD dataset file index (7 of 12) for access to data via CMS virtual machine",
       "size": 246,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20010_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ff185033ee025c939e975d3fd0d645695f0503a2",
       "description": "JetHT AOD dataset file index (8 of 12) for access to data via CMS virtual machine",
       "size": 246,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20014_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c72d50e5ef6f6aa840817e4f1a8e367f87142659",
       "description": "JetHT AOD dataset file index (9 of 12) for access to data via CMS virtual machine",
       "size": 123,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20015_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2c216665b0ccaf7b8ce3bf20b1cc10db11047e2d",
       "description": "JetHT AOD dataset file index (10 of 12) for access to data via CMS virtual machine",
       "size": 123,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20016_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:511893499357b620bd66f6a5aca91a8b713b77da",
       "description": "JetHT AOD dataset file index (11 of 12) for access to data via CMS virtual machine",
       "size": 123,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20018_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:01b55194bf3e9a6b641815ed693ac65a4513f452",
       "description": "JetHT AOD dataset file index (12 of 12) for access to data via CMS virtual machine",
       "size": 2337,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -1735,17 +2428,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e2564e74abb92537bf098e9005a5d29677ccd1b3",
+      "description": "JetMon AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 256639,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetMon_AOD_22Jan2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "sha1:9a8cd8bda56aff521e9f1feb05e0d3fa0990b6c6",
+      "description": "JetMon AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 1899,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetMon_AOD_22Jan2013-v1_110000_file_index.json"
+    },
+    {
+      "checksum": "sha1:d9d5ce9535420e59469f8ceba96e809fd74f1dba",
       "description": "JetMon AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 117428,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetMon_AOD_22Jan2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f3f2d2882466ac1007d1e0db2b75c0973d4e4705",
       "description": "JetMon AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 875,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetMon_AOD_22Jan2013-v1_110000_file_index.txt"
     }
   ],
@@ -1841,45 +2548,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:64d377d2a2d16eaad995909d0b7f122025a9156d",
+      "description": "MET AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 272826,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "sha1:0303f5570d76fe6d9804470a5852e1384c4e0537",
+      "description": "MET AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 203682,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10001_file_index.json"
+    },
+    {
+      "checksum": "sha1:5c8fdc636f6da2b78379038834726ce40b1a2b13",
+      "description": "MET AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 270,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10007_file_index.json"
+    },
+    {
+      "checksum": "sha1:71d3bf97370dced33828c80474f82fe984f5fdf2",
+      "description": "MET AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 270,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10008_file_index.json"
+    },
+    {
+      "checksum": "sha1:21186fb77ac2d567aca7d909cc099f7f79e5eeb7",
+      "description": "MET AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 538,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10015_file_index.json"
+    },
+    {
+      "checksum": "sha1:449e6fac786d2ff5df2863dbc03b5d72851e217b",
+      "description": "MET AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 1078,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_110000_file_index.json"
+    },
+    {
+      "checksum": "sha1:89b54453cc5414b892526a933c98654dfae1a8c5",
       "description": "MET AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 123178,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9aed61e1a50435c1a730136a4a237be63d8eb51e",
       "description": "MET AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 91960,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7dd022083ba299d6df5618c6342bc32a0853fc98",
       "description": "MET AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 121,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:75c17f2a5342a703b5941dabd80ceecba2903a38",
       "description": "MET AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 121,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:87ba26edd806ee09d4110a80f089b1c6af5d3b3a",
       "description": "MET AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 242,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10015_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:cbc1b44d882ced750e216aecdd47c8e178554415",
       "description": "MET AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 488,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_110000_file_index.txt"
     }
   ],
@@ -1975,17 +2724,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:004f313645b71a9f86107c8f04a46dbf90920153",
+      "description": "MinimumBias AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 276001,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MinimumBias_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:24c6131f375cc044f36dafe1143d47de7a09266e",
+      "description": "MinimumBias AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 276001,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MinimumBias_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:72ea612056817d5da7428230a898ebba56e9116a",
       "description": "MinimumBias AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 129000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MinimumBias_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:48f31c964d561ccba11a72e8611fe69e16fdcc3e",
       "description": "MinimumBias AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 129000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MinimumBias_AOD_22Jan2013-v1_20001_file_index.txt"
     }
   ],
@@ -2081,45 +2844,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a28f89d4b4f05bee24cb8a0b18e20612382e5fd3",
+      "description": "MuEG AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 268733,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:9cd0911421b909b1142468419b591ae535262abb",
+      "description": "MuEG AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 205249,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:8cae9414f395be246469d28c117094d962877af2",
+      "description": "MuEG AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 271,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:df392da0e4520908d10aa36748db93e2979a738d",
+      "description": "MuEG AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 271,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20011_file_index.json"
+    },
+    {
+      "checksum": "sha1:f1bc20c0d384e8197a731c9d0d9a91b2a1034fb7",
+      "description": "MuEG AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 271,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20013_file_index.json"
+    },
+    {
+      "checksum": "sha1:b01c2d717b3098b42e5a2ca5728f7846600f8594",
+      "description": "MuEG AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 9686,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:f3eadd27f49ce99c93d2725107a0cc1b7028e988",
       "description": "MuEG AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 121878,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:6747d5317e1dfe656198741f17d66e5b916f390f",
       "description": "MuEG AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 93086,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b1473a21fc1ea28eccbbf66ed1349c6cf29d3a7b",
       "description": "MuEG AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 122,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f4231dbf91a4da0e293f9c4c7e9e39ecb6286932",
       "description": "MuEG AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 122,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:46dfaa3b49c9cf89d6ca1f1e4876ca56b36f44b2",
       "description": "MuEG AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 122,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20013_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a20f67035faadecc805db01a8dfebd8cea104494",
       "description": "MuEG AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 4392,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -2215,66 +3020,129 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:6e837544362a8132bf82d2c9346db2394879c99b",
+      "description": "MuHad AOD dataset file index (1 of 9) for access to data via CMS virtual machine",
+      "size": 96930,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:54d476d265458f857cc59b5ccc056cf31354b57e",
+      "description": "MuHad AOD dataset file index (2 of 9) for access to data via CMS virtual machine",
+      "size": 270002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:f77d11e5da281303c1f583d6d4b387036ee510fb",
+      "description": "MuHad AOD dataset file index (3 of 9) for access to data via CMS virtual machine",
+      "size": 119882,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:4e568241843db01eb36a2c3f4db47d36387b5c16",
+      "description": "MuHad AOD dataset file index (4 of 9) for access to data via CMS virtual machine",
+      "size": 542,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:7dec5b56f7f061dd42268e2328bdccc6c1430499",
+      "description": "MuHad AOD dataset file index (5 of 9) for access to data via CMS virtual machine",
+      "size": 272,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30003_file_index.json"
+    },
+    {
+      "checksum": "sha1:b5c7149f6b867b9f1d0812a6b5cea8405beb8744",
+      "description": "MuHad AOD dataset file index (6 of 9) for access to data via CMS virtual machine",
+      "size": 542,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:6f011451a3c1ba9b06ef60a72cc8b25b56a99bd8",
+      "description": "MuHad AOD dataset file index (7 of 9) for access to data via CMS virtual machine",
+      "size": 272,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30005_file_index.json"
+    },
+    {
+      "checksum": "sha1:a48b5ab355081a663cfee9b96e18013c6c0c46d4",
+      "description": "MuHad AOD dataset file index (8 of 9) for access to data via CMS virtual machine",
+      "size": 272,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30007_file_index.json"
+    },
+    {
+      "checksum": "sha1:df1cd23d183693460e1d2b305d6240075159734e",
+      "description": "MuHad AOD dataset file index (9 of 9) for access to data via CMS virtual machine",
+      "size": 542,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30008_file_index.json"
+    },
+    {
+      "checksum": "sha1:e8fa372bb20d7c24e2c52bc1bec3c7a80350bfaa",
       "description": "MuHad AOD dataset file index (1 of 9) for access to data via CMS virtual machine",
       "size": 44157,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4dfcf3a80773fd8e9ead5e58f8f46f11870d7f56",
       "description": "MuHad AOD dataset file index (2 of 9) for access to data via CMS virtual machine",
       "size": 123000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d6a674c7eee086835c4666707e4034deb33b6266",
       "description": "MuHad AOD dataset file index (3 of 9) for access to data via CMS virtual machine",
       "size": 54612,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:cd4c683927f4749549caa822edc30af04a0db0e9",
       "description": "MuHad AOD dataset file index (4 of 9) for access to data via CMS virtual machine",
       "size": 246,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:dfc3cadd29139e81085ff9053ed63f23b1acc239",
       "description": "MuHad AOD dataset file index (5 of 9) for access to data via CMS virtual machine",
       "size": 123,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2d1837d22ba8522edcd52eb96663ad73c2d9ccd6",
       "description": "MuHad AOD dataset file index (6 of 9) for access to data via CMS virtual machine",
       "size": 246,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:cd98e9fbda6ac9ca8791d8962f3f6df769903359",
       "description": "MuHad AOD dataset file index (7 of 9) for access to data via CMS virtual machine",
       "size": 123,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:98c234b82c23431ac94bc09d54a45ae40a45b4ae",
       "description": "MuHad AOD dataset file index (8 of 9) for access to data via CMS virtual machine",
       "size": 123,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:6465ff203a900f6a156c3341be5f680439d105bb",
       "description": "MuHad AOD dataset file index (9 of 9) for access to data via CMS virtual machine",
       "size": 246,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30008_file_index.txt"
     }
   ],
@@ -2370,129 +3238,255 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0100ba6ec965d7f3715b39987aae33a2de002c0f",
+      "description": "MuOnia AOD dataset file index (1 of 18) for access to data via CMS virtual machine",
+      "size": 283197,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "sha1:54b18114b94ecd062a3173f044fccd632c6533b1",
+      "description": "MuOnia AOD dataset file index (2 of 18) for access to data via CMS virtual machine",
+      "size": 271002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10001_file_index.json"
+    },
+    {
+      "checksum": "sha1:a5ddc1853a83f17bc0803c7daa2840c8d6f446da",
+      "description": "MuOnia AOD dataset file index (3 of 18) for access to data via CMS virtual machine",
+      "size": 271273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10002_file_index.json"
+    },
+    {
+      "checksum": "sha1:2051a9fbe58dd815054eab884621f8e27cfd984a",
+      "description": "MuOnia AOD dataset file index (4 of 18) for access to data via CMS virtual machine",
+      "size": 271002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10003_file_index.json"
+    },
+    {
+      "checksum": "sha1:8ff58faa84eac2b4a639dc2ea2efe19865881c22",
+      "description": "MuOnia AOD dataset file index (5 of 18) for access to data via CMS virtual machine",
+      "size": 87263,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10004_file_index.json"
+    },
+    {
+      "checksum": "sha1:70c8d066333e553f11fdaa9eababe93f07a52c48",
+      "description": "MuOnia AOD dataset file index (6 of 18) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10007_file_index.json"
+    },
+    {
+      "checksum": "sha1:fc729c045bc400bd425986c697d378d1354c00da",
+      "description": "MuOnia AOD dataset file index (7 of 18) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10011_file_index.json"
+    },
+    {
+      "checksum": "sha1:bdf11d2365ac0ad80e0e7226f058a0ae48073898",
+      "description": "MuOnia AOD dataset file index (8 of 18) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10016_file_index.json"
+    },
+    {
+      "checksum": "sha1:c98194e697250c2fe7c21df738f187bf4cc7a1a6",
+      "description": "MuOnia AOD dataset file index (9 of 18) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10017_file_index.json"
+    },
+    {
+      "checksum": "sha1:05c02076bf3ec16733e9b852e2cbfd5226983a98",
+      "description": "MuOnia AOD dataset file index (10 of 18) for access to data via CMS virtual machine",
+      "size": 544,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10019_file_index.json"
+    },
+    {
+      "checksum": "sha1:34d73389af71dce5dd2765720ddb486b1432fb32",
+      "description": "MuOnia AOD dataset file index (11 of 18) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10024_file_index.json"
+    },
+    {
+      "checksum": "sha1:5f9de8f10428cf6e9bb8fdd36090efb6822f84b8",
+      "description": "MuOnia AOD dataset file index (12 of 18) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10027_file_index.json"
+    },
+    {
+      "checksum": "sha1:e903d74def5cde9adef4313c0335e913dfc80d6a",
+      "description": "MuOnia AOD dataset file index (13 of 18) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10033_file_index.json"
+    },
+    {
+      "checksum": "sha1:9450a681418eb37a76232002a63892b0d4e27b3e",
+      "description": "MuOnia AOD dataset file index (14 of 18) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10040_file_index.json"
+    },
+    {
+      "checksum": "sha1:b12779ca3e30b8e6204a7fe5f7c8a2f69dcc493e",
+      "description": "MuOnia AOD dataset file index (15 of 18) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10049_file_index.json"
+    },
+    {
+      "checksum": "sha1:72fb7e730a447b3a910be594710db3d76981057c",
+      "description": "MuOnia AOD dataset file index (16 of 18) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10051_file_index.json"
+    },
+    {
+      "checksum": "sha1:a30596def71e83f7610be7b85563425afcfa57c1",
+      "description": "MuOnia AOD dataset file index (17 of 18) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10053_file_index.json"
+    },
+    {
+      "checksum": "sha1:b20607f2786b9007cbe31127187f767baba57591",
+      "description": "MuOnia AOD dataset file index (18 of 18) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10055_file_index.json"
+    },
+    {
+      "checksum": "sha1:bb200246bc668519a227404c4cf9c13f13f2b2e3",
       "description": "MuOnia AOD dataset file index (1 of 18) for access to data via CMS virtual machine",
       "size": 129580,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ed653f396474b79af8d56407de99c460a3c9d17c",
       "description": "MuOnia AOD dataset file index (2 of 18) for access to data via CMS virtual machine",
       "size": 124000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:19df02712894382ed30a51f2dde631c9c55bb5cf",
       "description": "MuOnia AOD dataset file index (3 of 18) for access to data via CMS virtual machine",
       "size": 124124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:76531169284ae6addb3998dd0d5c49f7f289117a",
       "description": "MuOnia AOD dataset file index (4 of 18) for access to data via CMS virtual machine",
       "size": 124000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3d50c9e6c2ff05d9868a388a3a982e4edeb8219e",
       "description": "MuOnia AOD dataset file index (5 of 18) for access to data via CMS virtual machine",
       "size": 39928,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:40a4b32dddf539f1ba3b5fe294565faa1d46c138",
       "description": "MuOnia AOD dataset file index (6 of 18) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:06cc0eebe9756aec8af4f6cb79f8b2faeb54fd42",
       "description": "MuOnia AOD dataset file index (7 of 18) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:98e64a2ef1d64895a1b07212af3dd19fb579fdb4",
       "description": "MuOnia AOD dataset file index (8 of 18) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10016_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0d71089df293642c2c9a5b02d6f1b5e5800abbd7",
       "description": "MuOnia AOD dataset file index (9 of 18) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10017_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:67afad1e80edaa325b199c53f81eb8dac8ba5e0a",
       "description": "MuOnia AOD dataset file index (10 of 18) for access to data via CMS virtual machine",
       "size": 248,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10019_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c039cbf9cdc928423890a9cb99065d775c8bef74",
       "description": "MuOnia AOD dataset file index (11 of 18) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10024_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:705bbdb04a1768caf2556ff485b8f4a64f8e2fa8",
       "description": "MuOnia AOD dataset file index (12 of 18) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10027_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a19e8f0a1c2422a1bb73161d03cd3d50f94988c6",
       "description": "MuOnia AOD dataset file index (13 of 18) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10033_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e8b7a15e3788d736885a5537c8b18a62b0c026bc",
       "description": "MuOnia AOD dataset file index (14 of 18) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10040_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f98f287eea8bb867152640e63fdbea8c02797c65",
       "description": "MuOnia AOD dataset file index (15 of 18) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10049_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:026cf417dcf1d943050d7464ff286f2592a1b58a",
       "description": "MuOnia AOD dataset file index (16 of 18) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10051_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9352f84519c6aa732e87e6a4e8f1caa329ad462a",
       "description": "MuOnia AOD dataset file index (17 of 18) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10053_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b30c01e3f2d0553dd4d77738daa78c71c17f67eb",
       "description": "MuOnia AOD dataset file index (18 of 18) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10055_file_index.txt"
     }
   ],
@@ -2588,360 +3582,717 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:54677e1e54d0d714835c804200ebb50536b71614",
+      "description": "MuOniaParked AOD dataset file index (1 of 51) for access to data via CMS virtual machine",
+      "size": 366471,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:1684809d89ad5c7a78132b94e383382d7d9cc754",
+      "description": "MuOniaParked AOD dataset file index (2 of 51) for access to data via CMS virtual machine",
+      "size": 275063,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:5e1df510e05276b493d4e97c95f110119714203c",
+      "description": "MuOniaParked AOD dataset file index (3 of 51) for access to data via CMS virtual machine",
+      "size": 97783,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:4fa232d13ce39f703bdeb35594caf4fb2edbe8d4",
+      "description": "MuOniaParked AOD dataset file index (4 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20004_file_index.json"
+    },
+    {
+      "checksum": "sha1:7c572c564df7dc3b573ce5762751fae328365592",
+      "description": "MuOniaParked AOD dataset file index (5 of 51) for access to data via CMS virtual machine",
+      "size": 556,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20007_file_index.json"
+    },
+    {
+      "checksum": "sha1:118f3f2cd052f1a866323ce3bc18a6dd9be972cd",
+      "description": "MuOniaParked AOD dataset file index (6 of 51) for access to data via CMS virtual machine",
+      "size": 556,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20011_file_index.json"
+    },
+    {
+      "checksum": "sha1:b59cc0b2acd59a0bb2746713e400df3b154e9d9e",
+      "description": "MuOniaParked AOD dataset file index (7 of 51) for access to data via CMS virtual machine",
+      "size": 556,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20012_file_index.json"
+    },
+    {
+      "checksum": "sha1:471945c2c1979b9a8e120407cecf26958d5ff446",
+      "description": "MuOniaParked AOD dataset file index (8 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20013_file_index.json"
+    },
+    {
+      "checksum": "sha1:c46730f6fcd53343bc08ee35905d4279447e82f2",
+      "description": "MuOniaParked AOD dataset file index (9 of 51) for access to data via CMS virtual machine",
+      "size": 833,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20014_file_index.json"
+    },
+    {
+      "checksum": "sha1:30538fa086cadca6efa924dd33b831d3ae16961d",
+      "description": "MuOniaParked AOD dataset file index (10 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20015_file_index.json"
+    },
+    {
+      "checksum": "sha1:128e9f8c142300c9f0dda88fb1091adaa0e82def",
+      "description": "MuOniaParked AOD dataset file index (11 of 51) for access to data via CMS virtual machine",
+      "size": 556,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20016_file_index.json"
+    },
+    {
+      "checksum": "sha1:3cb93b70857e74596823e0f22de6503a47691e92",
+      "description": "MuOniaParked AOD dataset file index (12 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20017_file_index.json"
+    },
+    {
+      "checksum": "sha1:4f3b005a7b20e1a7ccdfd553dff1ee1410004b18",
+      "description": "MuOniaParked AOD dataset file index (13 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20018_file_index.json"
+    },
+    {
+      "checksum": "sha1:670e90aefcd21488824eb74440585cc77345dda7",
+      "description": "MuOniaParked AOD dataset file index (14 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20019_file_index.json"
+    },
+    {
+      "checksum": "sha1:b392a6695fb25bf9c22ae5d53ca7a54f02ae6eff",
+      "description": "MuOniaParked AOD dataset file index (15 of 51) for access to data via CMS virtual machine",
+      "size": 8341,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_210000_file_index.json"
+    },
+    {
+      "checksum": "sha1:11591427a72cf2fb835dacc2b44c65f101a79707",
+      "description": "MuOniaParked AOD dataset file index (16 of 51) for access to data via CMS virtual machine",
+      "size": 14958,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_230000_file_index.json"
+    },
+    {
+      "checksum": "sha1:f318f574a43ef97fc183cfc1c800e17eae2f8df1",
+      "description": "MuOniaParked AOD dataset file index (17 of 51) for access to data via CMS virtual machine",
+      "size": 446248,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:acb031ff60875ee6234287514191eb5ffea0859b",
+      "description": "MuOniaParked AOD dataset file index (18 of 51) for access to data via CMS virtual machine",
+      "size": 277279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:754f320ae96be40648fd38df00fdc3ead7b56807",
+      "description": "MuOniaParked AOD dataset file index (19 of 51) for access to data via CMS virtual machine",
+      "size": 277002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:bfc249821a2346d98554c3cbf63f1852982f3cd9",
+      "description": "MuOniaParked AOD dataset file index (20 of 51) for access to data via CMS virtual machine",
+      "size": 277002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30003_file_index.json"
+    },
+    {
+      "checksum": "sha1:5f587035450851b8d7f6f246a7bf29f0bf4d8791",
+      "description": "MuOniaParked AOD dataset file index (21 of 51) for access to data via CMS virtual machine",
+      "size": 249579,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:13e9f0a99d2ac31fb2cdff654e3030470a5c5639",
+      "description": "MuOniaParked AOD dataset file index (22 of 51) for access to data via CMS virtual machine",
+      "size": 269522,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30005_file_index.json"
+    },
+    {
+      "checksum": "sha1:14b778023dcab0e6ebf7071d878a45d504be5e66",
+      "description": "MuOniaParked AOD dataset file index (23 of 51) for access to data via CMS virtual machine",
+      "size": 100552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30006_file_index.json"
+    },
+    {
+      "checksum": "sha1:b1ac86545506484aab768f7062cd1238a3b6879c",
+      "description": "MuOniaParked AOD dataset file index (24 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30007_file_index.json"
+    },
+    {
+      "checksum": "sha1:56a94498eac268e26b183b13b4e8795de1ff420c",
+      "description": "MuOniaParked AOD dataset file index (25 of 51) for access to data via CMS virtual machine",
+      "size": 556,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30009_file_index.json"
+    },
+    {
+      "checksum": "sha1:0565bb85e561f3bea28063e2d22eaf0e5734149f",
+      "description": "MuOniaParked AOD dataset file index (26 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30011_file_index.json"
+    },
+    {
+      "checksum": "sha1:7bfa80cfee57c80f1fe7b8f4d61b9c5ec10d881e",
+      "description": "MuOniaParked AOD dataset file index (27 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30012_file_index.json"
+    },
+    {
+      "checksum": "sha1:9c897b173e3cbddcd8caddc1c59d86f39cdf4d81",
+      "description": "MuOniaParked AOD dataset file index (28 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30015_file_index.json"
+    },
+    {
+      "checksum": "sha1:ada26ff35ffd24ed00fece256a1a838a066a536a",
+      "description": "MuOniaParked AOD dataset file index (29 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30016_file_index.json"
+    },
+    {
+      "checksum": "sha1:e1e8d5958f4f148aef62eb1dbf4e43875ba122c7",
+      "description": "MuOniaParked AOD dataset file index (30 of 51) for access to data via CMS virtual machine",
+      "size": 556,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30017_file_index.json"
+    },
+    {
+      "checksum": "sha1:abb43b8ecae2b161684ddb1409f48e3b4a7de630",
+      "description": "MuOniaParked AOD dataset file index (31 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30020_file_index.json"
+    },
+    {
+      "checksum": "sha1:577658bdc43aa7fac9fa31b5932d145c829cef6d",
+      "description": "MuOniaParked AOD dataset file index (32 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30022_file_index.json"
+    },
+    {
+      "checksum": "sha1:61be0d6a26648c5a2aedf6ba968376991d98848e",
+      "description": "MuOniaParked AOD dataset file index (33 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30024_file_index.json"
+    },
+    {
+      "checksum": "sha1:87cbb870fbcbba9ff6d944168cdbc3771e3f1f06",
+      "description": "MuOniaParked AOD dataset file index (34 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30026_file_index.json"
+    },
+    {
+      "checksum": "sha1:430e40848d71f3a766a38eaf0cb2413863a3308e",
+      "description": "MuOniaParked AOD dataset file index (35 of 51) for access to data via CMS virtual machine",
+      "size": 1110,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30029_file_index.json"
+    },
+    {
+      "checksum": "sha1:870d2b2dba817071da180674ffe72ae6cea6ebf6",
+      "description": "MuOniaParked AOD dataset file index (36 of 51) for access to data via CMS virtual machine",
+      "size": 1110,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30032_file_index.json"
+    },
+    {
+      "checksum": "sha1:a5dd35469c69d33073c86b52a19e2da7d98417d5",
+      "description": "MuOniaParked AOD dataset file index (37 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30034_file_index.json"
+    },
+    {
+      "checksum": "sha1:01502b9426c5dc737845dcd9968dc4d348a14ec5",
+      "description": "MuOniaParked AOD dataset file index (38 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30036_file_index.json"
+    },
+    {
+      "checksum": "sha1:a5e1f867337ac52fba91405575e5d8889cd7999f",
+      "description": "MuOniaParked AOD dataset file index (39 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30038_file_index.json"
+    },
+    {
+      "checksum": "sha1:15aaeaa12771d2e7c8fe1ff7bcc57bdf508eb702",
+      "description": "MuOniaParked AOD dataset file index (40 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30039_file_index.json"
+    },
+    {
+      "checksum": "sha1:32056bdb394a877e7ab43c069cde4743371bafd7",
+      "description": "MuOniaParked AOD dataset file index (41 of 51) for access to data via CMS virtual machine",
+      "size": 556,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30041_file_index.json"
+    },
+    {
+      "checksum": "sha1:53e0ee6a667b74471d30dd2261aec50ec85a2ad2",
+      "description": "MuOniaParked AOD dataset file index (42 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30044_file_index.json"
+    },
+    {
+      "checksum": "sha1:b9bd9f847738a9d77903a73031f4dbbfad03bb2d",
+      "description": "MuOniaParked AOD dataset file index (43 of 51) for access to data via CMS virtual machine",
+      "size": 556,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30049_file_index.json"
+    },
+    {
+      "checksum": "sha1:0bcab46e9be100767573eb3193c2cfc2360e5495",
+      "description": "MuOniaParked AOD dataset file index (44 of 51) for access to data via CMS virtual machine",
+      "size": 833,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30051_file_index.json"
+    },
+    {
+      "checksum": "sha1:34a30c2539bb797482abd818579bf7bb79b257b9",
+      "description": "MuOniaParked AOD dataset file index (45 of 51) for access to data via CMS virtual machine",
+      "size": 556,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30054_file_index.json"
+    },
+    {
+      "checksum": "sha1:ff2d328276757064a6717811743305a8dba062a0",
+      "description": "MuOniaParked AOD dataset file index (46 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30055_file_index.json"
+    },
+    {
+      "checksum": "sha1:0aa4d63f432c8cc5ca3c8c819b35662e786860a8",
+      "description": "MuOniaParked AOD dataset file index (47 of 51) for access to data via CMS virtual machine",
+      "size": 556,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30057_file_index.json"
+    },
+    {
+      "checksum": "sha1:4ac2c016930c83622530592682f909bd204a43b7",
+      "description": "MuOniaParked AOD dataset file index (48 of 51) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30059_file_index.json"
+    },
+    {
+      "checksum": "sha1:c89d9e122a739cdda261d4815e5e929f2f0fbac8",
+      "description": "MuOniaParked AOD dataset file index (49 of 51) for access to data via CMS virtual machine",
+      "size": 10010,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_310000_file_index.json"
+    },
+    {
+      "checksum": "sha1:1f58657d64bdcf14a2ef4831df19e288190ff59a",
+      "description": "MuOniaParked AOD dataset file index (50 of 51) for access to data via CMS virtual machine",
+      "size": 836,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_320000_file_index.json"
+    },
+    {
+      "checksum": "sha1:3633de359e880e0368c7b3befbc3027cad76f98e",
+      "description": "MuOniaParked AOD dataset file index (51 of 51) for access to data via CMS virtual machine",
+      "size": 2772,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_330000_file_index.json"
+    },
+    {
+      "checksum": "sha1:25b6f6b748de5e84500cc4075e37175270088aa9",
       "description": "MuOniaParked AOD dataset file index (1 of 51) for access to data via CMS virtual machine",
       "size": 171990,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a20c481ac0c4c845761804603543dd714602c24c",
       "description": "MuOniaParked AOD dataset file index (2 of 51) for access to data via CMS virtual machine",
       "size": 129090,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:86e1da201c9c5beec9fe9522d4cf5d5744606ac7",
       "description": "MuOniaParked AOD dataset file index (3 of 51) for access to data via CMS virtual machine",
       "size": 45890,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9e09f0d52cc6e8eb173856b5c3e8d362d565f9e1",
       "description": "MuOniaParked AOD dataset file index (4 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:19775327bb326022fc2701837956374b0cccbd3d",
       "description": "MuOniaParked AOD dataset file index (5 of 51) for access to data via CMS virtual machine",
       "size": 260,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a78e209857ad6f7d1698855cd0aad5612807707c",
       "description": "MuOniaParked AOD dataset file index (6 of 51) for access to data via CMS virtual machine",
       "size": 260,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ed0337fc0b91172be3d7ea5823ce6fadb7cd6d5a",
       "description": "MuOniaParked AOD dataset file index (7 of 51) for access to data via CMS virtual machine",
       "size": 260,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20012_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c14d9b028ef31a436ca636a7f401abe31211a86f",
       "description": "MuOniaParked AOD dataset file index (8 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20013_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e6198ec9aa153bceae36e1b9a57f1e64a3233268",
       "description": "MuOniaParked AOD dataset file index (9 of 51) for access to data via CMS virtual machine",
       "size": 390,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20014_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:febd1fdeb75ef3a91e07e47e5455a0be59a9cc46",
       "description": "MuOniaParked AOD dataset file index (10 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20015_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7b09bd6b79eda79a7e39e3a34ee4cf415d5ac160",
       "description": "MuOniaParked AOD dataset file index (11 of 51) for access to data via CMS virtual machine",
       "size": 260,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20016_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:51eed3c211bdf5c90cc302ebf737a39ea48e7006",
       "description": "MuOniaParked AOD dataset file index (12 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20017_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:fb5c16cea63a03a2bc96690b0ea2bd289235fab7",
       "description": "MuOniaParked AOD dataset file index (13 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20018_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2f84358a1081475ece96033095f84022afec62bc",
       "description": "MuOniaParked AOD dataset file index (14 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20019_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:96072c5674327e31030f286f75270ea4dd5fa494",
       "description": "MuOniaParked AOD dataset file index (15 of 51) for access to data via CMS virtual machine",
       "size": 3930,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_210000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1b59d7ff70142e57eac755cd17d45f3e0df3e07a",
       "description": "MuOniaParked AOD dataset file index (16 of 51) for access to data via CMS virtual machine",
       "size": 7074,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_230000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:af39afaf50ce67d7b292cba6d76e6b3592b13e15",
       "description": "MuOniaParked AOD dataset file index (17 of 51) for access to data via CMS virtual machine",
       "size": 209430,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:55a164ead5f1e28a00fc4b7c5072d16ed66ada13",
       "description": "MuOniaParked AOD dataset file index (18 of 51) for access to data via CMS virtual machine",
       "size": 130130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2552a1fc3522c015e687f203969f89ae4523d4fc",
       "description": "MuOniaParked AOD dataset file index (19 of 51) for access to data via CMS virtual machine",
       "size": 130000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ca22ce43d4600dd3560878749df83ee0d02bbb7d",
       "description": "MuOniaParked AOD dataset file index (20 of 51) for access to data via CMS virtual machine",
       "size": 130000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:85581685b53db20961b216f059856a3bfd55542b",
       "description": "MuOniaParked AOD dataset file index (21 of 51) for access to data via CMS virtual machine",
       "size": 117130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b5db1aaf048da6486b854ede10951a887bf5c34e",
       "description": "MuOniaParked AOD dataset file index (22 of 51) for access to data via CMS virtual machine",
       "size": 126490,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:6389347b7002c54134edfcbe482863ef7dfa7b5a",
       "description": "MuOniaParked AOD dataset file index (23 of 51) for access to data via CMS virtual machine",
       "size": 47190,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:feeb0c36fb62b929785984bfa49ef760e9be17a1",
       "description": "MuOniaParked AOD dataset file index (24 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b62cd1797caff7dceb0dc7cd9bdf3169cc62d0e7",
       "description": "MuOniaParked AOD dataset file index (25 of 51) for access to data via CMS virtual machine",
       "size": 260,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f6c539dc108fad86e377fcbee08c818c68c861f2",
       "description": "MuOniaParked AOD dataset file index (26 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30011_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:cc0cfc2d8d39223350597ef25faabea404cae4aa",
       "description": "MuOniaParked AOD dataset file index (27 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30012_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1d7faf4121127aae23ce7cbed19983381c404b0d",
       "description": "MuOniaParked AOD dataset file index (28 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30015_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:15c434954571142fe2b1417040aab98134064130",
       "description": "MuOniaParked AOD dataset file index (29 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30016_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:858aa4c19aaeeec6d39edc93b95c2e932604f675",
       "description": "MuOniaParked AOD dataset file index (30 of 51) for access to data via CMS virtual machine",
       "size": 260,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30017_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:5da444ee1fd795b98b8b3204477980cdf248cc01",
       "description": "MuOniaParked AOD dataset file index (31 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30020_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:df6ca430c211c055a5f7fe4b2572894b849dbc32",
       "description": "MuOniaParked AOD dataset file index (32 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30022_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:41ec74c246cd6342686bd392d1b5009334a415da",
       "description": "MuOniaParked AOD dataset file index (33 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30024_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9b1fdb00effef67abb02ed48a6bd9180fee3bc3f",
       "description": "MuOniaParked AOD dataset file index (34 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30026_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4f7a148f757df7341b4e74575231c7638c75e26c",
       "description": "MuOniaParked AOD dataset file index (35 of 51) for access to data via CMS virtual machine",
       "size": 520,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30029_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:52b92318adaeacbf96dd23790b635a44fca566c3",
       "description": "MuOniaParked AOD dataset file index (36 of 51) for access to data via CMS virtual machine",
       "size": 520,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30032_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:60090b35bbd1c8345f82d58bc7d521d2be480edb",
       "description": "MuOniaParked AOD dataset file index (37 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30034_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7b7381d938b3cd3611d6c68051b9db6e7236d8fe",
       "description": "MuOniaParked AOD dataset file index (38 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30036_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f1879ebdb1e483cde8e53c7baa01dc401efa38b3",
       "description": "MuOniaParked AOD dataset file index (39 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30038_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:889337ed93ce41647b2a84d185322b0173dbd156",
       "description": "MuOniaParked AOD dataset file index (40 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30039_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3077a5f427a5694827fae3a98a51f09461296f84",
       "description": "MuOniaParked AOD dataset file index (41 of 51) for access to data via CMS virtual machine",
       "size": 260,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30041_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2130b139641e9f2829ca424f5a410325a4ff4843",
       "description": "MuOniaParked AOD dataset file index (42 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30044_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:174a81a746250d9e9d6787ee61ef227529afd883",
       "description": "MuOniaParked AOD dataset file index (43 of 51) for access to data via CMS virtual machine",
       "size": 260,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30049_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b4f5a620b7fa060dcd05d1dbc2ad607bd0d28eee",
       "description": "MuOniaParked AOD dataset file index (44 of 51) for access to data via CMS virtual machine",
       "size": 390,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30051_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:550919cdc14e728ac5deb9061727676db7d71715",
       "description": "MuOniaParked AOD dataset file index (45 of 51) for access to data via CMS virtual machine",
       "size": 260,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30054_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:22b5c99a77da8ced40512f0072b51e641b4f7eea",
       "description": "MuOniaParked AOD dataset file index (46 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30055_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ebd81630e59b1e748ebb4e0b82dbc2f708b6ee83",
       "description": "MuOniaParked AOD dataset file index (47 of 51) for access to data via CMS virtual machine",
       "size": 260,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30057_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8429406df6ffdac45d995a3bb1511481decff55b",
       "description": "MuOniaParked AOD dataset file index (48 of 51) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30059_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e17b5c350d0cf77c7e189ac53acdafcf1d4157f3",
       "description": "MuOniaParked AOD dataset file index (49 of 51) for access to data via CMS virtual machine",
       "size": 4716,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_310000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ce51e02c8937bc2352d04926633a0f7087004122",
       "description": "MuOniaParked AOD dataset file index (50 of 51) for access to data via CMS virtual machine",
       "size": 393,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_320000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2b446945cef6d74fdf31d7907306ef90bd87d245",
       "description": "MuOniaParked AOD dataset file index (51 of 51) for access to data via CMS virtual machine",
       "size": 1310,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_330000_file_index.txt"
     }
   ],
@@ -3037,17 +4388,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f74b2679546194502142e35e578a23e16a7d2323",
+      "description": "NoBPTX AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 271,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_NoBPTX_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:fa3af5483837844a305472f26d91c65abc629e17",
+      "description": "NoBPTX AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 65019,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_NoBPTX_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:3228705761b72b53fa28e0371b64687d2f801f97",
       "description": "NoBPTX AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 124,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_NoBPTX_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f7c70b13494e395d154814419c453ae1aacd4c93",
       "description": "NoBPTX AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 29760,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_NoBPTX_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -3143,24 +4508,45 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e8273fdb3b713e249ff309ea0bfdd3e6cf1e53d5",
+      "description": "PhotonHad AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
+      "size": 189610,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_PhotonHad_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:796059214835a30cacfc0de391385277f3699446",
+      "description": "PhotonHad AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_PhotonHad_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:9d24563e7734aaddfaaf29e754c45d9c922cac72",
+      "description": "PhotonHad AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
+      "size": 234545,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_PhotonHad_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:27e69f0d6a431cc0b1859a89489752f88d686310",
       "description": "PhotonHad AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
       "size": 87884,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_PhotonHad_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:22f99ffd269812a6ce7df11873afb81919bf86c8",
       "description": "PhotonHad AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_PhotonHad_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2454473f41d8841961ae585f7b608d6cd916a23f",
       "description": "PhotonHad AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
       "size": 108712,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_PhotonHad_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -3256,108 +4642,213 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:fb1757c0a4e49ef37988ef493424b92f026778e6",
+      "description": "SingleElectron AOD dataset file index (1 of 15) for access to data via CMS virtual machine",
+      "size": 39061,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "sha1:3253a1378b5f17535a504afdd2ab5278cc1ad7bb",
+      "description": "SingleElectron AOD dataset file index (2 of 15) for access to data via CMS virtual machine",
+      "size": 277886,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:4491830075330679e8983ad7a260e84794777f52",
+      "description": "SingleElectron AOD dataset file index (3 of 15) for access to data via CMS virtual machine",
+      "size": 278723,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:d93f522d9ec4a3914aa112865dc077d7e29a902a",
+      "description": "SingleElectron AOD dataset file index (4 of 15) for access to data via CMS virtual machine",
+      "size": 277328,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:52f826bb6154ae4320092b03613358526f7ff5ca",
+      "description": "SingleElectron AOD dataset file index (5 of 15) for access to data via CMS virtual machine",
+      "size": 146477,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:736559a635b5fafe98ecda8597d618244eb383c1",
+      "description": "SingleElectron AOD dataset file index (6 of 15) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20008_file_index.json"
+    },
+    {
+      "checksum": "sha1:5b202feb22931b4c8d31c1615bcd241ff0784da1",
+      "description": "SingleElectron AOD dataset file index (7 of 15) for access to data via CMS virtual machine",
+      "size": 302996,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:03972ae796197a002e9681d23197bd0697c467d3",
+      "description": "SingleElectron AOD dataset file index (8 of 15) for access to data via CMS virtual machine",
+      "size": 278723,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:e3ac8bcf82004d9834720ad92e4ba249ed9a3a87",
+      "description": "SingleElectron AOD dataset file index (9 of 15) for access to data via CMS virtual machine",
+      "size": 279002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:65c65a8e13983eab0261389ef33df7802f4d58df",
+      "description": "SingleElectron AOD dataset file index (10 of 15) for access to data via CMS virtual machine",
+      "size": 268121,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30003_file_index.json"
+    },
+    {
+      "checksum": "sha1:fe40d45472f06dfcf9646c6889482c9c3db7d0ac",
+      "description": "SingleElectron AOD dataset file index (11 of 15) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:0e8d77ecf5040d3eb25d443055a3fff4dc629ab1",
+      "description": "SingleElectron AOD dataset file index (12 of 15) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30014_file_index.json"
+    },
+    {
+      "checksum": "sha1:f894eed3a84cb761a6d003bb0f82b16940a64037",
+      "description": "SingleElectron AOD dataset file index (13 of 15) for access to data via CMS virtual machine",
+      "size": 560,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30024_file_index.json"
+    },
+    {
+      "checksum": "sha1:b4aeea8478afd9e89aae0333384e3953dcad377f",
+      "description": "SingleElectron AOD dataset file index (14 of 15) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30027_file_index.json"
+    },
+    {
+      "checksum": "sha1:b57788f0bd30a8cb6aa7d5a7322adf6f7ca257ce",
+      "description": "SingleElectron AOD dataset file index (15 of 15) for access to data via CMS virtual machine",
+      "size": 281,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30030_file_index.json"
+    },
+    {
+      "checksum": "sha1:9a51fbb4a25d0988d5a0d19ed84a51593395b682",
       "description": "SingleElectron AOD dataset file index (1 of 15) for access to data via CMS virtual machine",
       "size": 18480,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:83943067d03d94eeb543cde727b69fb12eef91f0",
       "description": "SingleElectron AOD dataset file index (2 of 15) for access to data via CMS virtual machine",
       "size": 131472,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8202cd4a7285722da31db8dc3e692015a4648ad0",
       "description": "SingleElectron AOD dataset file index (3 of 15) for access to data via CMS virtual machine",
       "size": 131868,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c7091b49a27cae2e2749a7ea26dc0d56cb1e3fc9",
       "description": "SingleElectron AOD dataset file index (4 of 15) for access to data via CMS virtual machine",
       "size": 131208,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9e31c62056507851dbf120366ede78d778c4f971",
       "description": "SingleElectron AOD dataset file index (5 of 15) for access to data via CMS virtual machine",
       "size": 69300,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:55642a2535c4ba82be6718bd379e704708b8d11a",
       "description": "SingleElectron AOD dataset file index (6 of 15) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0ac4beb9615a36b9d1740ab0a50289290b360975",
       "description": "SingleElectron AOD dataset file index (7 of 15) for access to data via CMS virtual machine",
       "size": 143352,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b9983be93c31672e56b3fb206a0c0a99761176fc",
       "description": "SingleElectron AOD dataset file index (8 of 15) for access to data via CMS virtual machine",
       "size": 131868,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8ebee88ba32cbbac857b7dafd00400450ba760c3",
       "description": "SingleElectron AOD dataset file index (9 of 15) for access to data via CMS virtual machine",
       "size": 132000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:466ad2061e26fc73d0ff7f0f455cc00e97a2ec6d",
       "description": "SingleElectron AOD dataset file index (10 of 15) for access to data via CMS virtual machine",
       "size": 126852,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:44b453eae62d41a4a3e0a0e9503529a47f3f4452",
       "description": "SingleElectron AOD dataset file index (11 of 15) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0f346736934f60919ea5072fc334f5e99cdae873",
       "description": "SingleElectron AOD dataset file index (12 of 15) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30014_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f7fb156bafd51a1cdefa97249815d2e139cf49c3",
       "description": "SingleElectron AOD dataset file index (13 of 15) for access to data via CMS virtual machine",
       "size": 264,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30024_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0653f2c01e91e7287a3a9cddae28488367779d64",
       "description": "SingleElectron AOD dataset file index (14 of 15) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30027_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:6d1e31ba8cadeae6bbf621f12de2b465219e9dfd",
       "description": "SingleElectron AOD dataset file index (15 of 15) for access to data via CMS virtual machine",
       "size": 132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30030_file_index.txt"
     }
   ],
@@ -3453,171 +4944,339 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:11e1c433a3bd1654a2bd50af07a8ecbbb0c29878",
+      "description": "SingleMu AOD dataset file index (1 of 24) for access to data via CMS virtual machine",
+      "size": 287197,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:1a0e4b60eeff2ae49b5735b8e085845bfc9047a6",
+      "description": "SingleMu AOD dataset file index (2 of 24) for access to data via CMS virtual machine",
+      "size": 273002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:02baf5fa1893a53697b06f2b9b34ea45f2ee0f90",
+      "description": "SingleMu AOD dataset file index (3 of 24) for access to data via CMS virtual machine",
+      "size": 273275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:ea7a61ecd75ff5311b702454148517cccaa875ff",
+      "description": "SingleMu AOD dataset file index (4 of 24) for access to data via CMS virtual machine",
+      "size": 273275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:36f7b1d70227a82f5c6b78c9be50519edcde071f",
+      "description": "SingleMu AOD dataset file index (5 of 24) for access to data via CMS virtual machine",
+      "size": 272456,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20004_file_index.json"
+    },
+    {
+      "checksum": "sha1:f9ab9803a001d132231b25fdfcb1f57198927375",
+      "description": "SingleMu AOD dataset file index (6 of 24) for access to data via CMS virtual machine",
+      "size": 37948,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20005_file_index.json"
+    },
+    {
+      "checksum": "sha1:228f51f5df365b87e3061d4068003f474cf17ef3",
+      "description": "SingleMu AOD dataset file index (7 of 24) for access to data via CMS virtual machine",
+      "size": 548,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20006_file_index.json"
+    },
+    {
+      "checksum": "sha1:9f2cbb8162662d1ba0f732a148b689ab7c37955e",
+      "description": "SingleMu AOD dataset file index (8 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20008_file_index.json"
+    },
+    {
+      "checksum": "sha1:6eabd17d1d5f3a09be107e92ebc97bef2c4a95d4",
+      "description": "SingleMu AOD dataset file index (9 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20017_file_index.json"
+    },
+    {
+      "checksum": "sha1:d03cc53d5b3d9ebe064205ed46858d498624c321",
+      "description": "SingleMu AOD dataset file index (10 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20018_file_index.json"
+    },
+    {
+      "checksum": "sha1:72cb03dffa6d76566d2fd389ce366e184b9a8786",
+      "description": "SingleMu AOD dataset file index (11 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20021_file_index.json"
+    },
+    {
+      "checksum": "sha1:880080e0c789ffc9f0221fd2da27466f5b6a6916",
+      "description": "SingleMu AOD dataset file index (12 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20030_file_index.json"
+    },
+    {
+      "checksum": "sha1:db345a1888f3f3a73a3d7421e1ffd94bc8b20dae",
+      "description": "SingleMu AOD dataset file index (13 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20040_file_index.json"
+    },
+    {
+      "checksum": "sha1:b7436fb13b5ddcda5854f4d37a57e9afcb207f21",
+      "description": "SingleMu AOD dataset file index (14 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20045_file_index.json"
+    },
+    {
+      "checksum": "sha1:52a993a6a15276b347c476c89edc37c3fc57df79",
+      "description": "SingleMu AOD dataset file index (15 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20046_file_index.json"
+    },
+    {
+      "checksum": "sha1:de92c10dd047f348a0239cf0edc33ccde9c4c1bc",
+      "description": "SingleMu AOD dataset file index (16 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20048_file_index.json"
+    },
+    {
+      "checksum": "sha1:b023e74c9b4eb7c1f8e9f3df754af06369b0067d",
+      "description": "SingleMu AOD dataset file index (17 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20055_file_index.json"
+    },
+    {
+      "checksum": "sha1:65379d91d3a174dd5016ed5c5f88add7c3036f30",
+      "description": "SingleMu AOD dataset file index (18 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20058_file_index.json"
+    },
+    {
+      "checksum": "sha1:b6c4d3b1653354b63869b1c1444368be3e1d9f71",
+      "description": "SingleMu AOD dataset file index (19 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20059_file_index.json"
+    },
+    {
+      "checksum": "sha1:52d6c5cc10d6b6ebd4a7934bbab15d43cd0d3b80",
+      "description": "SingleMu AOD dataset file index (20 of 24) for access to data via CMS virtual machine",
+      "size": 262627,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:e17f478303fcd64159d967251a787245ce4cdb4c",
+      "description": "SingleMu AOD dataset file index (21 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:19fc8f1b1cf2060640aede52840a551bd7d5116e",
+      "description": "SingleMu AOD dataset file index (22 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30007_file_index.json"
+    },
+    {
+      "checksum": "sha1:dd33dc0afdef59882472f3ffd661abdec9fbdac4",
+      "description": "SingleMu AOD dataset file index (23 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30008_file_index.json"
+    },
+    {
+      "checksum": "sha1:3692a6253985e3c6ffb74253b8a105dcb31a2323",
+      "description": "SingleMu AOD dataset file index (24 of 24) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30010_file_index.json"
+    },
+    {
+      "checksum": "sha1:4787517f5fe591bba6c108273c8efe1a56d692e1",
       "description": "SingleMu AOD dataset file index (1 of 24) for access to data via CMS virtual machine",
       "size": 132552,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:27c4fee3a4102b1abbfaaf103586eae45c3511aa",
       "description": "SingleMu AOD dataset file index (2 of 24) for access to data via CMS virtual machine",
       "size": 126000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:5384fd5109b7f423a585071dc8031d1b827e3c0d",
       "description": "SingleMu AOD dataset file index (3 of 24) for access to data via CMS virtual machine",
       "size": 126126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d1bf3a442e03cc2cdc797ec51cee0750ed2b436e",
       "description": "SingleMu AOD dataset file index (4 of 24) for access to data via CMS virtual machine",
       "size": 126126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:371d6ea436bdd88ab3f7d8ac611920ecf3092f23",
       "description": "SingleMu AOD dataset file index (5 of 24) for access to data via CMS virtual machine",
       "size": 125748,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:dbdcae89cb70380d15ee6e92b604e72a480ac6d8",
       "description": "SingleMu AOD dataset file index (6 of 24) for access to data via CMS virtual machine",
       "size": 17514,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:20a5f02c4cc1af29cc6f69a1f8a6d101c6a38ac1",
       "description": "SingleMu AOD dataset file index (7 of 24) for access to data via CMS virtual machine",
       "size": 252,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:01bd10d058f7b299f80cc88c1bf2b39c8944776f",
       "description": "SingleMu AOD dataset file index (8 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f4157630df5bdf558550eb7b1b80db4f4b2be72c",
       "description": "SingleMu AOD dataset file index (9 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20017_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b674e23c673b5032f3f4cf584ca23f47799b3e3a",
       "description": "SingleMu AOD dataset file index (10 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20018_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:750bf4809dda04075c5ee23a7ae6b9474b987ec4",
       "description": "SingleMu AOD dataset file index (11 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20021_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:94614af58eea36a9212af49e0913b10ca008b4f2",
       "description": "SingleMu AOD dataset file index (12 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20030_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0398babe954e4fbb8aba4392a9b71d7ea95d4486",
       "description": "SingleMu AOD dataset file index (13 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20040_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e0071fb1e8dc877c6a2bbe90b62324f2b8e87bfd",
       "description": "SingleMu AOD dataset file index (14 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20045_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9058af1430df4a2d3bf24a355423ff3f98d5e457",
       "description": "SingleMu AOD dataset file index (15 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20046_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0060fd7feececb733b152aba76dcbd5ae9f71983",
       "description": "SingleMu AOD dataset file index (16 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20048_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:69e73d19c0144b787074bd94dfa4935884a490b6",
       "description": "SingleMu AOD dataset file index (17 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20055_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8e6826f0eec400fd6aea139d1801b727646d75bd",
       "description": "SingleMu AOD dataset file index (18 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20058_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9376b7d75a8aa6e74b9fb9a420aa9e9384a710ac",
       "description": "SingleMu AOD dataset file index (19 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20059_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:6aa3c1cb5ddbb93ce9638cb7a72bd3ae20c893bb",
       "description": "SingleMu AOD dataset file index (20 of 24) for access to data via CMS virtual machine",
       "size": 121212,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:711070e4ff3f8608523c942ff37978d11c177baa",
       "description": "SingleMu AOD dataset file index (21 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a1d84d4a2e53cf8f6dba375212a94aa5b45ba113",
       "description": "SingleMu AOD dataset file index (22 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:cb27b7b9142587b271cae29b08d53a5b6256bc4b",
       "description": "SingleMu AOD dataset file index (23 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:10bd2575384bd3b4fea6a9de3269d0706f893f55",
       "description": "SingleMu AOD dataset file index (24 of 24) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30010_file_index.txt"
     }
   ],
@@ -3713,45 +5372,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:28efa2f11573a7ecf8e1b559f1de818d3255fabc",
+      "description": "SinglePhoton AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 276448,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:c342d38d4b1524e3bf563353a61ae7e32eb5e492",
+      "description": "SinglePhoton AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 170080,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:c7e6915e43d1873e1675a79a7feac0b7fe785090",
+      "description": "SinglePhoton AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20006_file_index.json"
+    },
+    {
+      "checksum": "sha1:b919dfd2edda3fbed5d302590b578da51b808fb2",
+      "description": "SinglePhoton AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 279,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20009_file_index.json"
+    },
+    {
+      "checksum": "sha1:cec7ce4c6c97808fda80dc5b5afa4e2506c2e3ca",
+      "description": "SinglePhoton AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 556,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20015_file_index.json"
+    },
+    {
+      "checksum": "sha1:4d7a16afeaebdab2e7889f6e1b546512414db9a5",
+      "description": "SinglePhoton AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 278,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:b3a90ff871a3e666a9938dd595d16d1f870d7ab7",
       "description": "SinglePhoton AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 129740,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:74d4120e48d2a83060487272e5f203e2866d2752",
       "description": "SinglePhoton AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 79820,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8489ae4dbce406e2d3c6a3ca5cddc2ac822355b2",
       "description": "SinglePhoton AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:51c8077afff0fbe728d2cb3561afa8eb04f83623",
       "description": "SinglePhoton AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:5fced397590302355166ba08bb0e8befdc2476f7",
       "description": "SinglePhoton AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 260,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20015_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:59fa52924b8670bfd8db87c26480c698089f70b0",
       "description": "SinglePhoton AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 130,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_30000_file_index.txt"
     }
   ],
@@ -3847,94 +5548,185 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:a90f9afcb0ed78a938ab51f44c3157e77b25773b",
+      "description": "TauParked AOD dataset file index (1 of 13) for access to data via CMS virtual machine",
+      "size": 6577,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "sha1:0d12e81308557c2f0db82bf208716d7f6d7ea3ec",
+      "description": "TauParked AOD dataset file index (2 of 13) for access to data via CMS virtual machine",
+      "size": 289345,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:caf2024c2e46d0a302bb3c837890c291bf81c797",
+      "description": "TauParked AOD dataset file index (3 of 13) for access to data via CMS virtual machine",
+      "size": 269344,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:34b5eb0300ebf4dd62b2670aac1fc12bcac43ca1",
+      "description": "TauParked AOD dataset file index (4 of 13) for access to data via CMS virtual machine",
+      "size": 274002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:afaaa0c3117ddf9d857951710bead3e732f2122d",
+      "description": "TauParked AOD dataset file index (5 of 13) for access to data via CMS virtual machine",
+      "size": 274002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:fdde044aae8bb5bff985dd305ee4ca999343194f",
+      "description": "TauParked AOD dataset file index (6 of 13) for access to data via CMS virtual machine",
+      "size": 92614,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20004_file_index.json"
+    },
+    {
+      "checksum": "sha1:da5164134460654da395aaa1ed067df175bc8cce",
+      "description": "TauParked AOD dataset file index (7 of 13) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20012_file_index.json"
+    },
+    {
+      "checksum": "sha1:5aeec4a8704aa5f6af08fe5f79b84000420cdd3f",
+      "description": "TauParked AOD dataset file index (8 of 13) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20028_file_index.json"
+    },
+    {
+      "checksum": "sha1:c7d09f537609867325094bd8feba5d8717fc8515",
+      "description": "TauParked AOD dataset file index (9 of 13) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20039_file_index.json"
+    },
+    {
+      "checksum": "sha1:80aea84ee27fd945b90664b2283712318a2f2a19",
+      "description": "TauParked AOD dataset file index (10 of 13) for access to data via CMS virtual machine",
+      "size": 550,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20043_file_index.json"
+    },
+    {
+      "checksum": "sha1:8eab8c27755164e7b02233aaf66dbbdbccf79651",
+      "description": "TauParked AOD dataset file index (11 of 13) for access to data via CMS virtual machine",
+      "size": 550,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20046_file_index.json"
+    },
+    {
+      "checksum": "sha1:d5d1c44121a92cc9ab5dc942f69bcf5b9259300b",
+      "description": "TauParked AOD dataset file index (12 of 13) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20048_file_index.json"
+    },
+    {
+      "checksum": "sha1:6e19f176434c9255bd95deffe16ef22cb248c70a",
+      "description": "TauParked AOD dataset file index (13 of 13) for access to data via CMS virtual machine",
+      "size": 276,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20050_file_index.json"
+    },
+    {
+      "checksum": "sha1:91751a03438708e83394e110673cb156d8c05357",
       "description": "TauParked AOD dataset file index (1 of 13) for access to data via CMS virtual machine",
       "size": 3048,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3ecad24403fc71ce61fd33883c8eb66c36392a26",
       "description": "TauParked AOD dataset file index (2 of 13) for access to data via CMS virtual machine",
       "size": 134112,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:55344d5c3d1490f306b9ea43fd5df4fba67619e4",
       "description": "TauParked AOD dataset file index (3 of 13) for access to data via CMS virtual machine",
       "size": 124841,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9e6ff5f99dd18db7d07e91d11fb7241e6b33c8ef",
       "description": "TauParked AOD dataset file index (4 of 13) for access to data via CMS virtual machine",
       "size": 127000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:98c27ca8e0b37aaef3fcef6e79abd05cf57c1eb4",
       "description": "TauParked AOD dataset file index (5 of 13) for access to data via CMS virtual machine",
       "size": 127000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:db2ed3755219a32428cd5b3cc3382b21870ff306",
       "description": "TauParked AOD dataset file index (6 of 13) for access to data via CMS virtual machine",
       "size": 42926,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c6bc7a1bb0341dfcc6525788297ad5e3211eeb9f",
       "description": "TauParked AOD dataset file index (7 of 13) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20012_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c3554f22046c2a1a70acc6465e222583c1dbafd4",
       "description": "TauParked AOD dataset file index (8 of 13) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20028_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d29a91c048bcb580f613c1c5eb7bd031f851f73b",
       "description": "TauParked AOD dataset file index (9 of 13) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20039_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:aa73b6556f71d572b4e632652deb8d749c7fdae7",
       "description": "TauParked AOD dataset file index (10 of 13) for access to data via CMS virtual machine",
       "size": 254,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20043_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1479d71798de46ec83439920cbb8db05194d76b3",
       "description": "TauParked AOD dataset file index (11 of 13) for access to data via CMS virtual machine",
       "size": 254,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20046_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:25877a7df7b95852dff466a183b7723c36ad7821",
       "description": "TauParked AOD dataset file index (12 of 13) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20048_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:64816b998c4b0abc83a47eac2003f7072c8da74f",
       "description": "TauParked AOD dataset file index (13 of 13) for access to data via CMS virtual machine",
       "size": 127,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20050_file_index.txt"
     }
   ],
@@ -4030,101 +5822,199 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:174e7add5e2b92b1e1f0a61782728b03a04d6253",
+      "description": "TauPlusX AOD dataset file index (1 of 14) for access to data via CMS virtual machine",
+      "size": 223862,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:f6a04b8f87cd1977da82d34464023d16649a7322",
+      "description": "TauPlusX AOD dataset file index (2 of 14) for access to data via CMS virtual machine",
+      "size": 146876,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:9d92ddf9fb6f6ef7c08098fceacc9f6cb53915f6",
+      "description": "TauPlusX AOD dataset file index (3 of 14) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_20004_file_index.json"
+    },
+    {
+      "checksum": "sha1:619dad4dd803b2c3f13fee6b00ea2ae99905945a",
+      "description": "TauPlusX AOD dataset file index (4 of 14) for access to data via CMS virtual machine",
+      "size": 439527,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_210000_file_index.json"
+    },
+    {
+      "checksum": "sha1:d265df0f7544cb3e5b82449654de2c9ebe66afbe",
+      "description": "TauPlusX AOD dataset file index (5 of 14) for access to data via CMS virtual machine",
+      "size": 171697,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_210001_file_index.json"
+    },
+    {
+      "checksum": "sha1:11fca40e5eeea9b23dfe892d22773f36e54f5024",
+      "description": "TauPlusX AOD dataset file index (6 of 14) for access to data via CMS virtual machine",
+      "size": 287743,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:ce0d19c669cdc2475a052bc1360a4f2f0db0ef0a",
+      "description": "TauPlusX AOD dataset file index (7 of 14) for access to data via CMS virtual machine",
+      "size": 225227,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:056111799399c25eabe315da42afcdfaaf6f1a0d",
+      "description": "TauPlusX AOD dataset file index (8 of 14) for access to data via CMS virtual machine",
+      "size": 107837,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:ff21eaec0fc7040104c902a8771d2aba37d1ffd9",
+      "description": "TauPlusX AOD dataset file index (9 of 14) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:404f2c4d38012de3a23767f5deeb160d0b843032",
+      "description": "TauPlusX AOD dataset file index (10 of 14) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30008_file_index.json"
+    },
+    {
+      "checksum": "sha1:6310b6d3ec5decd2a075b3b6896c7f72aa683c36",
+      "description": "TauPlusX AOD dataset file index (11 of 14) for access to data via CMS virtual machine",
+      "size": 548,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30022_file_index.json"
+    },
+    {
+      "checksum": "sha1:aeb56647d6b93e084c5c59746c167be498ff4220",
+      "description": "TauPlusX AOD dataset file index (12 of 14) for access to data via CMS virtual machine",
+      "size": 275,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30026_file_index.json"
+    },
+    {
+      "checksum": "sha1:5010a15a5ad85cbd6d1c19d1dc034951e4430823",
+      "description": "TauPlusX AOD dataset file index (13 of 14) for access to data via CMS virtual machine",
+      "size": 381389,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_310000_file_index.json"
+    },
+    {
+      "checksum": "sha1:ff8ab29c9482feedac9817f45a1356718331507f",
+      "description": "TauPlusX AOD dataset file index (14 of 14) for access to data via CMS virtual machine",
+      "size": 160514,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_310001_file_index.json"
+    },
+    {
+      "checksum": "sha1:363c068f3131455449516ab3bc8bdf966b0a9efc",
       "description": "TauPlusX AOD dataset file index (1 of 14) for access to data via CMS virtual machine",
       "size": 103320,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:480b137ca0459be257eaf509cb61e52a220371fa",
       "description": "TauPlusX AOD dataset file index (2 of 14) for access to data via CMS virtual machine",
       "size": 67788,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ed3b54ddf6b31af29c0dac0106cdadc9eb503f90",
       "description": "TauPlusX AOD dataset file index (3 of 14) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_20004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:30bb476564c763458151b3a0d046f9af4a5142da",
       "description": "TauPlusX AOD dataset file index (4 of 14) for access to data via CMS virtual machine",
       "size": 204470,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_210000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9e5305fcf1586462ab8be4f65357f183e659cbbf",
       "description": "TauPlusX AOD dataset file index (5 of 14) for access to data via CMS virtual machine",
       "size": 79883,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_210001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2033c875cdec7fbd07fe755b76140d8ba0ba75ca",
       "description": "TauPlusX AOD dataset file index (6 of 14) for access to data via CMS virtual machine",
       "size": 132804,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:08e9b7ac131064afe645b51b7942f5e607b4e46b",
       "description": "TauPlusX AOD dataset file index (7 of 14) for access to data via CMS virtual machine",
       "size": 103950,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e26810a4711388941f5922b52f7ae5db2da7e1a5",
       "description": "TauPlusX AOD dataset file index (8 of 14) for access to data via CMS virtual machine",
       "size": 49770,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:e7c601066c1820a5967fe72cd8772b3bef763e02",
       "description": "TauPlusX AOD dataset file index (9 of 14) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:32801ecd02df6295862709fba6cb28832e8747c4",
       "description": "TauPlusX AOD dataset file index (10 of 14) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f40a9f36ef7d9eae3ecfb05d8513c214fb21c3fc",
       "description": "TauPlusX AOD dataset file index (11 of 14) for access to data via CMS virtual machine",
       "size": 252,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30022_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2f8533c4e6652d867e1604583965c7863871f1f0",
       "description": "TauPlusX AOD dataset file index (12 of 14) for access to data via CMS virtual machine",
       "size": 126,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30026_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4a55cb7afabac8e88220b1286b68104f00899dab",
       "description": "TauPlusX AOD dataset file index (13 of 14) for access to data via CMS virtual machine",
       "size": 177419,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_310000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:fb11688e602218b12acc5966834c2612a1d3ee84",
       "description": "TauPlusX AOD dataset file index (14 of 14) for access to data via CMS virtual machine",
       "size": 74676,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_310001_file_index.txt"
     }
   ],
@@ -4220,346 +6110,689 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:76264a05c8b4d1b5b11bab29dac961f86fd9d6d6",
+      "description": "VBF1Parked AOD dataset file index (1 of 49) for access to data via CMS virtual machine",
+      "size": 279127,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "sha1:0c4ed2bb9a4e9a6920e954c050bc46ef51808740",
+      "description": "VBF1Parked AOD dataset file index (2 of 49) for access to data via CMS virtual machine",
+      "size": 275552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "sha1:271316e1bb53d767d57bad4ee339c13946f4650c",
+      "description": "VBF1Parked AOD dataset file index (3 of 49) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "sha1:fd53ee5a8c2ade5bca1eb76b447eba89cd7fbbac",
+      "description": "VBF1Parked AOD dataset file index (4 of 49) for access to data via CMS virtual machine",
+      "size": 275827,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "sha1:6e8547c1715e11bdca1f42ef6ca01c34ac865011",
+      "description": "VBF1Parked AOD dataset file index (5 of 49) for access to data via CMS virtual machine",
+      "size": 275277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20004_file_index.json"
+    },
+    {
+      "checksum": "sha1:e58b4e914d0e5838b60f89127bb026eed5967e42",
+      "description": "VBF1Parked AOD dataset file index (6 of 49) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20005_file_index.json"
+    },
+    {
+      "checksum": "sha1:76eaf87caf457e926809840a17524c1da8214ba2",
+      "description": "VBF1Parked AOD dataset file index (7 of 49) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20006_file_index.json"
+    },
+    {
+      "checksum": "sha1:4fc8070f0b358ea5ebc0942e0ae4bf1c293d28b8",
+      "description": "VBF1Parked AOD dataset file index (8 of 49) for access to data via CMS virtual machine",
+      "size": 274727,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20007_file_index.json"
+    },
+    {
+      "checksum": "sha1:d858df9a3697402c305c5789302f5174fce5e822",
+      "description": "VBF1Parked AOD dataset file index (9 of 49) for access to data via CMS virtual machine",
+      "size": 214227,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20008_file_index.json"
+    },
+    {
+      "checksum": "sha1:9d84f24386b76b610192aa4fd37104a142655b8a",
+      "description": "VBF1Parked AOD dataset file index (10 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20015_file_index.json"
+    },
+    {
+      "checksum": "sha1:d17945455babd780499061f8d80c03c5a0d344a9",
+      "description": "VBF1Parked AOD dataset file index (11 of 49) for access to data via CMS virtual machine",
+      "size": 1102,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20017_file_index.json"
+    },
+    {
+      "checksum": "sha1:8c9062311880fa44afb3928d4b316e6e6c5564ce",
+      "description": "VBF1Parked AOD dataset file index (12 of 49) for access to data via CMS virtual machine",
+      "size": 827,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20023_file_index.json"
+    },
+    {
+      "checksum": "sha1:11e633e074a5d59362fad303aaa6ad57cbc6f160",
+      "description": "VBF1Parked AOD dataset file index (13 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20024_file_index.json"
+    },
+    {
+      "checksum": "sha1:cb4821640b786b94a149e8053121b1d64232a3a0",
+      "description": "VBF1Parked AOD dataset file index (14 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20029_file_index.json"
+    },
+    {
+      "checksum": "sha1:1b61cc0ada572dbfee86bedbfddb96ef9724103a",
+      "description": "VBF1Parked AOD dataset file index (15 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20032_file_index.json"
+    },
+    {
+      "checksum": "sha1:a2a5f3c8add607085f6e635d9a31e2e4e18d0cf0",
+      "description": "VBF1Parked AOD dataset file index (16 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20033_file_index.json"
+    },
+    {
+      "checksum": "sha1:054ae1b87ccd6301259e8b0430b99ba126856330",
+      "description": "VBF1Parked AOD dataset file index (17 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20035_file_index.json"
+    },
+    {
+      "checksum": "sha1:595b4c3ab2355d7c3d4157fdf462e28d894631d1",
+      "description": "VBF1Parked AOD dataset file index (18 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20036_file_index.json"
+    },
+    {
+      "checksum": "sha1:893bac5f5be76cc03c3d9b4d07307e569b6d4a57",
+      "description": "VBF1Parked AOD dataset file index (19 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20037_file_index.json"
+    },
+    {
+      "checksum": "sha1:9140a1502983c585dbbe9818ee7902fb7f467129",
+      "description": "VBF1Parked AOD dataset file index (20 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20038_file_index.json"
+    },
+    {
+      "checksum": "sha1:9bc66c6581195fa37b147cb404c353b51ff20b40",
+      "description": "VBF1Parked AOD dataset file index (21 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20040_file_index.json"
+    },
+    {
+      "checksum": "sha1:337512fca9f00697484cac67faf31e5e2c7ba4fc",
+      "description": "VBF1Parked AOD dataset file index (22 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20042_file_index.json"
+    },
+    {
+      "checksum": "sha1:69821c759f1f8170b271ad62ebdce33ac476c649",
+      "description": "VBF1Parked AOD dataset file index (23 of 49) for access to data via CMS virtual machine",
+      "size": 277752,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30000_file_index.json"
+    },
+    {
+      "checksum": "sha1:ec9a9be10e82cf62bea652145db2723b3689cb30",
+      "description": "VBF1Parked AOD dataset file index (24 of 49) for access to data via CMS virtual machine",
+      "size": 275552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30001_file_index.json"
+    },
+    {
+      "checksum": "sha1:079919541fcd89daaf1b2a330cd5e08c6e138b36",
+      "description": "VBF1Parked AOD dataset file index (25 of 49) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30002_file_index.json"
+    },
+    {
+      "checksum": "sha1:cc80c2bc1091f994082f26d546ec36ec5e8f783d",
+      "description": "VBF1Parked AOD dataset file index (26 of 49) for access to data via CMS virtual machine",
+      "size": 275277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30003_file_index.json"
+    },
+    {
+      "checksum": "sha1:69811601668700d7a137695cca7fff40a11b23c1",
+      "description": "VBF1Parked AOD dataset file index (27 of 49) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30004_file_index.json"
+    },
+    {
+      "checksum": "sha1:e2af5fe17b59a19ae4205dad2e831e8505ab6889",
+      "description": "VBF1Parked AOD dataset file index (28 of 49) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30005_file_index.json"
+    },
+    {
+      "checksum": "sha1:da712d059077f379405012fc91fbd8205fc3ebb6",
+      "description": "VBF1Parked AOD dataset file index (29 of 49) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30006_file_index.json"
+    },
+    {
+      "checksum": "sha1:0e996ed8bd671b08cf5c5e0223222b3e8b455b76",
+      "description": "VBF1Parked AOD dataset file index (30 of 49) for access to data via CMS virtual machine",
+      "size": 275552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30007_file_index.json"
+    },
+    {
+      "checksum": "sha1:9132ed564efbaf80833e8340806be9dd049a7d25",
+      "description": "VBF1Parked AOD dataset file index (31 of 49) for access to data via CMS virtual machine",
+      "size": 275002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30008_file_index.json"
+    },
+    {
+      "checksum": "sha1:d6e1ca231bad3ca83606a00ff75d82280c13ab63",
+      "description": "VBF1Parked AOD dataset file index (32 of 49) for access to data via CMS virtual machine",
+      "size": 261252,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30009_file_index.json"
+    },
+    {
+      "checksum": "sha1:4956e1a21b2e88217cb93ae75696e3b08bec4c7f",
+      "description": "VBF1Parked AOD dataset file index (33 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30012_file_index.json"
+    },
+    {
+      "checksum": "sha1:0cb602d6c225ab554553d12f585e41cf22aa051f",
+      "description": "VBF1Parked AOD dataset file index (34 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30015_file_index.json"
+    },
+    {
+      "checksum": "sha1:d0b65e5225be527d2be1430f4a7d5c0189f53460",
+      "description": "VBF1Parked AOD dataset file index (35 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30017_file_index.json"
+    },
+    {
+      "checksum": "sha1:3fcf7fbd07845188d69339ba99c008b01f218997",
+      "description": "VBF1Parked AOD dataset file index (36 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30019_file_index.json"
+    },
+    {
+      "checksum": "sha1:af83b80a6afe34592f82e34ce4619c6112e181ca",
+      "description": "VBF1Parked AOD dataset file index (37 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30023_file_index.json"
+    },
+    {
+      "checksum": "sha1:1409111173539dc0bfec190a91dd6358ebc4cc03",
+      "description": "VBF1Parked AOD dataset file index (38 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30024_file_index.json"
+    },
+    {
+      "checksum": "sha1:e77cc92eee219f2b40553f49f4b7e2c9a940eb80",
+      "description": "VBF1Parked AOD dataset file index (39 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30026_file_index.json"
+    },
+    {
+      "checksum": "sha1:fd5ae25fab7f96f28a6eb516a244e225ee9a1605",
+      "description": "VBF1Parked AOD dataset file index (40 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30028_file_index.json"
+    },
+    {
+      "checksum": "sha1:1c2738ef80c267150bf4cd7d6b3c2f0eb261b504",
+      "description": "VBF1Parked AOD dataset file index (41 of 49) for access to data via CMS virtual machine",
+      "size": 827,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30031_file_index.json"
+    },
+    {
+      "checksum": "sha1:6727298dd1723ce4e8d181f06d8de1bbf152983d",
+      "description": "VBF1Parked AOD dataset file index (42 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30032_file_index.json"
+    },
+    {
+      "checksum": "sha1:1b9cdce68ad9c6e4bef50fd6a2688cf8611eb50b",
+      "description": "VBF1Parked AOD dataset file index (43 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30033_file_index.json"
+    },
+    {
+      "checksum": "sha1:72e8963345c9e930a2239c641a78f404ed4b444d",
+      "description": "VBF1Parked AOD dataset file index (44 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30035_file_index.json"
+    },
+    {
+      "checksum": "sha1:9ace8fe9899285f6f1402a706c38dd46dfdfe205",
+      "description": "VBF1Parked AOD dataset file index (45 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30036_file_index.json"
+    },
+    {
+      "checksum": "sha1:89ba47aa7b59917e8b71bf852532615c11786947",
+      "description": "VBF1Parked AOD dataset file index (46 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30038_file_index.json"
+    },
+    {
+      "checksum": "sha1:a83beb24a595362f928adc6761b3611fba3b363e",
+      "description": "VBF1Parked AOD dataset file index (47 of 49) for access to data via CMS virtual machine",
+      "size": 277,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30039_file_index.json"
+    },
+    {
+      "checksum": "sha1:38b0c52d5182ea1a5b834b7322a77659c3866e6a",
+      "description": "VBF1Parked AOD dataset file index (48 of 49) for access to data via CMS virtual machine",
+      "size": 827,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30041_file_index.json"
+    },
+    {
+      "checksum": "sha1:d910ae6d93f5672d73022b4b6bfdf4f3bda44222",
+      "description": "VBF1Parked AOD dataset file index (49 of 49) for access to data via CMS virtual machine",
+      "size": 552,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30043_file_index.json"
+    },
+    {
+      "checksum": "sha1:3fadcfa2c1911dcf005978ef8420046b4633085f",
       "description": "VBF1Parked AOD dataset file index (1 of 49) for access to data via CMS virtual machine",
       "size": 129920,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:5b5601cd2e888ca9b80d90dbad732a080d3dc563",
       "description": "VBF1Parked AOD dataset file index (2 of 49) for access to data via CMS virtual machine",
       "size": 128256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c97a184432c04d1852ee7d5be21be22818fac941",
       "description": "VBF1Parked AOD dataset file index (3 of 49) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0f286cc66e16ee67b45fcd68c2da5bac37ac996f",
       "description": "VBF1Parked AOD dataset file index (4 of 49) for access to data via CMS virtual machine",
       "size": 128384,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:7750e320f93af9b917cbe6c43a6f7050aab7729f",
       "description": "VBF1Parked AOD dataset file index (5 of 49) for access to data via CMS virtual machine",
       "size": 128128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2430cb490ed28d0165fafab6dc074520b221912f",
       "description": "VBF1Parked AOD dataset file index (6 of 49) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4c1bfad42d00901340656896afab6cf7b4eaac97",
       "description": "VBF1Parked AOD dataset file index (7 of 49) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b48c515bb7506e010da41688c9b61fa1b550c3de",
       "description": "VBF1Parked AOD dataset file index (8 of 49) for access to data via CMS virtual machine",
       "size": 127872,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:654ca390aaf687c5e18b7b39c6de97a7ca5862c7",
       "description": "VBF1Parked AOD dataset file index (9 of 49) for access to data via CMS virtual machine",
       "size": 99712,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ca8f66a00a8a243f21722e2226598f48afba2182",
       "description": "VBF1Parked AOD dataset file index (10 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20015_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9ea978881e0e4e93464c5457bc3e9a6f19559292",
       "description": "VBF1Parked AOD dataset file index (11 of 49) for access to data via CMS virtual machine",
       "size": 512,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20017_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d0dd4b2f75973fdbdf64e722fe25203272177522",
       "description": "VBF1Parked AOD dataset file index (12 of 49) for access to data via CMS virtual machine",
       "size": 384,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20023_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:5fc420dba959965f16a6327fe9444741dac23431",
       "description": "VBF1Parked AOD dataset file index (13 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20024_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8022b0a487a21ddd760b36665443f63396162869",
       "description": "VBF1Parked AOD dataset file index (14 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20029_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2b9bd3c35b06c24b9e72c834722e540262e7efd8",
       "description": "VBF1Parked AOD dataset file index (15 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20032_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:1650ad9f03ecc4897e73bdab286c93fc933c1e9b",
       "description": "VBF1Parked AOD dataset file index (16 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20033_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b22624f23885a6c4ce071ab6546d8f03fc9adc7f",
       "description": "VBF1Parked AOD dataset file index (17 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20035_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:0fdc10c7cefff3562846035b6dd36c4fa9c93fb1",
       "description": "VBF1Parked AOD dataset file index (18 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20036_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:619998301eb8a5bbaf62c030c64484d81690fa99",
       "description": "VBF1Parked AOD dataset file index (19 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20037_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:39c4b559f10a254860ac26613cff6ee1af0d3c85",
       "description": "VBF1Parked AOD dataset file index (20 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20038_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:dc84b810fe55c1845cdc4b2bb7923df706abaf85",
       "description": "VBF1Parked AOD dataset file index (21 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20040_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:00686dd9a26a6224b2bea009b78cc20db8d805bb",
       "description": "VBF1Parked AOD dataset file index (22 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20042_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d9ae7d668a5654258058f6b213ea26448c233976",
       "description": "VBF1Parked AOD dataset file index (23 of 49) for access to data via CMS virtual machine",
       "size": 129280,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30000_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:bb2616ed2e83c0cc64419576adad43e85b43049a",
       "description": "VBF1Parked AOD dataset file index (24 of 49) for access to data via CMS virtual machine",
       "size": 128256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30001_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:83cc24e462e82954db39fb970b22f9a4e4f89fe1",
       "description": "VBF1Parked AOD dataset file index (25 of 49) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30002_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:06b77271868834f7cb9667edbbde41adee351e32",
       "description": "VBF1Parked AOD dataset file index (26 of 49) for access to data via CMS virtual machine",
       "size": 128128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30003_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9897d1c21d096f6ba0b73a10a3b334c0cacc419f",
       "description": "VBF1Parked AOD dataset file index (27 of 49) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30004_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ff26d948abfa3de8a44f428f409ae3f41ecb2698",
       "description": "VBF1Parked AOD dataset file index (28 of 49) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30005_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d68dffcf6577352de1f2e435fa6353c375fc950f",
       "description": "VBF1Parked AOD dataset file index (29 of 49) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30006_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:5bef45714fe9dd19ea9afcfc936d64767366ac5f",
       "description": "VBF1Parked AOD dataset file index (30 of 49) for access to data via CMS virtual machine",
       "size": 128256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30007_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4ecff52b6e6946b69e04cc71b6f6ee42ddee8d19",
       "description": "VBF1Parked AOD dataset file index (31 of 49) for access to data via CMS virtual machine",
       "size": 128000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30008_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f39a4b8f5afcb31b744cd508569c64ac2fb2f97b",
       "description": "VBF1Parked AOD dataset file index (32 of 49) for access to data via CMS virtual machine",
       "size": 121600,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30009_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:4c93e1e1af0a5a3ab71712b528ae709533c6238f",
       "description": "VBF1Parked AOD dataset file index (33 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30012_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:f58a390c4f423b6b9f97507c56d3c33167e3ea59",
       "description": "VBF1Parked AOD dataset file index (34 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30015_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3cd3504f882cfe1aa14831342f4f2fb26419dbd7",
       "description": "VBF1Parked AOD dataset file index (35 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30017_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:15d355bd5b047c22664a5ecdd4bc6792b0fa668a",
       "description": "VBF1Parked AOD dataset file index (36 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30019_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c8e2c7ac1b3734b9f6a00fd02293af3b04e169c5",
       "description": "VBF1Parked AOD dataset file index (37 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30023_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:ccb46d4a129d2d7397cf18261ae107d62d0ac0df",
       "description": "VBF1Parked AOD dataset file index (38 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30024_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:d283c4af4feea6aff5448ed935164dae152fc340",
       "description": "VBF1Parked AOD dataset file index (39 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30026_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:47ae69d202b3509c7f2c4ac2f2e0f3fb9f65ed39",
       "description": "VBF1Parked AOD dataset file index (40 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30028_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:283b8ef06d3478491f7b4b14030e08282781e0b2",
       "description": "VBF1Parked AOD dataset file index (41 of 49) for access to data via CMS virtual machine",
       "size": 384,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30031_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:2a6214a6e0384254d33a2405d7e9da6caea34897",
       "description": "VBF1Parked AOD dataset file index (42 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30032_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:483b668b7735755bc03c98a2265ac599d41ff7ab",
       "description": "VBF1Parked AOD dataset file index (43 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30033_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:b4f631cad8588de7f5b179adcbf669330c958e62",
       "description": "VBF1Parked AOD dataset file index (44 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30035_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:acf5e117ed4ddf56526393746c013fc26d6b7dd3",
       "description": "VBF1Parked AOD dataset file index (45 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30036_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:9c579f132ec71ca750939161ce12b6eb00a3f9f2",
       "description": "VBF1Parked AOD dataset file index (46 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30038_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:3487d1bcf0e58abb863df35df8c87f609c715997",
       "description": "VBF1Parked AOD dataset file index (47 of 49) for access to data via CMS virtual machine",
       "size": 128,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30039_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:8963ebda38bf714f2be29ced67bff2661d009ae8",
       "description": "VBF1Parked AOD dataset file index (48 of 49) for access to data via CMS virtual machine",
       "size": 384,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30041_file_index.txt"
     },
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "sha1:c5debcd95bd6d7a11f2695a43c3e52ea21f86025",
       "description": "VBF1Parked AOD dataset file index (49 of 49) for access to data via CMS virtual machine",
       "size": 256,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30043_file_index.txt"
     }
   ],


### PR DESCRIPTION
* Adds rich index files (in TXT and JSON formats) for CMS 2012 collision
  datasets. (addresses #2093)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>