### PR TITLE
records: CMS 2011 PAT tuples rich index files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana-Run2011A.json
@@ -26,9 +26,15 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:284ed728c5d2d499dcc847768b82395f36d848b3",
+      "checksum": "adler32:c38a6f1a",
+      "size": 9830,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/PATtuples/file-indexes/CMS_Run2011A_DoubleMu_PATtuples_file_index.json"
+    },
+    {
+      "checksum": "adler32:1ac65b98",
       "size": 5400,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/PATtuples/file-indexes/CMS_Run2011A_DoubleMu_PATtuples_file_index.txt"
     }
   ],
@@ -117,9 +123,15 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:1a488a7298f9494bd15d1fbce29320c6d997ce98",
+      "checksum": "adler32:831cb67f",
+      "size": 13195,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/PATtuples/file-indexes/CMS_Run2011A_DoubleElectron_PATtuples_file_index.json"
+    },
+    {
+      "checksum": "adler32:4e4e9509",
       "size": 7616,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/PATtuples/file-indexes/CMS_Run2011A_DoubleElectron_PATtuples_file_index.txt"
     }
   ],


### PR DESCRIPTION
* Adds rich index files (TXT, JSON) to `cms-derived-pattuples-ana-Run2011A`
  records. (addresses #2093)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>