### PR TITLE
CMS: fix corrupted CMS-OpenData-1.0.0-rc7.ova

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
@@ -18,13 +18,13 @@
       "ova"
     ],
     "number_files": 1,
-    "size": 915956
+    "size": 15155200
   }, 
   "experiment": "CMS", 
   "files": [
     {
-      "checksum": "sha1:3a5d1ca5041a83a0db1c835b6e7af18d46e2ceb0", 
-      "size": 9159569, 
+      "checksum": "adler32:ae99a9cb", 
+      "size": 15155200, 
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/CMS-OpenData-1.0.0-rc7.ova"
     }
   ], 


### PR DESCRIPTION
* Fixes corrupted `CMS-OpenData-1.0.0-rc7.ova` and updates file size and
  checksum information accordingly. (closes #2255)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
