### PR TITLE
records: CMS PAT tuples rich index files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana.json
@@ -26,9 +26,15 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:8052ce9c1dce19e177bd903e167f5db0c6e33b09",
+      "checksum": "adler32:6e9637d8",
+      "size": 1059,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/PATtuples/file-indexes/CMS_Run2010B_Mu_PATtuples_file_index.json"
+    },
+    {
+      "checksum": "adler32:6a24c1ea",
       "size": 558,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/PATtuples/file-indexes/CMS_Run2010B_Mu_PATtuples_file_index.txt"
     }
   ],
@@ -117,9 +123,15 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:afdd7a69b341ccb1f2e0db820680a29e016e4a5a",
+      "checksum": "adler32:43825413",
+      "size": 1131,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/PATtuples/file-indexes/CMS_Run2010B_Electron_PATtuples_file_index.json"
+    },
+    {
+      "checksum": "adler32:16c8dfa2",
       "size": 630,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/PATtuples/file-indexes/CMS_Run2010B_Electron_PATtuples_file_index.txt"
     }
   ],


### PR DESCRIPTION
* Adds rich index files (TXT, JSON) to `cms-derived-pattuples-ana`
  records. (addresses #2093)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>