### PR TITLE
records: CMS condition data direct files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2011A.json
@@ -21,10 +21,14 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:79e2deb030d88f054bd994f712a1ca018c0ed18b",
-      "size": 145,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/db/file-indexes/CMS_Run2011A_db_FT_53_LV5_AN1_file_index.txt"
+      "checksum": "adler32:3e22607e",
+      "size": 82944,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/db/FT_53_LV5_AN1.db"
+    },
+    {
+      "checksum": "adler32:33ab47de",
+      "size": 11581209101,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/db/FT_53_LV5_AN1.tgz"
     }
   ],
   "publisher": "CERN Open Data Portal",
@@ -61,10 +65,14 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:a2f53ef78673c56e3ddae1d364fedc9aa45b6f61",
-      "size": 145,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/db/file-indexes/CMS_Run2011A_db_START53_LV6A1_file_index.txt"
+      "checksum": "adler32:57fd5840",
+      "size": 84992,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/db/START53_LV6A1.db"
+    },
+    {
+      "checksum": "adler32:3d686da6",
+      "size": 165990768,
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/db/START53_LV6A1.tgz"
     }
   ],
   "publisher": "CERN Open Data Portal",


### PR DESCRIPTION
* Changes `cms-condition-data-Run2011A` records by removing the index files and
  attaching the asset files directly. This is sufficient for this collection
  containing low number of files. (addresses #2093)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>