### PR TITLE
nginx: basic access and error log configuration

### DIFF
--- a/nginx/cernopendata.conf
+++ b/nginx/cernopendata.conf
@@ -27,6 +27,10 @@ server {
     server_tokens off;
     charset utf-8;
 
+    # Configure basic logging:
+    access_log /var/log/nginx/access.log combined;
+    error_log /var/log/nginx/error.log error;
+
     # Allow only GET and HEAD requests methods. This disables unnecessary
     # methods such as CONNECT, DELETE, OPTIONS, PATCH, POST, PUT, TRACE for
     # improved safety.


### PR DESCRIPTION
* Adds basic access and error log configuration. Suitable for use with `ngxtop`.
  Example: `docker logs -f opendatacernch_nginx_1 | ngxtop`. (closes #2127)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>