### PR TITLE
records: LHCb derived dataset direct files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/lhcb-derived-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/lhcb-derived-datasets.json
@@ -23,11 +23,879 @@
   "experiment": "LHCb",
   "files": [
     {
-      "checksum": "sha1:579137902ed34fc2061f8023afd15beed05f73fc",
-      "description": "LHCb Masterclass D0lifetime 2014 event files file index",
-      "size": 18442,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/file-indexes/LHCb_MasterclassDatasets_D0lifetime_2014_eventfiles_file_index.txt"
+      "checksum": "adler32:e8335c4b",
+      "size": 553275,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_1.root"
+    },
+    {
+      "checksum": "adler32:91daa539",
+      "size": 491569,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_10.root"
+    },
+    {
+      "checksum": "adler32:943bc1eb",
+      "size": 559434,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_100.root"
+    },
+    {
+      "checksum": "adler32:c9200d93",
+      "size": 614174,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_101.root"
+    },
+    {
+      "checksum": "adler32:013fb1d4",
+      "size": 478253,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_102.root"
+    },
+    {
+      "checksum": "adler32:55227773",
+      "size": 548798,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_103.root"
+    },
+    {
+      "checksum": "adler32:9380433f",
+      "size": 608320,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_104.root"
+    },
+    {
+      "checksum": "adler32:53b7841c",
+      "size": 577972,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_105.root"
+    },
+    {
+      "checksum": "adler32:927c67ee",
+      "size": 591225,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_106.root"
+    },
+    {
+      "checksum": "adler32:6c92ff54",
+      "size": 540740,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_107.root"
+    },
+    {
+      "checksum": "adler32:8444c662",
+      "size": 632520,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_108.root"
+    },
+    {
+      "checksum": "adler32:e8b65ecc",
+      "size": 564024,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_109.root"
+    },
+    {
+      "checksum": "adler32:11996158",
+      "size": 588479,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_11.root"
+    },
+    {
+      "checksum": "adler32:271c6b6c",
+      "size": 665802,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_110.root"
+    },
+    {
+      "checksum": "adler32:481546aa",
+      "size": 603210,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_111.root"
+    },
+    {
+      "checksum": "adler32:bef36279",
+      "size": 623009,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_112.root"
+    },
+    {
+      "checksum": "adler32:f77692f3",
+      "size": 569832,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_113.root"
+    },
+    {
+      "checksum": "adler32:deb466e7",
+      "size": 558142,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_114.root"
+    },
+    {
+      "checksum": "adler32:ec5893dd",
+      "size": 626669,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_115.root"
+    },
+    {
+      "checksum": "adler32:7d395cbd",
+      "size": 685192,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_116.root"
+    },
+    {
+      "checksum": "adler32:ce623f15",
+      "size": 617612,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_117.root"
+    },
+    {
+      "checksum": "adler32:237876b8",
+      "size": 618438,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_118.root"
+    },
+    {
+      "checksum": "adler32:2a3b52e7",
+      "size": 562310,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_119.root"
+    },
+    {
+      "checksum": "adler32:7264c5b7",
+      "size": 438622,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_12.root"
+    },
+    {
+      "checksum": "adler32:1f0a1055",
+      "size": 599337,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_120.root"
+    },
+    {
+      "checksum": "adler32:a985bc7e",
+      "size": 564208,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_121.root"
+    },
+    {
+      "checksum": "adler32:0fb78269",
+      "size": 529423,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_122.root"
+    },
+    {
+      "checksum": "adler32:85ac527f",
+      "size": 604452,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_123.root"
+    },
+    {
+      "checksum": "adler32:bad1b92e",
+      "size": 593614,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_124.root"
+    },
+    {
+      "checksum": "adler32:0809e5b6",
+      "size": 511393,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_125.root"
+    },
+    {
+      "checksum": "adler32:53835454",
+      "size": 601308,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_126.root"
+    },
+    {
+      "checksum": "adler32:79e6fa95",
+      "size": 607658,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_127.root"
+    },
+    {
+      "checksum": "adler32:6a3221b3",
+      "size": 535046,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_128.root"
+    },
+    {
+      "checksum": "adler32:52a4763c",
+      "size": 627587,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_129.root"
+    },
+    {
+      "checksum": "adler32:12af1c62",
+      "size": 571230,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_13.root"
+    },
+    {
+      "checksum": "adler32:da3b3113",
+      "size": 480426,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_130.root"
+    },
+    {
+      "checksum": "adler32:914f8eb5",
+      "size": 613214,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_131.root"
+    },
+    {
+      "checksum": "adler32:c350b2b1",
+      "size": 585320,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_132.root"
+    },
+    {
+      "checksum": "adler32:2d8cc47e",
+      "size": 531121,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_133.root"
+    },
+    {
+      "checksum": "adler32:1b9a2b76",
+      "size": 491759,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_134.root"
+    },
+    {
+      "checksum": "adler32:3903f091",
+      "size": 701117,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_135.root"
+    },
+    {
+      "checksum": "adler32:f6573b39",
+      "size": 611973,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_136.root"
+    },
+    {
+      "checksum": "adler32:8a345bbc",
+      "size": 619374,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_137.root"
+    },
+    {
+      "checksum": "adler32:cc727e1c",
+      "size": 523920,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_138.root"
+    },
+    {
+      "checksum": "adler32:0bc1ba27",
+      "size": 587350,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_139.root"
+    },
+    {
+      "checksum": "adler32:5452281f",
+      "size": 570482,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_14.root"
+    },
+    {
+      "checksum": "adler32:012bdcc8",
+      "size": 609076,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_140.root"
+    },
+    {
+      "checksum": "adler32:747edf31",
+      "size": 578403,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_141.root"
+    },
+    {
+      "checksum": "adler32:b1bbefff",
+      "size": 556523,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_142.root"
+    },
+    {
+      "checksum": "adler32:61afa1cf",
+      "size": 532463,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_143.root"
+    },
+    {
+      "checksum": "adler32:07550987",
+      "size": 485025,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_144.root"
+    },
+    {
+      "checksum": "adler32:dd1c8b95",
+      "size": 551534,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_145.root"
+    },
+    {
+      "checksum": "adler32:baaf0f7b",
+      "size": 580751,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_146.root"
+    },
+    {
+      "checksum": "adler32:c4b1bc7f",
+      "size": 588348,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_147.root"
+    },
+    {
+      "checksum": "adler32:6b545b13",
+      "size": 574374,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_148.root"
+    },
+    {
+      "checksum": "adler32:56812165",
+      "size": 520806,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_149.root"
+    },
+    {
+      "checksum": "adler32:5c8a36ba",
+      "size": 558753,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_15.root"
+    },
+    {
+      "checksum": "adler32:b93de61b",
+      "size": 731331,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_150.root"
+    },
+    {
+      "checksum": "adler32:45c0f40b",
+      "size": 569023,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_151.root"
+    },
+    {
+      "checksum": "adler32:6459e51b",
+      "size": 539481,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_152.root"
+    },
+    {
+      "checksum": "adler32:4f1aa475",
+      "size": 526879,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_153.root"
+    },
+    {
+      "checksum": "adler32:8e2f633f",
+      "size": 675784,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_154.root"
+    },
+    {
+      "checksum": "adler32:87f3214e",
+      "size": 628221,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_155.root"
+    },
+    {
+      "checksum": "adler32:af8e45e6",
+      "size": 518776,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_156.root"
+    },
+    {
+      "checksum": "adler32:a3e7c8fd",
+      "size": 586418,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_157.root"
+    },
+    {
+      "checksum": "adler32:32a2289e",
+      "size": 633591,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_158.root"
+    },
+    {
+      "checksum": "adler32:759ade30",
+      "size": 581017,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_159.root"
+    },
+    {
+      "checksum": "adler32:ca7b1c09",
+      "size": 509119,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_16.root"
+    },
+    {
+      "checksum": "adler32:70415467",
+      "size": 575387,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_160.root"
+    },
+    {
+      "checksum": "adler32:561373b5",
+      "size": 525971,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_161.root"
+    },
+    {
+      "checksum": "adler32:ea2e7c29",
+      "size": 551060,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_162.root"
+    },
+    {
+      "checksum": "adler32:5206512b",
+      "size": 628505,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_163.root"
+    },
+    {
+      "checksum": "adler32:3a4a3de2",
+      "size": 548977,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_164.root"
+    },
+    {
+      "checksum": "adler32:42b686d0",
+      "size": 559591,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_165.root"
+    },
+    {
+      "checksum": "adler32:a2008d17",
+      "size": 574903,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_166.root"
+    },
+    {
+      "checksum": "adler32:ca6ef0b6",
+      "size": 549987,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_167.root"
+    },
+    {
+      "checksum": "adler32:1941b53e",
+      "size": 586905,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_168.root"
+    },
+    {
+      "checksum": "adler32:ec05c324",
+      "size": 574848,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_169.root"
+    },
+    {
+      "checksum": "adler32:8f1b449e",
+      "size": 609131,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_17.root"
+    },
+    {
+      "checksum": "adler32:ae218d62",
+      "size": 599413,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_170.root"
+    },
+    {
+      "checksum": "adler32:f109c85f",
+      "size": 591474,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_171.root"
+    },
+    {
+      "checksum": "adler32:540f4871",
+      "size": 591252,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_172.root"
+    },
+    {
+      "checksum": "adler32:f01510c8",
+      "size": 453265,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_173.root"
+    },
+    {
+      "checksum": "adler32:215d91b2",
+      "size": 552974,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_174.root"
+    },
+    {
+      "checksum": "adler32:67b63805",
+      "size": 572137,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_175.root"
+    },
+    {
+      "checksum": "adler32:ce21d4cb",
+      "size": 531189,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_18.root"
+    },
+    {
+      "checksum": "adler32:3eb3c024",
+      "size": 582803,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_19.root"
+    },
+    {
+      "checksum": "adler32:a6dc0696",
+      "size": 555932,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_2.root"
+    },
+    {
+      "checksum": "adler32:eec59d47",
+      "size": 552996,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_20.root"
+    },
+    {
+      "checksum": "adler32:a3dcc1f0",
+      "size": 544609,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_21.root"
+    },
+    {
+      "checksum": "adler32:96e8c149",
+      "size": 672150,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_22.root"
+    },
+    {
+      "checksum": "adler32:e503cfc4",
+      "size": 571930,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_23.root"
+    },
+    {
+      "checksum": "adler32:a2ba3f10",
+      "size": 557505,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_24.root"
+    },
+    {
+      "checksum": "adler32:4152a8f6",
+      "size": 652575,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_25.root"
+    },
+    {
+      "checksum": "adler32:c092230e",
+      "size": 611263,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_26.root"
+    },
+    {
+      "checksum": "adler32:4a4d31d3",
+      "size": 638512,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_27.root"
+    },
+    {
+      "checksum": "adler32:ab84d3a0",
+      "size": 608943,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_28.root"
+    },
+    {
+      "checksum": "adler32:bdddf4a5",
+      "size": 641526,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_29.root"
+    },
+    {
+      "checksum": "adler32:3a117335",
+      "size": 470622,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_3.root"
+    },
+    {
+      "checksum": "adler32:e0566f30",
+      "size": 591248,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_30.root"
+    },
+    {
+      "checksum": "adler32:c8d3d5b8",
+      "size": 610586,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_31.root"
+    },
+    {
+      "checksum": "adler32:0e5701c7",
+      "size": 579287,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_32.root"
+    },
+    {
+      "checksum": "adler32:b249dae3",
+      "size": 618816,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_33.root"
+    },
+    {
+      "checksum": "adler32:49f10c45",
+      "size": 540252,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_34.root"
+    },
+    {
+      "checksum": "adler32:e9d5ee63",
+      "size": 583056,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_35.root"
+    },
+    {
+      "checksum": "adler32:ccb7bf68",
+      "size": 536611,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_36.root"
+    },
+    {
+      "checksum": "adler32:49b166b6",
+      "size": 515206,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_37.root"
+    },
+    {
+      "checksum": "adler32:39c36b2c",
+      "size": 537294,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_38.root"
+    },
+    {
+      "checksum": "adler32:8a28fb81",
+      "size": 597096,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_39.root"
+    },
+    {
+      "checksum": "adler32:b26fb422",
+      "size": 553631,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_4.root"
+    },
+    {
+      "checksum": "adler32:5bb6151f",
+      "size": 580408,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_40.root"
+    },
+    {
+      "checksum": "adler32:670e8c54",
+      "size": 556069,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_41.root"
+    },
+    {
+      "checksum": "adler32:b34d521f",
+      "size": 553198,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_42.root"
+    },
+    {
+      "checksum": "adler32:ca1e46d7",
+      "size": 558181,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_43.root"
+    },
+    {
+      "checksum": "adler32:26ecba13",
+      "size": 580865,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_44.root"
+    },
+    {
+      "checksum": "adler32:e61d75cc",
+      "size": 538580,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_45.root"
+    },
+    {
+      "checksum": "adler32:e5b7f532",
+      "size": 502055,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_46.root"
+    },
+    {
+      "checksum": "adler32:fea253ba",
+      "size": 554206,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_47.root"
+    },
+    {
+      "checksum": "adler32:83a9394c",
+      "size": 524715,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_48.root"
+    },
+    {
+      "checksum": "adler32:3b481958",
+      "size": 542090,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_49.root"
+    },
+    {
+      "checksum": "adler32:6b99df4a",
+      "size": 449088,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_5.root"
+    },
+    {
+      "checksum": "adler32:835b89f8",
+      "size": 533660,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_50.root"
+    },
+    {
+      "checksum": "adler32:ba66d22a",
+      "size": 571718,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_51.root"
+    },
+    {
+      "checksum": "adler32:b791df88",
+      "size": 582657,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_52.root"
+    },
+    {
+      "checksum": "adler32:e6fd5f92",
+      "size": 650958,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_53.root"
+    },
+    {
+      "checksum": "adler32:cf419e57",
+      "size": 521529,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_54.root"
+    },
+    {
+      "checksum": "adler32:14f7c802",
+      "size": 497876,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_55.root"
+    },
+    {
+      "checksum": "adler32:0532411e",
+      "size": 563034,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_56.root"
+    },
+    {
+      "checksum": "adler32:ec327979",
+      "size": 553089,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_57.root"
+    },
+    {
+      "checksum": "adler32:3d514acd",
+      "size": 549247,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_58.root"
+    },
+    {
+      "checksum": "adler32:70d0b7c6",
+      "size": 583278,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_59.root"
+    },
+    {
+      "checksum": "adler32:60eab853",
+      "size": 598279,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_6.root"
+    },
+    {
+      "checksum": "adler32:2e3ce65d",
+      "size": 547366,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_60.root"
+    },
+    {
+      "checksum": "adler32:fd02eed9",
+      "size": 582539,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_61.root"
+    },
+    {
+      "checksum": "adler32:3cc31fa3",
+      "size": 567443,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_62.root"
+    },
+    {
+      "checksum": "adler32:e68ca279",
+      "size": 516317,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_63.root"
+    },
+    {
+      "checksum": "adler32:9eb8ae8e",
+      "size": 556144,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_64.root"
+    },
+    {
+      "checksum": "adler32:2b5df131",
+      "size": 578104,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_65.root"
+    },
+    {
+      "checksum": "adler32:bb864fb6",
+      "size": 523158,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_66.root"
+    },
+    {
+      "checksum": "adler32:6c70f6f8",
+      "size": 579535,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_67.root"
+    },
+    {
+      "checksum": "adler32:09c7e87e",
+      "size": 656622,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_68.root"
+    },
+    {
+      "checksum": "adler32:5fb7c853",
+      "size": 574804,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_69.root"
+    },
+    {
+      "checksum": "adler32:1a6baa5b",
+      "size": 610895,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_7.root"
+    },
+    {
+      "checksum": "adler32:fafa4f76",
+      "size": 562798,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_70.root"
+    },
+    {
+      "checksum": "adler32:88434766",
+      "size": 522052,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_71.root"
+    },
+    {
+      "checksum": "adler32:75c5cb30",
+      "size": 546844,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_72.root"
+    },
+    {
+      "checksum": "adler32:1fa0d0e5",
+      "size": 560661,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_73.root"
+    },
+    {
+      "checksum": "adler32:3fe978c9",
+      "size": 570020,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_74.root"
+    },
+    {
+      "checksum": "adler32:e4371fd7",
+      "size": 629136,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_75.root"
+    },
+    {
+      "checksum": "adler32:9af79d50",
+      "size": 605013,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_76.root"
+    },
+    {
+      "checksum": "adler32:8f735cde",
+      "size": 476158,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_77.root"
+    },
+    {
+      "checksum": "adler32:1c3ad61f",
+      "size": 570710,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_78.root"
+    },
+    {
+      "checksum": "adler32:c6dfab2e",
+      "size": 611646,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_79.root"
+    },
+    {
+      "checksum": "adler32:a04e0e49",
+      "size": 573825,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_8.root"
+    },
+    {
+      "checksum": "adler32:c3beee93",
+      "size": 471950,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_80.root"
+    },
+    {
+      "checksum": "adler32:80824f57",
+      "size": 638873,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_81.root"
+    },
+    {
+      "checksum": "adler32:2f6b880d",
+      "size": 543416,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_82.root"
+    },
+    {
+      "checksum": "adler32:8d4337bb",
+      "size": 573873,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_83.root"
+    },
+    {
+      "checksum": "adler32:3e2d82c3",
+      "size": 576530,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_84.root"
+    },
+    {
+      "checksum": "adler32:2daf15fc",
+      "size": 511442,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_85.root"
+    },
+    {
+      "checksum": "adler32:28ac77fa",
+      "size": 511607,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_86.root"
+    },
+    {
+      "checksum": "adler32:2fbcd3fa",
+      "size": 531422,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_87.root"
+    },
+    {
+      "checksum": "adler32:003eff3a",
+      "size": 479890,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_88.root"
+    },
+    {
+      "checksum": "adler32:e3db3392",
+      "size": 507100,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_89.root"
+    },
+    {
+      "checksum": "adler32:9a7241bd",
+      "size": 630671,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_9.root"
+    },
+    {
+      "checksum": "adler32:27b99a97",
+      "size": 528572,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_90.root"
+    },
+    {
+      "checksum": "adler32:fba06e1a",
+      "size": 512238,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_91.root"
+    },
+    {
+      "checksum": "adler32:2d52bce6",
+      "size": 562598,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_92.root"
+    },
+    {
+      "checksum": "adler32:90491e66",
+      "size": 553116,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_93.root"
+    },
+    {
+      "checksum": "adler32:d693533b",
+      "size": 461304,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_94.root"
+    },
+    {
+      "checksum": "adler32:043efd51",
+      "size": 468772,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_95.root"
+    },
+    {
+      "checksum": "adler32:054861b6",
+      "size": 514657,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_96.root"
+    },
+    {
+      "checksum": "adler32:8b4fc6a2",
+      "size": 535802,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_97.root"
+    },
+    {
+      "checksum": "adler32:b8c09ac3",
+      "size": 472459,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_98.root"
+    },
+    {
+      "checksum": "adler32:00c1c588",
+      "size": 584063,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/mclasseventv2_D0_99.root"
     }
   ],
   "keywords": [
@@ -77,11 +945,9 @@
   "experiment": "LHCb",
   "files": [
     {
-      "checksum": "sha1:9a0d92c6159d4fa39f45e5f1b321eb0468a47558",
-      "description": "LHCb Masterclass D0lifetime 2014 real measurement file index",
-      "size": 101,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/file-indexes/LHCb_MasterclassDatasets_D0lifetime_2014_realmeasurement_file_index.txt"
+      "checksum": "adler32:2ebf133a",
+      "size": 1289541,
+      "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/MasterclassDatasets/D0lifetime/2014/MasterclassData.root"
     }
   ],
   "keywords": [


### PR DESCRIPTION
* Changes `lhcb-derived-datasets` records by removing the index files and
  attaching the asset files directly. This is sufficient for this collection
  containing relatively low number of files. (addresses #2093)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>