### PR TITLE
records: CMS raw dataset rich index files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2011A.json
@@ -30,9 +30,15 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0000000000000000000000000000000000000000",
+      "checksum": "adler32:cbdb81c5",
+      "size": 14700,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/file-indexes/CMS_Run2011A_MinimumBias_RAW_v1_000_160_957_file_index.json"
+    },
+    {
+      "checksum": "adler32:e7a2288e",
       "size": 8875,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/RAW/v1/000/160/file-indexes/CMS_Run2011A_MinimumBias_RAW_v1_000_160_957_file_index.txt"
     }
   ],


### PR DESCRIPTION
* Adds rich index files (TXT, JSON) to `cms-raw-datasets-Run2011A`
  records. (addresses #2093)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>