### PR TITLE
records: CMS 2012 simulated dataset generation information

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-configuration-files-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-configuration-files-2012.json
@@ -49,6 +49,54 @@
   },
   {
     "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "0d0714743f0204ed3c0144941eb3ca01",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5015
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:77558fd0580cb6f896cfe804cc17f1bea5c1e982",
+        "size": 5015,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0d0714743f0204ed3c0144941eb3ca01.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11001",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01894_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
       "description": "The configuration file used in RECO data processing step."
     },
     "accelerator": "CERN-LHC",
@@ -85,7 +133,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11001",
+    "recid": "11002",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step B2G-Summer12DR53X-00678_2_cfg",
     "type": {
@@ -133,7 +181,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11002",
+    "recid": "11003",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step ",
     "type": {
@@ -181,7 +229,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11003",
+    "recid": "11004",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
     "type": {
@@ -229,9 +277,201 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11004",
+    "recid": "11005",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "4740397cabbd08f77e728185d3901e4d",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 3960
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:47300e6f254c27a79cfc99b1b9569baffd3108a1",
+        "size": 3960,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4740397cabbd08f77e728185d3901e4d.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11006",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step FWD-Summer12-00027_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "4ab3250d23e554446ebc010f2394f820",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7206
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:ac71a4df5442f12af64fbb61056b237621ae938a",
+        "size": 7206,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4ab3250d23e554446ebc010f2394f820.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11007",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00293_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "8ff550697a152ca7e29535c8e2cdbc34",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 829102
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:ff55c74837179dc27c267e21e40c4f7b9be19cc1",
+        "size": 829102,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8ff550697a152ca7e29535c8e2cdbc34.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11008",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> ZZ -> 4l at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "df06ea86f6f8e8b03d64449d07d23f57",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 579953
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:0de1b4f48512a48b459261fb3b72c9d6605f62ad",
+        "size": 579953,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/df06ea86f6f8e8b03d64449d07d23f57.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11009",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -277,9 +517,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11005",
+    "recid": "11010",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step EXO-Summer12DR53X-02706_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> mumu, pThat = 170 .. 230 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "c8516b9454a656fd0efc1742d400d015",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13621
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:aed228472a95baaddb9164a498fe75368589a03f",
+        "size": 13621,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d400d015.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11011",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_9_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -325,7 +613,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11006",
+    "recid": "11012",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01521_1_cfg",
     "type": {
@@ -373,7 +661,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11007",
+    "recid": "11013",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01745_2_cfg",
     "type": {
@@ -421,7 +709,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11008",
+    "recid": "11014",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step ",
     "type": {
@@ -469,7 +757,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11009",
+    "recid": "11015",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step B2G-Summer12DR53X-00692_1_cfg",
     "type": {
@@ -517,7 +805,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11010",
+    "recid": "11016",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step B2G-Summer12DR53X-00594_1_cfg",
     "type": {
@@ -565,7 +853,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11011",
+    "recid": "11017",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01503_2_cfg",
     "type": {
@@ -613,7 +901,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11012",
+    "recid": "11018",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
     "type": {
@@ -661,9 +949,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11013",
+    "recid": "11019",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> mumu, pThat = 30 .. 50 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "db0105697625bdea8cedb18cd3ffa279",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13614
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:332ef25066b9daaabbb9a6fa4e20441c6974d9c6",
+        "size": 13614,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/db0105697625bdea8cedb18cd3ffa279.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11020",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_4_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -709,7 +1045,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11014",
+    "recid": "11021",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
     "type": {
@@ -757,7 +1093,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11015",
+    "recid": "11022",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
     "type": {
@@ -805,9 +1141,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11016",
+    "recid": "11023",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step B2G-Summer12DR53X-00431_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "2fecc267b797a1ea84edb843fbf9f2c7",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 513913
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:b05dc81d8f1baea40e786fd5f72e41a2aa9abf65",
+        "size": 513913,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2fecc267b797a1ea84edb843fbf9f2c7.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11024",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -853,7 +1237,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11017",
+    "recid": "11025",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step ",
     "type": {
@@ -901,7 +1285,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11018",
+    "recid": "11026",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step EWK-Summer12DR53X-00159_2_cfg",
     "type": {
@@ -949,7 +1333,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11019",
+    "recid": "11027",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01646_2_cfg",
     "type": {
@@ -997,9 +1381,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11020",
+    "recid": "11028",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step B2G-Summer12DR53X-00770_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "a8b87e4a93ad780670c2864baf18d8f4",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6207
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:bfbadbf5ad5278047c25bd7d492034a47110fb6c",
+        "size": 6207,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/a8b87e4a93ad780670c2864baf18d8f4.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11029",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00192_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "320df834ed2a0446c7a2485723eaebfa",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5688
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:a027e0a15c2e02674ced77f3eb6a46fcbbe612d9",
+        "size": 5688,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/320df834ed2a0446c7a2485723eaebfa.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11030",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00268_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -1045,7 +1525,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11021",
+    "recid": "11031",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg",
     "type": {
@@ -1093,7 +1573,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11022",
+    "recid": "11032",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
     "type": {
@@ -1141,9 +1621,201 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11023",
+    "recid": "11033",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01930_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> ZZ -> 2l2nu at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "bba69ae19e1fbc577b22ff737999dfc2",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8539
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:3016b84cbda7bbd1aff12ca2ce70ded8b7419a58",
+        "size": 8539,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/bba69ae19e1fbc577b22ff737999dfc2.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11034",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01808_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "791a4c1208863ba7b363a500a0f5e296",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6341
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:396ef1350c0d3357dacfa0271319bd67ae1db291",
+        "size": 6341,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/791a4c1208863ba7b363a500a0f5e296.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11035",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01739_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> 2gamma at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "7418839ecfc94eb105cf051859e786d5",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 519377
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:e5e327ade43d1b8433bcdc668759553efeecb65f",
+        "size": 519377,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7418839ecfc94eb105cf051859e786d5.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11036",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "c5be5f65754ad5ed58ab89beb1f6b672",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7171
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:324d683f047af0ab32906e30997d5df4cac46f3c",
+        "size": 7171,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c5be5f65754ad5ed58ab89beb1f6b672.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11037",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step EWK-Summer12-00145_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -1189,7 +1861,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11024",
+    "recid": "11038",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-02045_2_cfg",
     "type": {
@@ -1237,7 +1909,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11025",
+    "recid": "11039",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01981_2_cfg",
     "type": {
@@ -1285,7 +1957,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11026",
+    "recid": "11040",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step ",
     "type": {
@@ -1333,9 +2005,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11027",
+    "recid": "11041",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "426fb7c8dfa9efe58cac3521728d4943",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6723
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:71fd9b93df93e30d2cadc9def78e91a12fdd1ff9",
+        "size": 6723,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/426fb7c8dfa9efe58cac3521728d4943.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11042",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02121_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -1381,7 +2101,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11028",
+    "recid": "11043",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
     "type": {
@@ -1429,9 +2149,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11029",
+    "recid": "11044",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01937_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "5970a6fbd16ef9292bc7b024546d32d1",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7163
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:75097eb28d65d9d681951bd56b3a56fc8ac1fc23",
+        "size": 7163,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/5970a6fbd16ef9292bc7b024546d32d1.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11045",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00229_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -1477,7 +2245,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11030",
+    "recid": "11046",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step ",
     "type": {
@@ -1525,7 +2293,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11031",
+    "recid": "11047",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step EXO-Summer12DR53X-02813_1_cfg",
     "type": {
@@ -1573,7 +2341,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11032",
+    "recid": "11048",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
     "type": {
@@ -1621,9 +2389,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11033",
+    "recid": "11049",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step EXO-Summer12DR53X-02627_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> bb  at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "68bc98ede8b255529ddfb5a59dfdd761",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 578697
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:570db487a7e37f79a16444a2d7052c023ce581ad",
+        "size": 578697,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/68bc98ede8b255529ddfb5a59dfdd761.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11050",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -1669,9 +2485,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11034",
+    "recid": "11051",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01346_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Showering of generic aMCatNLO events with Herwig, 8 TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "476ed66a3dbb1efee54679522acfbbb2",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5471
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:fbd1b5efb5e0d8660514708db3dd59d2cc7f1c67",
+        "size": 5471,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/476ed66a3dbb1efee54679522acfbbb2.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11052",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_26_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "38a55ca555837edbc1cefe73e21f44e7",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6863
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:5227ecb0be5d3bb3c325501f85f807e4db12b1c5",
+        "size": 6863,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/38a55ca555837edbc1cefe73e21f44e7.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11053",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step SUS-Summer12-00097_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -1717,7 +2629,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11035",
+    "recid": "11054",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step ",
     "type": {
@@ -1765,9 +2677,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11036",
+    "recid": "11055",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "64b5791933f6728b5da9a18618023f81",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6183
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:213d91d9d21c1d7108b45a8753cdf55eea7c8320",
+        "size": 6183,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/64b5791933f6728b5da9a18618023f81.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11056",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01723_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> 2taus at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "2ee2be9aece8ed5991b918d37b75a7b5",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7642
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:9d1c7b51ad4185c0091d9d656db5d49e64309909",
+        "size": 7642,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2ee2be9aece8ed5991b918d37b75a7b5.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11057",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02140_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -1813,7 +2821,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11037",
+    "recid": "11058",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step ",
     "type": {
@@ -1861,7 +2869,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11038",
+    "recid": "11059",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step JME-Summer12DR53X-00163_2_cfg",
     "type": {
@@ -1909,9 +2917,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11039",
+    "recid": "11060",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> mumu, pThat = 15 .. 20 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "76b67a85cce50002d1f4cece162052f3",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13562
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:e3914f8d3f45467dd02055382a7848ca8b928443",
+        "size": 13562,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/76b67a85cce50002d1f4cece162052f3.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11061",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step JME-Summer12-00141_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "b0a9b9b5c10ea2a462ecdb5666e72aba",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 576645
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:bb8e8935cd7fdde65c30b21cfc42d9dce3f3ebaf",
+        "size": 576645,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b0a9b9b5c10ea2a462ecdb5666e72aba.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11062",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -1957,7 +3061,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11040",
+    "recid": "11063",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step JME-Summer12DR53X-00162_2_cfg",
     "type": {
@@ -2005,9 +3109,297 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11041",
+    "recid": "11064",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> ee, pThat > 300 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "db0105697625bdea8cedb18cd3ffdaa1",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13546
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:597dacae07d8b66e7fc03b434dbadbaacf72a58c",
+        "size": 13546,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/db0105697625bdea8cedb18cd3ffdaa1.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11065",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_5_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Herwig+Jimmy generation of QCD events, 8 TeV, CTEQ6L1, pthat [600,800] GeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "26fdddf613007b2ae46390fe57c48985",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 574951
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:6f25f7efcfb6124f959b634b3f768677ad2e00d8",
+        "size": 574951,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/26fdddf613007b2ae46390fe57c48985.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11066",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "320df834ed2a0446c7a2485723e840ff",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6752
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:177a621afc6588403059b1d0d8377b4f905d73c5",
+        "size": 6752,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/320df834ed2a0446c7a2485723e840ff.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11067",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02150_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> ee, pThat = 80 .. 120 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "c8516b9454a656fd0efc1742d4012f58",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13612
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:7b4f0aad98d67769a3c5b6a4e6401e2ed58b593a",
+        "size": 13612,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d4012f58.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11068",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_11_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "bbc8b4b8c9757ca67c6695d4cf5cc97f",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 578849
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:8f1ff42987aee352a7f98b50599752b334e3e0f2",
+        "size": 578849,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/bbc8b4b8c9757ca67c6695d4cf5cc97f.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11069",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "cec87afc37373850854c6eeb5a05a6ec",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 580565
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:5d829507508ff6cdcecb2402e523ccef62609ef5",
+        "size": 580565,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cec87afc37373850854c6eeb5a05a6ec.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11070",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2053,7 +3445,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11042",
+    "recid": "11071",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step ",
     "type": {
@@ -2101,7 +3493,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11043",
+    "recid": "11072",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
     "type": {
@@ -2149,9 +3541,201 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11044",
+    "recid": "11073",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "5f4b0cd39df51764c7fdb4d539b792fc",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 23285
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:ab9ef2e51e3d28d575c33e5133fa2f950e880432",
+        "size": 23285,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/5f4b0cd39df51764c7fdb4d539b792fc.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11074",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_2_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for PYTHIA6 bbH, H->tautau mH=125GeV with TAUOLA at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "a97a2f6c22dfba999c0131657a81ecfd",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7918
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:6fc0fe37956331f6d7fde7c2dc15e1250988da31",
+        "size": 7918,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/a97a2f6c22dfba999c0131657a81ecfd.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11075",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02276_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "7a7fe226d63c57f01b9283607fae7215",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 578252
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:88c0e2672f9a1bb49da9f924ef7a41733d477b71",
+        "size": 578252,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7a7fe226d63c57f01b9283607fae7215.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11076",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Herwig+Jimmy generation of QCD events, 8 TeV, CTEQ6L1, pthat [470,600] GeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "26fdddf613007b2ae46390fe57c51d48",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 574951
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:fcd42fa7d9c835839577b26db2f8e9ed02f66599",
+        "size": 574951,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/26fdddf613007b2ae46390fe57c51d48.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11077",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2197,7 +3781,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11045",
+    "recid": "11078",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step EXO-Summer12DR53X-02796_1_cfg",
     "type": {
@@ -2245,9 +3829,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11046",
+    "recid": "11079",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "fd559aa178861e2e34ae2dc367593c00",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7200
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:c063f5a1a336b8f161f88cea71d4ca7eec5a21c5",
+        "size": 7200,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/fd559aa178861e2e34ae2dc367593c00.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11080",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00264_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> ZZ -> 4l at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "7117df1fb73675a926c10ed36c4b5688",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6843
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:94299e8197f9216ea9207954c1fc86fcfa66e00b",
+        "size": 6843,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7117df1fb73675a926c10ed36c4b5688.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11081",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2293,7 +3973,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11047",
+    "recid": "11082",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
     "type": {
@@ -2341,9 +4021,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11048",
+    "recid": "11083",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "f487f1bc88531560fb99dea29f9bdb83",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 513913
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:b05dc81d8f1baea40e786fd5f72e41a2aa9abf65",
+        "size": 513913,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f487f1bc88531560fb99dea29f9bdb83.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11084",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2389,9 +4117,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11049",
+    "recid": "11085",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "47e7c86552e77dd5909308babf5edb8f",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6693
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:fe6a74d2ccecc0ee1eaf47ca8865c99e28e92072",
+        "size": 6693,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/47e7c86552e77dd5909308babf5edb8f.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11086",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00280_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2437,7 +4213,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11050",
+    "recid": "11087",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg",
     "type": {
@@ -2485,7 +4261,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11051",
+    "recid": "11088",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01545_1_cfg",
     "type": {
@@ -2533,7 +4309,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11052",
+    "recid": "11089",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
     "type": {
@@ -2581,9 +4357,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11053",
+    "recid": "11090",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for PYTHIA6 WH/ZH, H->2gamma mH=125GeV with TAUOLA at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "ab011660516de04655483c9cdbc31d55",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7831
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:d80b3abd395ae6537414d638d1e882fc954c6b9a",
+        "size": 7831,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ab011660516de04655483c9cdbc31d55.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11091",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02271_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2629,9 +4453,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11054",
+    "recid": "11092",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "cec87afc37373850854c6eeb5a0588de",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 580570
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:25d7b6b1ca63ca2bc15a3a58bcb7dca71b7a1c80",
+        "size": 580570,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cec87afc37373850854c6eeb5a0588de.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11093",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> bb  at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "d65fdd337ebdbb1418a6c9054f7de334",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7669
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:8236e27a2b97665d35ff7931db4dbab70fdf8eac",
+        "size": 7669,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d65fdd337ebdbb1418a6c9054f7de334.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11094",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02248_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2677,9 +4597,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11055",
+    "recid": "11095",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step EWK-Summer12DR53X-00159_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "d7c7e40a2583db7d5ecc08b5c9c2e71e",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5800
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:0274c26f22a70d736c989f806a327c3669a60db5",
+        "size": 5800,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d7c7e40a2583db7d5ecc08b5c9c2e71e.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11096",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01736_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2725,9 +4693,201 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11056",
+    "recid": "11097",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> Zgamma at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "8496a2ee52184a4ac590c87773b15218",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 444830
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:1297448f07f915356310d443848b4a3419df14d1",
+        "size": 444830,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8496a2ee52184a4ac590c87773b15218.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11098",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "4476f4abc138fcd5893171c122347692",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 510000
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:98e63989b719d46e47a9a014533fe47a5eecca20",
+        "size": 510000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4476f4abc138fcd5893171c122347692.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11099",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "0e46467874ef0e605ca0243ed42c5ef0",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7441
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:a13fc628e643baada62889794f720c1183faa561",
+        "size": 7441,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0e46467874ef0e605ca0243ed42c5ef0.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11100",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step SMP-Summer12-00017_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "392b7a9e9a323ab1a5f9f40cb88ea4c5",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 510000
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:98e63989b719d46e47a9a014533fe47a5eecca20",
+        "size": 510000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/392b7a9e9a323ab1a5f9f40cb88ea4c5.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11101",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2773,9 +4933,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11057",
+    "recid": "11102",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "040c0f24ce975888e625ff737c6f8f04",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 300671
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:6e825c3ca67ed6214c7403fab1a1b440cb11e763",
+        "size": 300671,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/040c0f24ce975888e625ff737c6f8f04.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11103",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "2d531935ea5bdbbab8a136c6fb2ad19a",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 510000
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:2f8bf27060956f9dc3532bbf413e258c946d0d7a",
+        "size": 510000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2d531935ea5bdbbab8a136c6fb2ad19a.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11104",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2821,9 +5077,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11058",
+    "recid": "11105",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01622_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "8a4510df07202188f24d952fc640ba19",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 510001
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:a39a362943c80ce841073e1b1b235bc42f0197ab",
+        "size": 510001,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8a4510df07202188f24d952fc640ba19.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11106",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2869,9 +5173,201 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11059",
+    "recid": "11107",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> ee, pThat = 120 .. 170 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "c8516b9454a656fd0efc1742d4008445",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13613
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:a8e7a393b9af70cd82e52935350d1d9c05ad822f",
+        "size": 13613,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d4008445.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11108",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_8_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> 2gamma at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "d8903f8e7b5a3e285332467c595a6a09",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7981
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:1e0ced7918dc10d0f62c7d4cbe1d9f1b4d7ec351",
+        "size": 7981,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d8903f8e7b5a3e285332467c595a6a09.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11109",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02074_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "4476f4abc138fcd5893171c1222bd91f",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 510000
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:98e63989b719d46e47a9a014533fe47a5eecca20",
+        "size": 510000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4476f4abc138fcd5893171c1222bd91f.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11110",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Herwig+Jimmy generation of QCD events, 8 TeV, CTEQ6L1, pthat [1000,Inf] GeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "26fdddf613007b2ae46390fe57c44789",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 574884
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:71d0410ffd51aef4622fb37e14638d1bdf1396fa",
+        "size": 574884,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/26fdddf613007b2ae46390fe57c44789.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11111",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2917,9 +5413,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11060",
+    "recid": "11112",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "946cfeb9b320e5e675f724fdadf15899",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6351
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:fa0f8cbc14a15a3a7dc7582aa7c5e4b427e8d250",
+        "size": 6351,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/946cfeb9b320e5e675f724fdadf15899.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11113",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_37_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "309f3e26aeb5d8fe86e7f46a5e4c48cd",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4811
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:41bade921bc1583ad1ec7fea3ee937ad193dec84",
+        "size": 4811,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/309f3e26aeb5d8fe86e7f46a5e4c48cd.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11114",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01866_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -2965,9 +5557,153 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11061",
+    "recid": "11115",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "da3e9a2c05ada265549f8f2880ae6fd0",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 31494
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:74083faff2547323e983cbaffde1ebb2e8deba29",
+        "size": 31494,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/da3e9a2c05ada265549f8f2880ae6fd0.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11116",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "f1aec7a9455c3b903a473b02eea8f9b2",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5932
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:c254be09bbf72d71bcb00af83a8a11c61210aae3",
+        "size": 5932,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f1aec7a9455c3b903a473b02eea8f9b2.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11117",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01726_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "28991b96748afc67ee2e050bc1d3f770",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 575635
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:1c4b89290c1a070a06d5bbcbb4a375ef1329ef64",
+        "size": 575635,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/28991b96748afc67ee2e050bc1d3f770.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11118",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3013,9 +5749,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11062",
+    "recid": "11119",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step SUS-Summer12DR53X-00088_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "9d54194e5d356ff42199d258d5ecc73e",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7149
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:5d819dca587841bea5bf189e071288cbbbc1f8f9",
+        "size": 7149,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/9d54194e5d356ff42199d258d5ecc73e.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11120",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00210_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3061,7 +5845,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11063",
+    "recid": "11121",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01623_1_cfg",
     "type": {
@@ -3109,7 +5893,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11064",
+    "recid": "11122",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-02029_2_cfg",
     "type": {
@@ -3157,9 +5941,153 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11065",
+    "recid": "11123",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01616_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Herwig+Jimmy generation of QCD events, 8 TeV, CTEQ6L1, pthat [300,470] GeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "26fdddf613007b2ae46390fe57c52c92",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 574952
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:734e7dbaa13225e5fa06b109746ec70ddc700cd6",
+        "size": 574952,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/26fdddf613007b2ae46390fe57c52c92.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11124",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Runs Z2* Herwig6 and Tauola."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "320df834ed2a0446c7a2485723ea3870",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6094
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:768a3418fd00516c9a50c8ae645b9e9991d8354a",
+        "size": 6094,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/320df834ed2a0446c7a2485723ea3870.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11125",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00266_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> ee, pThat = 15 .. 20 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "c8516b9454a656fd0efc1742d4018ab1",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13609
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:735a858fb89aa09efb68b09dcf5be658aeacc39f",
+        "size": 13609,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d4018ab1.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11126",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_13_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3205,7 +6133,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11066",
+    "recid": "11127",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
     "type": {
@@ -3253,9 +6181,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11067",
+    "recid": "11128",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step EXO-Summer12DR53X-02796_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "b31348c308254b46589d683f53afcbdf",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 513913
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:b05dc81d8f1baea40e786fd5f72e41a2aa9abf65",
+        "size": 513913,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b31348c308254b46589d683f53afcbdf.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11129",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3301,7 +6277,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11068",
+    "recid": "11130",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
     "type": {
@@ -3349,7 +6325,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11069",
+    "recid": "11131",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-02045_1_cfg",
     "type": {
@@ -3397,9 +6373,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11070",
+    "recid": "11132",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-02117_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "8a4510df07202188f24d952fc63eefae",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 510001
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:a39a362943c80ce841073e1b1b235bc42f0197ab",
+        "size": 510001,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8a4510df07202188f24d952fc63eefae.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11133",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3445,9 +6469,153 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11071",
+    "recid": "11134",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01621_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "474c963e5502a2add5b69e5adcc04e53",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 35425
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:10608ec3848a1849253e5d9ecda3d8c365d0783a",
+        "size": 35425,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/474c963e5502a2add5b69e5adcc04e53.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11135",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01833_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "240850ae487c32cc361680d59df1ad20",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 578577
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:c7507494c26916dd007874237031e25440527670",
+        "size": 578577,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/240850ae487c32cc361680d59df1ad20.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11136",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> ee, pThat = 170 .. 230 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "c8516b9454a656fd0efc1742d40056d7",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13615
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:bbd0e4a95f7cc92f5c5f2a12c79337e511a2cd45",
+        "size": 13615,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d40056d7.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11137",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_7_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3493,7 +6661,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11072",
+    "recid": "11138",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01623_2_cfg",
     "type": {
@@ -3541,9 +6709,153 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11073",
+    "recid": "11139",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step TOP-Summer12DR53X-00168_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> 2taus at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "b764adc8ec45bf8913ce4ec957217b5d",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 579072
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:d6fc68028f158842a3402e34d7e8c71ceb8a53fa",
+        "size": 579072,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b764adc8ec45bf8913ce4ec957217b5d.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11140",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> 2gamma at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "fca27096ac10e9418d7588ae4cd2470a",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7335
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:9c486bb56fa156bc8744bdacea730bfa96729da5",
+        "size": 7335,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/fca27096ac10e9418d7588ae4cd2470a.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11141",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "bd3f7129862b8627ae313cff5e003451",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 10671
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:d949ca64e5ad1534083d816924c94f0eec47240f",
+        "size": 10671,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/bd3f7129862b8627ae313cff5e003451.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11142",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3589,9 +6901,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11074",
+    "recid": "11143",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01624_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "cec87afc37373850854c6eeb5a057a99",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 580568
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:4f4fcb858f300865b0235e308cfd4968df2d96c5",
+        "size": 580568,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cec87afc37373850854c6eeb5a057a99.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11144",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "f1aec7a9455c3b903a473b02eeab0b16",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5932
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:fe7977a47f84057a6246ff35c263372452f127f1",
+        "size": 5932,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f1aec7a9455c3b903a473b02eeab0b16.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11145",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01725_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3637,9 +7045,201 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11075",
+    "recid": "11146",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> ZZ -> 4l at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "0b96e1e102bfd138d3d0f657dc92afde",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8214
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:b4d11aa02761f64ed4c111573abe0c452e1468b8",
+        "size": 8214,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0b96e1e102bfd138d3d0f657dc92afde.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11147",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> ZZ -> 2l2nu at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "64b5791933f6728b5da9a186180154be",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8116
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:b852431f22ba315f2437998128b2b66587787211",
+        "size": 8116,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/64b5791933f6728b5da9a186180154be.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11148",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01717_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "3096b1b45454d7d563e5c870da9c918e",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 19237
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:73e13dd3ada63fe5c1025b4a67da80a801be89e1",
+        "size": 19237,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/3096b1b45454d7d563e5c870da9c918e.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11149",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step SUS-Summer12-00090_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "cf4f2d0d0f3bc97530e34764ca4b3883",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 576064
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:4f6166f0cc32860e5854a66767a4b40575d3b570",
+        "size": 576064,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cf4f2d0d0f3bc97530e34764ca4b3883.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11150",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3685,9 +7285,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11076",
+    "recid": "11151",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "55e014650bd2a7ae5deb891f3aaa1b63",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 513507
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:c291a41b5ee373baab03bebe8f9aab10bc5b12f8",
+        "size": 513507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/55e014650bd2a7ae5deb891f3aaa1b63.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11152",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3733,7 +7381,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11077",
+    "recid": "11153",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01394_2_cfg",
     "type": {
@@ -3781,9 +7429,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11078",
+    "recid": "11154",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> 2gamma at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "4ab3250d23e554446ebc010f2394ef5f",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8946
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:6ec72a1d1713927811a1027055c80a7b095843c3",
+        "size": 8946,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4ab3250d23e554446ebc010f2394ef5f.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11155",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02273_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3829,9 +7525,249 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11079",
+    "recid": "11156",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01468_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> mumu, pThat = 230 .. 300 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "db0105697625bdea8cedb18cd3ff3d0c",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13620
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:e352711c140e5d81be0f345000d2959d83d0bc8f",
+        "size": 13620,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/db0105697625bdea8cedb18cd3ff3d0c.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11157",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_2_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "1847f5756a92904b22ee1933f2ef0212",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 510000
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:2f8bf27060956f9dc3532bbf413e258c946d0d7a",
+        "size": 510000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/1847f5756a92904b22ee1933f2ef0212.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11158",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> ZZ -> 4l at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "99c154f3323c3367abc654ed3ce106f1",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6843
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:f71f86b2e484e5b90d472b2cf99177dbf5b03e95",
+        "size": 6843,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/99c154f3323c3367abc654ed3ce106f1.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11159",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "48fd5522d9cefaff189bc7e5f45d50d9",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 513507
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:c291a41b5ee373baab03bebe8f9aab10bc5b12f8",
+        "size": 513507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/48fd5522d9cefaff189bc7e5f45d50d9.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11160",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "b8bdbfb779cf32668c3c9b17e71067ff",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7198
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:223753d879a10c77dc60f5b823fa3655529f58b8",
+        "size": 7198,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b8bdbfb779cf32668c3c9b17e71067ff.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11161",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00258_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3877,7 +7813,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11080",
+    "recid": "11162",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step EXO-Summer12DR53X-02794_1_cfg",
     "type": {
@@ -3925,9 +7861,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11081",
+    "recid": "11163",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "9d54194e5d356ff42199d258d5eac969",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7349
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:cf888d010f50eb31da0c21029453a7906e612f69",
+        "size": 7349,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/9d54194e5d356ff42199d258d5eac969.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11164",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01774_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -3973,9 +7957,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11082",
+    "recid": "11165",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Showering of generic aMCatNLO events with Herwig, 8 TeV, NNPDF21."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "476ed66a3dbb1efee54679522acec49a",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5528
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:b2969dc08776af174c5b310c641b3fab0da2a249",
+        "size": 5528,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/476ed66a3dbb1efee54679522acec49a.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11166",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4021,9 +8053,393 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11083",
+    "recid": "11167",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01646_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "ec289fabc2b840a4d120a0fc580145e7",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 577994
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:e4a8a0d13a1af79f97ed846c0336b52c5cfb2789",
+        "size": 577994,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ec289fabc2b840a4d120a0fc580145e7.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11168",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "7b09170ba4f82d70c8ecd2b2f6f05b0d",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6765
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:11c94543576860d6fdc82d200ae46fa7160612d0",
+        "size": 6765,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7b09170ba4f82d70c8ecd2b2f6f05b0d.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11169",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01936_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> WW -> lnujj at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "2c492950f4ccb7e3c32e3277b126f3b2",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8345
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:5d154d1e0d202c13f356eb346ae5038746f0934c",
+        "size": 8345,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2c492950f4ccb7e3c32e3277b126f3b2.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11170",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01977_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Comphep single top s-channel at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "4e0bcaa0704451048659be67b18d33b6",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6531
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:cda5b71ef10159dfd99521bc630cc07d8ba2d4a9",
+        "size": 6531,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4e0bcaa0704451048659be67b18d33b6.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11171",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00288_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Showering of generic aMCatNLO events with Herwig, 8 TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "c5be5f65754ad5ed58ab89beb1f54cc8",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5322
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:7a70bbcc6547920c5e1c4ab8247fb67302b78743",
+        "size": 5322,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c5be5f65754ad5ed58ab89beb1f54cc8.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11172",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step EWK-Summer12-00146_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> mumu, pThat = 80 .. 120 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "db0105697625bdea8cedb18cd3ff7611",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13617
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:493d1ca8fa789d672c6069c49b4ca9922686c17c",
+        "size": 13617,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/db0105697625bdea8cedb18cd3ff7611.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11173",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_3_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "ab011660516de04655483c9cdbd579db",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7981
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:bca4a4db541f4e80e248d594e06296855accdf4d",
+        "size": 7981,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ab011660516de04655483c9cdbd579db.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11174",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02269_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "717fe61569cf80753ee9308cb1eb7383",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6350
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:e1e71cfa237051c117c999fc6f0f78a819023bd7",
+        "size": 6350,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/717fe61569cf80753ee9308cb1eb7383.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11175",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_1_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4069,9 +8485,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11084",
+    "recid": "11176",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "476ed66a3dbb1efee54679522acf9bad",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4518
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:9600594420467b86126672b46a862d86de8d9400",
+        "size": 4518,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/476ed66a3dbb1efee54679522acf9bad.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11177",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_24_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "f4b3da317b12375f344f06bf28b77f72",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 512744
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:cae1fff5faad1b7e1307fb8d1ede6cdf5779e259",
+        "size": 512744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f4b3da317b12375f344f06bf28b77f72.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11178",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4117,9 +8629,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11085",
+    "recid": "11179",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Showering of Powheg TTbar events with Herwig+Jimmy, 7 TeV, AUET2."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "ea307f92467620d7382d109fe78ed368",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5762
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:4c8e6b98b0596b1888355e9a085f5236aad79832",
+        "size": 5762,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ea307f92467620d7382d109fe78ed368.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11180",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00254_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4165,9 +8725,201 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11086",
+    "recid": "11181",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "0d0714743f0204ed3c0144941edfcd23",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4749
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:efc14fae57b5a4de70e1a65b465f4be326fc48d0",
+        "size": 4749,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0d0714743f0204ed3c0144941edfcd23.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11182",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01927_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "2ee2be9aece8ed5991b918d37b78cda6",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8561
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:349def31d7cfbdeba164be09272043f48dd41e6d",
+        "size": 8561,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2ee2be9aece8ed5991b918d37b78cda6.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11183",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step MUO-Summer12-00001_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Herwig+Jimmy generation of QCD events, 8 TeV, CTEQ6L1, pthat [800,1000] GeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "26fdddf613007b2ae46390fe57c4552b",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 574954
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:e4b6e6bdf188944edec9632f40c0d33e3539f497",
+        "size": 574954,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/26fdddf613007b2ae46390fe57c4552b.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11184",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "f4b3da317b12375f344f06bf28b79c50",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 512744
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:334669407b491a13ec73e1d1d8a3eb4ed92464f3",
+        "size": 512744,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f4b3da317b12375f344f06bf28b79c50.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11185",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4213,9 +8965,249 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11087",
+    "recid": "11186",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> ee, pThat = 30 .. 50 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "c8516b9454a656fd0efc1742d401601b",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13609
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:5ad4db1f9e665360be0f36bce1a4a87578f59f3d",
+        "size": 13609,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d401601b.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11187",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_12_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> 2taus at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "3dee573dad60eed2500ca1e6db5138ec",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7636
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:53debadba5b6f9a37f6e2104e2f77726ade9c802",
+        "size": 7636,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/3dee573dad60eed2500ca1e6db5138ec.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11188",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02168_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for PYTHIA6 ttH, H->2gamma mH=125GeV with TAUOLA at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "ab011660516de04655483c9cdbc32939",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7825
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:c2f4407eeeed8779b49f05881345f4f721798aae",
+        "size": 7825,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ab011660516de04655483c9cdbc32939.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11189",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02272_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "0d0714743f0204ed3c0144941eb56b4a",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6783
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:1ddf66db712ee246cdbb29ca41080fbe5e381649",
+        "size": 6783,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0d0714743f0204ed3c0144941eb56b4a.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11190",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01909_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "f4b3da317b12375f344f06bf28b7ab9d",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 512739
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:c7400e547c33f99e57153f0d59cb17cc22b4e74e",
+        "size": 512739,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f4b3da317b12375f344f06bf28b7ab9d.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11191",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4261,7 +9253,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11088",
+    "recid": "11192",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01545_2_cfg",
     "type": {
@@ -4309,7 +9301,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11089",
+    "recid": "11193",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step B2G-Summer12DR53X-00431_1_cfg",
     "type": {
@@ -4357,9 +9349,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11090",
+    "recid": "11194",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step JME-Summer12DR53X-00167_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "1ac6d193605fc02b9ef72f9a139e9ac0",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6668
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:0cbe6a222451b55a9dbe1214f2ecb67fc80449ac",
+        "size": 6668,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/1ac6d193605fc02b9ef72f9a139e9ac0.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11195",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step FSQ-Summer12-00004_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "240850ae487c32cc361680d59d477704",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 1130776
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:4002f50d6a3cd79937da20e478b58c6a137e80c6",
+        "size": 1130776,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/240850ae487c32cc361680d59d477704.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11196",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4405,9 +9493,153 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11091",
+    "recid": "11197",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01636_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> ZZ -> 4l at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "b8194440c3a1867cea3313a723ffdce5",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 579584
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:eac0d5565c6cb8366dce0742711a125bea00ae68",
+        "size": 579584,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b8194440c3a1867cea3313a723ffdce5.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11198",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "131b82ef254ea71d1ea95c78e744ac00",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 46390
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:a09679c2ff72f000ddb2e5dd7f2b52c072648123",
+        "size": 46390,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/131b82ef254ea71d1ea95c78e744ac00.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11199",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00257_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> ZZ -> 4l at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "8496a2ee52184a4ac590c87773b0f346",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 443211
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:83bf51b8cbda88044fac3e316056683b5e95dd80",
+        "size": 443211,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8496a2ee52184a4ac590c87773b0f346.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11200",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4453,7 +9685,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11092",
+    "recid": "11201",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step EWK-Summer12DR53X-00159_2_cfg",
     "type": {
@@ -4501,9 +9733,297 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11093",
+    "recid": "11202",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01521_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "adda25dea992e96fb7e8f4be89889c0b",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5932
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:cdff7a371fd82b6b175f7fcb0a80d77013f9f17f",
+        "size": 5932,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/adda25dea992e96fb7e8f4be89889c0b.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11203",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01727_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "a8b87e4a93ad780670c2864baf162c61",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6153
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:e5371f5164fadad20c84b64df20d6d030d636a7d",
+        "size": 6153,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/a8b87e4a93ad780670c2864baf162c61.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11204",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step SMP-Summer12-00006_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "ef642a99908dbdb47abb111c45cb1c17",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 31943
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:79089c540e9e4dea07fcb3bbf68cce6ac1259f6a",
+        "size": 31943,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ef642a99908dbdb47abb111c45cb1c17.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11205",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01785_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for PYTHIA6-MinBias at 8TeV, pthat>20, with INCLUSIVE muon preselection (pt(mu) > 15)."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "604b1f2cb97826580dcee0388647af71",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7020
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:f4ce9bbb77b1f1796ee5f44b574c82e4bb92146c",
+        "size": 7020,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/604b1f2cb97826580dcee0388647af71.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11206",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step SMP-Summer12-00013_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> 2gamma at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "b37f1b3570d9d1afb6ab490d0b558bf0",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7319
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:7db6a7ece6e9bbaf471dc0636af550ac01e81eae",
+        "size": 7319,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b37f1b3570d9d1afb6ab490d0b558bf0.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11207",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01728_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "f4b3da317b12375f344f06bf28b78dbd",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 512739
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:b4b7f8057e4e409197ef32e1d4dcd1cd0b881030",
+        "size": 512739,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f4b3da317b12375f344f06bf28b78dbd.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11208",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4549,9 +10069,297 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11094",
+    "recid": "11209",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> 2gamma at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "df06ea86f6f8e8b03d64449d07d2bbf8",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 579073
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:413250b0d5588ffcb37393765d020cc0180cd366",
+        "size": 579073,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/df06ea86f6f8e8b03d64449d07d2bbf8.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11210",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Summer 12: Flat Random Pt Gun: neutrino, 2<Pt<20, -3<Eta<3."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "afce20d0a4ebee0ab7bd45ac218cd3b0",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 440909
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:2b23ec94117f5f08eeda9bbe9fc5ec4f87e8e3dc",
+        "size": 440909,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/afce20d0a4ebee0ab7bd45ac218cd3b0.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11211",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "cec87afc37373850854c6eeb5a05e3f8",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 575448
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:c47248c5f8fc67ad0e34880c651d18db40fc9379",
+        "size": 575448,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cec87afc37373850854c6eeb5a05e3f8.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11212",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "901f56a4732e8ea5a60cd45e0fcc141a",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 519203
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:188ac86a640f1dcdf172c9c67341ebad3f4c1472",
+        "size": 519203,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/901f56a4732e8ea5a60cd45e0fcc141a.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11213",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "4c16eb9ba250e1d23d813c1db6a4175d",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6867
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:5edb13d3d6d836a1805d16c9c5a61d41a810d487",
+        "size": 6867,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4c16eb9ba250e1d23d813c1db6a4175d.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11214",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step SUS-Summer12-00100_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "59687d1d79393aecf64d6439b6bfa710",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8766
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:0dc1504ab098a690c2b16091670af7036a644f3b",
+        "size": 8766,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/59687d1d79393aecf64d6439b6bfa710.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11215",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step SUS-Summer12-00104_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4597,9 +10405,249 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11095",
+    "recid": "11216",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step EXO-Summer12DR53X-02706_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "b354983335f663c9ca1bf9c81856e190",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7378
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:902f1542631840e88bf8f59e76bbe8baceb6e4d4",
+        "size": 7378,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b354983335f663c9ca1bf9c81856e190.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11217",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step SMP-Summer12-00007_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "1ac6d193605fc02b9ef72f9a139a7fe2",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6670
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:6ed395508934f46c5447362e252a167a1961b6db",
+        "size": 6670,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/1ac6d193605fc02b9ef72f9a139a7fe2.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11218",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step FSQ-Summer12-00003_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "8e6085cdbce6bc0ce24311750537fcba",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6720
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:ce5019d0ace1304c24419e4e8d74ca55825efcc7",
+        "size": 6720,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8e6085cdbce6bc0ce24311750537fcba.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11219",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02199_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> ee, pThat = 230 .. 300 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "c8516b9454a656fd0efc1742d4001c1a",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13615
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:bc7a174932c2a2c17a5709abaab949069bf4bb80",
+        "size": 13615,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d4001c1a.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11220",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_6_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "deea5caa7ac69677bb7713109c42a1dc",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7277
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:b9bb5df0986c33ce3e5c00fda20e292d0e22bd1d",
+        "size": 7277,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/deea5caa7ac69677bb7713109c42a1dc.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11221",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4645,9 +10693,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11096",
+    "recid": "11222",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01930_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> Zgamma at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "cd342343bfcfe5f9b2bae586f25f6eea",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 444830
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:1297448f07f915356310d443848b4a3419df14d1",
+        "size": 444830,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cd342343bfcfe5f9b2bae586f25f6eea.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11223",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4693,9 +10789,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11097",
+    "recid": "11224",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step B2G-Summer12DR53X-00594_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "36e728b9528949ad9a643e314bfca1c6",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 5573
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:65b37436c4fffb93965502e3dc5378db5b77e262",
+        "size": 5573,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/36e728b9528949ad9a643e314bfca1c6.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11225",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02178_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "d8903f8e7b5a3e285332467c595a7889",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6594
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:d93dcdca5e80c39ec346b3e5a7b4c85c283857a1",
+        "size": 6594,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d8903f8e7b5a3e285332467c595a7889.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11226",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02073_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4741,9 +10933,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11098",
+    "recid": "11227",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01503_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "f8745e0ea7dfc03fdc35ca88c453ac07",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6001
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:322f547da4bdafe0f6fb56a8741e513d6aa0cdac",
+        "size": 6001,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f8745e0ea7dfc03fdc35ca88c453ac07.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11228",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01741_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4789,7 +11029,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11099",
+    "recid": "11229",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01622_2_cfg",
     "type": {
@@ -4837,9 +11077,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11100",
+    "recid": "11230",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-02029_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "df27c7e3d4d321a821d24b3505228625",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13653
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:2ee626a42018277693a6eb1e02c270105bc3fadc",
+        "size": 13653,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/df27c7e3d4d321a821d24b3505228625.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11231",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_3_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "d8903f8e7b5a3e285332467c595a3067",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6741
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:ec810a84746c60b3b95ba6a305f6bd1993f50f6b",
+        "size": 6741,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d8903f8e7b5a3e285332467c595a3067.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11232",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-02056_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4885,9 +11221,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11101",
+    "recid": "11233",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01394_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "461fa132265397451d419bb8fc7def3e",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 510000
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:98e63989b719d46e47a9a014533fe47a5eecca20",
+        "size": 510000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/461fa132265397451d419bb8fc7def3e.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11234",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -4933,7 +11317,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11102",
+    "recid": "11235",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
     "type": {
@@ -4981,9 +11365,153 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11103",
+    "recid": "11236",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step FSQ-Summer12DR53X-00002_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "7b09170ba4f82d70c8ecd2b2f6f06525",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6728
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:b4438d4f833b31b580693f7de1b37cc3ebbf9a73",
+        "size": 6728,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7b09170ba4f82d70c8ecd2b2f6f06525.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11237",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01937_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "7afc415b5e06c9d7224775a35bfe9029",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 441834
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:1880f4f87b06a4bb6e8690e43a7c2e2990624f2a",
+        "size": 441834,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7afc415b5e06c9d7224775a35bfe9029.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11238",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "05e7f803b55fe910471147e8498f3f2d",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4462
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:6f227e73c30aafdd03d69d6fdc426a4ff7043d5e",
+        "size": 4462,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/05e7f803b55fe910471147e8498f3f2d.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11239",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step EGM-Summer12-00001_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -5029,7 +11557,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11104",
+    "recid": "11240",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
     "type": {
@@ -5077,9 +11605,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11105",
+    "recid": "11241",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "2a5c442b819a23729e85645ec23f0799",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6729
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:f59b9b46e3da6bd963d3d4cdfd8d91cb49f3a7c7",
+        "size": 6729,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2a5c442b819a23729e85645ec23f0799.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11242",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01835_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -5125,7 +11701,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11106",
+    "recid": "11243",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
     "type": {
@@ -5173,9 +11749,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11107",
+    "recid": "11244",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "9a1d64aafe0b81067d9ac04402ca825f",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 44751
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:c47615e4feaeacb8d013cf20f672df497b753e51",
+        "size": 44751,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/9a1d64aafe0b81067d9ac04402ca825f.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11245",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -5221,9 +11845,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11108",
+    "recid": "11246",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for PYTHIA6 WH, H->WW->lnulnu mH=125 with TAUOLA at 7TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "240850ae487c32cc361680d59def9cb1",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 580846
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:47083c7adbea4756f45e69e6ee52813ad7a9d612",
+        "size": 580846,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/240850ae487c32cc361680d59def9cb1.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11247",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "91fe8a2d7cd44a1fadbc1d407a80f092",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 512958
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:6f6293b0d50043178b412d490a6d806c44e12b06",
+        "size": 512958,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/91fe8a2d7cd44a1fadbc1d407a80f092.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11248",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -5269,9 +11989,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11109",
+    "recid": "11249",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01621_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "1ac6d193605fc02b9ef72f9a139d52e1",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4851
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:eda2667e372999d9deaf7b399d367d2711a541dc",
+        "size": 4851,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/1ac6d193605fc02b9ef72f9a139d52e1.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11250",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step FSQ-Summer12-00002_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -5317,7 +12085,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11110",
+    "recid": "11251",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
     "type": {
@@ -5365,7 +12133,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11111",
+    "recid": "11252",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01468_2_cfg",
     "type": {
@@ -5413,9 +12181,249 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11112",
+    "recid": "11253",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01981_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "29289acf35def22f963de630c850a8cd",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 513507
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:c291a41b5ee373baab03bebe8f9aab10bc5b12f8",
+        "size": 513507,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/29289acf35def22f963de630c850a8cd.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11254",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Summer2012 sample with PYTHIA8: QCD dijet production, pThat = 15 .. 3000 GeV, weighted, Tune4C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "8d24bab03a9447be589727bad8f8a2a5",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 575907
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:2b6bcdee5bb617423081ed581a22015bb12cbc1e",
+        "size": 575907,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8d24bab03a9447be589727bad8f8a2a5.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11255",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "791a4c1208863ba7b363a500a0f3f219",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6339
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:5281d44a4fa8e7a27bf2aab00840b9c5514ef5fd",
+        "size": 6339,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/791a4c1208863ba7b363a500a0f3f219.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11256",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01732_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> ee, pThat = 0 .. 15 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "76b67a85cce50002d1f4cece1622b1db",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13557
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:cae9349473abd07d205d1e04041d2a30bc8bdf02",
+        "size": 13557,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/76b67a85cce50002d1f4cece1622b1db.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11257",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step JME-Summer12-00140_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "47e7c86552e77dd5909308babf660ce5",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7430
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:60fa95a4ba0084abc72e525220b1199249c2bdee",
+        "size": 7430,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/47e7c86552e77dd5909308babf660ce5.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11258",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step SMP-Summer12-00014_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -5461,7 +12469,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11113",
+    "recid": "11259",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step JME-Summer12DR53X-00162_1_cfg",
     "type": {
@@ -5509,9 +12517,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11114",
+    "recid": "11260",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "77a3ead6ad2fd8a3ee6652b760be2fd9",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 512742
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:e78f594a556fd65b1efefc2f9458686b22adb47b",
+        "size": 512742,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/77a3ead6ad2fd8a3ee6652b760be2fd9.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11261",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -5557,7 +12613,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11115",
+    "recid": "11262",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
     "type": {
@@ -5605,9 +12661,201 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11116",
+    "recid": "11263",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01745_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "47e7c86552e77dd5909308babf59f357",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7853
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:ea0623dea8b6790f4f4bf92bff616bf2d1fe5590",
+        "size": 7853,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/47e7c86552e77dd5909308babf59f357.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11264",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step SMP-Summer12-00016_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "8630bdb103dad448ac350c124678dcc5",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 583177
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:b2ab52fb58c152cc97557801fe4e8f58e75e2078",
+        "size": 583177,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8630bdb103dad448ac350c124678dcc5.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11265",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> ZZ -> 2l2q at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "2df75b5f3a22f36fe622ef135ce000be",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8082
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:340b5d3b3fb65faa5136bfe765e5771b1c8d0561",
+        "size": 8082,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2df75b5f3a22f36fe622ef135ce000be.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11266",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01590_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "bba69ae19e1fbc577b22ff73799f156e",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6863
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:6e32bff6b85e4c5227be4d86e31f070b5fc12f8d",
+        "size": 6863,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/bba69ae19e1fbc577b22ff73799f156e.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11267",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step SUS-Summer12-00096_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -5653,9 +12901,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11117",
+    "recid": "11268",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01346_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "7d57c3abb9981f8e962ad0921ebfc0fb",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6350
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:0b4eb5a50c5909d24c10543cc670a230be47261c",
+        "size": 6350,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7d57c3abb9981f8e962ad0921ebfc0fb.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11269",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -5701,9 +12997,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11118",
+    "recid": "11270",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "03d0c452db253224763ab1bf4655c3e6",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 62664
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:f23f766b9b0f203069cc89f9b41e90fa89bf1048",
+        "size": 62664,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/03d0c452db253224763ab1bf4655c3e6.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11271",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_2_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -5749,9 +13093,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11119",
+    "recid": "11272",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01500_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> mumu, pThat > 300 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "db0105697625bdea8cedb18cd3ff0597",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13552
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:d77439c3e7848ddd4e6517469de3db1ec8c6aa90",
+        "size": 13552,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/db0105697625bdea8cedb18cd3ff0597.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11273",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_1_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> mumu, pThat = 120 .. 170 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "c8516b9454a656fd0efc1742d400fd95",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13621
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:32a4f7f54a0f2980d44e6f01cfe5c470ddcdb20e",
+        "size": 13621,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d400fd95.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11274",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_10_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -5797,9 +13237,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11120",
+    "recid": "11275",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for runs Z2* Pythia6."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "32e6e06e42ce14eaad2990144133985b",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 6350
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:6af844ae0597301d7656239e30f737c73a1c4d9f",
+        "size": 6350,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/32e6e06e42ce14eaad2990144133985b.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11276",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Sumer2012 sample with HERWIGPP: Z + Jet production, Z -> mumu, pThat = 15 .. 20 GeV, TuneEE3C."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "db0105697625bdea8cedb18cd3fecfa0",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 13614
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:f4990c821f19dc4449e3d3a9e8ad342492f118f0",
+        "size": 13614,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/db0105697625bdea8cedb18cd3fecfa0.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11277",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -5845,7 +13381,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11121",
+    "recid": "11278",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step EXO-Summer12DR53X-02813_2_cfg",
     "type": {
@@ -5893,7 +13429,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11122",
+    "recid": "11279",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01624_2_cfg",
     "type": {
@@ -5941,7 +13477,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11123",
+    "recid": "11280",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step EXO-Summer12DR53X-02794_2_cfg",
     "type": {
@@ -5989,9 +13525,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11124",
+    "recid": "11281",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "4476f4abc138fcd5893171c122428f8e",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 510000
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:98e63989b719d46e47a9a014533fe47a5eecca20",
+        "size": 510000,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4476f4abc138fcd5893171c122428f8e.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11282",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -6037,9 +13621,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11125",
+    "recid": "11283",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step HIG-Summer12DR53X-01937_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "1f2ff1a5230d60b6d26f0a41bdd280c6",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7311
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:17a9788871316c33beff157511882a84857b6f92",
+        "size": 7311,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/1f2ff1a5230d60b6d26f0a41bdd280c6.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11284",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00248_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -6085,9 +13717,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11126",
+    "recid": "11285",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "bd3f7129862b8627ae313cff5e016121",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 361076
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:f08c83b400981f665d13e3015b6f698ab4cfc290",
+        "size": 361076,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/bd3f7129862b8627ae313cff5e016121.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11286",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_2_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for Showering of Powheg TTbar events with Herwig+Jimmy, 7 TeV, AUET2."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "34d68021bbbfb64692432c553bba6859",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 576826
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:f30e76cae971cd445efa7c22996a126775e2c1c5",
+        "size": 576826,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/34d68021bbbfb64692432c553bba6859.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11287",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -6133,9 +13861,105 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11127",
+    "recid": "11288",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step config_0_2_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step for POWHEG + PYTHIA6 + Tauola - Higgs -> WW -> lnujj at 8TeV."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "a30b01ec31a6214af3ada4153c7765b0",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 8029
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:fd148740fff8b0eba083fffa12328992a97de946",
+        "size": 8029,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/a30b01ec31a6214af3ada4153c7765b0.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11289",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step config_0_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "cec87afc37373850854c6eeb5a058c9e",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 580569
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:8cb63a6c39255e94ffa80a5391b58404dcbb0701",
+        "size": 580569,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cec87afc37373850854c6eeb5a058c9e.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11290",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -6181,7 +14005,7 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11128",
+    "recid": "11291",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for RECO step HIG-Summer12DR53X-02117_2_cfg",
     "type": {
@@ -6229,9 +14053,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11129",
+    "recid": "11292",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step JME-Summer12DR53X-00163_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "0d0714743f0204ed3c0144941eb1468c",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 4971
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:584937a682ef9b1bc8d90467e99aaf55fd9cddb3",
+        "size": 4971,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0d0714743f0204ed3c0144941eb1468c.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11293",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01886_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -6277,9 +14149,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11130",
+    "recid": "11294",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step B2G-Summer12DR53X-00678_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "9d146c40331d0b1ca09582720ad3d275",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 690032
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:fbfced8232acb826a3c97d55b682e985a7ae30e7",
+        "size": 690032,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/9d146c40331d0b1ca09582720ad3d275.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11295",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step TOP-Summer12-00190_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -6325,9 +14245,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11131",
+    "recid": "11296",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step EWK-Summer12DR53X-00159_1_cfg",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "e4da65342a00bdb04dc8fdc3e635261c",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 578250
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:b7104249848a31150729b34c425b22005d8c52cf",
+        "size": 578250,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/e4da65342a00bdb04dc8fdc3e635261c.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11297",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step ",
     "type": {
       "primary": "Supplementaries",
       "secondary": [
@@ -6373,9 +14341,57 @@
       "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "11132",
+    "recid": "11298",
     "run_period": "Run2012A-Run2012D",
     "title": "Configuration file for HLT step ",
+    "type": {
+      "primary": "Supplementaries",
+      "secondary": [
+        "Configuration"
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "The configuration file used in SIM data processing step."
+    },
+    "accelerator": "CERN-LHC",
+    "cms_confdb_id": "dc93d4968faf1343ed9a38b33b80758c",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Configuration-Files"
+    ],
+    "collision_information": {
+      "energy": "8TeV",
+      "type": "pp"
+    },
+    "date_created": "2012",
+    "date_published": "2017",
+    "distribution": {
+      "formats": [
+        "py"
+      ],
+      "number_files": 1,
+      "size": 7077
+    },
+    "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "sha1:3e9278185f37fd6b6a8d9eddb4c1b915e4d674af",
+        "size": 7077,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/dc93d4968faf1343ed9a38b33b80758c.configFile.py"
+      }
+    ],
+    "note": {
+      "description": "This file describes the exact setup for the CMS software executable which was used in a data-processing step. It is provided only <i>for information purposes</i>. Although all the components required to <i>analyse</i> the public primary datasets - such as corresponding input data, condition data, software version - are provided on this portal, it is not necessarily possible to <i>reproduce</i> all the described data-processing steps."
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "11299",
+    "run_period": "Run2012A-Run2012D",
+    "title": "Configuration file for SIM step HIG-Summer12-01588_1_cfg",
     "type": {
       "primary": "Supplementaries",
       "secondary": [

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2012.json
@@ -66,7 +66,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11075\">Configuration file for SIM step HIG-Summer12-02276_1_cfg</a><br>Output dataset: /BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11132\">Configuration file for HLT step HIG-Summer12DR53X-02117_1_cfg</a><br><a href=\"/record/11291\">Configuration file for RECO step HIG-Summer12DR53X-02117_2_cfg</a><br>Output dataset: /BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -84,10 +84,6 @@
   },
   "title": "/BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -179,7 +175,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11276\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11233\">Configuration file for HLT step HIG-Summer12DR53X-01394_1_cfg</a><br><a href=\"/record/11153\">Configuration file for RECO step HIG-Summer12DR53X-01394_2_cfg</a><br>Output dataset: /Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -197,10 +193,6 @@
   },
   "title": "/Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -278,7 +270,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11261\">Configuration file for SIM step </a><br>Output dataset: /DiPhotonBorn_Pt-10To25_8TeV_ext-pythia6/Summer12-START52_V9-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /DiPhotonBorn_Pt-10To25_8TeV_ext-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -296,10 +288,6 @@
   },
   "title": "/DiPhotonBorn_Pt-10To25_8TeV_ext-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM",
   "title_additional": "Simulated dataset DiPhotonBorn_Pt-10To25_8TeV_ext-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -377,7 +365,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11208\">Configuration file for SIM step </a><br>Output dataset: /DiPhotonBorn_Pt-250ToInf_8TeV_ext-pythia6/Summer12-START52_V9-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /DiPhotonBorn_Pt-250ToInf_8TeV_ext-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -395,10 +383,6 @@
   },
   "title": "/DiPhotonBorn_Pt-250ToInf_8TeV_ext-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM",
   "title_additional": "Simulated dataset DiPhotonBorn_Pt-250ToInf_8TeV_ext-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -476,7 +460,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11178\">Configuration file for SIM step </a><br>Output dataset: /DiPhotonBorn_Pt-25To250_8TeV_ext-pythia6/Summer12-START52_V9-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /DiPhotonBorn_Pt-25To250_8TeV_ext-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -494,10 +478,6 @@
   },
   "title": "/DiPhotonBorn_Pt-25To250_8TeV_ext-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM",
   "title_additional": "Simulated dataset DiPhotonBorn_Pt-25To250_8TeV_ext-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -575,7 +555,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11018\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11092\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /DiPhotonBox_Pt-10To25_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -593,10 +573,6 @@
   },
   "title": "/DiPhotonBox_Pt-10To25_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DiPhotonBox_Pt-10To25_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -674,7 +650,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11191\">Configuration file for SIM step </a><br>Output dataset: /DiPhotonBox_Pt-250ToInf_8TeV_ext-pythia6/Summer12-START52_V9-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11018\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11092\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /DiPhotonBox_Pt-250ToInf_8TeV_ext-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -692,10 +668,6 @@
   },
   "title": "/DiPhotonBox_Pt-250ToInf_8TeV_ext-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DiPhotonBox_Pt-250ToInf_8TeV_ext-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -773,7 +745,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11185\">Configuration file for SIM step </a><br>Output dataset: /DiPhotonBox_Pt-25To250_8TeV_ext-pythia6/Summer12-START52_V9-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11018\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11092\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /DiPhotonBox_Pt-25To250_8TeV_ext-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -791,10 +763,6 @@
   },
   "title": "/DiPhotonBox_Pt-25To250_8TeV_ext-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM",
   "title_additional": "Simulated dataset DiPhotonBox_Pt-25To250_8TeV_ext-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -872,7 +840,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM SIM</strong><br><a href=\"/record/11104\">Configuration file for SIM step </a><br><a href=\"/record/11158\">Configuration file for SIM step </a><br>Output dataset: /DiPhotonJets_7TeV-madgraph/Summer12-START52_V9-v3/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /DiPhotonJets_7TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -890,10 +858,6 @@
   },
   "title": "/DiPhotonJets_7TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DiPhotonJets_7TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -971,7 +935,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11101\">Configuration file for SIM step </a><br>Output dataset: /DiPhotonJets_8TeV-madgraph-tarball-v2/Summer12-START52_V9-v3/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11092\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11018\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /DiPhotonJets_8TeV-madgraph-tarball-v2/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -989,10 +953,6 @@
   },
   "title": "/DiPhotonJets_8TeV-madgraph-tarball-v2/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DiPhotonJets_8TeV-madgraph-tarball-v2 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -1084,7 +1044,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11150\">Configuration file for SIM step </a><br>Output dataset: /DiPhotonJetsBox_M60_8TeV-sherpa/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11018\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11092\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /DiPhotonJetsBox_M60_8TeV-sherpa/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -1102,10 +1062,6 @@
   },
   "title": "/DiPhotonJetsBox_M60_8TeV-sherpa/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DiPhotonJetsBox_M60_8TeV-sherpa in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -1183,7 +1139,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11084\">Configuration file for SIM step </a><br>Output dataset: /DiPhotonJets_M0_8TeV-madgraph/Summer12-START52_V9-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /DiPhotonJets_M0_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -1201,10 +1157,6 @@
   },
   "title": "/DiPhotonJets_M0_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DiPhotonJets_M0_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -1282,7 +1234,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11239\">Configuration file for SIM step EGM-Summer12-00001_1_cfg</a><br>Output dataset: /DoubleElectron_FlatPt-5To300_gun/Summer12-START53_V29B-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br>Output dataset: /DoubleElectron_FlatPt-5To300_gun/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -1300,10 +1252,6 @@
   },
   "title": "/DoubleElectron_FlatPt-5To300_gun/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DoubleElectron_FlatPt-5To300_gun in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -1381,7 +1329,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11283\">Configuration file for HLT step HIG-Summer12DR53X-01937_1_cfg</a><br><a href=\"/record/11044\">Configuration file for RECO step HIG-Summer12DR53X-01937_2_cfg</a><br>Output dataset: /DY1JetsToLL_M-10To50_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -1399,10 +1347,6 @@
   },
   "title": "/DY1JetsToLL_M-10To50_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DY1JetsToLL_M-10To50_TuneZ2Star_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -1564,7 +1508,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11271\">Configuration file for SIM step config_2_1_cfg</a><br>Output dataset: /DY1JetsToLL_M-50_8TeV_ext-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11102\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11244\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /DY1JetsToLL_M-50_8TeV_ext-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -1582,10 +1526,6 @@
   },
   "title": "/DY1JetsToLL_M-50_8TeV_ext-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DY1JetsToLL_M-50_8TeV_ext-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -1663,7 +1603,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11271\">Configuration file for SIM step config_2_1_cfg</a><br>Output dataset: /DY2JetsToLL_M-50_8TeV_ext-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11235\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11112\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /DY2JetsToLL_M-50_8TeV_ext-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -1681,10 +1621,6 @@
   },
   "title": "/DY2JetsToLL_M-50_8TeV_ext-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DY2JetsToLL_M-50_8TeV_ext-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -1762,7 +1698,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11129\">Configuration file for SIM step </a><br>Output dataset: /DY2JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/Summer12-START52_V9-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11283\">Configuration file for HLT step HIG-Summer12DR53X-01937_1_cfg</a><br><a href=\"/record/11044\">Configuration file for RECO step HIG-Summer12DR53X-01937_2_cfg</a><br>Output dataset: /DY2JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -1780,10 +1716,6 @@
   },
   "title": "/DY2JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DY2JetsToLL_M-50_TuneZ2Star_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -1875,7 +1807,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11238\">Configuration file for SIM step </a><br>Output dataset: /DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/Summer12-START50_V13-v3/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11044\">Configuration file for RECO step HIG-Summer12DR53X-01937_2_cfg</a><br><a href=\"/record/11283\">Configuration file for HLT step HIG-Summer12DR53X-01937_1_cfg</a><br>Output dataset: /DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -1893,10 +1825,6 @@
   },
   "title": "/DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -1974,7 +1902,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11238\">Configuration file for SIM step </a><br>Output dataset: /DY4JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/Summer12-START50_V13-v4/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11283\">Configuration file for HLT step HIG-Summer12DR53X-01937_1_cfg</a><br><a href=\"/record/11044\">Configuration file for RECO step HIG-Summer12DR53X-01937_2_cfg</a><br>Output dataset: /DY4JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -1992,10 +1920,6 @@
   },
   "title": "/DY4JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DY4JetsToLL_M-50_TuneZ2Star_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -2213,7 +2137,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11118\">Configuration file for SIM step </a><br>Output dataset: /DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11275\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11048\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -2231,10 +2155,6 @@
   },
   "title": "/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -2326,7 +2246,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11205\">Configuration file for SIM step HIG-Summer12-01785_1_cfg</a><br>Output dataset: /DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11002\">Configuration file for RECO step B2G-Summer12DR53X-00678_2_cfg</a><br><a href=\"/record/11294\">Configuration file for HLT step B2G-Summer12DR53X-00678_1_cfg</a><br>Output dataset: /DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -2344,10 +2264,6 @@
   },
   "title": "/DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -2439,7 +2355,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11135\">Configuration file for SIM step HIG-Summer12-01833_1_cfg</a><br>Output dataset: /DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11002\">Configuration file for RECO step B2G-Summer12DR53X-00678_2_cfg</a><br><a href=\"/record/11294\">Configuration file for HLT step B2G-Summer12DR53X-00678_1_cfg</a><br>Output dataset: /DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -2457,10 +2373,6 @@
   },
   "title": "/DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -2552,7 +2464,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11215\">Configuration file for SIM step SUS-Summer12-00104_1_cfg</a><br>Output dataset: /DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11015\">Configuration file for HLT step B2G-Summer12DR53X-00692_1_cfg</a><br><a href=\"/record/11028\">Configuration file for RECO step B2G-Summer12DR53X-00770_2_cfg</a><br>Output dataset: /DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -2570,10 +2482,6 @@
   },
   "title": "/DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -2665,7 +2573,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11215\">Configuration file for SIM step SUS-Summer12-00104_1_cfg</a><br>Output dataset: /DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11015\">Configuration file for HLT step B2G-Summer12DR53X-00692_1_cfg</a><br><a href=\"/record/11028\">Configuration file for RECO step B2G-Summer12DR53X-00770_2_cfg</a><br>Output dataset: /DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -2683,10 +2591,6 @@
   },
   "title": "/DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -2764,7 +2668,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11213\">Configuration file for SIM step </a><br>Output dataset: /DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball/Summer12-START53_V7D-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO HLT RECO</strong><br><a href=\"/record/11296\">Configuration file for HLT step EWK-Summer12DR53X-00159_1_cfg</a><br><a href=\"/record/11201\">Configuration file for RECO step EWK-Summer12DR53X-00159_2_cfg</a><br><a href=\"/record/11095\">Configuration file for HLT step EWK-Summer12DR53X-00159_1_cfg</a><br><a href=\"/record/11026\">Configuration file for RECO step EWK-Summer12DR53X-00159_2_cfg</a><br>Output dataset: /DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball/Summer12_DR53X-No_PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -2782,10 +2686,6 @@
   },
   "title": "/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball/Summer12_DR53X-No_PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -2891,7 +2791,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11018\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11092\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -2909,10 +2809,6 @@
   },
   "title": "/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -3004,7 +2900,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11183\">Configuration file for SIM step MUO-Summer12-00001_1_cfg</a><br>Output dataset: /DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br>Output dataset: /DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -3022,10 +2918,6 @@
   },
   "title": "/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -3103,7 +2995,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11145\">Configuration file for SIM step HIG-Summer12-01725_1_cfg</a><br>Output dataset: /DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12-START53_V14B_ExtFlat10-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11105\">Configuration file for HLT step HIG-Summer12DR53X-01622_1_cfg</a><br><a href=\"/record/11229\">Configuration file for RECO step HIG-Summer12DR53X-01622_2_cfg</a><br>Output dataset: /DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12_DR53X-ExtFlat10_PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -3121,10 +3013,6 @@
   },
   "title": "/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12_DR53X-ExtFlat10_PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -3202,7 +3090,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11117\">Configuration file for SIM step HIG-Summer12-01726_1_cfg</a><br>Output dataset: /DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12-START53_V14B_ExtFlat20-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11138\">Configuration file for RECO step HIG-Summer12DR53X-01623_2_cfg</a><br><a href=\"/record/11121\">Configuration file for HLT step HIG-Summer12DR53X-01623_1_cfg</a><br>Output dataset: /DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12_DR53X-ExtFlat20_PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -3220,10 +3108,6 @@
   },
   "title": "/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12_DR53X-ExtFlat20_PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -3315,7 +3199,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11203\">Configuration file for SIM step HIG-Summer12-01727_1_cfg</a><br>Output dataset: /DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12-START53_V14B_ExtFlat30-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11143\">Configuration file for HLT step HIG-Summer12DR53X-01624_1_cfg</a><br><a href=\"/record/11279\">Configuration file for RECO step HIG-Summer12DR53X-01624_2_cfg</a><br>Output dataset: /DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12_DR53X-ExtFlat30_PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -3333,10 +3217,6 @@
   },
   "title": "/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12_DR53X-ExtFlat30_PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -3428,7 +3308,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11226\">Configuration file for SIM step HIG-Summer12-02073_1_cfg</a><br>Output dataset: /DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12-START53_V7C_NewG4Phys-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11044\">Configuration file for RECO step HIG-Summer12DR53X-01937_2_cfg</a><br><a href=\"/record/11283\">Configuration file for HLT step HIG-Summer12DR53X-01937_1_cfg</a><br>Output dataset: /DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12_DR53X-NewG4Phys_PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -3446,10 +3326,6 @@
   },
   "title": "/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12_DR53X-NewG4Phys_PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -3583,7 +3459,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11248\">Configuration file for SIM step </a><br>Output dataset: /DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12-START52_V9-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11262\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11072\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v3/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -3601,10 +3477,6 @@
   },
   "title": "/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v3/AODSIM",
   "title_additional": "Simulated dataset DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -3682,7 +3554,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11250\">Configuration file for SIM step FSQ-Summer12-00002_1_cfg</a><br>Output dataset: /DYToMuMu_M-15To50_Tune4C_8TeV-pythia8/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br><a href=\"/record/11236\">Configuration file for HLT step FSQ-Summer12DR53X-00002_1_cfg</a><br>Output dataset: /DYToMuMu_M-15To50_Tune4C_8TeV-pythia8/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -3700,10 +3572,6 @@
   },
   "title": "/DYToMuMu_M-15To50_Tune4C_8TeV-pythia8/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYToMuMu_M-15To50_Tune4C_8TeV-pythia8 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -3781,7 +3649,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11250\">Configuration file for SIM step FSQ-Summer12-00002_1_cfg</a><br>Output dataset: /DYToMuMu_M-15To50_Tune4C_8TeV-pythia8/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br>Output dataset: /DYToMuMu_M-15To50_Tune4C_8TeV-pythia8/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -3799,10 +3667,6 @@
   },
   "title": "/DYToMuMu_M-15To50_Tune4C_8TeV-pythia8/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYToMuMu_M-15To50_Tune4C_8TeV-pythia8 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -3880,7 +3744,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11195\">Configuration file for SIM step FSQ-Summer12-00004_1_cfg</a><br>Output dataset: /DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br><a href=\"/record/11236\">Configuration file for HLT step FSQ-Summer12DR53X-00002_1_cfg</a><br>Output dataset: /DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -3898,10 +3762,6 @@
   },
   "title": "/DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -3979,7 +3839,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11195\">Configuration file for SIM step FSQ-Summer12-00004_1_cfg</a><br>Output dataset: /DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br>Output dataset: /DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -3997,10 +3857,6 @@
   },
   "title": "/DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -4092,7 +3948,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11100\">Configuration file for SIM step SMP-Summer12-00017_1_cfg</a><br>Output dataset: /DYToMuMu_M-20_CT10_8TeV-powheg-pythia6/Summer12-START53_V7C_ext1-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br>Output dataset: /DYToMuMu_M-20_CT10_8TeV-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -4110,10 +3966,6 @@
   },
   "title": "/DYToMuMu_M-20_CT10_8TeV-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYToMuMu_M-20_CT10_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -4233,7 +4085,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11248\">Configuration file for SIM step </a><br>Output dataset: /DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12-START52_V9-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11092\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11018\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -4251,10 +4103,6 @@
   },
   "title": "/DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -4346,7 +4194,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11236\">Configuration file for HLT step FSQ-Summer12DR53X-00002_1_cfg</a><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br>Output dataset: /DYToMuMu_M-6To15_Tune4C_8TeV-pythia8/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -4364,10 +4212,6 @@
   },
   "title": "/DYToMuMu_M-6To15_Tune4C_8TeV-pythia8/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYToMuMu_M-6To15_Tune4C_8TeV-pythia8 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -4459,7 +4303,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br>Output dataset: /DYToMuMu_M-6To15_Tune4C_8TeV-pythia8/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -4477,10 +4321,6 @@
   },
   "title": "/DYToMuMu_M-6To15_Tune4C_8TeV-pythia8/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYToMuMu_M-6To15_Tune4C_8TeV-pythia8 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -4558,7 +4398,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11218\">Configuration file for SIM step FSQ-Summer12-00003_1_cfg</a><br>Output dataset: /DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11236\">Configuration file for HLT step FSQ-Summer12DR53X-00002_1_cfg</a><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br>Output dataset: /DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -4576,10 +4416,6 @@
   },
   "title": "/DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -4657,7 +4493,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11218\">Configuration file for SIM step FSQ-Summer12-00003_1_cfg</a><br>Output dataset: /DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br>Output dataset: /DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -4675,10 +4511,6 @@
   },
   "title": "/DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -4756,7 +4588,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11168\">Configuration file for SIM step </a><br>Output dataset: /EtabToPsi2SPhi_8TeV-pythia6-evtgen/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11025\">Configuration file for RECO step </a><br><a href=\"/record/11071\">Configuration file for HLT step </a><br>Output dataset: /EtabToPsi2SPhi_8TeV-pythia6-evtgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -4774,10 +4606,6 @@
   },
   "title": "/EtabToPsi2SPhi_8TeV-pythia6-evtgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset EtabToPsi2SPhi_8TeV-pythia6-evtgen in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -4855,7 +4683,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11212\">Configuration file for SIM step </a><br>Output dataset: /GammaGammaToEE_Elastic_Pt15_8TeV-lpair/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11089\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11107\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /GammaGammaToEE_Elastic_Pt15_8TeV-lpair/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -4873,10 +4701,6 @@
   },
   "title": "/GammaGammaToEE_Elastic_Pt15_8TeV-lpair/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GammaGammaToEE_Elastic_Pt15_8TeV-lpair in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -4954,7 +4778,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11177\">Configuration file for SIM step config_24_1_cfg</a><br>Output dataset: /GammaGammaToEE_Inel-Inel_Pt15_8TeV-lpair/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11003\">Configuration file for RECO step </a><br><a href=\"/record/11246\">Configuration file for HLT step </a><br>Output dataset: /GammaGammaToEE_Inel-Inel_Pt15_8TeV-lpair/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -4972,10 +4796,6 @@
   },
   "title": "/GammaGammaToEE_Inel-Inel_Pt15_8TeV-lpair/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GammaGammaToEE_Inel-Inel_Pt15_8TeV-lpair in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -5053,7 +4873,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11212\">Configuration file for SIM step </a><br>Output dataset: /GammaGammaToEE_SingleDiss-pmod11_Pt15_8TeV-lpair/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11025\">Configuration file for RECO step </a><br><a href=\"/record/11071\">Configuration file for HLT step </a><br>Output dataset: /GammaGammaToEE_SingleDiss-pmod11_Pt15_8TeV-lpair/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -5071,10 +4891,6 @@
   },
   "title": "/GammaGammaToEE_SingleDiss-pmod11_Pt15_8TeV-lpair/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GammaGammaToEE_SingleDiss-pmod11_Pt15_8TeV-lpair in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -5152,7 +4968,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11212\">Configuration file for SIM step </a><br>Output dataset: /GammaGammaToMuMu_Elastic_Pt15_8TeV-lpair/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11071\">Configuration file for HLT step </a><br><a href=\"/record/11025\">Configuration file for RECO step </a><br>Output dataset: /GammaGammaToMuMu_Elastic_Pt15_8TeV-lpair/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -5170,10 +4986,6 @@
   },
   "title": "/GammaGammaToMuMu_Elastic_Pt15_8TeV-lpair/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GammaGammaToMuMu_Elastic_Pt15_8TeV-lpair in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -5265,7 +5077,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11177\">Configuration file for SIM step config_24_1_cfg</a><br>Output dataset: /GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11130\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11021\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -5283,10 +5095,6 @@
   },
   "title": "/GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -5364,7 +5172,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11212\">Configuration file for SIM step </a><br>Output dataset: /GammaGammaToMuMu_SingleDiss-pmod11_Pt15_8TeV-lpair/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11025\">Configuration file for RECO step </a><br><a href=\"/record/11071\">Configuration file for HLT step </a><br>Output dataset: /GammaGammaToMuMu_SingleDiss-pmod11_Pt15_8TeV-lpair/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -5382,10 +5190,6 @@
   },
   "title": "/GammaGammaToMuMu_SingleDiss-pmod11_Pt15_8TeV-lpair/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GammaGammaToMuMu_SingleDiss-pmod11_Pt15_8TeV-lpair in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -5463,7 +5267,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11006\">Configuration file for SIM step FWD-Summer12-00027_1_cfg</a><br>Output dataset: /GammaGammaToTauTau_SingleDiss-pmod11_Pt25_8TeV-lpair/Summer12-START53_V7C_castor-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11023\">Configuration file for RECO step B2G-Summer12DR53X-00431_2_cfg</a><br><a href=\"/record/11193\">Configuration file for HLT step B2G-Summer12DR53X-00431_1_cfg</a><br>Output dataset: /GammaGammaToTauTau_SingleDiss-pmod11_Pt25_8TeV-lpair/Summer12_DR53X-castor_PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -5481,10 +5285,6 @@
   },
   "title": "/GammaGammaToTauTau_SingleDiss-pmod11_Pt25_8TeV-lpair/Summer12_DR53X-castor_PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GammaGammaToTauTau_SingleDiss-pmod11_Pt25_8TeV-lpair in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -5562,7 +5362,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11214\">Configuration file for SIM step SUS-Summer12-00100_1_cfg</a><br>Output dataset: /GG4J_HT-0To300_TuneZ2star_8TeV-madgraph/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11078\">Configuration file for HLT step EXO-Summer12DR53X-02796_1_cfg</a><br><a href=\"/record/11128\">Configuration file for RECO step EXO-Summer12DR53X-02796_2_cfg</a><br>Output dataset: /GG4J_HT-0To300_TuneZ2star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -5580,10 +5380,6 @@
   },
   "title": "/GG4J_HT-0To300_TuneZ2star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GG4J_HT-0To300_TuneZ2star_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -5675,7 +5471,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11267\">Configuration file for SIM step SUS-Summer12-00096_1_cfg</a><br>Output dataset: /GG4J_HT-300To700_TuneZ2star_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11002\">Configuration file for RECO step B2G-Summer12DR53X-00678_2_cfg</a><br><a href=\"/record/11294\">Configuration file for HLT step B2G-Summer12DR53X-00678_1_cfg</a><br>Output dataset: /GG4J_HT-300To700_TuneZ2star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -5693,10 +5489,6 @@
   },
   "title": "/GG4J_HT-300To700_TuneZ2star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GG4J_HT-300To700_TuneZ2star_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -5774,7 +5566,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11053\">Configuration file for SIM step SUS-Summer12-00097_1_cfg</a><br>Output dataset: /GG4J_HT-700ToInf_TuneZ2star_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11002\">Configuration file for RECO step B2G-Summer12DR53X-00678_2_cfg</a><br><a href=\"/record/11294\">Configuration file for HLT step B2G-Summer12DR53X-00678_1_cfg</a><br>Output dataset: /GG4J_HT-700ToInf_TuneZ2star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -5792,10 +5584,6 @@
   },
   "title": "/GG4J_HT-700ToInf_TuneZ2star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GG4J_HT-700ToInf_TuneZ2star_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -5887,7 +5675,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11219\">Configuration file for SIM step HIG-Summer12-02199_1_cfg</a><br>Output dataset: /ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11131\">Configuration file for HLT step HIG-Summer12DR53X-02045_1_cfg</a><br><a href=\"/record/11038\">Configuration file for RECO step HIG-Summer12DR53X-02045_2_cfg</a><br>Output dataset: /ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -5905,10 +5693,6 @@
   },
   "title": "/ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM",
   "title_additional": "Simulated dataset ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -6028,7 +5812,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11299\">Configuration file for SIM step HIG-Summer12-01588_1_cfg</a><br>Output dataset: /GJet_M80_doubleEMEnriched_8TeV-sherpa/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11202\">Configuration file for RECO step HIG-Summer12DR53X-01521_2_cfg</a><br><a href=\"/record/11012\">Configuration file for HLT step HIG-Summer12DR53X-01521_1_cfg</a><br>Output dataset: /GJet_M80_doubleEMEnriched_8TeV-sherpa/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -6046,10 +5830,6 @@
   },
   "title": "/GJet_M80_doubleEMEnriched_8TeV-sherpa/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset GJet_M80_doubleEMEnriched_8TeV-sherpa in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -6141,7 +5921,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11228\">Configuration file for SIM step HIG-Summer12-01741_1_cfg</a><br>Output dataset: /GJet_M80_nofilter_8TeV-sherpa/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11027\">Configuration file for RECO step HIG-Summer12DR53X-01646_2_cfg</a><br><a href=\"/record/11167\">Configuration file for HLT step HIG-Summer12DR53X-01646_1_cfg</a><br>Output dataset: /GJet_M80_nofilter_8TeV-sherpa/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -6159,10 +5939,6 @@
   },
   "title": "/GJet_M80_nofilter_8TeV-sherpa/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset GJet_M80_nofilter_8TeV-sherpa in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -6268,7 +6044,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11136\">Configuration file for SIM step </a><br>Output dataset: /GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11165\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11281\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -6286,10 +6062,6 @@
   },
   "title": "/GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -6381,7 +6153,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11062\">Configuration file for SIM step </a><br>Output dataset: /GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11018\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11092\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -6399,10 +6171,6 @@
   },
   "title": "/GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -6480,7 +6248,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11008\">Configuration file for SIM step </a><br>Output dataset: /GJets_HT-100To200_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11181\">Configuration file for RECO step </a><br><a href=\"/record/11085\">Configuration file for HLT step </a><br>Output dataset: /GJets_HT-100To200_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -6498,10 +6266,6 @@
   },
   "title": "/GJets_HT-100To200_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GJets_HT-100To200_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -6593,7 +6357,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11286\">Configuration file for SIM step config_2_1_cfg</a><br>Output dataset: /GJets_HT-40To100_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11115\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11209\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /GJets_HT-40To100_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -6611,10 +6375,6 @@
   },
   "title": "/GJets_HT-40To100_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GJets_HT-40To100_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -6720,7 +6480,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11174\">Configuration file for SIM step HIG-Summer12-02269_1_cfg</a><br>Output dataset: /GluGluHToGG_M-125_8TeV-pythia6/Summer12-START53_V7C_ext1-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11038\">Configuration file for RECO step HIG-Summer12DR53X-02045_2_cfg</a><br><a href=\"/record/11131\">Configuration file for HLT step HIG-Summer12DR53X-02045_1_cfg</a><br>Output dataset: /GluGluHToGG_M-125_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -6738,10 +6498,6 @@
   },
   "title": "/GluGluHToGG_M-125_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM",
   "title_additional": "Simulated dataset GluGluHToGG_M-125_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -6833,7 +6589,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11190\">Configuration file for SIM step HIG-Summer12-01909_1_cfg</a><br>Output dataset: /GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br>Output dataset: /GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -6851,10 +6607,6 @@
   },
   "title": "/GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -6946,7 +6698,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11190\">Configuration file for SIM step HIG-Summer12-01909_1_cfg</a><br>Output dataset: /GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br>Output dataset: /GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -6964,10 +6716,6 @@
   },
   "title": "/GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -7059,7 +6807,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11190\">Configuration file for SIM step HIG-Summer12-01909_1_cfg</a><br>Output dataset: /GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br>Output dataset: /GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -7077,10 +6825,6 @@
   },
   "title": "/GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -7158,7 +6902,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11232\">Configuration file for SIM step HIG-Summer12-02056_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_Bkgd_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11010\">Configuration file for RECO step EXO-Summer12DR53X-02706_2_cfg</a><br><a href=\"/record/11216\">Configuration file for HLT step EXO-Summer12DR53X-02706_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_Bkgd_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -7176,10 +6920,6 @@
   },
   "title": "/GluGluTo2L2Nu_Bkgd_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo2L2Nu_Bkgd_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -7257,7 +6997,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11232\">Configuration file for SIM step HIG-Summer12-02056_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_Bkgd_down_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11216\">Configuration file for HLT step EXO-Summer12DR53X-02706_1_cfg</a><br><a href=\"/record/11010\">Configuration file for RECO step EXO-Summer12DR53X-02706_2_cfg</a><br>Output dataset: /GluGluTo2L2Nu_Bkgd_down_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -7275,10 +7015,6 @@
   },
   "title": "/GluGluTo2L2Nu_Bkgd_down_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo2L2Nu_Bkgd_down_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -7356,7 +7092,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11232\">Configuration file for SIM step HIG-Summer12-02056_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_Bkgd_up_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11010\">Configuration file for RECO step EXO-Summer12DR53X-02706_2_cfg</a><br><a href=\"/record/11216\">Configuration file for HLT step EXO-Summer12DR53X-02706_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_Bkgd_up_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -7374,10 +7110,6 @@
   },
   "title": "/GluGluTo2L2Nu_Bkgd_up_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo2L2Nu_Bkgd_up_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -7455,7 +7187,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11232\">Configuration file for SIM step HIG-Summer12-02056_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_Signal_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11010\">Configuration file for RECO step EXO-Summer12DR53X-02706_2_cfg</a><br><a href=\"/record/11216\">Configuration file for HLT step EXO-Summer12DR53X-02706_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_Signal_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -7473,10 +7205,6 @@
   },
   "title": "/GluGluTo2L2Nu_Signal_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo2L2Nu_Signal_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -7554,7 +7282,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11232\">Configuration file for SIM step HIG-Summer12-02056_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_Signal_down_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11216\">Configuration file for HLT step EXO-Summer12DR53X-02706_1_cfg</a><br><a href=\"/record/11010\">Configuration file for RECO step EXO-Summer12DR53X-02706_2_cfg</a><br>Output dataset: /GluGluTo2L2Nu_Signal_down_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -7572,10 +7300,6 @@
   },
   "title": "/GluGluTo2L2Nu_Signal_down_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo2L2Nu_Signal_down_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -7653,7 +7377,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11232\">Configuration file for SIM step HIG-Summer12-02056_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_SignalplusBkgd_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11216\">Configuration file for HLT step EXO-Summer12DR53X-02706_1_cfg</a><br><a href=\"/record/11010\">Configuration file for RECO step EXO-Summer12DR53X-02706_2_cfg</a><br>Output dataset: /GluGluTo2L2Nu_SignalplusBkgd_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -7671,10 +7395,6 @@
   },
   "title": "/GluGluTo2L2Nu_SignalplusBkgd_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo2L2Nu_SignalplusBkgd_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -7752,7 +7472,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11232\">Configuration file for SIM step HIG-Summer12-02056_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_SignalplusBkgd_down_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11280\">Configuration file for RECO step EXO-Summer12DR53X-02794_2_cfg</a><br><a href=\"/record/11162\">Configuration file for HLT step EXO-Summer12DR53X-02794_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_SignalplusBkgd_down_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -7770,10 +7490,6 @@
   },
   "title": "/GluGluTo2L2Nu_SignalplusBkgd_down_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo2L2Nu_SignalplusBkgd_down_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -7851,7 +7567,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11232\">Configuration file for SIM step HIG-Summer12-02056_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_SignalplusBkgd_up_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11010\">Configuration file for RECO step EXO-Summer12DR53X-02706_2_cfg</a><br><a href=\"/record/11216\">Configuration file for HLT step EXO-Summer12DR53X-02706_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_SignalplusBkgd_up_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -7869,10 +7585,6 @@
   },
   "title": "/GluGluTo2L2Nu_SignalplusBkgd_up_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo2L2Nu_SignalplusBkgd_up_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -7950,7 +7662,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11232\">Configuration file for SIM step HIG-Summer12-02056_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_Signal_up_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11010\">Configuration file for RECO step EXO-Summer12DR53X-02706_2_cfg</a><br><a href=\"/record/11216\">Configuration file for HLT step EXO-Summer12DR53X-02706_1_cfg</a><br>Output dataset: /GluGluTo2L2Nu_Signal_up_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -7968,10 +7680,6 @@
   },
   "title": "/GluGluTo2L2Nu_Signal_up_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo2L2Nu_Signal_up_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -8063,7 +7771,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11190\">Configuration file for SIM step HIG-Summer12-01909_1_cfg</a><br>Output dataset: /GluGluTo4e_Contin_8TeV-MCFM67-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br>Output dataset: /GluGluTo4e_Contin_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -8081,10 +7789,6 @@
   },
   "title": "/GluGluTo4e_Contin_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo4e_Contin_8TeV-MCFM67-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -8176,7 +7880,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11190\">Configuration file for SIM step HIG-Summer12-01909_1_cfg</a><br>Output dataset: /GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br>Output dataset: /GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -8194,10 +7898,6 @@
   },
   "title": "/GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -8289,7 +7989,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11190\">Configuration file for SIM step HIG-Summer12-01909_1_cfg</a><br>Output dataset: /GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br>Output dataset: /GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -8307,10 +8007,6 @@
   },
   "title": "/GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -8402,7 +8098,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11169\">Configuration file for SIM step HIG-Summer12-01936_1_cfg</a><br>Output dataset: /GluGluTo4L_Contin_8TeV-gg2vv315-pythia6/Summer12-START53_V7C-v3/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11128\">Configuration file for RECO step EXO-Summer12DR53X-02796_2_cfg</a><br><a href=\"/record/11078\">Configuration file for HLT step EXO-Summer12DR53X-02796_1_cfg</a><br>Output dataset: /GluGluTo4L_Contin_8TeV-gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v3/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -8420,10 +8116,6 @@
   },
   "title": "/GluGluTo4L_Contin_8TeV-gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v3/AODSIM",
   "title_additional": "Simulated dataset GluGluTo4L_Contin_8TeV-gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -8529,7 +8221,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11242\">Configuration file for SIM step HIG-Summer12-01835_1_cfg</a><br>Output dataset: /GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11002\">Configuration file for RECO step B2G-Summer12DR53X-00678_2_cfg</a><br><a href=\"/record/11294\">Configuration file for HLT step B2G-Summer12DR53X-00678_1_cfg</a><br>Output dataset: /GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -8547,10 +8239,6 @@
   },
   "title": "/GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -8628,7 +8316,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11242\">Configuration file for SIM step HIG-Summer12-01835_1_cfg</a><br>Output dataset: /GluGluTo4L_H_M-125p6_8TeV-gg2vv315-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11002\">Configuration file for RECO step B2G-Summer12DR53X-00678_2_cfg</a><br><a href=\"/record/11294\">Configuration file for HLT step B2G-Summer12DR53X-00678_1_cfg</a><br>Output dataset: /GluGluTo4L_H_M-125p6_8TeV-gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -8646,10 +8334,6 @@
   },
   "title": "/GluGluTo4L_H_M-125p6_8TeV-gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo4L_H_M-125p6_8TeV-gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -8741,7 +8425,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11190\">Configuration file for SIM step HIG-Summer12-01909_1_cfg</a><br>Output dataset: /GluGluTo4mu_Contin_8TeV-MCFM67-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br>Output dataset: /GluGluTo4mu_Contin_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -8759,10 +8443,6 @@
   },
   "title": "/GluGluTo4mu_Contin_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo4mu_Contin_8TeV-MCFM67-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -8854,7 +8534,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11190\">Configuration file for SIM step HIG-Summer12-01909_1_cfg</a><br>Output dataset: /GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br>Output dataset: /GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -8872,10 +8552,6 @@
   },
   "title": "/GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -8967,7 +8643,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11190\">Configuration file for SIM step HIG-Summer12-01909_1_cfg</a><br>Output dataset: /GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br>Output dataset: /GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -8985,10 +8661,6 @@
   },
   "title": "/GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -9066,7 +8738,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11190\">Configuration file for SIM step HIG-Summer12-01909_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2G_M-125_8TeV-madgraph-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11013\">Configuration file for RECO step HIG-Summer12DR53X-01745_2_cfg</a><br><a href=\"/record/11263\">Configuration file for HLT step HIG-Summer12DR53X-01745_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2G_M-125_8TeV-madgraph-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -9084,10 +8756,6 @@
   },
   "title": "/GluGluToHHTo2B2G_M-125_8TeV-madgraph-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHHTo2B2G_M-125_8TeV-madgraph-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -9179,7 +8847,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11113\">Configuration file for SIM step config_37_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11000\">Configuration file for RECO step HIG-Summer12DR53X-01500_2_cfg</a><br><a href=\"/record/11272\">Configuration file for HLT step HIG-Summer12DR53X-01500_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -9197,10 +8865,6 @@
   },
   "title": "/GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -9278,7 +8942,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11113\">Configuration file for SIM step config_37_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11051\">Configuration file for RECO step HIG-Summer12DR53X-01346_2_cfg</a><br><a href=\"/record/11268\">Configuration file for HLT step HIG-Summer12DR53X-01346_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -9296,10 +8960,6 @@
   },
   "title": "/GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -9377,7 +9037,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11169\">Configuration file for SIM step HIG-Summer12-01936_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2Tau_M-125_8TeV-madgraph-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br>Output dataset: /GluGluToHHTo2B2Tau_M-125_8TeV-madgraph-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -9395,10 +9055,6 @@
   },
   "title": "/GluGluToHHTo2B2Tau_M-125_8TeV-madgraph-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHHTo2B2Tau_M-125_8TeV-madgraph-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -9476,7 +9132,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11113\">Configuration file for SIM step config_37_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2Tau_mH-125_8TeV-madgraph-pythia6-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11051\">Configuration file for RECO step HIG-Summer12DR53X-01346_2_cfg</a><br><a href=\"/record/11268\">Configuration file for HLT step HIG-Summer12DR53X-01346_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2Tau_mH-125_8TeV-madgraph-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -9494,10 +9150,6 @@
   },
   "title": "/GluGluToHHTo2B2Tau_mH-125_8TeV-madgraph-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHHTo2B2Tau_mH-125_8TeV-madgraph-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -9575,7 +9227,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11113\">Configuration file for SIM step config_37_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2WToJJLNu_mH-125_8TeV-madgraph-pythia6-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11268\">Configuration file for HLT step HIG-Summer12DR53X-01346_1_cfg</a><br><a href=\"/record/11051\">Configuration file for RECO step HIG-Summer12DR53X-01346_2_cfg</a><br>Output dataset: /GluGluToHHTo2B2WToJJLNu_mH-125_8TeV-madgraph-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -9593,10 +9245,6 @@
   },
   "title": "/GluGluToHHTo2B2WToJJLNu_mH-125_8TeV-madgraph-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHHTo2B2WToJJLNu_mH-125_8TeV-madgraph-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -9674,7 +9322,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11237\">Configuration file for SIM step HIG-Summer12-01937_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2WToLNuLNu_M-125_8TeV-madgraph-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2WToLNuLNu_M-125_8TeV-madgraph-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -9692,10 +9340,6 @@
   },
   "title": "/GluGluToHHTo2B2WToLNuLNu_M-125_8TeV-madgraph-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHHTo2B2WToLNuLNu_M-125_8TeV-madgraph-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -9773,7 +9417,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11113\">Configuration file for SIM step config_37_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2WToLNuLNu_mH-125_8TeV-madgraph-pythia6-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11268\">Configuration file for HLT step HIG-Summer12DR53X-01346_1_cfg</a><br><a href=\"/record/11051\">Configuration file for RECO step HIG-Summer12DR53X-01346_2_cfg</a><br>Output dataset: /GluGluToHHTo2B2WToLNuLNu_mH-125_8TeV-madgraph-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -9791,10 +9435,6 @@
   },
   "title": "/GluGluToHHTo2B2WToLNuLNu_mH-125_8TeV-madgraph-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHHTo2B2WToLNuLNu_mH-125_8TeV-madgraph-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -9886,7 +9526,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11237\">Configuration file for SIM step HIG-Summer12-01937_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br>Output dataset: /GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -9904,10 +9544,6 @@
   },
   "title": "/GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -9999,7 +9635,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11094\">Configuration file for SIM step HIG-Summer12-02248_1_cfg</a><br>Output dataset: /GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11015\">Configuration file for HLT step B2G-Summer12DR53X-00692_1_cfg</a><br><a href=\"/record/11028\">Configuration file for RECO step B2G-Summer12DR53X-00770_2_cfg</a><br>Output dataset: /GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -10017,10 +9653,6 @@
   },
   "title": "/GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -10098,7 +9730,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11050\">Configuration file for SIM step </a><br>Output dataset: /GluGluToHToBB_M-125_8TeV-powheg-pythia6_ext/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11046\">Configuration file for HLT step </a><br><a href=\"/record/11040\">Configuration file for RECO step </a><br>Output dataset: /GluGluToHToBB_M-125_8TeV-powheg-pythia6_ext/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -10116,10 +9748,6 @@
   },
   "title": "/GluGluToHToBB_M-125_8TeV-powheg-pythia6_ext/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToBB_M-125_8TeV-powheg-pythia6_ext in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -10211,7 +9839,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11210\">Configuration file for SIM step </a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11165\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11281\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -10229,10 +9857,6 @@
   },
   "title": "/GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -10324,7 +9948,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11141\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-powheg15-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11000\">Configuration file for RECO step HIG-Summer12DR53X-01500_2_cfg</a><br><a href=\"/record/11272\">Configuration file for HLT step HIG-Summer12DR53X-01500_1_cfg</a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-powheg15-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -10342,10 +9966,6 @@
   },
   "title": "/GluGluToHToGG_M-125_8TeV-powheg15-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToGG_M-125_8TeV-powheg15-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -10423,7 +10043,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11207\">Configuration file for SIM step HIG-Summer12-01728_1_cfg</a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12-START53_V14B_Ext30-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-Ext30_PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -10441,10 +10061,6 @@
   },
   "title": "/GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-Ext30_PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToGG_M-125_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -10522,7 +10138,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11207\">Configuration file for SIM step HIG-Summer12-01728_1_cfg</a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12-START53_V14B_Ext30-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11249\">Configuration file for RECO step HIG-Summer12DR53X-01621_2_cfg</a><br><a href=\"/record/11134\">Configuration file for HLT step HIG-Summer12DR53X-01621_1_cfg</a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-ExtFlat30_PU_RD1_START53_V7N-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -10540,10 +10156,6 @@
   },
   "title": "/GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-ExtFlat30_PU_RD1_START53_V7N-v2/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToGG_M-125_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -10621,7 +10233,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11109\">Configuration file for SIM step HIG-Summer12-02074_1_cfg</a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12-START53_V7C_NewG4Phys-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11222\">Configuration file for HLT step HIG-Summer12DR53X-01930_1_cfg</a><br><a href=\"/record/11033\">Configuration file for RECO step HIG-Summer12DR53X-01930_2_cfg</a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-NewG4Phys_PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -10639,10 +10251,6 @@
   },
   "title": "/GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-NewG4Phys_PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToGG_M-125_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -10720,7 +10328,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11036\">Configuration file for SIM step </a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12-START53_V7D-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT HLT RECO</strong><br><a href=\"/record/11201\">Configuration file for RECO step EWK-Summer12DR53X-00159_2_cfg</a><br><a href=\"/record/11296\">Configuration file for HLT step EWK-Summer12DR53X-00159_1_cfg</a><br><a href=\"/record/11095\">Configuration file for HLT step EWK-Summer12DR53X-00159_1_cfg</a><br><a href=\"/record/11026\">Configuration file for RECO step EWK-Summer12DR53X-00159_2_cfg</a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-No_PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -10738,10 +10346,6 @@
   },
   "title": "/GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-No_PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToGG_M-125_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -10819,7 +10423,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11018\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11092\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -10837,10 +10441,6 @@
   },
   "title": "/GluGluToHToGG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToGG_M-125_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -10918,7 +10518,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11148\">Configuration file for SIM step HIG-Summer12-01717_1_cfg</a><br>Output dataset: /GluGluToHToInvisible_M-125_8TeV-powheg-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11193\">Configuration file for HLT step B2G-Summer12DR53X-00431_1_cfg</a><br><a href=\"/record/11023\">Configuration file for RECO step B2G-Summer12DR53X-00431_2_cfg</a><br>Output dataset: /GluGluToHToInvisible_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -10936,10 +10536,6 @@
   },
   "title": "/GluGluToHToInvisible_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToInvisible_M-125_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -11017,7 +10613,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11221\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /GluGluToHToMM_M-125_TuneZ2star_8TeV-minloHJJ-powheg-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11022\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11154\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /GluGluToHToMM_M-125_TuneZ2star_8TeV-minloHJJ-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -11035,10 +10631,6 @@
   },
   "title": "/GluGluToHToMM_M-125_TuneZ2star_8TeV-minloHJJ-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToMM_M-125_TuneZ2star_8TeV-minloHJJ-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -11130,7 +10722,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11140\">Configuration file for SIM step </a><br>Output dataset: /GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11090\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11240\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -11148,10 +10740,6 @@
   },
   "title": "/GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -11229,7 +10817,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11188\">Configuration file for SIM step HIG-Summer12-02168_1_cfg</a><br>Output dataset: /GluGluToHToTauTau_M-125_8TeV-powheg-pythia6-tauPolarOff/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br>Output dataset: /GluGluToHToTauTau_M-125_8TeV-powheg-pythia6-tauPolarOff/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -11247,10 +10835,6 @@
   },
   "title": "/GluGluToHToTauTau_M-125_8TeV-powheg-pythia6-tauPolarOff/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToTauTau_M-125_8TeV-powheg-pythia6-tauPolarOff in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -11328,7 +10912,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11170\">Configuration file for SIM step HIG-Summer12-01977_1_cfg</a><br>Output dataset: /GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11216\">Configuration file for HLT step EXO-Summer12DR53X-02706_1_cfg</a><br><a href=\"/record/11010\">Configuration file for RECO step EXO-Summer12DR53X-02706_2_cfg</a><br>Output dataset: /GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -11346,10 +10930,6 @@
   },
   "title": "/GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -11441,7 +11021,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11289\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12-START53_V7C-v3/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11156\">Configuration file for HLT step HIG-Summer12DR53X-01468_1_cfg</a><br><a href=\"/record/11252\">Configuration file for RECO step HIG-Summer12DR53X-01468_2_cfg</a><br>Output dataset: /GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -11459,10 +11039,6 @@
   },
   "title": "/GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -11540,7 +11116,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11170\">Configuration file for SIM step HIG-Summer12-01977_1_cfg</a><br>Output dataset: /GluGluToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11216\">Configuration file for HLT step EXO-Summer12DR53X-02706_1_cfg</a><br><a href=\"/record/11010\">Configuration file for RECO step EXO-Summer12DR53X-02706_2_cfg</a><br>Output dataset: /GluGluToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -11558,10 +11134,6 @@
   },
   "title": "/GluGluToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -11653,7 +11225,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11098\">Configuration file for SIM step </a><br>Output dataset: /GluGluToHToZG_M-125_8TeV-powheg-pythia6/Summer12-START50_V13-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11013\">Configuration file for RECO step HIG-Summer12DR53X-01745_2_cfg</a><br><a href=\"/record/11263\">Configuration file for HLT step HIG-Summer12DR53X-01745_1_cfg</a><br>Output dataset: /GluGluToHToZG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v3/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -11671,10 +11243,6 @@
   },
   "title": "/GluGluToHToZG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v3/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToZG_M-125_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -11766,7 +11334,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11293\">Configuration file for SIM step HIG-Summer12-01886_1_cfg</a><br>Output dataset: /GluGluToHToZG_M-125_8TeV-powheg-pythia8175/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11013\">Configuration file for RECO step HIG-Summer12DR53X-01745_2_cfg</a><br><a href=\"/record/11263\">Configuration file for HLT step HIG-Summer12DR53X-01745_1_cfg</a><br>Output dataset: /GluGluToHToZG_M-125_8TeV-powheg-pythia8175/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -11784,10 +11352,6 @@
   },
   "title": "/GluGluToHToZG_M-125_8TeV-powheg-pythia8175/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToZG_M-125_8TeV-powheg-pythia8175 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -11879,7 +11443,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11034\">Configuration file for SIM step HIG-Summer12-01808_1_cfg</a><br>Output dataset: /GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11294\">Configuration file for HLT step B2G-Summer12DR53X-00678_1_cfg</a><br><a href=\"/record/11002\">Configuration file for RECO step B2G-Summer12DR53X-00678_2_cfg</a><br>Output dataset: /GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -11897,10 +11461,6 @@
   },
   "title": "/GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -11992,7 +11552,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11266\">Configuration file for SIM step HIG-Summer12-01590_1_cfg</a><br>Output dataset: /GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11059\">Configuration file for RECO step JME-Summer12DR53X-00163_2_cfg</a><br><a href=\"/record/11292\">Configuration file for HLT step JME-Summer12DR53X-00163_1_cfg</a><br>Output dataset: /GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -12010,10 +11570,6 @@
   },
   "title": "/GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -12105,7 +11661,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11009\">Configuration file for SIM step </a><br>Output dataset: /GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11090\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11240\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -12123,10 +11679,6 @@
   },
   "title": "/GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -12204,7 +11756,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11198\">Configuration file for SIM step </a><br>Output dataset: /GluGluToHToZZTo4L_M-125_8TeV-powheg15-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11041\">Configuration file for RECO step </a><br><a href=\"/record/11058\">Configuration file for HLT step </a><br>Output dataset: /GluGluToHToZZTo4L_M-125_8TeV-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -12222,10 +11774,6 @@
   },
   "title": "/GluGluToHToZZTo4L_M-125_8TeV-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-125_8TeV-powheg15-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -12303,7 +11851,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11067\">Configuration file for SIM step HIG-Summer12-02150_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -12321,10 +11869,6 @@
   },
   "title": "/GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -12402,7 +11946,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11067\">Configuration file for SIM step HIG-Summer12-02150_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -12420,10 +11964,6 @@
   },
   "title": "/GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -12501,7 +12041,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11067\">Configuration file for SIM step HIG-Summer12-02150_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -12519,10 +12059,6 @@
   },
   "title": "/GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -12600,7 +12136,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11067\">Configuration file for SIM step HIG-Summer12-02150_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -12618,10 +12154,6 @@
   },
   "title": "/GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -12699,7 +12231,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11067\">Configuration file for SIM step HIG-Summer12-02150_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -12717,10 +12249,6 @@
   },
   "title": "/GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -12798,7 +12326,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11067\">Configuration file for SIM step HIG-Summer12-02150_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -12816,10 +12344,6 @@
   },
   "title": "/GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -12897,7 +12421,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11067\">Configuration file for SIM step HIG-Summer12-02150_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_Contin_mWW-0to300_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_Contin_mWW-0to300_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -12915,10 +12439,6 @@
   },
   "title": "/GluGluToWWTo2L2Nu_Contin_mWW-0to300_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToWWTo2L2Nu_Contin_mWW-0to300_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -12996,7 +12516,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11067\">Configuration file for SIM step HIG-Summer12-02150_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_Contin_mWW-300_8TeV_gg2vv315-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11122\">Configuration file for RECO step HIG-Summer12DR53X-02029_2_cfg</a><br><a href=\"/record/11230\">Configuration file for HLT step HIG-Summer12DR53X-02029_1_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_Contin_mWW-300_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -13014,10 +12534,6 @@
   },
   "title": "/GluGluToWWTo2L2Nu_Contin_mWW-300_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToWWTo2L2Nu_Contin_mWW-300_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -13095,7 +12611,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br>Output dataset: /GluGluToWWTo2L2Nu_Signal_25xHWidth_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -13113,10 +12629,6 @@
   },
   "title": "/GluGluToWWTo2L2Nu_Signal_25xHWidth_8TeV_gg2vv315-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset GluGluToWWTo2L2Nu_Signal_25xHWidth_8TeV_gg2vv315-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -13208,7 +12720,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br>Output dataset: /G_Pt-120to170_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -13226,10 +12738,6 @@
   },
   "title": "/G_Pt-120to170_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset G_Pt-120to170_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -13321,7 +12829,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br>Output dataset: /G_Pt-1400to1800_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -13339,10 +12847,6 @@
   },
   "title": "/G_Pt-1400to1800_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset G_Pt-1400to1800_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -13434,7 +12938,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br>Output dataset: /G_Pt-170to300_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -13452,10 +12956,6 @@
   },
   "title": "/G_Pt-170to300_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset G_Pt-170to300_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -13547,7 +13047,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br>Output dataset: /G_Pt-1800_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -13565,10 +13065,6 @@
   },
   "title": "/G_Pt-1800_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset G_Pt-1800_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -13646,7 +13142,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br>Output dataset: /G_Pt-300to470_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -13664,10 +13160,6 @@
   },
   "title": "/G_Pt-300to470_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset G_Pt-300to470_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -13759,7 +13251,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br>Output dataset: /G_Pt-30to50_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -13777,10 +13269,6 @@
   },
   "title": "/G_Pt-30to50_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset G_Pt-30to50_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -13872,7 +13360,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br>Output dataset: /G_Pt-470to800_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -13890,10 +13378,6 @@
   },
   "title": "/G_Pt-470to800_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset G_Pt-470to800_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -13985,7 +13469,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br>Output dataset: /G_Pt-50to80_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -14003,10 +13487,6 @@
   },
   "title": "/G_Pt-50to80_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset G_Pt-50to80_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -14098,7 +13578,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br>Output dataset: /G_Pt-800to1400_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -14116,10 +13596,6 @@
   },
   "title": "/G_Pt-800to1400_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset G_Pt-800to1400_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -14211,7 +13687,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br>Output dataset: /G_Pt-80to120_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -14229,10 +13705,6 @@
   },
   "title": "/G_Pt-80to120_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset G_Pt-80to120_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -14324,7 +13796,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11074\">Configuration file for SIM step config_2_1_cfg</a><br>Output dataset: /LminusNubarVBF_Mqq-120_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11244\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11102\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /LminusNubarVBF_Mqq-120_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -14342,10 +13814,6 @@
   },
   "title": "/LminusNubarVBF_Mqq-120_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset LminusNubarVBF_Mqq-120_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -14423,7 +13891,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11142\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /LNuGG_enhanced_FSR_8TeV_madgraph/Summer12-START53_V7C-ext-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11249\">Configuration file for RECO step HIG-Summer12DR53X-01621_2_cfg</a><br><a href=\"/record/11197\">Configuration file for HLT step HIG-Summer12DR53X-01636_1_cfg</a><br>Output dataset: /LNuGG_enhanced_FSR_8TeV_madgraph/Summer12_DR53X-PU_RD1_START53_V7N_ext1-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -14441,10 +13909,6 @@
   },
   "title": "/LNuGG_enhanced_FSR_8TeV_madgraph/Summer12_DR53X-PU_RD1_START53_V7N_ext1-v1/AODSIM",
   "title_additional": "Simulated dataset LNuGG_enhanced_FSR_8TeV_madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -14536,7 +14000,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11142\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /LNuGG_enhanced_FSR_8TeV_madgraph/Summer12-START53_V7C-ext-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11209\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11115\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /LNuGG_enhanced_FSR_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -14554,10 +14018,6 @@
   },
   "title": "/LNuGG_enhanced_FSR_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset LNuGG_enhanced_FSR_8TeV_madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -14635,7 +14095,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11142\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /LNuGG_enhanced_ISR_8TeV_madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11197\">Configuration file for HLT step HIG-Summer12DR53X-01636_1_cfg</a><br><a href=\"/record/11249\">Configuration file for RECO step HIG-Summer12DR53X-01621_2_cfg</a><br>Output dataset: /LNuGG_enhanced_ISR_8TeV_madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -14653,10 +14113,6 @@
   },
   "title": "/LNuGG_enhanced_ISR_8TeV_madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset LNuGG_enhanced_ISR_8TeV_madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -14748,7 +14204,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11142\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /LNuGG_enhanced_ISR_8TeV_madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11073\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11004\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /LNuGG_enhanced_ISR_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -14766,10 +14222,6 @@
   },
   "title": "/LNuGG_enhanced_ISR_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset LNuGG_enhanced_ISR_8TeV_madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -14861,7 +14313,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11116\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /LplusNuVBF_Mqq-120_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11055\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11243\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /LplusNuVBF_Mqq-120_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -14879,10 +14331,6 @@
   },
   "title": "/LplusNuVBF_Mqq-120_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset LplusNuVBF_Mqq-120_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -14974,7 +14422,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11211\">Configuration file for SIM step </a><br>Output dataset: /Neutrino_Pt_2to20_gun/Summer12-START50_V13-v3/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br>Output dataset: /Neutrino_Pt_2to20_gun/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -14992,10 +14440,6 @@
   },
   "title": "/Neutrino_Pt_2to20_gun/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset Neutrino_Pt_2to20_gun in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -15073,7 +14517,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11175\">Configuration file for SIM step config_1_1_cfg</a><br>Output dataset: /QCD4Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11241\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11186\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /QCD4Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -15091,10 +14535,6 @@
   },
   "title": "/QCD4Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD4Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -15186,7 +14626,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11269\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11193\">Configuration file for HLT step B2G-Summer12DR53X-00431_1_cfg</a><br><a href=\"/record/11023\">Configuration file for RECO step B2G-Summer12DR53X-00431_2_cfg</a><br>Output dataset: /QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -15204,10 +14644,6 @@
   },
   "title": "/QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -15285,7 +14721,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11175\">Configuration file for SIM step config_1_1_cfg</a><br>Output dataset: /QCD4Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11186\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11241\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /QCD4Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -15303,10 +14739,6 @@
   },
   "title": "/QCD4Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD4Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -15384,7 +14816,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11175\">Configuration file for SIM step config_1_1_cfg</a><br>Output dataset: /QCD4Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11186\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11241\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /QCD4Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -15402,10 +14834,6 @@
   },
   "title": "/QCD4Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD4Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -15483,7 +14911,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11175\">Configuration file for SIM step config_1_1_cfg</a><br>Output dataset: /QCD6Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11241\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11186\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /QCD6Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -15501,10 +14929,6 @@
   },
   "title": "/QCD6Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD6Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -15582,7 +15006,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11175\">Configuration file for SIM step config_1_1_cfg</a><br>Output dataset: /QCD6Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11186\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11241\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /QCD6Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -15600,10 +15024,6 @@
   },
   "title": "/QCD6Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD6Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -15681,7 +15101,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11175\">Configuration file for SIM step config_1_1_cfg</a><br>Output dataset: /QCD6Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11241\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11186\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /QCD6Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -15699,10 +15119,6 @@
   },
   "title": "/QCD6Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD6Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -15780,7 +15196,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11175\">Configuration file for SIM step config_1_1_cfg</a><br>Output dataset: /QCD6Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11241\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11186\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /QCD6Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -15798,10 +15214,6 @@
   },
   "title": "/QCD6Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD6Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -15879,7 +15291,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11111\">Configuration file for SIM step </a><br>Output dataset: /QCD_Pt-1000_CTEQ6L1_8TeV_herwig6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11054\">Configuration file for RECO step </a><br><a href=\"/record/11270\">Configuration file for HLT step </a><br>Output dataset: /QCD_Pt-1000_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -15897,10 +15309,6 @@
   },
   "title": "/QCD_Pt-1000_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt-1000_CTEQ6L1_8TeV_herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -15978,7 +15386,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11270\">Configuration file for HLT step </a><br><a href=\"/record/11054\">Configuration file for RECO step </a><br>Output dataset: /QCD_Pt_120to170_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -15996,10 +15404,6 @@
   },
   "title": "/QCD_Pt_120to170_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt_120to170_CTEQ6L1_8TeV_herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -16077,7 +15481,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11255\">Configuration file for SIM step </a><br>Output dataset: /QCD_Pt-15to3000_Tune4C_Flat_8TeV_pythia8/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11298\">Configuration file for HLT step </a><br><a href=\"/record/11014\">Configuration file for RECO step </a><br>Output dataset: /QCD_Pt-15to3000_Tune4C_Flat_8TeV_pythia8/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -16095,10 +15499,6 @@
   },
   "title": "/QCD_Pt-15to3000_Tune4C_Flat_8TeV_pythia8/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt-15to3000_Tune4C_Flat_8TeV_pythia8 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -16190,7 +15590,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11194\">Configuration file for HLT step JME-Summer12DR53X-00167_1_cfg</a><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br>Output dataset: /QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6/Summer12_DR53X-NoPileUp_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -16208,10 +15608,6 @@
   },
   "title": "/QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6/Summer12_DR53X-NoPileUp_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -16303,7 +15699,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br>Output dataset: /QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -16321,10 +15717,6 @@
   },
   "title": "/QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -16402,7 +15794,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11054\">Configuration file for RECO step </a><br><a href=\"/record/11270\">Configuration file for HLT step </a><br>Output dataset: /QCD_Pt_15to30_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -16420,10 +15812,6 @@
   },
   "title": "/QCD_Pt_15to30_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt_15to30_CTEQ6L1_8TeV_herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -16879,7 +16267,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br>Output dataset: /QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -16897,10 +16285,6 @@
   },
   "title": "/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -16978,7 +16362,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11270\">Configuration file for HLT step </a><br><a href=\"/record/11054\">Configuration file for RECO step </a><br>Output dataset: /QCD_Pt_170to300_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -16996,10 +16380,6 @@
   },
   "title": "/QCD_Pt_170to300_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt_170to300_CTEQ6L1_8TeV_herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -17091,7 +16471,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11206\">Configuration file for SIM step SMP-Summer12-00013_1_cfg</a><br>Output dataset: /QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6/Summer12-START53_V7C_ext1-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br>Output dataset: /QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -17109,10 +16489,6 @@
   },
   "title": "/QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -17246,7 +16622,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -17264,10 +16640,6 @@
   },
   "title": "/QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v4/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -17345,7 +16717,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11124\">Configuration file for SIM step </a><br>Output dataset: /QCD_Pt-300to470_CTEQ6L1_8TeV_herwig6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11270\">Configuration file for HLT step </a><br><a href=\"/record/11054\">Configuration file for RECO step </a><br>Output dataset: /QCD_Pt-300to470_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -17363,10 +16735,6 @@
   },
   "title": "/QCD_Pt-300to470_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt-300to470_CTEQ6L1_8TeV_herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -17472,7 +16840,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11060\">Configuration file for HLT step HIG-Summer12DR53X-01648_1_cfg</a><br><a href=\"/record/11285\">Configuration file for RECO step HIG-Summer12DR53X-01648_2_cfg</a><br>Output dataset: /QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -17490,10 +16858,6 @@
   },
   "title": "/QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -17571,7 +16935,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11092\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11018\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /QCD_Pt-30to40_doubleEMEnriched_TuneZ2star_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -17589,10 +16953,6 @@
   },
   "title": "/QCD_Pt-30to40_doubleEMEnriched_TuneZ2star_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt-30to40_doubleEMEnriched_TuneZ2star_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -17670,7 +17030,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11054\">Configuration file for RECO step </a><br><a href=\"/record/11270\">Configuration file for HLT step </a><br>Output dataset: /QCD_Pt_30to50_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -17688,10 +17048,6 @@
   },
   "title": "/QCD_Pt_30to50_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt_30to50_CTEQ6L1_8TeV_herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -17769,7 +17125,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11018\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11092\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /QCD_Pt-40_doubleEMEnriched_TuneZ2star_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -17787,10 +17143,6 @@
   },
   "title": "/QCD_Pt-40_doubleEMEnriched_TuneZ2star_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt-40_doubleEMEnriched_TuneZ2star_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -17868,7 +17220,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11077\">Configuration file for SIM step </a><br>Output dataset: /QCD_Pt-470to600_CTEQ6L1_8TeV_herwig6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11270\">Configuration file for HLT step </a><br><a href=\"/record/11054\">Configuration file for RECO step </a><br>Output dataset: /QCD_Pt-470to600_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -17886,10 +17238,6 @@
   },
   "title": "/QCD_Pt-470to600_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt-470to600_CTEQ6L1_8TeV_herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -17967,7 +17315,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11270\">Configuration file for HLT step </a><br><a href=\"/record/11054\">Configuration file for RECO step </a><br>Output dataset: /QCD_Pt_50to80_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -17985,10 +17333,6 @@
   },
   "title": "/QCD_Pt_50to80_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt_50to80_CTEQ6L1_8TeV_herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -18066,7 +17410,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11066\">Configuration file for SIM step </a><br>Output dataset: /QCD_Pt-600to800_CTEQ6L1_8TeV_herwig6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11054\">Configuration file for RECO step </a><br><a href=\"/record/11270\">Configuration file for HLT step </a><br>Output dataset: /QCD_Pt-600to800_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -18084,10 +17428,6 @@
   },
   "title": "/QCD_Pt-600to800_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt-600to800_CTEQ6L1_8TeV_herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -18165,7 +17505,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11184\">Configuration file for SIM step </a><br>Output dataset: /QCD_Pt-800to1000_CTEQ6L1_8TeV_herwig6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11054\">Configuration file for RECO step </a><br><a href=\"/record/11270\">Configuration file for HLT step </a><br>Output dataset: /QCD_Pt-800to1000_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -18183,10 +17523,6 @@
   },
   "title": "/QCD_Pt-800to1000_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt-800to1000_CTEQ6L1_8TeV_herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -18404,7 +17740,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -18422,10 +17758,6 @@
   },
   "title": "/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v3/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -18503,7 +17835,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11270\">Configuration file for HLT step </a><br><a href=\"/record/11054\">Configuration file for RECO step </a><br>Output dataset: /QCD_Pt_80to120_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -18521,10 +17853,6 @@
   },
   "title": "/QCD_Pt_80to120_CTEQ6L1_8TeV_herwig6/Summer12_DR53X-NoPileUp_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset QCD_Pt_80to120_CTEQ6L1_8TeV_herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -18602,7 +17930,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11147\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /SMHiggsToZZTo4L_M-125_8TeV-powheg15-JHUgenV3-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11102\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11244\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /SMHiggsToZZTo4L_M-125_8TeV-powheg15-JHUgenV3-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -18620,10 +17948,6 @@
   },
   "title": "/SMHiggsToZZTo4L_M-125_8TeV-powheg15-JHUgenV3-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-125_8TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -18701,7 +18025,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11166\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /T4QZ_8TeV-aMCatNLO-herwig/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11055\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11243\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /T4QZ_8TeV-aMCatNLO-herwig/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -18719,10 +18043,6 @@
   },
   "title": "/T4QZ_8TeV-aMCatNLO-herwig/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset T4QZ_8TeV-aMCatNLO-herwig in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -18800,7 +18120,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11180\">Configuration file for SIM step TOP-Summer12-00254_1_cfg</a><br>Output dataset: /TBarToLeptons_t-channel_8TeV-herwig-tauola/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br>Output dataset: /TBarToLeptons_t-channel_8TeV-herwig-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -18818,10 +18138,6 @@
   },
   "title": "/TBarToLeptons_t-channel_8TeV-herwig-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TBarToLeptons_t-channel_8TeV-herwig-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -18899,7 +18215,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11125\">Configuration file for SIM step TOP-Summer12-00266_1_cfg</a><br>Output dataset: /TBarToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br>Output dataset: /TBarToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -18917,10 +18233,6 @@
   },
   "title": "/TBarToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TBarToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -18998,7 +18310,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11030\">Configuration file for SIM step TOP-Summer12-00268_1_cfg</a><br>Output dataset: /TBarToLeptons_t-channel_Pythia8_8TeV-aMCatNLO-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br>Output dataset: /TBarToLeptons_t-channel_Pythia8_8TeV-aMCatNLO-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -19016,10 +18328,6 @@
   },
   "title": "/TBarToLeptons_t-channel_Pythia8_8TeV-aMCatNLO-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TBarToLeptons_t-channel_Pythia8_8TeV-aMCatNLO-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -19097,7 +18405,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11166\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /TBZ_8TeV-Madspin_aMCatNLO-herwig/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11083\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11179\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /TBZ_8TeV-Madspin_aMCatNLO-herwig/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -19115,10 +18423,6 @@
   },
   "title": "/TBZ_8TeV-Madspin_aMCatNLO-herwig/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TBZ_8TeV-Madspin_aMCatNLO-herwig in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -19210,7 +18514,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11120\">Configuration file for SIM step TOP-Summer12-00210_1_cfg</a><br>Output dataset: /tGamma_8TeV_madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11002\">Configuration file for RECO step B2G-Summer12DR53X-00678_2_cfg</a><br><a href=\"/record/11294\">Configuration file for HLT step B2G-Summer12DR53X-00678_1_cfg</a><br>Output dataset: /tGamma_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -19228,10 +18532,6 @@
   },
   "title": "/tGamma_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset tGamma_8TeV_madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -19323,7 +18623,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11029\">Configuration file for SIM step TOP-Summer12-00192_1_cfg</a><br>Output dataset: /tGamma_FCNC_tGc_8TeV_protos/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11016\">Configuration file for HLT step B2G-Summer12DR53X-00594_1_cfg</a><br><a href=\"/record/11224\">Configuration file for RECO step B2G-Summer12DR53X-00594_2_cfg</a><br>Output dataset: /tGamma_FCNC_tGc_8TeV_protos/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -19341,10 +18641,6 @@
   },
   "title": "/tGamma_FCNC_tGc_8TeV_protos/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset tGamma_FCNC_tGc_8TeV_protos in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -19422,7 +18718,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11029\">Configuration file for SIM step TOP-Summer12-00192_1_cfg</a><br>Output dataset: /tGamma_FCNC_tGu_8TeV_protos/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11224\">Configuration file for RECO step B2G-Summer12DR53X-00594_2_cfg</a><br><a href=\"/record/11016\">Configuration file for HLT step B2G-Summer12DR53X-00594_1_cfg</a><br>Output dataset: /tGamma_FCNC_tGu_8TeV_protos/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -19440,10 +18736,6 @@
   },
   "title": "/tGamma_FCNC_tGu_8TeV_protos/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset tGamma_FCNC_tGu_8TeV_protos in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -19535,7 +18827,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11096\">Configuration file for SIM step HIG-Summer12-01736_1_cfg</a><br>Output dataset: /tGG_8TeV-whizard-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11249\">Configuration file for RECO step HIG-Summer12DR53X-01621_2_cfg</a><br><a href=\"/record/11197\">Configuration file for HLT step HIG-Summer12DR53X-01636_1_cfg</a><br>Output dataset: /tGG_8TeV-whizard-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -19553,10 +18845,6 @@
   },
   "title": "/tGG_8TeV-whizard-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset tGG_8TeV-whizard-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -19648,7 +18936,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11166\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /TTbar_8TeV-Madspin_aMCatNLO-herwig/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11119\">Configuration file for RECO step SUS-Summer12DR53X-00088_2_cfg</a><br><a href=\"/record/11049\">Configuration file for HLT step EXO-Summer12DR53X-02627_1_cfg</a><br>Output dataset: /TTbar_8TeV-Madspin_aMCatNLO-herwig/Summer12_DR53X-PU_S10_START53_V19-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -19666,10 +18954,6 @@
   },
   "title": "/TTbar_8TeV-Madspin_aMCatNLO-herwig/Summer12_DR53X-PU_S10_START53_V19-v2/AODSIM",
   "title_additional": "Simulated dataset TTbar_8TeV-Madspin_aMCatNLO-herwig in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -19747,7 +19031,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11166\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /ttbarZ_8TeV-Madspin_aMCatNLO-herwig/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11243\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11055\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /ttbarZ_8TeV-Madspin_aMCatNLO-herwig/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -19765,10 +19049,6 @@
   },
   "title": "/ttbarZ_8TeV-Madspin_aMCatNLO-herwig/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ttbarZ_8TeV-Madspin_aMCatNLO-herwig in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -19888,7 +19168,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11287\">Configuration file for SIM step </a><br>Output dataset: /TT_CT10_AUET2_8TeV-powheg-herwig/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11260\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11032\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /TT_CT10_AUET2_8TeV-powheg-herwig/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -19906,10 +19186,6 @@
   },
   "title": "/TT_CT10_AUET2_8TeV-powheg-herwig/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TT_CT10_AUET2_8TeV-powheg-herwig in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -19987,7 +19263,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11086\">Configuration file for SIM step TOP-Summer12-00280_1_cfg</a><br>Output dataset: /TTGamma_TuneZ2star_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11278\">Configuration file for RECO step EXO-Summer12DR53X-02813_2_cfg</a><br><a href=\"/record/11047\">Configuration file for HLT step EXO-Summer12DR53X-02813_1_cfg</a><br>Output dataset: /TTGamma_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -20005,10 +19281,6 @@
   },
   "title": "/TTGamma_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset TTGamma_TuneZ2star_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -20086,7 +19358,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11056\">Configuration file for SIM step HIG-Summer12-01723_1_cfg</a><br>Output dataset: /ttGG_8TeV-whizard-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11197\">Configuration file for HLT step HIG-Summer12DR53X-01636_1_cfg</a><br><a href=\"/record/11249\">Configuration file for RECO step HIG-Summer12DR53X-01621_2_cfg</a><br>Output dataset: /ttGG_8TeV-whizard-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -20104,10 +19376,6 @@
   },
   "title": "/ttGG_8TeV-whizard-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset ttGG_8TeV-whizard-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -20199,7 +19467,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11245\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /TTGJets_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11272\">Configuration file for HLT step HIG-Summer12DR53X-01500_1_cfg</a><br><a href=\"/record/11000\">Configuration file for RECO step HIG-Summer12DR53X-01500_2_cfg</a><br>Output dataset: /TTGJets_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -20217,10 +19485,6 @@
   },
   "title": "/TTGJets_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset TTGJets_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -20312,7 +19576,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11245\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /TTGJets_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11243\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11055\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /TTGJets_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -20330,10 +19594,6 @@
   },
   "title": "/TTGJets_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTGJets_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -20453,7 +19713,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11189\">Configuration file for SIM step HIG-Summer12-02272_1_cfg</a><br>Output dataset: /TTH_HToGG_M-125_8TeV-pythia6/Summer12-START53_V7C_ext1-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11131\">Configuration file for HLT step HIG-Summer12DR53X-02045_1_cfg</a><br><a href=\"/record/11038\">Configuration file for RECO step HIG-Summer12DR53X-02045_2_cfg</a><br>Output dataset: /TTH_HToGG_M-125_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -20471,10 +19731,6 @@
   },
   "title": "/TTH_HToGG_M-125_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM",
   "title_additional": "Simulated dataset TTH_HToGG_M-125_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -20552,7 +19808,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11013\">Configuration file for RECO step HIG-Summer12DR53X-01745_2_cfg</a><br><a href=\"/record/11263\">Configuration file for HLT step HIG-Summer12DR53X-01745_1_cfg</a><br>Output dataset: /TTH_HToZG_M-125_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -20570,10 +19826,6 @@
   },
   "title": "/TTH_HToZG_M-125_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM",
   "title_additional": "Simulated dataset TTH_HToZG_M-125_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -20651,7 +19903,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11182\">Configuration file for SIM step HIG-Summer12-01927_1_cfg</a><br>Output dataset: /TTH_HToZG_M-125_8TeV-pythia8175/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11263\">Configuration file for HLT step HIG-Summer12DR53X-01745_1_cfg</a><br><a href=\"/record/11013\">Configuration file for RECO step HIG-Summer12DR53X-01745_2_cfg</a><br>Output dataset: /TTH_HToZG_M-125_8TeV-pythia8175/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -20669,10 +19921,6 @@
   },
   "title": "/TTH_HToZG_M-125_8TeV-pythia8175/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset TTH_HToZG_M-125_8TeV-pythia8175 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -20778,7 +20026,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11265\">Configuration file for SIM step </a><br>Output dataset: /TTJets_DileptDecays_8TeV-sherpa/Summer12-START53_V7C-v3/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11025\">Configuration file for RECO step </a><br><a href=\"/record/11071\">Configuration file for HLT step </a><br>Output dataset: /TTJets_DileptDecays_8TeV-sherpa/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -20796,10 +20044,6 @@
   },
   "title": "/TTJets_DileptDecays_8TeV-sherpa/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_DileptDecays_8TeV-sherpa in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -20891,7 +20135,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11160\">Configuration file for SIM step </a><br>Output dataset: /TTJets_FullLeptMGDecays_8TeV-madgraph/Summer12-START52_V9-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /TTJets_FullLeptMGDecays_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -20909,10 +20153,6 @@
   },
   "title": "/TTJets_FullLeptMGDecays_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_FullLeptMGDecays_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -20990,7 +20230,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11070\">Configuration file for SIM step </a><br>Output dataset: /TTJets_FullLeptMGDecays_TuneP11_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11107\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11089\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /TTJets_FullLeptMGDecays_TuneP11_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -21008,10 +20248,6 @@
   },
   "title": "/TTJets_FullLeptMGDecays_TuneP11_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_FullLeptMGDecays_TuneP11_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -21089,7 +20325,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11093\">Configuration file for SIM step </a><br>Output dataset: /TTJets_FullLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11288\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11082\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /TTJets_FullLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -21107,10 +20343,6 @@
   },
   "title": "/TTJets_FullLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_FullLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -21188,7 +20420,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11290\">Configuration file for SIM step </a><br>Output dataset: /TTJets_FullLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11107\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11089\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /TTJets_FullLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -21206,10 +20438,6 @@
   },
   "title": "/TTJets_FullLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_FullLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -21287,7 +20515,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11144\">Configuration file for SIM step </a><br>Output dataset: /TTJets_FullLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11107\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11089\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /TTJets_FullLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -21305,10 +20533,6 @@
   },
   "title": "/TTJets_FullLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_FullLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -21428,7 +20652,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11254\">Configuration file for SIM step </a><br>Output dataset: /TTJets_HadronicMGDecays_8TeV-madgraph/Summer12-START52_V9-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /TTJets_HadronicMGDecays_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -21446,10 +20670,6 @@
   },
   "title": "/TTJets_HadronicMGDecays_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_HadronicMGDecays_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -21541,7 +20761,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11070\">Configuration file for SIM step </a><br>Output dataset: /TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11127\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11043\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -21559,10 +20779,6 @@
   },
   "title": "/TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -21640,7 +20856,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11093\">Configuration file for SIM step </a><br>Output dataset: /TTJets_HadronicMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11107\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11089\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /TTJets_HadronicMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -21658,10 +20874,6 @@
   },
   "title": "/TTJets_HadronicMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_HadronicMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -21753,7 +20965,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11290\">Configuration file for SIM step </a><br>Output dataset: /TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11107\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11089\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -21771,10 +20983,6 @@
   },
   "title": "/TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -21852,7 +21060,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11144\">Configuration file for SIM step </a><br>Output dataset: /TTJets_HadronicMGDecays_TuneP11TeV_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11107\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11089\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /TTJets_HadronicMGDecays_TuneP11TeV_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -21870,10 +21078,6 @@
   },
   "title": "/TTJets_HadronicMGDecays_TuneP11TeV_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_HadronicMGDecays_TuneP11TeV_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -22063,7 +21267,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11295\">Configuration file for SIM step TOP-Summer12-00190_1_cfg</a><br>Output dataset: /TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11049\">Configuration file for HLT step EXO-Summer12DR53X-02627_1_cfg</a><br><a href=\"/record/11119\">Configuration file for RECO step SUS-Summer12DR53X-00088_2_cfg</a><br>Output dataset: /TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -22081,10 +21285,6 @@
   },
   "title": "/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -22162,7 +21362,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11199\">Configuration file for SIM step TOP-Summer12-00257_1_cfg</a><br>Output dataset: /TTJets_MSDecays_width_x5_TuneZ2star_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br>Output dataset: /TTJets_MSDecays_width_x5_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -22180,10 +21380,6 @@
   },
   "title": "/TTJets_MSDecays_width_x5_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_MSDecays_width_x5_TuneZ2star_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -22289,7 +21485,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11069\">Configuration file for SIM step </a><br>Output dataset: /TTJets_SemiLeptDecays_8TeV-sherpa/Summer12-START53_V7C-v4/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11019\">Configuration file for HLT step </a><br><a href=\"/record/11064\">Configuration file for RECO step </a><br>Output dataset: /TTJets_SemiLeptDecays_8TeV-sherpa/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -22307,10 +21503,6 @@
   },
   "title": "/TTJets_SemiLeptDecays_8TeV-sherpa/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_SemiLeptDecays_8TeV-sherpa in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -22416,7 +21608,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11152\">Configuration file for SIM step </a><br>Output dataset: /TTJets_SemiLeptMGDecays_8TeV-madgraph/Summer12-START52_V9-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /TTJets_SemiLeptMGDecays_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -22434,10 +21626,6 @@
   },
   "title": "/TTJets_SemiLeptMGDecays_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_SemiLeptMGDecays_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -22529,7 +21717,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11070\">Configuration file for SIM step </a><br>Output dataset: /TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11146\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11097\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -22547,10 +21735,6 @@
   },
   "title": "/TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -22628,7 +21812,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11093\">Configuration file for SIM step </a><br>Output dataset: /TTJets_SemiLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11102\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11244\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /TTJets_SemiLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -22646,10 +21830,6 @@
   },
   "title": "/TTJets_SemiLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_SemiLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -22741,7 +21921,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11290\">Configuration file for SIM step </a><br>Output dataset: /TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11089\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11107\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -22759,10 +21939,6 @@
   },
   "title": "/TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -22854,7 +22030,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11144\">Configuration file for SIM step </a><br>Output dataset: /TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11043\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11127\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -22872,10 +22048,6 @@
   },
   "title": "/TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -22967,7 +22139,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11149\">Configuration file for SIM step SUS-Summer12-00090_1_cfg</a><br>Output dataset: /TTJets_WToBC_8TeV-madgraph-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11049\">Configuration file for HLT step EXO-Summer12DR53X-02627_1_cfg</a><br><a href=\"/record/11119\">Configuration file for RECO step SUS-Summer12DR53X-00088_2_cfg</a><br>Output dataset: /TTJets_WToBC_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -22985,10 +22157,6 @@
   },
   "title": "/TTJets_WToBC_8TeV-madgraph-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TTJets_WToBC_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -23066,7 +22234,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11171\">Configuration file for SIM step TOP-Summer12-00288_1_cfg</a><br>Output dataset: /TToBLNuJ_FCNC_kc_TuneZ2star_8TeV-comphep-ext1/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br>Output dataset: /TToBLNuJ_FCNC_kc_TuneZ2star_8TeV-comphep-ext1/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -23084,10 +22252,6 @@
   },
   "title": "/TToBLNuJ_FCNC_kc_TuneZ2star_8TeV-comphep-ext1/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TToBLNuJ_FCNC_kc_TuneZ2star_8TeV-comphep-ext1 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -23165,7 +22329,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11171\">Configuration file for SIM step TOP-Summer12-00288_1_cfg</a><br>Output dataset: /TToBLNuJ_FCNC_ku_TuneZ2star_8TeV-comphep-ext1/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br>Output dataset: /TToBLNuJ_FCNC_ku_TuneZ2star_8TeV-comphep-ext1/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -23183,10 +22347,6 @@
   },
   "title": "/TToBLNuJ_FCNC_ku_TuneZ2star_8TeV-comphep-ext1/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TToBLNuJ_FCNC_ku_TuneZ2star_8TeV-comphep-ext1 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -23264,7 +22424,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11180\">Configuration file for SIM step TOP-Summer12-00254_1_cfg</a><br>Output dataset: /TToLeptons_t-channel_8TeV-herwig-tauola/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11031\">Configuration file for RECO step EXO-Summer12DR53X-02701_2_cfg</a><br><a href=\"/record/11005\">Configuration file for HLT step EXO-Summer12DR53X-02701_1_cfg</a><br>Output dataset: /TToLeptons_t-channel_8TeV-herwig-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -23282,10 +22442,6 @@
   },
   "title": "/TToLeptons_t-channel_8TeV-herwig-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TToLeptons_t-channel_8TeV-herwig-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -23363,7 +22519,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11125\">Configuration file for SIM step TOP-Summer12-00266_1_cfg</a><br>Output dataset: /TToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br>Output dataset: /TToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -23381,10 +22537,6 @@
   },
   "title": "/TToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -23462,7 +22614,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11030\">Configuration file for SIM step TOP-Summer12-00268_1_cfg</a><br>Output dataset: /TToLeptons_t-channel_Pythia8_8TeV-aMCatNLO/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br>Output dataset: /TToLeptons_t-channel_Pythia8_8TeV-aMCatNLO/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -23480,10 +22632,6 @@
   },
   "title": "/TToLeptons_t-channel_Pythia8_8TeV-aMCatNLO/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TToLeptons_t-channel_Pythia8_8TeV-aMCatNLO in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -23603,7 +22751,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11128\">Configuration file for RECO step EXO-Summer12DR53X-02796_2_cfg</a><br><a href=\"/record/11078\">Configuration file for HLT step EXO-Summer12DR53X-02796_1_cfg</a><br>Output dataset: /TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola/Summer12_DR53X-PU_S10_START53_V19-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -23621,10 +22769,6 @@
   },
   "title": "/TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola/Summer12_DR53X-PU_S10_START53_V19-v2/AODSIM",
   "title_additional": "Simulated dataset TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -23716,7 +22860,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11123\">Configuration file for HLT step HIG-Summer12DR53X-01616_1_cfg</a><br><a href=\"/record/11139\">Configuration file for RECO step TOP-Summer12DR53X-00168_2_cfg</a><br>Output dataset: /TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg/Summer12_DR53X-PU_S10_START53_V19-v2/GEN-SIM-RAW</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11139\">Configuration file for RECO step TOP-Summer12DR53X-00168_2_cfg</a><br><a href=\"/record/11123\">Configuration file for HLT step HIG-Summer12DR53X-01616_1_cfg</a><br>Output dataset: /TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg/Summer12_DR53X-PU_S10_START53_V19-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -23734,10 +22878,6 @@
   },
   "title": "/TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg/Summer12_DR53X-PU_S10_START53_V19-v2/AODSIM",
   "title_additional": "Simulated dataset TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -23815,7 +22955,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11110\">Configuration file for SIM step </a><br>Output dataset: /TTZJets_8TeV-madgraph_v2/Summer12-START52_V9-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /TTZJets_8TeV-madgraph_v2/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -23833,10 +22973,6 @@
   },
   "title": "/TTZJets_8TeV-madgraph_v2/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset TTZJets_8TeV-madgraph_v2 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -23928,7 +23064,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11007\">Configuration file for SIM step TOP-Summer12-00293_1_cfg</a><br>Output dataset: /TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11132\">Configuration file for HLT step HIG-Summer12DR53X-02117_1_cfg</a><br><a href=\"/record/11291\">Configuration file for RECO step HIG-Summer12DR53X-02117_2_cfg</a><br>Output dataset: /TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -23946,10 +23082,6 @@
   },
   "title": "/TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -24041,7 +23173,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11045\">Configuration file for SIM step TOP-Summer12-00229_1_cfg</a><br>Output dataset: /TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11294\">Configuration file for HLT step B2G-Summer12DR53X-00678_1_cfg</a><br><a href=\"/record/11002\">Configuration file for RECO step B2G-Summer12DR53X-00678_2_cfg</a><br>Output dataset: /TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -24059,10 +23191,6 @@
   },
   "title": "/TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -24140,7 +23268,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11080\">Configuration file for SIM step TOP-Summer12-00264_1_cfg</a><br>Output dataset: /TZJetsTo3LNuB_FCNC_kappa_gut_8TeV_madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11128\">Configuration file for RECO step EXO-Summer12DR53X-02796_2_cfg</a><br><a href=\"/record/11078\">Configuration file for HLT step EXO-Summer12DR53X-02796_1_cfg</a><br>Output dataset: /TZJetsTo3LNuB_FCNC_kappa_gut_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -24158,10 +23286,6 @@
   },
   "title": "/TZJetsTo3LNuB_FCNC_kappa_gut_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TZJetsTo3LNuB_FCNC_kappa_gut_8TeV_madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -24239,7 +23363,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11161\">Configuration file for SIM step TOP-Summer12-00258_1_cfg</a><br>Output dataset: /TZJetsTo3LNuB_FCNC_kappa_zct_8TeV_madgraph/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br>Output dataset: /TZJetsTo3LNuB_FCNC_kappa_zct_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -24257,10 +23381,6 @@
   },
   "title": "/TZJetsTo3LNuB_FCNC_kappa_zct_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v2/AODSIM",
   "title_additional": "Simulated dataset TZJetsTo3LNuB_FCNC_kappa_zct_8TeV_madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -24352,7 +23472,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11161\">Configuration file for SIM step TOP-Summer12-00258_1_cfg</a><br>Output dataset: /TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11078\">Configuration file for HLT step EXO-Summer12DR53X-02796_1_cfg</a><br><a href=\"/record/11128\">Configuration file for RECO step EXO-Summer12DR53X-02796_2_cfg</a><br>Output dataset: /TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -24370,10 +23490,6 @@
   },
   "title": "/TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v2/AODSIM",
   "title_additional": "Simulated dataset TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -24451,7 +23567,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11161\">Configuration file for SIM step TOP-Summer12-00258_1_cfg</a><br>Output dataset: /TZJetsTo3LNuB_FCNC_zeta_zut_8TeV_madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11078\">Configuration file for HLT step EXO-Summer12DR53X-02796_1_cfg</a><br><a href=\"/record/11128\">Configuration file for RECO step EXO-Summer12DR53X-02796_2_cfg</a><br>Output dataset: /TZJetsTo3LNuB_FCNC_zeta_zut_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -24469,10 +23585,6 @@
   },
   "title": "/TZJetsTo3LNuB_FCNC_zeta_zut_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset TZJetsTo3LNuB_FCNC_zeta_zut_8TeV_madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -24550,7 +23662,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11172\">Configuration file for SIM step EWK-Summer12-00146_1_cfg</a><br>Output dataset: /VBF_HToBB_125GeV_aMCatNLO_herwig6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11023\">Configuration file for RECO step B2G-Summer12DR53X-00431_2_cfg</a><br><a href=\"/record/11193\">Configuration file for HLT step B2G-Summer12DR53X-00431_1_cfg</a><br>Output dataset: /VBF_HToBB_125GeV_aMCatNLO_herwig6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -24568,10 +23680,6 @@
   },
   "title": "/VBF_HToBB_125GeV_aMCatNLO_herwig6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset VBF_HToBB_125GeV_aMCatNLO_herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -24677,7 +23785,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11155\">Configuration file for SIM step HIG-Summer12-02273_1_cfg</a><br>Output dataset: /VBF_HToGG_M-125_8TeV-powheg-pythia6/Summer12-START53_V7C_ext1-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11038\">Configuration file for RECO step HIG-Summer12DR53X-02045_2_cfg</a><br><a href=\"/record/11131\">Configuration file for HLT step HIG-Summer12DR53X-02045_1_cfg</a><br>Output dataset: /VBF_HToGG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -24695,10 +23803,6 @@
   },
   "title": "/VBF_HToGG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM",
   "title_additional": "Simulated dataset VBF_HToGG_M-125_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -24776,7 +23880,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /VBFHToGG_M-125_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -24794,10 +23898,6 @@
   },
   "title": "/VBFHToGG_M-125_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset VBFHToGG_M-125_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -24875,7 +23975,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11057\">Configuration file for SIM step HIG-Summer12-02140_1_cfg</a><br>Output dataset: /VBF_HToTauTau_M-125_8TeV-powheg-pythia6-tauola-tauPolarOff/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11253\">Configuration file for HLT step HIG-Summer12DR53X-01981_1_cfg</a><br><a href=\"/record/11039\">Configuration file for RECO step HIG-Summer12DR53X-01981_2_cfg</a><br>Output dataset: /VBF_HToTauTau_M-125_8TeV-powheg-pythia6-tauola-tauPolarOff/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -24893,10 +23993,6 @@
   },
   "title": "/VBF_HToTauTau_M-125_8TeV-powheg-pythia6-tauola-tauPolarOff/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset VBF_HToTauTau_M-125_8TeV-powheg-pythia6-tauola-tauPolarOff in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -24974,7 +24070,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11223\">Configuration file for SIM step </a><br>Output dataset: /VBF_HToZG_M-125_8TeV-powheg-pythia6/Summer12-START50_V13-v3/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11263\">Configuration file for HLT step HIG-Summer12DR53X-01745_1_cfg</a><br><a href=\"/record/11013\">Configuration file for RECO step HIG-Summer12DR53X-01745_2_cfg</a><br>Output dataset: /VBF_HToZG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -24992,10 +24088,6 @@
   },
   "title": "/VBF_HToZG_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset VBF_HToZG_M-125_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -25073,7 +24165,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11170\">Configuration file for SIM step HIG-Summer12-01977_1_cfg</a><br>Output dataset: /VBFToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11078\">Configuration file for HLT step EXO-Summer12DR53X-02796_1_cfg</a><br><a href=\"/record/11128\">Configuration file for RECO step EXO-Summer12DR53X-02796_2_cfg</a><br>Output dataset: /VBFToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -25091,10 +24183,6 @@
   },
   "title": "/VBFToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset VBFToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -25172,7 +24260,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11001\">Configuration file for SIM step HIG-Summer12-01894_1_cfg</a><br>Output dataset: /VBFToHToZG_M-125_8TeV-powheg-pythia8175/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11013\">Configuration file for RECO step HIG-Summer12DR53X-01745_2_cfg</a><br><a href=\"/record/11263\">Configuration file for HLT step HIG-Summer12DR53X-01745_1_cfg</a><br>Output dataset: /VBFToHToZG_M-125_8TeV-powheg-pythia8175/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -25190,10 +24278,6 @@
   },
   "title": "/VBFToHToZG_M-125_8TeV-powheg-pythia8175/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset VBFToHToZG_M-125_8TeV-powheg-pythia8175 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -25299,7 +24383,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11103\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /W1JetsToLNu_TuneZ2Star_8TeV-madgraph/Summer12-START53_V7C-ext-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11073\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11004\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /W1JetsToLNu_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -25317,10 +24401,6 @@
   },
   "title": "/W1JetsToLNu_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset W1JetsToLNu_TuneZ2Star_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -25426,7 +24506,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11103\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /W2JetsToLNu_TuneZ2Star_8TeV-madgraph/Summer12-START53_V7C-ext-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11055\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11243\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /W2JetsToLNu_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -25444,10 +24524,6 @@
   },
   "title": "/W2JetsToLNu_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset W2JetsToLNu_TuneZ2Star_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -25539,7 +24615,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11196\">Configuration file for SIM step </a><br>Output dataset: /W3JetsToLNu_TuneZ2Star_8TeV-madgraph/Summer12-START53_V7C-ext-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11090\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11240\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /W3JetsToLNu_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -25557,10 +24633,6 @@
   },
   "title": "/W3JetsToLNu_TuneZ2Star_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset W3JetsToLNu_TuneZ2Star_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -25652,7 +24724,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -25670,10 +24742,6 @@
   },
   "title": "/WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset WGToLNuG_TuneZ2star_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -25765,7 +24833,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -25783,10 +24851,6 @@
   },
   "title": "/WH_WToQQ_HToInv_M-125_8TeV_pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WH_WToQQ_HToInv_M-125_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -25906,7 +24970,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11091\">Configuration file for SIM step HIG-Summer12-02271_1_cfg</a><br>Output dataset: /WH_ZH_HToGG_M-125_8TeV-pythia6/Summer12-START53_V7C_ext1-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11038\">Configuration file for RECO step HIG-Summer12DR53X-02045_2_cfg</a><br><a href=\"/record/11131\">Configuration file for HLT step HIG-Summer12DR53X-02045_1_cfg</a><br>Output dataset: /WH_ZH_HToGG_M-125_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v3/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -25924,10 +24988,6 @@
   },
   "title": "/WH_ZH_HToGG_M-125_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v3/AODSIM",
   "title_additional": "Simulated dataset WH_ZH_HToGG_M-125_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -26005,7 +25065,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11263\">Configuration file for HLT step HIG-Summer12DR53X-01745_1_cfg</a><br><a href=\"/record/11013\">Configuration file for RECO step HIG-Summer12DR53X-01745_2_cfg</a><br>Output dataset: /WH_ZH_HToZG_M-125_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -26023,10 +25083,6 @@
   },
   "title": "/WH_ZH_HToZG_M-125_8TeV-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset WH_ZH_HToZG_M-125_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -26104,7 +25160,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11114\">Configuration file for SIM step HIG-Summer12-01866_1_cfg</a><br>Output dataset: /WH_ZH_HToZG_M-125_8TeV-pythia8175/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11013\">Configuration file for RECO step HIG-Summer12DR53X-01745_2_cfg</a><br><a href=\"/record/11263\">Configuration file for HLT step HIG-Summer12DR53X-01745_1_cfg</a><br>Output dataset: /WH_ZH_HToZG_M-125_8TeV-pythia8175/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -26122,10 +25178,6 @@
   },
   "title": "/WH_ZH_HToZG_M-125_8TeV-pythia8175/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset WH_ZH_HToZG_M-125_8TeV-pythia8175 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -26217,7 +25269,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11247\">Configuration file for SIM step </a><br>Output dataset: /WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6/Summer12-START53_V7C-ext-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11240\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11090\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -26235,10 +25287,6 @@
   },
   "title": "/WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -26316,7 +25364,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11225\">Configuration file for SIM step HIG-Summer12-02178_1_cfg</a><br>Output dataset: /WH_ZH_WZToAll_HToZG_M-125_8TeV-pythia8/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br>Output dataset: /WH_ZH_WZToAll_HToZG_M-125_8TeV-pythia8/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -26334,10 +25382,6 @@
   },
   "title": "/WH_ZH_WZToAll_HToZG_M-125_8TeV-pythia8/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WH_ZH_WZToAll_HToZG_M-125_8TeV-pythia8 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -26443,7 +25487,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11052\">Configuration file for SIM step config_26_1_cfg</a><br>Output dataset: /WLNubbar_8TeV-massive_amcatnlo-herwig6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11179\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11083\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /WLNubbar_8TeV-massive_amcatnlo-herwig6/Summer12_DR53X-PU_S10_START53_V19-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -26461,10 +25505,6 @@
   },
   "title": "/WLNubbar_8TeV-massive_amcatnlo-herwig6/Summer12_DR53X-PU_S10_START53_V19-v2/AODSIM",
   "title_additional": "Simulated dataset WLNubbar_8TeV-massive_amcatnlo-herwig6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -26556,7 +25596,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11079\">Configuration file for RECO step EXO-Summer12DR53X-03199_2_cfg</a><br><a href=\"/record/11087\">Configuration file for HLT step EXO-Summer12DR53X-03199_1_cfg</a><br>Output dataset: /WminusToMuNu_CT10_8TeV-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -26574,10 +25614,6 @@
   },
   "title": "/WminusToMuNu_CT10_8TeV-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WminusToMuNu_CT10_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -26655,7 +25691,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11264\">Configuration file for SIM step SMP-Summer12-00016_1_cfg</a><br>Output dataset: /WminusToTauNu_CT10_8TeV-powheg-pythia6-tauola/Summer12-START53_V7C_ext1-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br>Output dataset: /WminusToTauNu_CT10_8TeV-powheg-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -26673,10 +25709,6 @@
   },
   "title": "/WminusToTauNu_CT10_8TeV-powheg-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WminusToTauNu_CT10_8TeV-powheg-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -26782,7 +25814,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11258\">Configuration file for SIM step SMP-Summer12-00014_1_cfg</a><br>Output dataset: /WplusToMuNu_CT10_8TeV-powheg-pythia6/Summer12-START53_V7C_ext1-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br>Output dataset: /WplusToMuNu_CT10_8TeV-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -26800,10 +25832,6 @@
   },
   "title": "/WplusToMuNu_CT10_8TeV-powheg-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WplusToMuNu_CT10_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -26881,7 +25909,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11264\">Configuration file for SIM step SMP-Summer12-00016_1_cfg</a><br>Output dataset: /WplusToTauNu_CT10_8TeV-powheg-pythia6-tauola/Summer12-START53_V7C_ext1-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br>Output dataset: /WplusToTauNu_CT10_8TeV-powheg-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -26899,10 +25927,6 @@
   },
   "title": "/WplusToTauNu_CT10_8TeV-powheg-pythia6-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WplusToTauNu_CT10_8TeV-powheg-pythia6-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -26994,7 +26018,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11204\">Configuration file for SIM step SMP-Summer12-00006_1_cfg</a><br>Output dataset: /WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11224\">Configuration file for RECO step B2G-Summer12DR53X-00594_2_cfg</a><br><a href=\"/record/11016\">Configuration file for HLT step B2G-Summer12DR53X-00594_1_cfg</a><br>Output dataset: /WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -27012,10 +26036,6 @@
   },
   "title": "/WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -27093,7 +26113,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11204\">Configuration file for SIM step SMP-Summer12-00006_1_cfg</a><br>Output dataset: /WpWmJJToQQLNuBar_TuneZ2star_8TeV-vbfnlo-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11016\">Configuration file for HLT step B2G-Summer12DR53X-00594_1_cfg</a><br><a href=\"/record/11224\">Configuration file for RECO step B2G-Summer12DR53X-00594_2_cfg</a><br>Output dataset: /WpWmJJToQQLNuBar_TuneZ2star_8TeV-vbfnlo-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -27111,10 +26131,6 @@
   },
   "title": "/WpWmJJToQQLNuBar_TuneZ2star_8TeV-vbfnlo-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WpWmJJToQQLNuBar_TuneZ2star_8TeV-vbfnlo-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -27206,7 +26222,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11035\">Configuration file for SIM step HIG-Summer12-01739_1_cfg</a><br>Output dataset: /WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11224\">Configuration file for RECO step B2G-Summer12DR53X-00594_2_cfg</a><br><a href=\"/record/11016\">Configuration file for HLT step B2G-Summer12DR53X-00594_1_cfg</a><br>Output dataset: /WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -27224,10 +26240,6 @@
   },
   "title": "/WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -27319,7 +26331,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11256\">Configuration file for SIM step HIG-Summer12-01732_1_cfg</a><br>Output dataset: /WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11224\">Configuration file for RECO step B2G-Summer12DR53X-00594_2_cfg</a><br><a href=\"/record/11016\">Configuration file for HLT step B2G-Summer12DR53X-00594_1_cfg</a><br>Output dataset: /WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -27337,10 +26349,6 @@
   },
   "title": "/WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -27418,7 +26426,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11076\">Configuration file for SIM step </a><br>Output dataset: /WW2JetsTo2L2Nu_EW4_QCD2_8TeV-madgraph-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11181\">Configuration file for RECO step </a><br><a href=\"/record/11085\">Configuration file for HLT step </a><br>Output dataset: /WW2JetsTo2L2Nu_EW4_QCD2_8TeV-madgraph-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -27436,10 +26444,6 @@
   },
   "title": "/WW2JetsTo2L2Nu_EW4_QCD2_8TeV-madgraph-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WW2JetsTo2L2Nu_EW4_QCD2_8TeV-madgraph-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -27517,7 +26521,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11024\">Configuration file for SIM step </a><br>Output dataset: /WWGJets_8TeV-madgraph_v2/Summer12-START52_V9-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /WWGJets_8TeV-madgraph_v2/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -27535,10 +26539,6 @@
   },
   "title": "/WWGJets_8TeV-madgraph_v2/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset WWGJets_8TeV-madgraph_v2 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -27616,7 +26616,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /WWJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -27634,10 +26634,6 @@
   },
   "title": "/WWJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset WWJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -27715,7 +26711,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11297\">Configuration file for SIM step </a><br>Output dataset: /WWjjTo2L2Nu_8TeV_madgraph_qed6_qcd0/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11181\">Configuration file for RECO step </a><br><a href=\"/record/11085\">Configuration file for HLT step </a><br>Output dataset: /WWjjTo2L2Nu_8TeV_madgraph_qed6_qcd0/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -27733,10 +26729,6 @@
   },
   "title": "/WWjjTo2L2Nu_8TeV_madgraph_qed6_qcd0/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WWjjTo2L2Nu_8TeV_madgraph_qed6_qcd0 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -27814,7 +26806,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11106\">Configuration file for SIM step </a><br>Output dataset: /WWWJets_8TeV-madgraph/Summer12-START50_V13-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /WWWJets_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -27832,10 +26824,6 @@
   },
   "title": "/WWWJets_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset WWWJets_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -27913,7 +26901,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11282\">Configuration file for SIM step </a><br>Output dataset: /WWZNoGstarJets_8TeV-madgraph/Summer12-START52_V9-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /WWZNoGstarJets_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -27931,10 +26919,6 @@
   },
   "title": "/WWZNoGstarJets_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset WWZNoGstarJets_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -28012,7 +26996,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11099\">Configuration file for SIM step </a><br>Output dataset: /WZJetsTo2L2Q_TuneZ2star_8TeV-madgraph-tauola/Summer12-START52_V9-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /WZJetsTo2L2Q_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -28030,10 +27014,6 @@
   },
   "title": "/WZJetsTo2L2Q_TuneZ2star_8TeV-madgraph-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset WZJetsTo2L2Q_TuneZ2star_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -28125,7 +27105,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11284\">Configuration file for SIM step TOP-Summer12-00248_1_cfg</a><br>Output dataset: /WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11002\">Configuration file for RECO step B2G-Summer12DR53X-00678_2_cfg</a><br><a href=\"/record/11294\">Configuration file for HLT step B2G-Summer12DR53X-00678_1_cfg</a><br>Output dataset: /WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -28143,10 +27123,6 @@
   },
   "title": "/WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -28224,7 +27200,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11234\">Configuration file for SIM step </a><br>Output dataset: /WZJetsTo3LNu_TuneZ2_8TeV-madgraph-tauola/Summer12-START52_V9-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /WZJetsTo3LNu_TuneZ2_8TeV-madgraph-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -28242,10 +27218,6 @@
   },
   "title": "/WZJetsTo3LNu_TuneZ2_8TeV-madgraph-tauola/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset WZJetsTo3LNu_TuneZ2_8TeV-madgraph-tauola in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -28323,7 +27295,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11133\">Configuration file for SIM step </a><br>Output dataset: /WZZNoGstarJets_8TeV-madgraph/Summer12-START50_V13-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /WZZNoGstarJets_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -28341,10 +27313,6 @@
   },
   "title": "/WZZNoGstarJets_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset WZZNoGstarJets_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -28422,7 +27390,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11037\">Configuration file for SIM step EWK-Summer12-00145_1_cfg</a><br>Output dataset: /Zbb_4F_8TeV_madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11193\">Configuration file for HLT step B2G-Summer12DR53X-00431_1_cfg</a><br><a href=\"/record/11023\">Configuration file for RECO step B2G-Summer12DR53X-00431_2_cfg</a><br>Output dataset: /Zbb_4F_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -28440,10 +27408,6 @@
   },
   "title": "/Zbb_4F_8TeV_madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset Zbb_4F_8TeV_madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -28549,7 +27513,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11217\">Configuration file for SIM step SMP-Summer12-00007_1_cfg</a><br>Output dataset: /ZG3JetsToLL_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11294\">Configuration file for HLT step B2G-Summer12DR53X-00678_1_cfg</a><br><a href=\"/record/11002\">Configuration file for RECO step B2G-Summer12DR53X-00678_2_cfg</a><br>Output dataset: /ZG3JetsToLL_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -28567,10 +27531,6 @@
   },
   "title": "/ZG3JetsToLL_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZG3JetsToLL_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -28648,7 +27608,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11099\">Configuration file for SIM step </a><br>Output dataset: /ZGToLLG_8TeV-madgraph/Summer12-START52_V9-v3/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZGToLLG_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -28666,10 +27626,6 @@
   },
   "title": "/ZGToLLG_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset ZGToLLG_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -28747,7 +27703,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11231\">Configuration file for SIM step config_3_1_cfg</a><br>Output dataset: /ZH_HToMuMu_M-125_8TeV-powheg-herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11102\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11244\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /ZH_HToMuMu_M-125_8TeV-powheg-herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -28765,10 +27721,6 @@
   },
   "title": "/ZH_HToMuMu_M-125_8TeV-powheg-herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZH_HToMuMu_M-125_8TeV-powheg-herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -28860,7 +27812,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11164\">Configuration file for SIM step HIG-Summer12-01774_1_cfg</a><br>Output dataset: /ZH_ZToQQ_HToInv_M-125_8TeV_pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11016\">Configuration file for HLT step B2G-Summer12DR53X-00594_1_cfg</a><br><a href=\"/record/11224\">Configuration file for RECO step B2G-Summer12DR53X-00594_2_cfg</a><br>Output dataset: /ZH_ZToQQ_HToInv_M-125_8TeV_pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -28878,10 +27830,6 @@
   },
   "title": "/ZH_ZToQQ_HToInv_M-125_8TeV_pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZH_ZToQQ_HToInv_M-125_8TeV_pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -28973,7 +27921,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11257\">Configuration file for SIM step JME-Summer12-00140_1_cfg</a><br>Output dataset: /ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11259\">Configuration file for HLT step JME-Summer12DR53X-00162_1_cfg</a><br><a href=\"/record/11063\">Configuration file for RECO step JME-Summer12DR53X-00162_2_cfg</a><br>Output dataset: /ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -28991,10 +27939,6 @@
   },
   "title": "/ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -29086,7 +28030,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11108\">Configuration file for SIM step config_8_1_cfg</a><br>Output dataset: /ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11073\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11004\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -29104,10 +28048,6 @@
   },
   "title": "/ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -29199,7 +28139,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11126\">Configuration file for SIM step config_13_1_cfg</a><br>Output dataset: /ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11004\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11073\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -29217,10 +28157,6 @@
   },
   "title": "/ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -29298,7 +28234,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11137\">Configuration file for SIM step config_7_1_cfg</a><br>Output dataset: /ZJetToEE_Pt-170to230_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11235\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11112\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /ZJetToEE_Pt-170to230_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -29316,10 +28252,6 @@
   },
   "title": "/ZJetToEE_Pt-170to230_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToEE_Pt-170to230_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -29397,7 +28329,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11220\">Configuration file for SIM step config_6_1_cfg</a><br>Output dataset: /ZJetToEE_Pt-230to300_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11004\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11073\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZJetToEE_Pt-230to300_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -29415,10 +28347,6 @@
   },
   "title": "/ZJetToEE_Pt-230to300_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToEE_Pt-230to300_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -29496,7 +28424,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11065\">Configuration file for SIM step config_5_1_cfg</a><br>Output dataset: /ZJetToEE_Pt-300_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11112\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11235\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZJetToEE_Pt-300_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -29514,10 +28442,6 @@
   },
   "title": "/ZJetToEE_Pt-300_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToEE_Pt-300_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -29609,7 +28533,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11187\">Configuration file for SIM step config_12_1_cfg</a><br>Output dataset: /ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11073\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11004\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -29627,10 +28551,6 @@
   },
   "title": "/ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -29708,7 +28628,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11068\">Configuration file for SIM step config_11_1_cfg</a><br>Output dataset: /ZJetToEE_Pt-80to120_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11004\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11073\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZJetToEE_Pt-80to120_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -29726,10 +28646,6 @@
   },
   "title": "/ZJetToEE_Pt-80to120_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToEE_Pt-80to120_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -29821,7 +28737,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11061\">Configuration file for SIM step JME-Summer12-00141_1_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11292\">Configuration file for HLT step JME-Summer12DR53X-00163_1_cfg</a><br><a href=\"/record/11059\">Configuration file for RECO step JME-Summer12DR53X-00163_2_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -29839,10 +28755,6 @@
   },
   "title": "/ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -29920,7 +28832,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11274\">Configuration file for SIM step config_10_1_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-120to170_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11073\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11004\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-120to170_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -29938,10 +28850,6 @@
   },
   "title": "/ZJetToMuMu_Pt-120to170_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToMuMu_Pt-120to170_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -30033,7 +28941,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11277\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11004\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11073\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -30051,10 +28959,6 @@
   },
   "title": "/ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -30132,7 +29036,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11011\">Configuration file for SIM step config_9_1_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-170to230_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11235\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11112\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-170to230_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -30150,10 +29054,6 @@
   },
   "title": "/ZJetToMuMu_Pt-170to230_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToMuMu_Pt-170to230_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -30231,7 +29131,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11157\">Configuration file for SIM step config_2_1_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-230to300_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11073\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11004\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-230to300_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -30249,10 +29149,6 @@
   },
   "title": "/ZJetToMuMu_Pt-230to300_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToMuMu_Pt-230to300_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -30330,7 +29226,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11273\">Configuration file for SIM step config_1_1_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-300_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11004\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11073\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-300_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -30348,10 +29244,6 @@
   },
   "title": "/ZJetToMuMu_Pt-300_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToMuMu_Pt-300_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -30429,7 +29321,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11020\">Configuration file for SIM step config_4_1_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-30to50_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11112\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11235\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-30to50_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -30447,10 +29339,6 @@
   },
   "title": "/ZJetToMuMu_Pt-30to50_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToMuMu_Pt-30to50_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -30528,7 +29416,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11173\">Configuration file for SIM step config_3_1_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-80to120_TuneEE3C_8TeV_herwigpp/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11073\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11004\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /ZJetToMuMu_Pt-80to120_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -30546,10 +29434,6 @@
   },
   "title": "/ZJetToMuMu_Pt-80to120_TuneEE3C_8TeV_herwigpp/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZJetToMuMu_Pt-80to120_TuneEE3C_8TeV_herwigpp in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -30641,7 +29525,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11116\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /ZVBF_Mqq-120_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11167\">Configuration file for HLT step HIG-Summer12DR53X-01646_1_cfg</a><br><a href=\"/record/11027\">Configuration file for RECO step HIG-Summer12DR53X-01646_2_cfg</a><br>Output dataset: /ZVBF_Mqq-120_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -30659,10 +29543,6 @@
   },
   "title": "/ZVBF_Mqq-120_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset ZVBF_Mqq-120_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -30740,7 +29620,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11116\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /ZVBF_Mqq-120_8TeV-madgraph/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11243\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11055\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /ZVBF_Mqq-120_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -30758,10 +29638,6 @@
   },
   "title": "/ZVBF_Mqq-120_8TeV-madgraph/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZVBF_Mqq-120_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -30853,7 +29729,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11159\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11192\">Configuration file for RECO step HIG-Summer12DR53X-01545_2_cfg</a><br><a href=\"/record/11088\">Configuration file for HLT step HIG-Summer12DR53X-01545_1_cfg</a><br>Output dataset: /ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -30871,10 +29747,6 @@
   },
   "title": "/ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -30952,7 +29824,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11200\">Configuration file for SIM step </a><br>Output dataset: /ZZTo2e2mu_8TeV-powheg-pythia6/Summer12-START50_V13-v3/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /ZZTo2e2mu_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -30970,10 +29842,6 @@
   },
   "title": "/ZZTo2e2mu_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM",
   "title_additional": "Simulated dataset ZZTo2e2mu_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -31051,7 +29919,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11042\">Configuration file for SIM step HIG-Summer12-02121_1_cfg</a><br>Output dataset: /ZZTo2e2muJJ_Contin_8TeV-phantom-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br>Output dataset: /ZZTo2e2muJJ_Contin_8TeV-phantom-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -31069,10 +29937,6 @@
   },
   "title": "/ZZTo2e2muJJ_Contin_8TeV-phantom-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo2e2muJJ_Contin_8TeV-phantom-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -31150,7 +30014,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11042\">Configuration file for SIM step HIG-Summer12-02121_1_cfg</a><br>Output dataset: /ZZTo2e2muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br>Output dataset: /ZZTo2e2muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -31168,10 +30032,6 @@
   },
   "title": "/ZZTo2e2muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo2e2muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -31263,7 +30123,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11159\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11017\">Configuration file for RECO step HIG-Summer12DR53X-01503_2_cfg</a><br><a href=\"/record/11227\">Configuration file for HLT step HIG-Summer12DR53X-01503_1_cfg</a><br>Output dataset: /ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -31281,10 +30141,6 @@
   },
   "title": "/ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -31362,7 +30218,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11200\">Configuration file for SIM step </a><br>Output dataset: /ZZTo2e2tau_8TeV-powheg-pythia6/Summer12-START50_V13-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZZTo2e2tau_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -31380,10 +30236,6 @@
   },
   "title": "/ZZTo2e2tau_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo2e2tau_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -31475,7 +30327,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11159\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11268\">Configuration file for HLT step HIG-Summer12DR53X-01346_1_cfg</a><br><a href=\"/record/11051\">Configuration file for RECO step HIG-Summer12DR53X-01346_2_cfg</a><br>Output dataset: /ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -31493,10 +30345,6 @@
   },
   "title": "/ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -31574,7 +30422,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11200\">Configuration file for SIM step </a><br>Output dataset: /ZZTo2mu2tau_8TeV-powheg-pythia6/Summer12-START50_V13-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZZTo2mu2tau_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -31592,10 +30440,6 @@
   },
   "title": "/ZZTo2mu2tau_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo2mu2tau_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -31687,7 +30531,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11081\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11268\">Configuration file for HLT step HIG-Summer12DR53X-01346_1_cfg</a><br><a href=\"/record/11051\">Configuration file for RECO step HIG-Summer12DR53X-01346_2_cfg</a><br>Output dataset: /ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -31705,10 +30549,6 @@
   },
   "title": "/ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -31786,7 +30626,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11200\">Configuration file for SIM step </a><br>Output dataset: /ZZTo4e_8TeV-powheg-pythia6/Summer12-START50_V13-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZZTo4e_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -31804,10 +30644,6 @@
   },
   "title": "/ZZTo4e_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v2/AODSIM",
   "title_additional": "Simulated dataset ZZTo4e_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -31885,7 +30721,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11042\">Configuration file for SIM step HIG-Summer12-02121_1_cfg</a><br>Output dataset: /ZZTo4eJJ_Contin_8TeV-phantom-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br>Output dataset: /ZZTo4eJJ_Contin_8TeV-phantom-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -31903,10 +30739,6 @@
   },
   "title": "/ZZTo4eJJ_Contin_8TeV-phantom-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo4eJJ_Contin_8TeV-phantom-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -31984,7 +30816,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11042\">Configuration file for SIM step HIG-Summer12-02121_1_cfg</a><br>Output dataset: /ZZTo4eJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br>Output dataset: /ZZTo4eJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -32002,10 +30834,6 @@
   },
   "title": "/ZZTo4eJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo4eJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -32097,7 +30925,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11159\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11268\">Configuration file for HLT step HIG-Summer12DR53X-01346_1_cfg</a><br><a href=\"/record/11051\">Configuration file for RECO step HIG-Summer12DR53X-01346_2_cfg</a><br>Output dataset: /ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -32115,10 +30943,6 @@
   },
   "title": "/ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -32196,7 +31020,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11200\">Configuration file for SIM step </a><br>Output dataset: /ZZTo4mu_8TeV-powheg-pythia6/Summer12-START50_V13-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZZTo4mu_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -32214,10 +31038,6 @@
   },
   "title": "/ZZTo4mu_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo4mu_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -32295,7 +31115,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11042\">Configuration file for SIM step HIG-Summer12-02121_1_cfg</a><br>Output dataset: /ZZTo4muJJ_Contin_8TeV-phantom-pythia6/Summer12-START53_V7C-v1/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br>Output dataset: /ZZTo4muJJ_Contin_8TeV-phantom-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -32313,10 +31133,6 @@
   },
   "title": "/ZZTo4muJJ_Contin_8TeV-phantom-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo4muJJ_Contin_8TeV-phantom-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -32394,7 +31210,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11042\">Configuration file for SIM step HIG-Summer12-02121_1_cfg</a><br>Output dataset: /ZZTo4muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11163\">Configuration file for HLT step HIG-Summer12DR53X-01973_1_cfg</a><br><a href=\"/record/11151\">Configuration file for RECO step HIG-Summer12DR53X-01973_2_cfg</a><br>Output dataset: /ZZTo4muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -32412,10 +31228,6 @@
   },
   "title": "/ZZTo4muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo4muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -32507,7 +31319,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11159\">Configuration file for SIM step config_0_1_cfg</a><br>Output dataset: /ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12-START53_V7C-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11051\">Configuration file for RECO step HIG-Summer12DR53X-01346_2_cfg</a><br><a href=\"/record/11268\">Configuration file for HLT step HIG-Summer12DR53X-01346_1_cfg</a><br>Output dataset: /ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -32525,10 +31337,6 @@
   },
   "title": "/ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/Summer12_DR53X-PU_S10_START53_V19-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -32606,7 +31414,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11200\">Configuration file for SIM step </a><br>Output dataset: /ZZTo4tau_8TeV-powheg-pythia6/Summer12-START50_V13-v2/GEN-SIM</p>\n\n<p><strong>Step HLT RECO</strong><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br>Output dataset: /ZZTo4tau_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -32624,10 +31432,6 @@
   },
   "title": "/ZZTo4tau_8TeV-powheg-pythia6/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset ZZTo4tau_8TeV-powheg-pythia6 in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -32705,7 +31509,7 @@
     "attribution": "CC0"
   },
   "methodology": {
-    "description": ""
+    "description": "<p>These data were processed in several steps:</p>\n<p><strong>Step SIM</strong><br><a href=\"/record/11133\">Configuration file for SIM step </a><br>Output dataset: /ZZZNoGstarJets_8TeV-madgraph/Summer12-START50_V13-v2/GEN-SIM</p>\n\n<p><strong>Step RECO HLT</strong><br><a href=\"/record/11176\">Configuration file for RECO step config_0_2_cfg</a><br><a href=\"/record/11251\">Configuration file for HLT step config_0_1_cfg</a><br>Output dataset: /ZZZNoGstarJets_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM</p>\n"
   },
   "note": {
     "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
@@ -32723,10 +31527,6 @@
   },
   "title": "/ZZZNoGstarJets_8TeV-madgraph/Summer12_DR53X-PU_RD1_START53_V7N-v1/AODSIM",
   "title_additional": "Simulated dataset ZZZNoGstarJets_8TeV-madgraph in AODSIM format for 2012 collision data",
-  "topic": {
-    "category": "",
-    "source": "CMS collaboration"
-  },
   "type": {
     "primary": "Dataset",
     "secondary": [


### PR DESCRIPTION
* Adds generation information to CMS 2012 simulated datasets. (closes #2151)

* Adds new configuration files accordingly. (Beware, record IDs may have
  changed.)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>