### PR TITLE
records: CMS 2011 dimuon spectrum file updates

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-dimuon-spectrum-2011.json
+++ b/cernopendata/modules/fixtures/data/records/cms-dimuon-spectrum-2011.json
@@ -25,7 +25,11 @@
   "date_published": "2017",
   "distribution": {
     "formats": [
-      "gz"
+      "cc", 
+      "gz", 
+      "py", 
+      "root", 
+      "xml"
     ],
     "number_files": 1,
     "size": 122975
@@ -34,9 +38,29 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:4bfc8b8bad13b9c2dbf2d091cc6bf171a1877845",
-      "size": 122975,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/DimuonSpectrum2011/DimuonSpectrum2011-1.0.0.tar.gz"
+      "checksum": "adler32:6e016b92",
+      "size": 123567,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/DimuonSpectrum2011/DimuonSpectrum2011-1.0.3.tar.gz"
+    },
+    {
+      "checksum": "adler32:19ce6f2b",
+      "size": 331,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-spectrum-2011/BuildFile.xml"
+    },
+    {
+      "checksum": "adler32:327d8f5d",
+      "size": 14689,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-spectrum-2011/DemoAnalyzer.cc"
+    },
+    {
+      "checksum": "adler32:e6e3930e",
+      "size": 16435,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-spectrum-2011/Mudemo.root"
+    },
+    {
+      "checksum": "adler32:a2784e3a",
+      "size": 3826,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-spectrum-2011/demoanalyzer_cfg.py"
     }
   ],
   "license": {


### PR DESCRIPTION
* Adds new release of DimuonSpectrum2011 v1.0.3 and attaches individual files
  for the CMS 2011 dimuon spectrum record. (closes #2132)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>