### PR TITLE
elasticsearch: disable deprecation warnings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,7 @@ services:
   elasticsearch:
     restart: "always"
     image: elasticsearch:5
+    command: ["elasticsearch", "-E", "logger.org.elasticsearch.deprecation=error"]
     environment:
       - bootstrap.memory_lock=true
       # set to reasonable values on production


### PR DESCRIPTION
* We are not using last elsticsearch python packages which causes
  some deprecation warnings. Since we can not update the packages
  right now, we disable them for production environment.

* Closes #2087.

Signed-off-by: Diego Rodriguez <diego.rodriguez@cern.ch>