### PR TITLE
installation: addition of web-files service

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -103,6 +103,43 @@ services:
       - rabbitmq
       - wdb
 
+  web-files:
+    restart: "always"
+    image: cernopendata/static # Use this to make sure that COD3 Python-code image is built only once.
+    depends_on:
+      - static # Just to make sure that latest cernopendata/static -image is build before creating this container.
+    command: "cernopendata run -h 0.0.0.0" # In case one needs to test/work with uWSGI comment out this.
+    environment:
+      - DEBUG=True
+      - WDB_SOCKET_SERVER=wdb
+      - WDB_NO_BROWSER_AUTO_OPEN=True
+      - APP_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://cernopendata:dbpass123@postgresql:5432/cernopendata
+      - APP_CACHE_REDIS_HOST=redis
+      - APP_CACHE_REDIS_URL=redis://redis:6379/0
+      - APP_ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/1
+      - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 3
+      - APP_CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 4
+      - APP_CELERY_RESULT_BACKEND=redis://redis:6379/2
+      - APP_SEARCH_ELASTIC_HOSTS=elasticsearch
+      - APP_PIDSTORE_DATACITE_TESTMODE=False
+      - APP_PIDSTORE_DATACITE_DOI_PREFIX=10.5072
+      - APP_PIDSTORE_DATACITE_USERNAME=CERN.OPENDATA
+      - APP_PIDSTORE_DATACITE_PASSWORD=CHANGE_ME
+      - APP_PIDSTORE_LANDING_BASE_URL=http://opendata.cern.ch/record/
+    volumes:
+      - ./cernopendata:/code/cernopendata
+      - ./scripts:/code/scripts
+    volumes_from:
+      - static
+    links:
+      - postgresql
+      - redis
+      - elasticsearch
+      - rabbitmq
+      - wdb
+    ports:
+      - "5001:5000"
+
   postgresql:
     restart: "always"
     image: postgres
@@ -152,6 +189,7 @@ services:
       - static
     links:
       - web
+      - web-files
 
   static:
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,46 @@ services:
       - elasticsearch
       - rabbitmq
 
+  web-files:
+    restart: "always"
+    build:
+      context: .
+    image: cernopendata/web
+    depends_on:
+      - elasticsearch
+      - postgresql
+      - rabbitmq
+      - redis
+    environment:
+      - DEBUG=False
+      - APP_SQLALCHEMY_DATABASE_URI=postgresql+psycopg2://cernopendata:dbpass123@postgresql:5432/cernopendata
+      - APP_CACHE_REDIS_HOST=redis
+      - APP_CACHE_REDIS_URL=redis://redis:6379/0
+      - APP_ACCOUNTS_SESSION_REDIS_URL=redis://redis:6379/1
+      - APP_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 3
+      - APP_CELERY_BROKER_URL=amqp://guest:guest@rabbitmq:5672/ # Celery 4
+      - APP_CELERY_RESULT_BACKEND=redis://redis:6379/2
+      - APP_PIDSTORE_DATACITE_TESTMODE=False
+      - APP_PIDSTORE_DATACITE_DOI_PREFIX=10.5072
+      - APP_PIDSTORE_DATACITE_USERNAME=CERN.OPENDATA
+      - APP_PIDSTORE_DATACITE_PASSWORD=CHANGE_ME
+      - APP_PIDSTORE_LANDING_BASE_URL=http://opendata.cern.ch/record/
+      - ELASTICSEARCH_HOST=elasticsearch-proxy
+      - ELASTICSEARCH_PORT=443
+      - ELASTICSEARCH_USER=esuser
+      - ELASTICSEARCH_PASSWORD=espass
+      - ELASTICSEARCH_USE_SSL=true
+      - ELASTICSEARCH_VERIFY_CERTS=false
+    volumes:
+      - web_data:/usr/local/var/cernopendata/var/cernopendata-instance/static
+    links:
+      - postgresql
+      - redis
+      - elasticsearch
+      - rabbitmq
+    ports:
+      - "5000"
+
   postgresql:
     restart: "always"
     image: postgres
@@ -158,6 +198,7 @@ services:
       - web_data:/usr/local/var/cernopendata/var/cernopendata-instance/static
     links:
       - web
+      - web-files
 
 volumes:
   web_data:

--- a/nginx/cernopendata.conf
+++ b/nginx/cernopendata.conf
@@ -1,11 +1,27 @@
 
 # Cache for ''*/files/*'
-proxy_cache_path /var/cache/nginx/cache_cod_files levels=1:2 keys_zone=cache_cod_files:100m inactive=60m max_size=500m use_temp_path=off;
+proxy_cache_path /var/cache/nginx/cache_web_files levels=1:2 keys_zone=cache_web_files:100m inactive=60m max_size=500m use_temp_path=off;
 
 # Cache for anything else than '*/files/*'
-proxy_cache_path /var/cache/nginx/cache_cod_global levels=1:2 keys_zone=cache_cod_global:100m inactive=60m max_size=500m use_temp_path=off;
+proxy_cache_path /var/cache/nginx/cache_web_app levels=1:2 keys_zone=cache_web_app:100m inactive=60m max_size=500m use_temp_path=off;
 
 large_client_header_buffers 8 32k;
+
+upstream web-files {
+    server web-files:5000 max_conns=4;
+}
+
+upstream web-app {
+    server web:5000 max_conns=4;
+}
+
+# From: https://forum.nginx.org/read.php?2,253260,253662#msg-253662
+# Something like this should work to disable cache for responses
+# with Content-Length larger than 1000000:
+map $upstream_http_content_length $nocache {
+    default 1;
+    "~^[1-9]{0,6}$" 0;
+}
 
 server {
     listen 80 default;
@@ -23,7 +39,7 @@ server {
     location ~ ^/(?!(\b(files/|record/|static/|eos/)\b)).*[A-Z] {
         # Simple rewriter that rewrites everything in path to lowercase
         # and continues processing of rewritten URI with internal_redirect.
-        # Doesn't update URI displayed in browser.
+        # Doesn't update URI displayed in browser
         perl 'sub { my $r = shift; $r->internal_redirect(lc($r->uri)); }';
     }
 
@@ -34,7 +50,8 @@ server {
     # Cache any URL that has '/files/' pattern in it.
     # (e.g. '/records/123/files/abc', '/dataset/test/files/storage/higgs.txt')
     location ~ ^/.+/files/.+ {
-        proxy_cache cache_cod_files;
+        proxy_no_cache $nocache;
+        proxy_cache cache_web_files;
         proxy_cache_key $host$uri$is_args$args;
         proxy_cache_valid 200 301 302 30m;
         expires 1h;
@@ -42,11 +59,11 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_ignore_headers Set-Cookie;
-        proxy_pass http://web:5000;
+        proxy_pass http://web-files;
     }
 
     location / {
-        proxy_cache cache_cod_global;
+        proxy_cache cache_web_app;
         proxy_cache_key $host$uri$is_args$args;
         proxy_cache_valid 200 301 302 30m;
         expires 1h;
@@ -54,7 +71,7 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_ignore_headers Set-Cookie;
-        proxy_pass http://web:5000;
+        proxy_pass http://web-app;
     }
 
 }


### PR DESCRIPTION
* Introduces web-files service that is dedicated to serving `*/files/*` pages.
  Amends nginx proxy forwarding accordingly. (closes #2130)

* Note that this commit adds a minimal working example tested on both DEV snd
  PROD deployment scenarios. The proxy parameters will be tuned later based on
  wider performance tests.

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>
Co-authored-by: Tibor Simko <tibor.simko@cern.ch>
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>