### PR TITLE
nginx: allow only GET and HEAD requests

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -20,6 +20,7 @@ integration purposes. A usage example:
    $ docker-compose -f docker-compose-dev.yml up
    $ docker exec -i -t opendatacernch_web_1 /code/scripts/populate-instance.sh --skip-files
    $ firefox http://0.0.0.0:5000/
+   $ docker-compose -f docker-compose-dev.yml down
 
 If you want to use production-like conditions locally, you can use Docker with
 ``docker-compose.yml`` configuration. This is useful for tuning overall system
@@ -32,6 +33,7 @@ mounted in the container in this case. A usage example:
    $ docker-compose up
    $ docker exec -i -t opendatacernch_web_1 /code/scripts/populate-instance.sh
    $ firefox http://0.0.0.0/
+   $ docker-compose -f docker-compose-dev.yml down -v
 
 Appendix: Git workflow
 ======================

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,4 +92,4 @@ ENV DEBUG=${DEBUG:-False}
 RUN if [ -z "$DEBUG" ]; then pip install -r requirements-dev.txt; fi;
 
 # Start the CERN Open Data Portal application:
-CMD uwsgi --module ${UWSGI_WSGI_MODULE} --http-socket 0.0.0.0:${UWSGI_PORT} --master --processes ${UWSGI_PROCESSES} --threads ${UWSGI_THREADS} --stats /tmp/stats.socket
+CMD uwsgi --module ${UWSGI_WSGI_MODULE} --socket 0.0.0.0:${UWSGI_PORT} --master --processes ${UWSGI_PROCESSES} --threads ${UWSGI_THREADS} --stats /tmp/stats.socket

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -176,21 +176,6 @@ services:
       - "4369:4369"
       - "5672:5672"
 
-  nginx:
-    restart: "always"
-    build: ./nginx
-    image: cernopendata/nginx
-    ports:
-      - "80:80"
-    volumes:
-      - ./cernopendata:/code/cernopendata
-      - ./scripts:/code/scripts
-    volumes_from:
-      - static
-    links:
-      - web
-      - web-files
-
   static:
     restart: "no"
     command: "echo 'Static running...'"

--- a/nginx/cernopendata.conf
+++ b/nginx/cernopendata.conf
@@ -1,26 +1,24 @@
-
 # Cache for ''*/files/*'
-proxy_cache_path /var/cache/nginx/cache_web_files levels=1:2 keys_zone=cache_web_files:100m inactive=60m max_size=500m use_temp_path=off;
+uwsgi_cache_path /var/cache/nginx/cache_web_files levels=1:2 keys_zone=cache_web_files:100m inactive=60m max_size=1000m use_temp_path=off;
 
 # Cache for anything else than '*/files/*'
-proxy_cache_path /var/cache/nginx/cache_web_app levels=1:2 keys_zone=cache_web_app:100m inactive=60m max_size=500m use_temp_path=off;
+uwsgi_cache_path /var/cache/nginx/cache_web_app levels=1:2 keys_zone=cache_web_app:100m inactive=60m max_size=8000m use_temp_path=off;
 
 large_client_header_buffers 8 32k;
 
 upstream web-files {
-    server web-files:5000 max_conns=4;
+    server web-files:5000 max_conns=20;
 }
 
 upstream web-app {
-    server web:5000 max_conns=4;
+    server web:5000 max_conns=20;
 }
 
-# From: https://forum.nginx.org/read.php?2,253260,253662#msg-253662
-# Something like this should work to disable cache for responses
-# with Content-Length larger than 1000000:
+# Disable cache for responses with Content-Length larger than 10000000 bytes:
+# Based on https://forum.nginx.org/read.php?2,253260,253662#msg-253662
 map $upstream_http_content_length $nocache {
     default 1;
-    "~^[1-9]{0,6}$" 0;
+    "~^[1-9]{0,7}$" 0;
 }
 
 server {
@@ -50,28 +48,36 @@ server {
     # Cache any URL that has '/files/' pattern in it.
     # (e.g. '/records/123/files/abc', '/dataset/test/files/storage/higgs.txt')
     location ~ ^/.+/files/.+ {
-        proxy_no_cache $nocache;
-        proxy_cache cache_web_files;
-        proxy_cache_key $host$uri$is_args$args;
-        proxy_cache_valid 200 301 302 30m;
+        include uwsgi_params;
+        uwsgi_pass web-files;
+        uwsgi_no_cache $nocache;
+        uwsgi_cache cache_web_files;
+        uwsgi_cache_key $host$uri$is_args$args;
+        uwsgi_cache_valid 200 301 302 30m;
+        uwsgi_cache_lock on;
+        uwsgi_cache_use_stale updating;
         expires 1h;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_ignore_headers Set-Cookie;
-        proxy_pass http://web-files;
+        uwsgi_param X-Real-IP $remote_addr;
+        uwsgi_param Host $host;
+        uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
+        uwsgi_param X-Forwarded-Proto $http_x_forwarded_proto;
+        uwsgi_ignore_headers Set-Cookie;
     }
 
     location / {
-        proxy_cache cache_web_app;
-        proxy_cache_key $host$uri$is_args$args;
-        proxy_cache_valid 200 301 302 30m;
+        include uwsgi_params;
+        uwsgi_pass web-app;
+        uwsgi_cache cache_web_app;
+        uwsgi_cache_key $host$uri$is_args$args;
+        uwsgi_cache_valid 200 301 302 30m;
+        uwsgi_cache_lock on;
+        uwsgi_cache_use_stale updating;
         expires 1h;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header Host $host;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_ignore_headers Set-Cookie;
-        proxy_pass http://web-app;
+        uwsgi_param X-Real-IP $remote_addr;
+        uwsgi_param Host $host;
+        uwsgi_param X-Forwarded-For $proxy_add_x_forwarded_for;
+        uwsgi_param X-Forwarded-Proto $http_x_forwarded_proto;
+        uwsgi_ignore_headers Set-Cookie;
     }
 
 }

--- a/nginx/cernopendata.conf
+++ b/nginx/cernopendata.conf
@@ -27,6 +27,13 @@ server {
     server_tokens off;
     charset utf-8;
 
+    # Allow only GET and HEAD requests methods. This disables unnecessary
+    # methods such as CONNECT, DELETE, OPTIONS, PATCH, POST, PUT, TRACE for
+    # improved safety.
+    if ($request_method !~ ^(GET|HEAD)) {
+        return 405;
+    }
+
     # Tell nginx to rewrite URI if the path contains uppercase characters and
     # path doesn't start with '/files/' or with `/records/`.
     # If more paths need to be excluded, add them to the selection group


### PR DESCRIPTION
* Allows only GET and HEAD request methods. This disables unnecessary methods
  such as CONNECT, DELETE, OPTIONS, PATCH, POST, PUT, TRACE for improved
  safety. (closes #2199)
    
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
