### PR TITLE
records: renaming of Dimuon SingleMu/DoubleMu files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-csv-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-csv-Run2011A.json
@@ -133,12 +133,12 @@
     {
       "checksum": "sha1:a340510faad27eb26e7c5507bda17be245e51b58", 
       "size": 11806904, 
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/CSV/12Oct2013-v1/Dimuon.csv"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/CSV/12Oct2013-v1/Dimuon_SingleMu.csv"
     }, 
     {
       "checksum": "sha1:0a5808fab9b380dce5d55f2aa5864f2931d49404", 
       "size": 13935840, 
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/CSV/12Oct2013-v1/Dimuon.csv"
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/CSV/12Oct2013-v1/Dimuon_DoubleMu.csv"
     }, 
     {
       "checksum": "sha1:8cc5dae7b28a24ed17e7b1cf05cbb21092e8d85a", 


### PR DESCRIPTION
* Renames `Dimuon.csv` files in record 545 to `Dimuon_SingleMu.csv` and
  `Dimuon_DoubleMu.csv` following up EOS file name updates. (closes #1299)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>