### PR TITLE
nginx: reverse proxy to EOSPUBLIC

### DIFF
--- a/nginx/cernopendata.conf
+++ b/nginx/cernopendata.conf
@@ -56,6 +56,16 @@ server {
         root /usr/local/var/cernopendata/var/cernopendata-instance;
     }
 
+    # Old reverse proxy to EOS locations used from COD2 times. (Not advertised
+    # much in COD3 times anymore, but it is good to keep it to serve old URLs.)
+    location ~* /eos/opendata/(alice|atlas|lhcb|cms|opera)/.*\.(root|tgz|zip)$ {
+        proxy_cache off;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_pass https://eospublichttp.cern.ch;
+    }
+
     # Cache any URL that has '/files/' pattern in it.
     # (e.g. '/records/123/files/abc', '/dataset/test/files/storage/higgs.txt')
     location ~ ^/.+/files/.+ {


### PR DESCRIPTION
* Adds the old reverse proxy to EOSPUBLIC that was used in COD2 times for
  backward compliance.  (closes #2279)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>