### PR TITLE
records: ATLAS simulated dataset direct files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/atlas-simulated-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-simulated-datasets.json
@@ -28,11 +28,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:6b0362da276817f9e7e76dc19e200d17650af97e",
-      "description": "mc_105985.WW file index",
-      "size": 94,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_105985.WW_file_index.txt"
+      "checksum": "adler32:c5065c55",
+      "size": 64727099,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_105985.WW.root"
     }
   ],
   "license": {
@@ -105,11 +103,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:45c47263faa2f32af26647edc2d3c837f1fd8a0c",
-      "description": "mc_105986.ZZ file index",
-      "size": 94,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_105986.ZZ_file_index.txt"
+      "checksum": "adler32:a516edda",
+      "size": 19849729,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_105986.ZZ.root"
     }
   ],
   "license": {
@@ -182,11 +178,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:51469f8fb8744139f796cf687fd88a23fb212d74",
-      "description": "mc_105987.WZ file index",
-      "size": 94,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_105987.WZ_file_index.txt"
+      "checksum": "adler32:bab48f41",
+      "size": 69459481,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_105987.WZ.root"
     }
   ],
   "license": {
@@ -259,11 +253,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:5dae7933cd531a971d9e5918a9398c9feb3f76e1",
-      "description": "mc_110090.stop_tchan_top file index",
-      "size": 106,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110090.stop_tchan_top_file_index.txt"
+      "checksum": "adler32:315a4921",
+      "size": 21637659,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110090.stop_tchan_top.root"
     }
   ],
   "license": {
@@ -336,11 +328,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:e9fd5833d406a12a438415ee26bdf09e78661d2d",
-      "description": "mc_110091.stop_tchan_antitop file index",
-      "size": 110,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110091.stop_tchan_antitop_file_index.txt"
+      "checksum": "adler32:29f3b1a0",
+      "size": 14509120,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110091.stop_tchan_antitop.root"
     }
   ],
   "license": {
@@ -413,11 +403,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:f9a7f7dbee4f1b8bdc785c08df93ef6c3a3b950c",
-      "description": "mc_110119.stop_schan file index",
-      "size": 102,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110119.stop_schan_file_index.txt"
+      "checksum": "adler32:026ac360",
+      "size": 15148662,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110119.stop_schan.root"
     }
   ],
   "license": {
@@ -490,11 +478,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:76b5a692f9f724d69e58bd60539863b94f13e3b2",
-      "description": "mc_110140.stop_wtchan file index",
-      "size": 103,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110140.stop_wtchan_file_index.txt"
+      "checksum": "adler32:f0261652",
+      "size": 26422422,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110140.stop_wtchan.root"
     }
   ],
   "license": {
@@ -567,11 +553,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:59b3536667a2fc4cd76bf86858874180c1afbeba",
-      "description": "mc_110899.ZPrime400 file index",
-      "size": 101,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110899.ZPrime400_file_index.txt"
+      "checksum": "adler32:45f7bd17",
+      "size": 4389879,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110899.ZPrime400.root"
     }
   ],
   "license": {
@@ -644,11 +628,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:ad13d0e0a02830b960f89727356492af0e97d12a",
-      "description": "mc_110901.ZPrime500 file index",
-      "size": 101,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110901.ZPrime500_file_index.txt"
+      "checksum": "adler32:fc90ecdf",
+      "size": 4765016,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110901.ZPrime500.root"
     }
   ],
   "license": {
@@ -721,11 +703,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:be8e658e7a35ff33a09844ca2cd42fba32d1b27a",
-      "description": "mc_110902.ZPrime750 file index",
-      "size": 101,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110902.ZPrime750_file_index.txt"
+      "checksum": "adler32:91f90400",
+      "size": 5400815,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110902.ZPrime750.root"
     }
   ],
   "license": {
@@ -798,11 +778,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:65342d8a7a78d65f2abb6a4cb7f93f106ac9e8ce",
-      "description": "mc_110903.ZPrime1000 file index",
-      "size": 102,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110903.ZPrime1000_file_index.txt"
+      "checksum": "adler32:d1393b04",
+      "size": 5678500,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110903.ZPrime1000.root"
     }
   ],
   "license": {
@@ -875,11 +853,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:49fc84f300a72b06f3059fedf1f7ee8c829c5f04",
-      "description": "mc_110904.ZPrime1250 file index",
-      "size": 102,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110904.ZPrime1250_file_index.txt"
+      "checksum": "adler32:34cba4a6",
+      "size": 5635939,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110904.ZPrime1250.root"
     }
   ],
   "license": {
@@ -952,11 +928,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:2c54b2216ab29f870541da6272f1f3f0da592231",
-      "description": "mc_110905.ZPrime1500 file index",
-      "size": 102,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110905.ZPrime1500_file_index.txt"
+      "checksum": "adler32:861dc267",
+      "size": 5474660,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110905.ZPrime1500.root"
     }
   ],
   "license": {
@@ -1029,11 +1003,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:7f0aa8c5f77d0629469e32ddccf7266cf1f98dd5",
-      "description": "mc_110906.ZPrime1750 file index",
-      "size": 102,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110906.ZPrime1750_file_index.txt"
+      "checksum": "adler32:8979361f",
+      "size": 5241751,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110906.ZPrime1750.root"
     }
   ],
   "license": {
@@ -1106,11 +1078,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:22836dfb04723e84b1821436c6cdf9fbd2048c6a",
-      "description": "mc_110907.ZPrime2000 file index",
-      "size": 102,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110907.ZPrime2000_file_index.txt"
+      "checksum": "adler32:44ccc0e4",
+      "size": 5000024,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110907.ZPrime2000.root"
     }
   ],
   "license": {
@@ -1183,11 +1153,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:8f5e1480521d65780c512aa528e1669f4fe5db74",
-      "description": "mc_110908.ZPrime2250 file index",
-      "size": 102,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110908.ZPrime2250_file_index.txt"
+      "checksum": "adler32:8a715319",
+      "size": 4798092,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110908.ZPrime2250.root"
     }
   ],
   "license": {
@@ -1260,11 +1228,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:e2fb15d972156c608bb0578edf583734ff7aaded",
-      "description": "mc_110909.ZPrime2500 file index",
-      "size": 102,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110909.ZPrime2500_file_index.txt"
+      "checksum": "adler32:b9f2f382",
+      "size": 4610759,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110909.ZPrime2500.root"
     }
   ],
   "license": {
@@ -1337,11 +1303,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:28fa2d3eef8ecafb8a7ae913e775c26f80833496",
-      "description": "mc_110910.ZPrime3000 file index",
-      "size": 102,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_110910.ZPrime3000_file_index.txt"
+      "checksum": "adler32:1f04805c",
+      "size": 4408997,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_110910.ZPrime3000.root"
     }
   ],
   "license": {
@@ -1414,11 +1378,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:372e9a25d64ba0d9620933d044309afbb1af9e42",
-      "description": "mc_117049.ttbar_had file index",
-      "size": 101,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_117049.ttbar_had_file_index.txt"
+      "checksum": "adler32:c5b2bc2f",
+      "size": 5825184,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_117049.ttbar_had.root"
     }
   ],
   "license": {
@@ -1491,11 +1453,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:b222789b168ec73757861a972551ce6d15df3c65",
-      "description": "mc_117050.ttbar_lep file index",
-      "size": 101,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_117050.ttbar_lep_file_index.txt"
+      "checksum": "adler32:739b97f1",
+      "size": 300090186,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_117050.ttbar_lep.root"
     }
   ],
   "license": {
@@ -1568,11 +1528,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:0ec22fcf3672c4894cfc4a02077e2fd19eb5768c",
-      "description": "mc_147770.Zee file index",
-      "size": 95,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_147770.Zee_file_index.txt"
+      "checksum": "adler32:2fe49d81",
+      "size": 966133549,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_147770.Zee.root"
     }
   ],
   "license": {
@@ -1645,11 +1603,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:db1963f48a5fd7593bb5cea95894dd0b1f547a2b",
-      "description": "mc_147771.Zmumu file index",
-      "size": 97,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_147771.Zmumu_file_index.txt"
+      "checksum": "adler32:a63be344",
+      "size": 946361551,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_147771.Zmumu.root"
     }
   ],
   "license": {
@@ -1722,11 +1678,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:dca491d7f809386ecdcca3a2bb8538d95398cb0c",
-      "description": "mc_147772.Ztautau file index",
-      "size": 99,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_147772.Ztautau_file_index.txt"
+      "checksum": "adler32:c1bf3e1e",
+      "size": 95788974,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_147772.Ztautau.root"
     }
   ],
   "license": {
@@ -1799,11 +1753,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:5ca869a32b00263d9d0fb7621417d8bc635ae9f1",
-      "description": "mc_160155.ggH125_ZZ4lep file index",
-      "size": 105,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_160155.ggH125_ZZ4lep_file_index.txt"
+      "checksum": "adler32:4849beb7",
+      "size": 17580529,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_160155.ggH125_ZZ4lep.root"
     }
   ],
   "license": {
@@ -1876,11 +1828,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:189d304908cc77bd57277710750752dc671eef10",
-      "description": "mc_160205.VBFH125_ZZ4lep file index",
-      "size": 106,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_160205.VBFH125_ZZ4lep_file_index.txt"
+      "checksum": "adler32:73aecce0",
+      "size": 19380185,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_160205.VBFH125_ZZ4lep.root"
     }
   ],
   "license": {
@@ -1953,11 +1903,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:870a2dc7d73ccdd919694b9e52b891dc1f265567",
-      "description": "mc_161005.ggH125_WW2lep file index",
-      "size": 105,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_161005.ggH125_WW2lep_file_index.txt"
+      "checksum": "adler32:c1bb2430",
+      "size": 13607410,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_161005.ggH125_WW2lep.root"
     }
   ],
   "license": {
@@ -2030,11 +1978,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:3014b3b5d65a9cc16c87e1b4806f89fee819ac70",
-      "description": "mc_161055.VBFH125_WW2lep file index",
-      "size": 106,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_161055.VBFH125_WW2lep_file_index.txt"
+      "checksum": "adler32:685880a5",
+      "size": 15389694,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_161055.VBFH125_WW2lep.root"
     }
   ],
   "license": {
@@ -2107,11 +2053,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:4762644180e4a4bf2d53d9f198cf243fb8d7cf7a",
-      "description": "mc_167740.WenuWithB file index",
-      "size": 101,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167740.WenuWithB_file_index.txt"
+      "checksum": "adler32:306ec0e9",
+      "size": 88002379,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167740.WenuWithB.root"
     }
   ],
   "license": {
@@ -2184,11 +2128,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:bc613318223d2bae555453290608dffc52c039e1",
-      "description": "mc_167741.WenuJetsBVeto file index",
-      "size": 105,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167741.WenuJetsBVeto_file_index.txt"
+      "checksum": "adler32:855cecce",
+      "size": 305358713,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167741.WenuJetsBVeto.root"
     }
   ],
   "license": {
@@ -2261,11 +2203,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:734e2c48e086b5d31ab49c8b96a6ffccc434e2bf",
-      "description": "mc_167742.WenuNoJetsBVeto file index",
-      "size": 107,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167742.WenuNoJetsBVeto_file_index.txt"
+      "checksum": "adler32:c7949506",
+      "size": 747210223,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167742.WenuNoJetsBVeto.root"
     }
   ],
   "license": {
@@ -2338,11 +2278,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:1c3a9725038565ad9b57abd8a0e5f489762f8728",
-      "description": "mc_167743.WmunuWithB file index",
-      "size": 102,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167743.WmunuWithB_file_index.txt"
+      "checksum": "adler32:c5097278",
+      "size": 86686414,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167743.WmunuWithB.root"
     }
   ],
   "license": {
@@ -2415,11 +2353,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:734babf11fc95007d0532b2428d50f4ad7fef458",
-      "description": "mc_167744.WmunuJetsBVeto file index",
-      "size": 106,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167744.WmunuJetsBVeto_file_index.txt"
+      "checksum": "adler32:0da8b716",
+      "size": 296131195,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167744.WmunuJetsBVeto.root"
     }
   ],
   "license": {
@@ -2492,11 +2428,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:85af66043c143bc092e97beced849879104446ce",
-      "description": "mc_167745.WmunuNoJetsBVeto file index",
-      "size": 108,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167745.WmunuNoJetsBVeto_file_index.txt"
+      "checksum": "adler32:735861b7",
+      "size": 689245060,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167745.WmunuNoJetsBVeto.root"
     }
   ],
   "license": {
@@ -2569,11 +2503,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:8c0199782363ed8d89f66d5ba4841fad83e1b42e",
-      "description": "mc_167746.WtaunuWithB file index",
-      "size": 103,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167746.WtaunuWithB_file_index.txt"
+      "checksum": "adler32:adfe0b4d",
+      "size": 12840353,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167746.WtaunuWithB.root"
     }
   ],
   "license": {
@@ -2646,11 +2578,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:683ed792e12a674b0c28be1a28ea1c5baa98090d",
-      "description": "mc_167747.WtaunuJetsBVeto file index",
-      "size": 107,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167747.WtaunuJetsBVeto_file_index.txt"
+      "checksum": "adler32:21ed90b9",
+      "size": 31642922,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167747.WtaunuJetsBVeto.root"
     }
   ],
   "license": {
@@ -2723,11 +2653,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:63b213f52777589b71981ee5a53b577a2e0fe246",
-      "description": "mc_167748.WtaunuNoJetsBVeto file index",
-      "size": 109,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_167748.WtaunuNoJetsBVeto_file_index.txt"
+      "checksum": "adler32:e2ddcc3f",
+      "size": 56349987,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_167748.WtaunuNoJetsBVeto.root"
     }
   ],
   "license": {
@@ -2800,11 +2728,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:fc90de73e1112f3b90a26c19c819fa189cda66ba",
-      "description": "mc_173041.DYeeM08to15 file index",
-      "size": 103,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_173041.DYeeM08to15_file_index.txt"
+      "checksum": "adler32:11c2ca09",
+      "size": 58248307,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173041.DYeeM08to15.root"
     }
   ],
   "license": {
@@ -2877,11 +2803,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:0e00c1719a2cde5173e166ed383b65757ef9678b",
-      "description": "mc_173042.DYeeM15to40 file index",
-      "size": 103,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_173042.DYeeM15to40_file_index.txt"
+      "checksum": "adler32:2c329f72",
+      "size": 102182246,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173042.DYeeM15to40.root"
     }
   ],
   "license": {
@@ -2954,11 +2878,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:126995d67309c29ad08bc5b1db371aa7a9b89197",
-      "description": "mc_173043.DYmumuM08to15 file index",
-      "size": 105,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_173043.DYmumuM08to15_file_index.txt"
+      "checksum": "adler32:8324e5d7",
+      "size": 76091119,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173043.DYmumuM08to15.root"
     }
   ],
   "license": {
@@ -3031,11 +2953,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:c77ca51a91b971ce5cacdb2b1c9dbf72cbcd124b",
-      "description": "mc_173044.DYmumuM15to40 file index",
-      "size": 105,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_173044.DYmumuM15to40_file_index.txt"
+      "checksum": "adler32:d484260a",
+      "size": 105863682,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173044.DYmumuM15to40.root"
     }
   ],
   "license": {
@@ -3108,11 +3028,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:2af9e54ae009c365ed98dde1e3863d3149359e1b",
-      "description": "mc_173045.DYtautauM08to15 file index",
-      "size": 107,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_173045.DYtautauM08to15_file_index.txt"
+      "checksum": "adler32:d02217ff",
+      "size": 1463082,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173045.DYtautauM08to15.root"
     }
   ],
   "license": {
@@ -3185,11 +3103,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:0de82d71c3307d0302c4755c3e22f40c5dfed8c1",
-      "description": "mc_173046.DYtautauM15to40 file index",
-      "size": 107,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/mc_173046.DYtautauM15to40_file_index.txt"
+      "checksum": "adler32:172979ae",
+      "size": 4629749,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/MC/mc_173046.DYtautauM15to40.root"
     }
   ],
   "license": {


### PR DESCRIPTION
* Changes `atlas-simulated-dataset` records by removing the index files and
  attaching the asset files directly. This is sufficient for this collection
  containing low number of files. (addresses #2093)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>