### PR TITLE
docker: add debug flag for dev build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,10 +84,6 @@ RUN /code/scripts/create-instance.sh && \
     chgrp -R 0 ${APP_INSTANCE_PATH} && \
     chmod -R g=u ${APP_INSTANCE_PATH}
 
-RUN adduser --uid 1000 invenio --gid 0 && \
-    chown -R invenio:root /code
-USER 1000
-
 # uWSGI configuration
 ARG UWSGI_WSGI_MODULE=cernopendata.wsgi:application
 ENV UWSGI_WSGI_MODULE ${UWSGI_WSGI_MODULE:-cernopendata.wsgi:application}
@@ -99,11 +95,15 @@ ARG UWSGI_THREADS=2
 ENV UWSGI_THREADS ${UWSGI_THREADS:-2}
 
 # Debug off by default
-ARG DEBUG=False
-ENV DEBUG=${DEBUG:-False}
+ARG DEBUG=""
+ENV DEBUG=${DEBUG:-""}
 
 # Install Python packages needed for development
-RUN if [ -z "$DEBUG" ]; then pip install -r requirements-dev.txt; fi;
+RUN if [ "$DEBUG" ]; then pip install -r requirements-dev.txt; fi;
+
+RUN adduser --uid 1000 invenio --gid 0 && \
+    chown -R invenio:root /code
+USER 1000
 
 # Start the CERN Open Data Portal application:
 CMD uwsgi --module ${UWSGI_WSGI_MODULE} --socket 0.0.0.0:${UWSGI_PORT} --master --processes ${UWSGI_PROCESSES} --threads ${UWSGI_THREADS} --stats /tmp/stats.socket

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Open Data Portal.
-# Copyright (C) 2015, 2016, 2017 CERN.
+# Copyright (C) 2015, 2016, 2017, 2018 CERN.
 #
 # CERN Open Data Portal is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -181,6 +181,8 @@ services:
     command: "echo 'Static running...'"
     build:
       context: .
+      args:
+        DEBUG: 1
     image: cernopendata/static
     volumes:
       - /usr/local/var/cernopendata/var/cernopendata-instance/static


### PR DESCRIPTION
* Postpones user creation in Dockerfile to avoid permission denied
  when installing `requirements-dev.txt`.