### PR TITLE
templates: next page link labels

### DIFF
--- a/cernopendata/templates/cernopendata_pages/front/lva.html
+++ b/cernopendata/templates/cernopendata_pages/front/lva.html
@@ -95,7 +95,7 @@
         <div class="icon justify-content-center align-items-center">
             <a href="#news">
                 <img src="{{url_for('static', filename='assets/img/mouse-scrolling.png')}}" alt="">
-                <span>News ..</span>
+                <span>News</span>
                 <img src="{{url_for('static', filename='assets/img/mouse-scrolling.png')}}" alt="">
             </a>
         </div>

--- a/cernopendata/templates/cernopendata_pages/front/main.html
+++ b/cernopendata/templates/cernopendata_pages/front/main.html
@@ -52,7 +52,7 @@
                 <div class="icon justify-content-center align-items-center">
                     <a href="#lva">
                         <img src="{{url_for('static', filename='assets/img/mouse-scrolling.png')}}" alt="">
-                        <span>Get started ..</span>
+                        <span>Get started</span>
                         <img src="{{url_for('static', filename='assets/img/mouse-scrolling.png')}}" alt="">
                     </a>
                 </div>


### PR DESCRIPTION
* Renames next page link labels `Get started ..` and `News ..` to remove
  trailing dots.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>