### PR TITLE
nginx: respecing case for glossary URLs

### DIFF
--- a/nginx/cernopendata.conf
+++ b/nginx/cernopendata.conf
@@ -45,7 +45,7 @@ server {
     # Paths must end with `/`-char.
     # Works correctly only when defined as first location block of the server.
     # Based on https://stackoverflow.com/a/11170826
-    location ~ ^/(?!(\b(files/|record/|static/|eos/)\b)).*[A-Z] {
+    location ~ ^/(?!(\b(files/|record/|static/|eos/|glossary/)\b)).*[A-Z] {
         # Simple rewriter that rewrites everything in path to lowercase
         # and continues processing of rewritten URI with internal_redirect.
         # Doesn't update URI displayed in browser


### PR DESCRIPTION
* Does not lowercase glossary URLs such as `/glossary/AOD`, fixing "not found"
  problems for several terms that contain uppercase characters.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>