### PR TITLE
records: addition of missing file for CMS HiggsExample11-12

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-higgsexample11-12.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-higgsexample11-12.json
@@ -45,6 +45,11 @@
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/HiggsDemoAnalyzer.cc"
     },
     {
+      "checksum": "adler32:46a907fc",
+      "size": 1669,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/List_indexfile.txt"
+    },
+    {
       "checksum": "adler32:af301992",
       "size": 14943,
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/M4Lnormdatall.cc"},

--- a/cernopendata/modules/fixtures/data/records/cms-tools-higgsexample20112012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-higgsexample20112012.json
@@ -25,6 +25,7 @@
       "py",
       "cc",
       "xml",
+      "txt",
       "pdf",
       "png"
     ],
@@ -37,56 +38,56 @@
     {
       "checksum": "adler32:ff63668a",
       "size": 305,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/BuildFile.xml"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/BuildFile.xml"
     },
     {
       "checksum": "adler32:f205f068",
       "size": 83761,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/HiggsDemoAnalyzer.cc"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/HiggsDemoAnalyzer.cc"
     },
     {
       "checksum": "adler32:46a907fc",
       "size": 1669,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/List_indexfile.txt"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/List_indexfile.txt"
     },
     {
       "checksum": "adler32:af301992",
       "size": 14943,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/M4Lnormdatall.cc"},
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/M4Lnormdatall.cc"},
     {
       "checksum": "adler32:9d9b2126",
       "size": 15805,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/M4Lnormdatall_lvl3.cc"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/M4Lnormdatall_lvl3.cc"
     },
     {
       "checksum": "adler32:cc943381",
       "size": 3741,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/demoanalyzer_cfg_level3MC.py"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/demoanalyzer_cfg_level3MC.py"
     },
     {
       "checksum": "adler32:1d3e2a43",
       "size": 3689,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/demoanalyzer_cfg_level3data.py"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/demoanalyzer_cfg_level3data.py"
     },
     {
       "checksum": "adler32:9cbd53a3",
       "size": 3874,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/demoanalyzer_cfg_level4MC.py"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/demoanalyzer_cfg_level4MC.py"
     },
     {
       "checksum": "adler32:177b49c0",
       "size": 3821,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/demoanalyzer_cfg_level4data.py"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/demoanalyzer_cfg_level4data.py"
     },
     {
       "checksum": "adler32:19c6a6a2",
       "size": 18170,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/mass4l_combine.pdf"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/mass4l_combine.pdf"
     },
     {
       "checksum": "adler32:62e0c299",
       "size": 93152,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/mass4l_combine.png"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/mass4l_combine.png"
     }
   ],
   "license": {
@@ -216,117 +217,117 @@
     {
       "checksum": "adler32:90cb6b24",
       "size": 66215,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/DY1011.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/DY1011.root"
     },
     {
       "checksum": "adler32:a55fe748",
       "size": 67648,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/DY1012.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/DY1012.root"
     },
     {
       "checksum": "adler32:b87b46e3",
       "size": 65418,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/DY101Jets12.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/DY101Jets12.root"
     },
     {
       "checksum": "adler32:ef0a2275",
       "size": 71402,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/DY50Mag12.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/DY50Mag12.root"
     },
     {
       "checksum": "adler32:c166c66b",
       "size": 71524,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/DY50TuneZ11.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/DY50TuneZ11.root"
     },
     {
       "checksum": "adler32:b82b0a01",
       "size": 70776,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/DY50TuneZ12.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/DY50TuneZ12.root"
     },
     {
       "checksum": "adler32:e7764055",
       "size": 61720,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/DYTo2mu12.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/DYTo2mu12.root"
     },
     {
       "checksum": "adler32:7944cd82",
       "size": 68531,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/DoubleE11.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/DoubleE11.root"
     },
     {
       "checksum": "adler32:6f7b4a98",
       "size": 71621,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/DoubleE12.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/DoubleE12.root"
     },
     {
       "checksum": "adler32:86de9000",
       "size": 70933,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/DoubleMu11.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/DoubleMu11.root"
     },
     {
       "checksum": "adler32:63849033",
       "size": 74483,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/DoubleMu12.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/DoubleMu12.root"
     },
     {
       "checksum": "adler32:6bca010d",
       "size": 70789,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/HZZ11.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/HZZ11.root"
     },
     {
       "checksum": "adler32:4169df3f",
       "size": 70752,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/HZZ12.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/HZZ12.root"
     },
     {
       "checksum": "adler32:5c10862e",
       "size": 71657,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/TTBar11.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/TTBar11.root"
     },
     {
       "checksum": "adler32:eb78c43b",
       "size": 67994,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/TTBar12.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/TTBar12.root"
     },
     {
       "checksum": "adler32:bb54e5de",
       "size": 73350,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/TTJets11.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/TTJets11.root"
     },
     {
       "checksum": "adler32:8f268633",
       "size": 73386,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/TTJets12.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/TTJets12.root"
     },
     {
       "checksum": "adler32:a1aa79d6",
       "size": 69836,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/ZZ2mu2e11.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/ZZ2mu2e11.root"
     },
     {
       "checksum": "adler32:bc06de85",
       "size": 69966,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/ZZ2mu2e12.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/ZZ2mu2e12.root"
     },
     {
       "checksum": "adler32:f65713e6",
       "size": 64345,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/ZZ4e11.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/ZZ4e11.root"
     },
     {
       "checksum": "adler32:191e5429",
       "size": 65011,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/ZZ4e12.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/ZZ4e12.root"
     },
     {
       "checksum": "adler32:9f269d41",
       "size": 67169,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/ZZ4mu11.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/ZZ4mu11.root"
     },
     {
       "checksum": "adler32:58bebe9e",
       "size": 67882,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample11-12/ZZ4mu12.root"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsExample20112012/ZZ4mu12.root"
     }
   ],
   "license": {


### PR DESCRIPTION
* Adds one file that was accidentally left out to the H4L analysis example
  software record. (addresses #1966)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>