### PR TITLE
docs: CMS dimuon spectrum 2011 file removal

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-dimuon-spectrum-2011.json
+++ b/cernopendata/modules/fixtures/data/records/cms-dimuon-spectrum-2011.json
@@ -25,23 +25,17 @@
   "date_published": "2017",
   "distribution": {
     "formats": [
-      "cc", 
-      "gz", 
-      "py", 
-      "root", 
+      "cc",
+      "py",
+      "root",
       "xml"
     ],
-    "number_files": 1,
-    "size": 122975
+    "number_files": 4,
+    "size": 35281
   },
   "doi": "10.7483/OPENDATA.CMS.D00J.UVB1",
   "experiment": "CMS",
   "files": [
-    {
-      "checksum": "adler32:6e016b92",
-      "size": 123567,
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/DimuonSpectrum2011/DimuonSpectrum2011-1.0.3.tar.gz"
-    },
     {
       "checksum": "adler32:19ce6f2b",
       "size": 331,


### PR DESCRIPTION
* Removes tarball for the CMS dimuon spectrum 2011 record. (closes #2174)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>