### PR TITLE
CMS event display file name

### DIFF
--- a/cernopendata/modules/theme/bundles.py
+++ b/cernopendata/modules/theme/bundles.py
@@ -204,7 +204,7 @@ ispy_js = NpmBundle(
     "node_modules/ispy-webgl/js/ispy.js",
     output='gen/cernopendata.ispy.%(version)s.js',
     npm={
-        "ispy-webgl": "0.9.8-COD3.10"
+        "ispy-webgl": "0.9.8-COD3.11"
     },
 )
 
@@ -214,6 +214,6 @@ ispy_css = NpmBundle(
     filters='node-scss, cleancss',
     output='gen/cernopendata.ispy.%(version)s.css',
     npm={
-        "ispy-webgl": "0.9.8-COD3.10"
+        "ispy-webgl": "0.9.8-COD3.11"
     }
 )


### PR DESCRIPTION
* Use newer ispy-webgl from npm in bundles

* New version fetches correct ig file name from url

* Closes 2211