### PR TITLE
docs: order of news items

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cms-summer-student-report-2017/cms-summer-student-report-2017.json
+++ b/cernopendata/modules/fixtures/data/docs/cms-summer-student-report-2017/cms-summer-student-report-2017.json
@@ -1,6 +1,6 @@
 [
   {
-    "title": "Improving educational content with high-school teachers: A field report from our summer students",
+    "title": "Improving educational content with high-school teachers: A field report from the CMS summer students",
     "slug": "cms-summer-student-report-2017",
     "type": {"primary": "News"},
     "body": {
@@ -15,6 +15,6 @@
     "author": "Henna Silvennoinen, Mira Tengvall, Edith Villegas Garcia",
     "created": "2017-11-15",
     "screenshot": "/static/docs/cms-summer-student-report-2017/opendatasummer.jpeg",
-    "featured": 2
+    "featured": 3
   }
 ]

--- a/cernopendata/modules/fixtures/data/docs/cms-the-future-is-open-2017/cms-the-future-is-open-2017.json
+++ b/cernopendata/modules/fixtures/data/docs/cms-the-future-is-open-2017/cms-the-future-is-open-2017.json
@@ -14,6 +14,6 @@
     ],
     "author": "Jesse Thaler (MIT)",
     "created": "2017-12-01",
-    "featured": 3
+    "featured": 2
   }
 ]

--- a/cernopendata/modules/fixtures/data/docs/cod-welcome/cod-welcome.json
+++ b/cernopendata/modules/fixtures/data/docs/cod-welcome/cod-welcome.json
@@ -1,6 +1,6 @@
 [
     {
-        "title": "Welcome to our updated portal",
+        "title": "Welcome to our updated CERN Open Data portal",
         "slug": "welcome",
         "type": {"primary": "News"},
         "body": {
@@ -10,7 +10,7 @@
         "collections": [
             {"primary": "News" }
         ],
-        "author": "Open Data Portal team",
+        "author": "CERN Open Data team",
         "created": "2017-12-18",
         "screenshot": "/static/docs/welcome/header-image2.png",
         "featured": 1


### PR DESCRIPTION
* Updates some news items and reorders the featured stories for the home page.
  (addresses #2207)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>