### PR TITLE
fixtures: fix for `--skip-files` mode

### DIFF
--- a/cernopendata/modules/fixtures/cli.py
+++ b/cernopendata/modules/fixtures/cli.py
@@ -220,7 +220,8 @@ def records(skip_files, files, profile, mode):
                         pid, schema, data, files, skip_files)
                     action = 'updated'
 
-                record.files.flush()
+                if not skip_files:
+                    record.files.flush()
                 record.commit()
                 db.session.commit()
                 click.echo(

--- a/cernopendata/templates/cernopendata_records_ui/records/detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/detail.html
@@ -79,7 +79,9 @@
                         {% endif %}
                         {% endblock metadata_block %}
 
+                        {% if record.files %}
                         {% include 'cernopendata_records_ui/records/components/previewer.html' %}
+                        {% endif %}
 
                         {% block files_block %}
                         <div ng-controller="paginationCtrl as $ctrl" ng-init="$ctrl.getFiles()">


### PR DESCRIPTION
* Fixes traceback in fixture loading in the `--skip-files` mode following up the
  PR #2108.

* Fixes traceback in the detailed record page view on case there are no files
  attached to the record.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>