### PR TITLE
records: ATLAS derived dataset direct files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/atlas-derived-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-derived-datasets.json
@@ -21,11 +21,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:0e939950342474f3bd3e35188a8b1a6c54fc8efe",
-      "description": "ATLAS Masterclass WPath 2014 dataset 1 file index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_1_file_index.txt"
+      "checksum": "adler32:b7014f6f",
+      "size": 9056420,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1A.zip"
+    },
+    {
+      "checksum": "adler32:9e7b4f28",
+      "size": 8315774,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1B.zip"
+    },
+    {
+      "checksum": "adler32:cbe218c3",
+      "size": 8248112,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1C.zip"
+    },
+    {
+      "checksum": "adler32:f5bdb328",
+      "size": 8100827,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1D.zip"
+    },
+    {
+      "checksum": "adler32:ed1a689c",
+      "size": 8772260,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1E.zip"
+    },
+    {
+      "checksum": "adler32:214118d1",
+      "size": 8659304,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1F.zip"
+    },
+    {
+      "checksum": "adler32:78a6ca5f",
+      "size": 9691015,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1G.zip"
+    },
+    {
+      "checksum": "adler32:37880c13",
+      "size": 8789941,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1H.zip"
+    },
+    {
+      "checksum": "adler32:43e84671",
+      "size": 8594653,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1I.zip"
+    },
+    {
+      "checksum": "adler32:c07589a7",
+      "size": 8954967,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1J.zip"
+    },
+    {
+      "checksum": "adler32:690e33cd",
+      "size": 8492818,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1K.zip"
+    },
+    {
+      "checksum": "adler32:661a3eca",
+      "size": 8713526,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1L.zip"
+    },
+    {
+      "checksum": "adler32:ca8e22ae",
+      "size": 8513112,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1M.zip"
+    },
+    {
+      "checksum": "adler32:ec88e5f3",
+      "size": 8637884,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1N.zip"
+    },
+    {
+      "checksum": "adler32:de7b92bd",
+      "size": 8780793,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1O.zip"
+    },
+    {
+      "checksum": "adler32:ab3979d5",
+      "size": 8222216,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1P.zip"
+    },
+    {
+      "checksum": "adler32:5ef0f8f4",
+      "size": 9202088,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1Q.zip"
+    },
+    {
+      "checksum": "adler32:cbf0677b",
+      "size": 8708754,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1R.zip"
+    },
+    {
+      "checksum": "adler32:330327a9",
+      "size": 8437830,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1S.zip"
+    },
+    {
+      "checksum": "adler32:43d6f182",
+      "size": 8297961,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/1/1T.zip"
     }
   ],
   "keywords": [
@@ -73,11 +166,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:19f9dd913e3909a8b0b271eb6c68f1a1b91b7635",
-      "description": "ATLAS Masterclass WPath 2014 dataset 2 file index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_2_file_index.txt"
+      "checksum": "adler32:c65fdd44",
+      "size": 9500821,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2A.zip"
+    },
+    {
+      "checksum": "adler32:63e09b69",
+      "size": 8409874,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2B.zip"
+    },
+    {
+      "checksum": "adler32:5cd63bf1",
+      "size": 9046999,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2C.zip"
+    },
+    {
+      "checksum": "adler32:53af276f",
+      "size": 8531583,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2D.zip"
+    },
+    {
+      "checksum": "adler32:0d573c0e",
+      "size": 8359971,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2E.zip"
+    },
+    {
+      "checksum": "adler32:df05c9f3",
+      "size": 8365154,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2F.zip"
+    },
+    {
+      "checksum": "adler32:2d65740c",
+      "size": 9216142,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2G.zip"
+    },
+    {
+      "checksum": "adler32:a98b4eb2",
+      "size": 8818383,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2H.zip"
+    },
+    {
+      "checksum": "adler32:824885b4",
+      "size": 8851808,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2I.zip"
+    },
+    {
+      "checksum": "adler32:cedf8e74",
+      "size": 8901275,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2J.zip"
+    },
+    {
+      "checksum": "adler32:ea81e95a",
+      "size": 8737761,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2K.zip"
+    },
+    {
+      "checksum": "adler32:4935d1c3",
+      "size": 9120625,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2L.zip"
+    },
+    {
+      "checksum": "adler32:104791ec",
+      "size": 8968323,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2M.zip"
+    },
+    {
+      "checksum": "adler32:ff97d0fc",
+      "size": 9129604,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2N.zip"
+    },
+    {
+      "checksum": "adler32:57a78050",
+      "size": 8909060,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2O.zip"
+    },
+    {
+      "checksum": "adler32:b18324c4",
+      "size": 9565932,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2P.zip"
+    },
+    {
+      "checksum": "adler32:78305040",
+      "size": 8587197,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2Q.zip"
+    },
+    {
+      "checksum": "adler32:c7f1511c",
+      "size": 8807101,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2R.zip"
+    },
+    {
+      "checksum": "adler32:5a750c4c",
+      "size": 9294270,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2S.zip"
+    },
+    {
+      "checksum": "adler32:f3a996ad",
+      "size": 8765904,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/2/2T.zip"
     }
   ],
   "keywords": [
@@ -125,11 +311,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:9458f35cfba943ab50ace18067632e7f7350f897",
-      "description": "ATLAS Masterclass WPath 2014 dataset 3 file index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_3_file_index.txt"
+      "checksum": "adler32:ffe66499",
+      "size": 8566739,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3A.zip"
+    },
+    {
+      "checksum": "adler32:c023f3c1",
+      "size": 8139585,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3B.zip"
+    },
+    {
+      "checksum": "adler32:2ebc7d92",
+      "size": 8930952,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3C.zip"
+    },
+    {
+      "checksum": "adler32:bc607340",
+      "size": 8993619,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3D.zip"
+    },
+    {
+      "checksum": "adler32:5c370c94",
+      "size": 9078548,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3E.zip"
+    },
+    {
+      "checksum": "adler32:0e6cf73f",
+      "size": 8924912,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3F.zip"
+    },
+    {
+      "checksum": "adler32:7f28ebfe",
+      "size": 9243672,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3G.zip"
+    },
+    {
+      "checksum": "adler32:1ec8d172",
+      "size": 9046473,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3H.zip"
+    },
+    {
+      "checksum": "adler32:b0cb6df6",
+      "size": 9337272,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3I.zip"
+    },
+    {
+      "checksum": "adler32:783efe9e",
+      "size": 8867283,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3J.zip"
+    },
+    {
+      "checksum": "adler32:3e10a579",
+      "size": 8171998,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3K.zip"
+    },
+    {
+      "checksum": "adler32:e3193d0c",
+      "size": 8600529,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3L.zip"
+    },
+    {
+      "checksum": "adler32:1c890c7d",
+      "size": 9026120,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3M.zip"
+    },
+    {
+      "checksum": "adler32:417cd1e0",
+      "size": 9416872,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3N.zip"
+    },
+    {
+      "checksum": "adler32:e17489ae",
+      "size": 9185137,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3O.zip"
+    },
+    {
+      "checksum": "adler32:685ef507",
+      "size": 8937956,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3P.zip"
+    },
+    {
+      "checksum": "adler32:6156ff2f",
+      "size": 8423767,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3Q.zip"
+    },
+    {
+      "checksum": "adler32:1ced83dc",
+      "size": 9657868,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3R.zip"
+    },
+    {
+      "checksum": "adler32:2aec118b",
+      "size": 9416560,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3S.zip"
+    },
+    {
+      "checksum": "adler32:b7b2a870",
+      "size": 8032391,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/3/3T.zip"
     }
   ],
   "keywords": [
@@ -177,11 +456,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:baabd34e5eb1eca0df8450eb3f49d94251927689",
-      "description": "ATLAS Masterclass WPath 2014 dataset 4 file index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_4_file_index.txt"
+      "checksum": "adler32:12ddc923",
+      "size": 7916767,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4A.zip"
+    },
+    {
+      "checksum": "adler32:4e043816",
+      "size": 8485396,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4B.zip"
+    },
+    {
+      "checksum": "adler32:24a2e8f1",
+      "size": 8799482,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4C.zip"
+    },
+    {
+      "checksum": "adler32:15e23174",
+      "size": 8859058,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4D.zip"
+    },
+    {
+      "checksum": "adler32:e0ef9e37",
+      "size": 8399867,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4E.zip"
+    },
+    {
+      "checksum": "adler32:4442394e",
+      "size": 8360521,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4F.zip"
+    },
+    {
+      "checksum": "adler32:4c3bd048",
+      "size": 8176153,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4G.zip"
+    },
+    {
+      "checksum": "adler32:3eafa3dc",
+      "size": 8370810,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4H.zip"
+    },
+    {
+      "checksum": "adler32:170ef5bf",
+      "size": 7931902,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4I.zip"
+    },
+    {
+      "checksum": "adler32:660c6804",
+      "size": 7918859,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4J.zip"
+    },
+    {
+      "checksum": "adler32:9ddfc17c",
+      "size": 8449295,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4K.zip"
+    },
+    {
+      "checksum": "adler32:1e84bafa",
+      "size": 8507779,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4L.zip"
+    },
+    {
+      "checksum": "adler32:562a4150",
+      "size": 8749142,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4M.zip"
+    },
+    {
+      "checksum": "adler32:9eb71a44",
+      "size": 8615619,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4N.zip"
+    },
+    {
+      "checksum": "adler32:e4475915",
+      "size": 7897939,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4O.zip"
+    },
+    {
+      "checksum": "adler32:b8167595",
+      "size": 7969204,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4P.zip"
+    },
+    {
+      "checksum": "adler32:603d9e59",
+      "size": 7995581,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4Q.zip"
+    },
+    {
+      "checksum": "adler32:a59f63cd",
+      "size": 7581294,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4R.zip"
+    },
+    {
+      "checksum": "adler32:d3ea95d7",
+      "size": 8543351,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4S.zip"
+    },
+    {
+      "checksum": "adler32:afea9316",
+      "size": 8305498,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/4/4T.zip"
     }
   ],
   "keywords": [
@@ -229,11 +601,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:e111b9f1495f05e0bae75d7fa02893328500ca65",
-      "description": "ATLAS Masterclass WPath 2014 dataset 5 file index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_5_file_index.txt"
+      "checksum": "adler32:3ef6a365",
+      "size": 7973515,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5A.zip"
+    },
+    {
+      "checksum": "adler32:a3de07d9",
+      "size": 8079257,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5B.zip"
+    },
+    {
+      "checksum": "adler32:5a66218a",
+      "size": 8211932,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5C.zip"
+    },
+    {
+      "checksum": "adler32:aa44f865",
+      "size": 8488071,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5D.zip"
+    },
+    {
+      "checksum": "adler32:fb9ca4a9",
+      "size": 8815744,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5E.zip"
+    },
+    {
+      "checksum": "adler32:73057ab6",
+      "size": 8186308,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5F.zip"
+    },
+    {
+      "checksum": "adler32:a9ce9351",
+      "size": 8364274,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5G.zip"
+    },
+    {
+      "checksum": "adler32:40dc1eea",
+      "size": 8287266,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5H.zip"
+    },
+    {
+      "checksum": "adler32:87f5f59c",
+      "size": 7808219,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5I.zip"
+    },
+    {
+      "checksum": "adler32:5fd94aad",
+      "size": 8252637,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5J.zip"
+    },
+    {
+      "checksum": "adler32:89abffaf",
+      "size": 8669833,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5K.zip"
+    },
+    {
+      "checksum": "adler32:cdfd6046",
+      "size": 8202569,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5L.zip"
+    },
+    {
+      "checksum": "adler32:a39caec7",
+      "size": 8969141,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5M.zip"
+    },
+    {
+      "checksum": "adler32:9a91b401",
+      "size": 8562605,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5N.zip"
+    },
+    {
+      "checksum": "adler32:86ce79a5",
+      "size": 8360823,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5O.zip"
+    },
+    {
+      "checksum": "adler32:149882ec",
+      "size": 7945465,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5P.zip"
+    },
+    {
+      "checksum": "adler32:1f2279ae",
+      "size": 8298524,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5Q.zip"
+    },
+    {
+      "checksum": "adler32:e0010589",
+      "size": 8229453,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5R.zip"
+    },
+    {
+      "checksum": "adler32:c9864c79",
+      "size": 9063763,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5S.zip"
+    },
+    {
+      "checksum": "adler32:f4cfbc8f",
+      "size": 8198176,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/5/5T.zip"
     }
   ],
   "keywords": [
@@ -281,11 +746,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:4ba0cd08395b25272d5d69b261711fbef169174a",
-      "description": "ATLAS Masterclass WPath 2014 dataset 6 file index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/file-indexes/ATLAS_MasterclassDatasets_WPath_2014_dataset_6_file_index.txt"
+      "checksum": "adler32:555f02c5",
+      "size": 8314172,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6A.zip"
+    },
+    {
+      "checksum": "adler32:455fdd2d",
+      "size": 8430270,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6B.zip"
+    },
+    {
+      "checksum": "adler32:aaf79f1e",
+      "size": 8372738,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6C.zip"
+    },
+    {
+      "checksum": "adler32:968202c0",
+      "size": 7837058,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6D.zip"
+    },
+    {
+      "checksum": "adler32:6f738fb4",
+      "size": 8168037,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6E.zip"
+    },
+    {
+      "checksum": "adler32:a4b9c4d1",
+      "size": 8251696,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6F.zip"
+    },
+    {
+      "checksum": "adler32:28a9481b",
+      "size": 8422022,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6G.zip"
+    },
+    {
+      "checksum": "adler32:4145c08f",
+      "size": 8429415,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6H.zip"
+    },
+    {
+      "checksum": "adler32:0b7af432",
+      "size": 7796461,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6I.zip"
+    },
+    {
+      "checksum": "adler32:66d10e59",
+      "size": 8165085,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6J.zip"
+    },
+    {
+      "checksum": "adler32:3337b7a7",
+      "size": 8729638,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6K.zip"
+    },
+    {
+      "checksum": "adler32:2e4ce743",
+      "size": 8051855,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6L.zip"
+    },
+    {
+      "checksum": "adler32:db492549",
+      "size": 8075916,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6M.zip"
+    },
+    {
+      "checksum": "adler32:922e7710",
+      "size": 8835846,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6N.zip"
+    },
+    {
+      "checksum": "adler32:2b99b114",
+      "size": 8271104,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6O.zip"
+    },
+    {
+      "checksum": "adler32:dd5c8261",
+      "size": 8608128,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6P.zip"
+    },
+    {
+      "checksum": "adler32:5f8cb215",
+      "size": 7997176,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6Q.zip"
+    },
+    {
+      "checksum": "adler32:a88034fe",
+      "size": 8259946,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6R.zip"
+    },
+    {
+      "checksum": "adler32:5783348c",
+      "size": 8091207,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6S.zip"
+    },
+    {
+      "checksum": "adler32:5276ccd0",
+      "size": 8637499,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2014/6/6T.zip"
     }
   ],
   "keywords": [
@@ -333,11 +891,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:ae01e8162582ac968c0ab905a3f428b002121a9b",
-      "description": "ATLAS Masterclass WPath 2015 dataset 1 file\n      index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_1_file_index.txt"
+      "checksum": "adler32:70c0f91f",
+      "size": 10810547,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1A.zip"
+    },
+    {
+      "checksum": "adler32:bd3022ae",
+      "size": 11909756,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1B.zip"
+    },
+    {
+      "checksum": "adler32:58a8becb",
+      "size": 11624299,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1C.zip"
+    },
+    {
+      "checksum": "adler32:9bcf06d1",
+      "size": 12331064,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1D.zip"
+    },
+    {
+      "checksum": "adler32:3c93ba74",
+      "size": 12970556,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1E.zip"
+    },
+    {
+      "checksum": "adler32:0a2a0d5e",
+      "size": 11612265,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1F.zip"
+    },
+    {
+      "checksum": "adler32:25452c57",
+      "size": 13134018,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1G.zip"
+    },
+    {
+      "checksum": "adler32:0f92edbd",
+      "size": 11601412,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1H.zip"
+    },
+    {
+      "checksum": "adler32:1ccb5b45",
+      "size": 11959081,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1I.zip"
+    },
+    {
+      "checksum": "adler32:0e95880d",
+      "size": 13132335,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1J.zip"
+    },
+    {
+      "checksum": "adler32:63b2ef82",
+      "size": 10599341,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1K.zip"
+    },
+    {
+      "checksum": "adler32:9f3d9124",
+      "size": 12512066,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1L.zip"
+    },
+    {
+      "checksum": "adler32:012906a8",
+      "size": 11722583,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1M.zip"
+    },
+    {
+      "checksum": "adler32:cdcdfe7f",
+      "size": 11275642,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1N.zip"
+    },
+    {
+      "checksum": "adler32:86c666f0",
+      "size": 11566808,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1O.zip"
+    },
+    {
+      "checksum": "adler32:f3234e9f",
+      "size": 11982228,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1P.zip"
+    },
+    {
+      "checksum": "adler32:702d3e4e",
+      "size": 12352964,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1Q.zip"
+    },
+    {
+      "checksum": "adler32:b6a953ae",
+      "size": 11631185,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1R.zip"
+    },
+    {
+      "checksum": "adler32:bf24a3d9",
+      "size": 10522743,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1S.zip"
+    },
+    {
+      "checksum": "adler32:ad72a2fa",
+      "size": 12512876,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/1/1T.zip"
     }
   ],
   "keywords": [
@@ -385,11 +1036,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:b91bdb77921a1f47a7c95a75a3c9a9260b8c3266",
-      "description": "ATLAS Masterclass WPath 2015 dataset 2 file\n      index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_2_file_index.txt"
+      "checksum": "adler32:8808e0cf",
+      "size": 13013826,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2A.zip"
+    },
+    {
+      "checksum": "adler32:a524c959",
+      "size": 11681324,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2B.zip"
+    },
+    {
+      "checksum": "adler32:14f85865",
+      "size": 11854024,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2C.zip"
+    },
+    {
+      "checksum": "adler32:925e7d95",
+      "size": 13002341,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2D.zip"
+    },
+    {
+      "checksum": "adler32:046fbb4b",
+      "size": 11415267,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2E.zip"
+    },
+    {
+      "checksum": "adler32:8cc8cd77",
+      "size": 12559351,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2F.zip"
+    },
+    {
+      "checksum": "adler32:4ae92b1a",
+      "size": 11626928,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2G.zip"
+    },
+    {
+      "checksum": "adler32:5e962b55",
+      "size": 11675993,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2H.zip"
+    },
+    {
+      "checksum": "adler32:2c2f1999",
+      "size": 11112401,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2I.zip"
+    },
+    {
+      "checksum": "adler32:02148181",
+      "size": 11717661,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2J.zip"
+    },
+    {
+      "checksum": "adler32:14a2cbca",
+      "size": 12710054,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2K.zip"
+    },
+    {
+      "checksum": "adler32:e14ed077",
+      "size": 11181891,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2L.zip"
+    },
+    {
+      "checksum": "adler32:46506221",
+      "size": 11232219,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2M.zip"
+    },
+    {
+      "checksum": "adler32:3a14f057",
+      "size": 11922624,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2N.zip"
+    },
+    {
+      "checksum": "adler32:60709f6a",
+      "size": 13230571,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2O.zip"
+    },
+    {
+      "checksum": "adler32:e70fda68",
+      "size": 12248148,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2P.zip"
+    },
+    {
+      "checksum": "adler32:f85e3558",
+      "size": 12527541,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2Q.zip"
+    },
+    {
+      "checksum": "adler32:b7214018",
+      "size": 14010160,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2R.zip"
+    },
+    {
+      "checksum": "adler32:8ed02a2c",
+      "size": 10532921,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2S.zip"
+    },
+    {
+      "checksum": "adler32:9d8cfb2a",
+      "size": 11821966,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/2/2T.zip"
     }
   ],
   "keywords": [
@@ -437,11 +1181,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:9194cb011e2a52122b07f3d85124ec81b92300e4",
-      "description": "ATLAS Masterclass WPath 2015 dataset 3 file\n      index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_3_file_index.txt"
+      "checksum": "adler32:1a700a05",
+      "size": 11390330,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3A.zip"
+    },
+    {
+      "checksum": "adler32:5a1f7c86",
+      "size": 11594306,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3B.zip"
+    },
+    {
+      "checksum": "adler32:311afce6",
+      "size": 11661583,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3C.zip"
+    },
+    {
+      "checksum": "adler32:cbfa3056",
+      "size": 11842794,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3D.zip"
+    },
+    {
+      "checksum": "adler32:a6c8a1be",
+      "size": 12678978,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3E.zip"
+    },
+    {
+      "checksum": "adler32:60c70ae8",
+      "size": 12563961,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3F.zip"
+    },
+    {
+      "checksum": "adler32:2a42931c",
+      "size": 11987611,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3G.zip"
+    },
+    {
+      "checksum": "adler32:d69639fc",
+      "size": 11019580,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3H.zip"
+    },
+    {
+      "checksum": "adler32:5d55091a",
+      "size": 11447205,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3I.zip"
+    },
+    {
+      "checksum": "adler32:ff5f421c",
+      "size": 11852199,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3J.zip"
+    },
+    {
+      "checksum": "adler32:dc3e4ae6",
+      "size": 11405380,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3K.zip"
+    },
+    {
+      "checksum": "adler32:04ad70e6",
+      "size": 11297717,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3L.zip"
+    },
+    {
+      "checksum": "adler32:87e059a9",
+      "size": 11302443,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3M.zip"
+    },
+    {
+      "checksum": "adler32:02259269",
+      "size": 11312798,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3N.zip"
+    },
+    {
+      "checksum": "adler32:ff06f244",
+      "size": 11533119,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3O.zip"
+    },
+    {
+      "checksum": "adler32:5c7278a1",
+      "size": 10800383,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3P.zip"
+    },
+    {
+      "checksum": "adler32:15ea3733",
+      "size": 11560330,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3Q.zip"
+    },
+    {
+      "checksum": "adler32:46ecb476",
+      "size": 11808942,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3R.zip"
+    },
+    {
+      "checksum": "adler32:ad603d47",
+      "size": 10583188,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3S.zip"
+    },
+    {
+      "checksum": "adler32:9bd98e9b",
+      "size": 10964115,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/3/3T.zip"
     }
   ],
   "keywords": [
@@ -489,11 +1326,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:afef1556624720f659aa1bf1eb65baa4d83d1ee8",
-      "description": "ATLAS Masterclass WPath 2015 dataset 4 file\n      index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_4_file_index.txt"
+      "checksum": "adler32:a2d1ef8f",
+      "size": 11064028,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4A.zip"
+    },
+    {
+      "checksum": "adler32:9be3a4ff",
+      "size": 10534590,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4B.zip"
+    },
+    {
+      "checksum": "adler32:5c30c90d",
+      "size": 11031987,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4C.zip"
+    },
+    {
+      "checksum": "adler32:47f31717",
+      "size": 11643492,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4D.zip"
+    },
+    {
+      "checksum": "adler32:30fac986",
+      "size": 10865149,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4E.zip"
+    },
+    {
+      "checksum": "adler32:48b2b134",
+      "size": 11417154,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4F.zip"
+    },
+    {
+      "checksum": "adler32:36b027d5",
+      "size": 12255014,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4G.zip"
+    },
+    {
+      "checksum": "adler32:f50e9eb8",
+      "size": 10364695,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4H.zip"
+    },
+    {
+      "checksum": "adler32:28145c65",
+      "size": 11671359,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4I.zip"
+    },
+    {
+      "checksum": "adler32:6331a901",
+      "size": 11392636,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4J.zip"
+    },
+    {
+      "checksum": "adler32:bec07cda",
+      "size": 11253586,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4K.zip"
+    },
+    {
+      "checksum": "adler32:e4708e98",
+      "size": 11586046,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4L.zip"
+    },
+    {
+      "checksum": "adler32:cacd0c59",
+      "size": 11011508,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4M.zip"
+    },
+    {
+      "checksum": "adler32:d0a819e4",
+      "size": 11561337,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4N.zip"
+    },
+    {
+      "checksum": "adler32:c057a111",
+      "size": 10916309,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4O.zip"
+    },
+    {
+      "checksum": "adler32:16a8e6ea",
+      "size": 10907296,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4P.zip"
+    },
+    {
+      "checksum": "adler32:4746973f",
+      "size": 12243249,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4Q.zip"
+    },
+    {
+      "checksum": "adler32:95932435",
+      "size": 10735928,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4R.zip"
+    },
+    {
+      "checksum": "adler32:585ce026",
+      "size": 10250374,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4S.zip"
+    },
+    {
+      "checksum": "adler32:7f820a82",
+      "size": 12003126,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/4/4T.zip"
     }
   ],
   "keywords": [
@@ -541,11 +1471,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:9e326b1bd615ea6141c253ef52db0cdb643daf9e",
-      "description": "ATLAS Masterclass WPath 2015 dataset 5 file\n      index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_5_file_index.txt"
+      "checksum": "adler32:ce55d137",
+      "size": 11189209,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5A.zip"
+    },
+    {
+      "checksum": "adler32:c3821291",
+      "size": 12267762,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5B.zip"
+    },
+    {
+      "checksum": "adler32:255f866f",
+      "size": 11470481,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5C.zip"
+    },
+    {
+      "checksum": "adler32:5b6768d7",
+      "size": 11733227,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5D.zip"
+    },
+    {
+      "checksum": "adler32:7a322435",
+      "size": 11460241,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5E.zip"
+    },
+    {
+      "checksum": "adler32:64a7debe",
+      "size": 11169202,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5F.zip"
+    },
+    {
+      "checksum": "adler32:07ab1996",
+      "size": 11276306,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5G.zip"
+    },
+    {
+      "checksum": "adler32:1a2836a6",
+      "size": 10914042,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5H.zip"
+    },
+    {
+      "checksum": "adler32:01585ed2",
+      "size": 10593162,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5I.zip"
+    },
+    {
+      "checksum": "adler32:88f99c7c",
+      "size": 12592482,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5J.zip"
+    },
+    {
+      "checksum": "adler32:a83e9c33",
+      "size": 13295865,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5K.zip"
+    },
+    {
+      "checksum": "adler32:b8e4eb6e",
+      "size": 12550412,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5L.zip"
+    },
+    {
+      "checksum": "adler32:fd49d74f",
+      "size": 10927291,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5M.zip"
+    },
+    {
+      "checksum": "adler32:3964bb02",
+      "size": 11207435,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5N.zip"
+    },
+    {
+      "checksum": "adler32:aea333e9",
+      "size": 10928009,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5O.zip"
+    },
+    {
+      "checksum": "adler32:e9a8c808",
+      "size": 11014463,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5P.zip"
+    },
+    {
+      "checksum": "adler32:7e7cb55a",
+      "size": 10677096,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5Q.zip"
+    },
+    {
+      "checksum": "adler32:7e121686",
+      "size": 12421827,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5R.zip"
+    },
+    {
+      "checksum": "adler32:3a822f4d",
+      "size": 10767452,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5S.zip"
+    },
+    {
+      "checksum": "adler32:1cbd67d1",
+      "size": 12183104,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/5/5T.zip"
     }
   ],
   "keywords": [
@@ -593,11 +1616,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:f49dca3c4c46f801ea6301215c1957cee840abed",
-      "description": "ATLAS Masterclass WPath 2015 dataset 6 file\n      index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_6_file_index.txt"
+      "checksum": "adler32:3db51324",
+      "size": 12002565,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6A.zip"
+    },
+    {
+      "checksum": "adler32:db20aad6",
+      "size": 12734846,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6B.zip"
+    },
+    {
+      "checksum": "adler32:4566719c",
+      "size": 11320598,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6C.zip"
+    },
+    {
+      "checksum": "adler32:08036c40",
+      "size": 11386506,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6D.zip"
+    },
+    {
+      "checksum": "adler32:6240c519",
+      "size": 11712149,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6E.zip"
+    },
+    {
+      "checksum": "adler32:2485d5f7",
+      "size": 10794624,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6F.zip"
+    },
+    {
+      "checksum": "adler32:6836bf76",
+      "size": 11050563,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6G.zip"
+    },
+    {
+      "checksum": "adler32:8b390703",
+      "size": 9912239,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6H.zip"
+    },
+    {
+      "checksum": "adler32:38057e46",
+      "size": 10848940,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6I.zip"
+    },
+    {
+      "checksum": "adler32:91eab78f",
+      "size": 10809783,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6J.zip"
+    },
+    {
+      "checksum": "adler32:7ab6210a",
+      "size": 11669602,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6K.zip"
+    },
+    {
+      "checksum": "adler32:91aff0c3",
+      "size": 11197651,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6L.zip"
+    },
+    {
+      "checksum": "adler32:585a192a",
+      "size": 12069169,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6M.zip"
+    },
+    {
+      "checksum": "adler32:aebe6416",
+      "size": 13059686,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6N.zip"
+    },
+    {
+      "checksum": "adler32:dec4cbcc",
+      "size": 10903806,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6O.zip"
+    },
+    {
+      "checksum": "adler32:dee077d4",
+      "size": 10959915,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6P.zip"
+    },
+    {
+      "checksum": "adler32:b2672ec5",
+      "size": 12407033,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6Q.zip"
+    },
+    {
+      "checksum": "adler32:764b861e",
+      "size": 11171817,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6R.zip"
+    },
+    {
+      "checksum": "adler32:91bd81c9",
+      "size": 10715231,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6S.zip"
+    },
+    {
+      "checksum": "adler32:1da4f4a7",
+      "size": 10245624,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/6/6T.zip"
     }
   ],
   "keywords": [
@@ -645,11 +1761,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:863081e06706bb91b277c14ec0e52839d271c769",
-      "description": "ATLAS Masterclass WPath 2015 dataset 7 file\n      index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_7_file_index.txt"
+      "checksum": "adler32:e11c92f7",
+      "size": 10652461,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7A.zip"
+    },
+    {
+      "checksum": "adler32:500f4869",
+      "size": 10420422,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7B.zip"
+    },
+    {
+      "checksum": "adler32:53768fca",
+      "size": 11045126,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7C.zip"
+    },
+    {
+      "checksum": "adler32:ed03b99e",
+      "size": 9977547,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7D.zip"
+    },
+    {
+      "checksum": "adler32:6ccdee2a",
+      "size": 10425070,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7E.zip"
+    },
+    {
+      "checksum": "adler32:819b2d64",
+      "size": 11458180,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7F.zip"
+    },
+    {
+      "checksum": "adler32:d990888f",
+      "size": 12460054,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7G.zip"
+    },
+    {
+      "checksum": "adler32:70f8960a",
+      "size": 11728719,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7H.zip"
+    },
+    {
+      "checksum": "adler32:f50c5674",
+      "size": 10708991,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7I.zip"
+    },
+    {
+      "checksum": "adler32:9c598eae",
+      "size": 11564762,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7J.zip"
+    },
+    {
+      "checksum": "adler32:4301a8df",
+      "size": 10529550,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7K.zip"
+    },
+    {
+      "checksum": "adler32:c50d68c8",
+      "size": 11320193,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7L.zip"
+    },
+    {
+      "checksum": "adler32:faaf3fa7",
+      "size": 10876806,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7M.zip"
+    },
+    {
+      "checksum": "adler32:92880b9a",
+      "size": 10622561,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7N.zip"
+    },
+    {
+      "checksum": "adler32:bf7ddf68",
+      "size": 12737721,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7O.zip"
+    },
+    {
+      "checksum": "adler32:11356674",
+      "size": 11543838,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7P.zip"
+    },
+    {
+      "checksum": "adler32:7daad53a",
+      "size": 11124998,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7Q.zip"
+    },
+    {
+      "checksum": "adler32:462e011c",
+      "size": 10742126,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7R.zip"
+    },
+    {
+      "checksum": "adler32:ec22c5e6",
+      "size": 11301299,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7S.zip"
+    },
+    {
+      "checksum": "adler32:be945258",
+      "size": 11538696,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/7/7T.zip"
     }
   ],
   "keywords": [
@@ -697,11 +1906,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:4591a6340caaba53e7def12c7844e93a33c8f49c",
-      "description": "ATLAS Masterclass WPath 2015 dataset 8 file\n      index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_8_file_index.txt"
+      "checksum": "adler32:236c97e9",
+      "size": 11896743,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8A.zip"
+    },
+    {
+      "checksum": "adler32:8b86c31d",
+      "size": 12605596,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8B.zip"
+    },
+    {
+      "checksum": "adler32:706abd19",
+      "size": 10562343,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8C.zip"
+    },
+    {
+      "checksum": "adler32:febe77f1",
+      "size": 10756611,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8D.zip"
+    },
+    {
+      "checksum": "adler32:a69d4fd5",
+      "size": 11210163,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8E.zip"
+    },
+    {
+      "checksum": "adler32:a03fba84",
+      "size": 10954342,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8F.zip"
+    },
+    {
+      "checksum": "adler32:79075b1f",
+      "size": 12259891,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8G.zip"
+    },
+    {
+      "checksum": "adler32:c69a693d",
+      "size": 10265671,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8H.zip"
+    },
+    {
+      "checksum": "adler32:48534b82",
+      "size": 11421884,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8I.zip"
+    },
+    {
+      "checksum": "adler32:8f5b48b6",
+      "size": 10383610,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8J.zip"
+    },
+    {
+      "checksum": "adler32:6edaae1a",
+      "size": 10952968,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8K.zip"
+    },
+    {
+      "checksum": "adler32:229a3098",
+      "size": 10502191,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8L.zip"
+    },
+    {
+      "checksum": "adler32:761b35ac",
+      "size": 11491627,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8M.zip"
+    },
+    {
+      "checksum": "adler32:0917819a",
+      "size": 11241246,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8N.zip"
+    },
+    {
+      "checksum": "adler32:f9e07dd3",
+      "size": 11059346,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8O.zip"
+    },
+    {
+      "checksum": "adler32:c0dca35e",
+      "size": 11078722,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8P.zip"
+    },
+    {
+      "checksum": "adler32:3892b8ac",
+      "size": 11476375,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8Q.zip"
+    },
+    {
+      "checksum": "adler32:105a047a",
+      "size": 11961869,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8R.zip"
+    },
+    {
+      "checksum": "adler32:b8269a54",
+      "size": 11356393,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8S.zip"
+    },
+    {
+      "checksum": "adler32:693d61a0",
+      "size": 11125793,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/8/8T.zip"
     }
   ],
   "keywords": [
@@ -749,11 +2051,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:371f5619044a3752d5320591bf4ed890df02d0f2",
-      "description": "ATLAS Masterclass WPath 2015 dataset 9 file\n      index",
-      "size": 1700,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_9_file_index.txt"
+      "checksum": "adler32:432becd1",
+      "size": 11406332,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9A.zip"
+    },
+    {
+      "checksum": "adler32:e3ed55d6",
+      "size": 11932537,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9B.zip"
+    },
+    {
+      "checksum": "adler32:000f8cba",
+      "size": 12408033,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9C.zip"
+    },
+    {
+      "checksum": "adler32:7192daf8",
+      "size": 11507675,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9D.zip"
+    },
+    {
+      "checksum": "adler32:0dd03d3a",
+      "size": 13850646,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9E.zip"
+    },
+    {
+      "checksum": "adler32:01dfb525",
+      "size": 12086578,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9F.zip"
+    },
+    {
+      "checksum": "adler32:30b6eac8",
+      "size": 13494385,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9G.zip"
+    },
+    {
+      "checksum": "adler32:753aab06",
+      "size": 12864207,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9H.zip"
+    },
+    {
+      "checksum": "adler32:ce4af1b9",
+      "size": 13735032,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9I.zip"
+    },
+    {
+      "checksum": "adler32:9d505394",
+      "size": 14032275,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9J.zip"
+    },
+    {
+      "checksum": "adler32:df5c21b9",
+      "size": 12200052,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9K.zip"
+    },
+    {
+      "checksum": "adler32:46693d05",
+      "size": 13326866,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9L.zip"
+    },
+    {
+      "checksum": "adler32:65e837fa",
+      "size": 11790989,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9M.zip"
+    },
+    {
+      "checksum": "adler32:e24c8d75",
+      "size": 11107454,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9N.zip"
+    },
+    {
+      "checksum": "adler32:74c221e2",
+      "size": 10526218,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9O.zip"
+    },
+    {
+      "checksum": "adler32:5877c3c2",
+      "size": 14285812,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9P.zip"
+    },
+    {
+      "checksum": "adler32:0fe9b02a",
+      "size": 11571144,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9Q.zip"
+    },
+    {
+      "checksum": "adler32:ce335a84",
+      "size": 11832141,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9R.zip"
+    },
+    {
+      "checksum": "adler32:5c6281fa",
+      "size": 12065300,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9S.zip"
+    },
+    {
+      "checksum": "adler32:f656acb5",
+      "size": 10890972,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/9/9T.zip"
     }
   ],
   "keywords": [
@@ -801,11 +2196,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:e1791e69339e27898e8b86715c0a89ba3a0f4f53",
-      "description": "ATLAS Masterclass WPath 2015 dataset 10 file\n      index",
-      "size": 1740,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_10_file_index.txt"
+      "checksum": "adler32:63468ce9",
+      "size": 11870581,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10A.zip"
+    },
+    {
+      "checksum": "adler32:c97d5c5b",
+      "size": 13414500,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10B.zip"
+    },
+    {
+      "checksum": "adler32:d18b840d",
+      "size": 12651143,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10C.zip"
+    },
+    {
+      "checksum": "adler32:7a44d294",
+      "size": 13159060,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10D.zip"
+    },
+    {
+      "checksum": "adler32:336a228d",
+      "size": 12279704,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10E.zip"
+    },
+    {
+      "checksum": "adler32:0d618659",
+      "size": 13031813,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10F.zip"
+    },
+    {
+      "checksum": "adler32:dc1acb84",
+      "size": 11606770,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10G.zip"
+    },
+    {
+      "checksum": "adler32:5f9d5987",
+      "size": 12977092,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10H.zip"
+    },
+    {
+      "checksum": "adler32:e3386982",
+      "size": 13731408,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10I.zip"
+    },
+    {
+      "checksum": "adler32:ab5af041",
+      "size": 12369306,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10J.zip"
+    },
+    {
+      "checksum": "adler32:f2f16607",
+      "size": 14469137,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10K.zip"
+    },
+    {
+      "checksum": "adler32:66c0ce49",
+      "size": 11377620,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10L.zip"
+    },
+    {
+      "checksum": "adler32:644763b1",
+      "size": 11960268,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10M.zip"
+    },
+    {
+      "checksum": "adler32:e2c0e924",
+      "size": 11417132,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10N.zip"
+    },
+    {
+      "checksum": "adler32:6f301576",
+      "size": 11529520,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10O.zip"
+    },
+    {
+      "checksum": "adler32:91f8e4b0",
+      "size": 12107486,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10P.zip"
+    },
+    {
+      "checksum": "adler32:086593aa",
+      "size": 13432261,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10Q.zip"
+    },
+    {
+      "checksum": "adler32:60a49d66",
+      "size": 12924292,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10R.zip"
+    },
+    {
+      "checksum": "adler32:892f58cd",
+      "size": 11062843,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10S.zip"
+    },
+    {
+      "checksum": "adler32:53b3e3e6",
+      "size": 11837451,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/10/10T.zip"
     }
   ],
   "keywords": [
@@ -853,11 +2341,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:138561889b4a7c692c81a25a8c4e27b79137f523",
-      "description": "ATLAS Masterclass WPath 2015 dataset 11 file\n      index",
-      "size": 1740,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_11_file_index.txt"
+      "checksum": "adler32:399ca8b2",
+      "size": 10737535,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11A.zip"
+    },
+    {
+      "checksum": "adler32:dfdac5d4",
+      "size": 10564550,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11B.zip"
+    },
+    {
+      "checksum": "adler32:3fe10f5d",
+      "size": 11760284,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11C.zip"
+    },
+    {
+      "checksum": "adler32:0b32fad8",
+      "size": 11470703,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11D.zip"
+    },
+    {
+      "checksum": "adler32:20eee30e",
+      "size": 12629827,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11E.zip"
+    },
+    {
+      "checksum": "adler32:627044b8",
+      "size": 11043880,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11F.zip"
+    },
+    {
+      "checksum": "adler32:562fdca2",
+      "size": 11996721,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11G.zip"
+    },
+    {
+      "checksum": "adler32:5452a469",
+      "size": 12574894,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11H.zip"
+    },
+    {
+      "checksum": "adler32:5e0418e0",
+      "size": 10988969,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11I.zip"
+    },
+    {
+      "checksum": "adler32:dd9b0bbb",
+      "size": 13925083,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11J.zip"
+    },
+    {
+      "checksum": "adler32:168a9f79",
+      "size": 12122960,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11K.zip"
+    },
+    {
+      "checksum": "adler32:81f35771",
+      "size": 12658765,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11L.zip"
+    },
+    {
+      "checksum": "adler32:66bf59bb",
+      "size": 11743547,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11M.zip"
+    },
+    {
+      "checksum": "adler32:1db6befc",
+      "size": 11897241,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11N.zip"
+    },
+    {
+      "checksum": "adler32:ec6fce03",
+      "size": 11335534,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11O.zip"
+    },
+    {
+      "checksum": "adler32:5e1d8810",
+      "size": 10782835,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11P.zip"
+    },
+    {
+      "checksum": "adler32:06dd1428",
+      "size": 12405352,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11Q.zip"
+    },
+    {
+      "checksum": "adler32:6b377572",
+      "size": 12001086,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11R.zip"
+    },
+    {
+      "checksum": "adler32:d3320738",
+      "size": 12271293,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11S.zip"
+    },
+    {
+      "checksum": "adler32:2fbc41e4",
+      "size": 11492346,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/11/11T.zip"
     }
   ],
   "keywords": [
@@ -905,11 +2486,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:b4e81bab8ffb298170b3ef3497f8ae486da2d605",
-      "description": "ATLAS Masterclass WPath 2015 dataset 12 file\n      index",
-      "size": 1740,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/file-indexes/ATLAS_MasterclassDatasets_WPath_2015_dataset_12_file_index.txt"
+      "checksum": "adler32:2068f055",
+      "size": 11878214,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12A.zip"
+    },
+    {
+      "checksum": "adler32:7d933b6d",
+      "size": 13589506,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12B.zip"
+    },
+    {
+      "checksum": "adler32:c29de9aa",
+      "size": 10276974,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12C.zip"
+    },
+    {
+      "checksum": "adler32:a07869cd",
+      "size": 10866253,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12D.zip"
+    },
+    {
+      "checksum": "adler32:7abedf40",
+      "size": 10567707,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12E.zip"
+    },
+    {
+      "checksum": "adler32:2fe758ea",
+      "size": 12299766,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12F.zip"
+    },
+    {
+      "checksum": "adler32:b6e33a17",
+      "size": 13045344,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12G.zip"
+    },
+    {
+      "checksum": "adler32:1e85ab2c",
+      "size": 10654630,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12H.zip"
+    },
+    {
+      "checksum": "adler32:249f6fed",
+      "size": 11245747,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12I.zip"
+    },
+    {
+      "checksum": "adler32:aedd5c69",
+      "size": 10903952,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12J.zip"
+    },
+    {
+      "checksum": "adler32:45576c5f",
+      "size": 12749686,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12K.zip"
+    },
+    {
+      "checksum": "adler32:722fee7d",
+      "size": 11623884,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12L.zip"
+    },
+    {
+      "checksum": "adler32:24769212",
+      "size": 10905542,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12M.zip"
+    },
+    {
+      "checksum": "adler32:fb34c6e9",
+      "size": 11512382,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12N.zip"
+    },
+    {
+      "checksum": "adler32:69639d9c",
+      "size": 11315426,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12O.zip"
+    },
+    {
+      "checksum": "adler32:9f25ba88",
+      "size": 11399287,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12P.zip"
+    },
+    {
+      "checksum": "adler32:2ecbe6e9",
+      "size": 12041618,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12Q.zip"
+    },
+    {
+      "checksum": "adler32:74a0ebe7",
+      "size": 12599432,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12R.zip"
+    },
+    {
+      "checksum": "adler32:a9214bbb",
+      "size": 10769830,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12S.zip"
+    },
+    {
+      "checksum": "adler32:3e8f2a18",
+      "size": 12511530,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/WPath/2015/12/12T.zip"
     }
   ],
   "keywords": [
@@ -957,11 +2631,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:2e4cd6794a2961d86cc0f330e759bd5154ac1d53",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 1 file\n      index",
-      "size": 1780,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_1_file_index.txt"
+      "checksum": "adler32:78925496",
+      "size": 29376316,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupA.zip"
+    },
+    {
+      "checksum": "adler32:67277ff3",
+      "size": 30435287,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupB.zip"
+    },
+    {
+      "checksum": "adler32:6b6838f7",
+      "size": 31450999,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupC.zip"
+    },
+    {
+      "checksum": "adler32:64bdb100",
+      "size": 35044973,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupD.zip"
+    },
+    {
+      "checksum": "adler32:652d9144",
+      "size": 29518337,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupE.zip"
+    },
+    {
+      "checksum": "adler32:38d1fb52",
+      "size": 32410285,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupF.zip"
+    },
+    {
+      "checksum": "adler32:24e905f9",
+      "size": 30115899,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupG.zip"
+    },
+    {
+      "checksum": "adler32:7a74740a",
+      "size": 30214418,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupH.zip"
+    },
+    {
+      "checksum": "adler32:60b25fca",
+      "size": 29081133,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupI.zip"
+    },
+    {
+      "checksum": "adler32:8fae14ea",
+      "size": 29623640,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:236ca43c",
+      "size": 32886287,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupK.zip"
+    },
+    {
+      "checksum": "adler32:d38325d4",
+      "size": 34076633,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupL.zip"
+    },
+    {
+      "checksum": "adler32:94500952",
+      "size": 32467184,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupM.zip"
+    },
+    {
+      "checksum": "adler32:3df6b5ac",
+      "size": 31894195,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupN.zip"
+    },
+    {
+      "checksum": "adler32:6348da6e",
+      "size": 32874933,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupO.zip"
+    },
+    {
+      "checksum": "adler32:0813aba0",
+      "size": 31185893,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupP.zip"
+    },
+    {
+      "checksum": "adler32:555508b5",
+      "size": 32186308,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:0a32bac1",
+      "size": 29625851,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupR.zip"
+    },
+    {
+      "checksum": "adler32:332f11cb",
+      "size": 26950890,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupS.zip"
+    },
+    {
+      "checksum": "adler32:4e65fd43",
+      "size": 30257271,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/1/groupT.zip"
     }
   ],
   "keywords": [
@@ -1009,11 +2776,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:2e5689eafbd3833177f84ef8e360d9b179068531",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 2 file\n      index",
-      "size": 1780,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_2_file_index.txt"
+      "checksum": "adler32:7da2d7a8",
+      "size": 31701967,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupA.zip"
+    },
+    {
+      "checksum": "adler32:5c155082",
+      "size": 28857005,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupB.zip"
+    },
+    {
+      "checksum": "adler32:fdd33ecf",
+      "size": 31367400,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupC.zip"
+    },
+    {
+      "checksum": "adler32:321d4373",
+      "size": 29687023,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupD.zip"
+    },
+    {
+      "checksum": "adler32:77d37a21",
+      "size": 31622164,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupE.zip"
+    },
+    {
+      "checksum": "adler32:1c0a6c5a",
+      "size": 29731961,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupF.zip"
+    },
+    {
+      "checksum": "adler32:498793d9",
+      "size": 30678574,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupG.zip"
+    },
+    {
+      "checksum": "adler32:5d7d728c",
+      "size": 29716266,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupH.zip"
+    },
+    {
+      "checksum": "adler32:894c19aa",
+      "size": 29707400,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupI.zip"
+    },
+    {
+      "checksum": "adler32:5b5bd7ef",
+      "size": 30398322,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:60a3afe4",
+      "size": 31434951,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupK.zip"
+    },
+    {
+      "checksum": "adler32:dfb82c71",
+      "size": 30474412,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupL.zip"
+    },
+    {
+      "checksum": "adler32:92d92b61",
+      "size": 30373024,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupM.zip"
+    },
+    {
+      "checksum": "adler32:0d9a8505",
+      "size": 31677043,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupN.zip"
+    },
+    {
+      "checksum": "adler32:010b8691",
+      "size": 31291257,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupO.zip"
+    },
+    {
+      "checksum": "adler32:35902206",
+      "size": 31389325,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupP.zip"
+    },
+    {
+      "checksum": "adler32:259674a5",
+      "size": 32341424,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:8358fc73",
+      "size": 31213183,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupR.zip"
+    },
+    {
+      "checksum": "adler32:381c135a",
+      "size": 30643323,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupS.zip"
+    },
+    {
+      "checksum": "adler32:a9a3150e",
+      "size": 32936560,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/2/groupT.zip"
     }
   ],
   "keywords": [
@@ -1061,11 +2921,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:8f24e91338b32308302b704aaecf8205fe712e2a",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 3 file\n      index",
-      "size": 1780,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_3_file_index.txt"
+      "checksum": "adler32:eae15c39",
+      "size": 33685260,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupA.zip"
+    },
+    {
+      "checksum": "adler32:146beba1",
+      "size": 33173825,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupB.zip"
+    },
+    {
+      "checksum": "adler32:5fede0d6",
+      "size": 30631562,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupC.zip"
+    },
+    {
+      "checksum": "adler32:093e9163",
+      "size": 32435612,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupD.zip"
+    },
+    {
+      "checksum": "adler32:83cc06ea",
+      "size": 29404717,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupE.zip"
+    },
+    {
+      "checksum": "adler32:551154a4",
+      "size": 33274728,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupF.zip"
+    },
+    {
+      "checksum": "adler32:fd7dfada",
+      "size": 34154753,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupG.zip"
+    },
+    {
+      "checksum": "adler32:2b07c47d",
+      "size": 29159338,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupH.zip"
+    },
+    {
+      "checksum": "adler32:3ac431f2",
+      "size": 30661296,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupI.zip"
+    },
+    {
+      "checksum": "adler32:edd33929",
+      "size": 31086793,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:c424388a",
+      "size": 30153311,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupK.zip"
+    },
+    {
+      "checksum": "adler32:8e1c7330",
+      "size": 30320490,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupL.zip"
+    },
+    {
+      "checksum": "adler32:12fe8536",
+      "size": 31013379,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupM.zip"
+    },
+    {
+      "checksum": "adler32:f2f34e5c",
+      "size": 28698108,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupN.zip"
+    },
+    {
+      "checksum": "adler32:8c830326",
+      "size": 27818616,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupO.zip"
+    },
+    {
+      "checksum": "adler32:41d75558",
+      "size": 33053744,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupP.zip"
+    },
+    {
+      "checksum": "adler32:8486df8c",
+      "size": 31567082,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:f1dfb436",
+      "size": 30087579,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupR.zip"
+    },
+    {
+      "checksum": "adler32:0488a52f",
+      "size": 31698877,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupS.zip"
+    },
+    {
+      "checksum": "adler32:b5f10d5e",
+      "size": 34328077,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/3/groupT.zip"
     }
   ],
   "keywords": [
@@ -1113,11 +3066,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:18d751acc5de0997a217de9421369c24291f7c5b",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 4 file\n      index",
-      "size": 1780,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_4_file_index.txt"
+      "checksum": "adler32:a3621597",
+      "size": 31925663,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupA.zip"
+    },
+    {
+      "checksum": "adler32:a9867e0b",
+      "size": 31746716,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupB.zip"
+    },
+    {
+      "checksum": "adler32:4019d113",
+      "size": 29147467,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupC.zip"
+    },
+    {
+      "checksum": "adler32:bfc68b06",
+      "size": 28641611,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupD.zip"
+    },
+    {
+      "checksum": "adler32:cf7b6bb5",
+      "size": 29248430,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupE.zip"
+    },
+    {
+      "checksum": "adler32:9dcd08bf",
+      "size": 31692714,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupF.zip"
+    },
+    {
+      "checksum": "adler32:f5fa281b",
+      "size": 29397961,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupG.zip"
+    },
+    {
+      "checksum": "adler32:90dd8c47",
+      "size": 31614578,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupH.zip"
+    },
+    {
+      "checksum": "adler32:29e2e64b",
+      "size": 33361948,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupI.zip"
+    },
+    {
+      "checksum": "adler32:a8fbba8c",
+      "size": 30954238,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:37a99ca9",
+      "size": 30492688,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupK.zip"
+    },
+    {
+      "checksum": "adler32:5e5a6523",
+      "size": 28183900,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupL.zip"
+    },
+    {
+      "checksum": "adler32:813b740d",
+      "size": 30706292,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupM.zip"
+    },
+    {
+      "checksum": "adler32:930417f3",
+      "size": 30198860,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupN.zip"
+    },
+    {
+      "checksum": "adler32:01971f4b",
+      "size": 30468522,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupO.zip"
+    },
+    {
+      "checksum": "adler32:3e03154a",
+      "size": 31241882,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupP.zip"
+    },
+    {
+      "checksum": "adler32:385fe36a",
+      "size": 30625334,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:8e4b7379",
+      "size": 30138969,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupR.zip"
+    },
+    {
+      "checksum": "adler32:5921b361",
+      "size": 32455201,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupS.zip"
+    },
+    {
+      "checksum": "adler32:fad46230",
+      "size": 28889206,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/4/groupT.zip"
     }
   ],
   "keywords": [
@@ -1165,11 +3211,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:e63b8364308d1dfe994e0590fd1a495a78662e4e",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 5 file\n      index",
-      "size": 1780,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_5_file_index.txt"
+      "checksum": "adler32:1d8a07bf",
+      "size": 32274393,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupA.zip"
+    },
+    {
+      "checksum": "adler32:95a79d7c",
+      "size": 30703203,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupB.zip"
+    },
+    {
+      "checksum": "adler32:14f3b014",
+      "size": 29176362,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupC.zip"
+    },
+    {
+      "checksum": "adler32:fe5e1c8c",
+      "size": 29249094,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupD.zip"
+    },
+    {
+      "checksum": "adler32:866ffea0",
+      "size": 30300337,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupE.zip"
+    },
+    {
+      "checksum": "adler32:0091d761",
+      "size": 27062694,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupF.zip"
+    },
+    {
+      "checksum": "adler32:61bb5ac9",
+      "size": 31292443,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupG.zip"
+    },
+    {
+      "checksum": "adler32:595cb2fa",
+      "size": 30855842,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupH.zip"
+    },
+    {
+      "checksum": "adler32:9ca07753",
+      "size": 32153069,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupI.zip"
+    },
+    {
+      "checksum": "adler32:ea0af255",
+      "size": 31695769,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:6e0e2f5f",
+      "size": 30426028,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupK.zip"
+    },
+    {
+      "checksum": "adler32:5c8c6035",
+      "size": 30417528,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupL.zip"
+    },
+    {
+      "checksum": "adler32:4865c2fa",
+      "size": 30640676,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupM.zip"
+    },
+    {
+      "checksum": "adler32:5023df96",
+      "size": 31062814,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupN.zip"
+    },
+    {
+      "checksum": "adler32:70d598f9",
+      "size": 30618521,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupO.zip"
+    },
+    {
+      "checksum": "adler32:3acb216b",
+      "size": 31515467,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupP.zip"
+    },
+    {
+      "checksum": "adler32:8331744a",
+      "size": 28503344,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:b10e31d3",
+      "size": 31292548,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupR.zip"
+    },
+    {
+      "checksum": "adler32:94755023",
+      "size": 30608842,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupS.zip"
+    },
+    {
+      "checksum": "adler32:6cb2dc73",
+      "size": 29727784,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/5/groupT.zip"
     }
   ],
   "keywords": [
@@ -1217,11 +3356,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:17a8c7cebda71a6fdf97548f0d24cd182c731462",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 6 file\n      index",
-      "size": 1780,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_6_file_index.txt"
+      "checksum": "adler32:b9c7d6a5",
+      "size": 31744117,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupA.zip"
+    },
+    {
+      "checksum": "adler32:8512ad23",
+      "size": 27652908,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupB.zip"
+    },
+    {
+      "checksum": "adler32:93ac4401",
+      "size": 30228292,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupC.zip"
+    },
+    {
+      "checksum": "adler32:f3fa6451",
+      "size": 32531967,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupD.zip"
+    },
+    {
+      "checksum": "adler32:bb9c574d",
+      "size": 32188629,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupE.zip"
+    },
+    {
+      "checksum": "adler32:59bad7a5",
+      "size": 30274661,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupF.zip"
+    },
+    {
+      "checksum": "adler32:02aae1ce",
+      "size": 32253233,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupG.zip"
+    },
+    {
+      "checksum": "adler32:14f4bf66",
+      "size": 31039900,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupH.zip"
+    },
+    {
+      "checksum": "adler32:c710237d",
+      "size": 30405795,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupI.zip"
+    },
+    {
+      "checksum": "adler32:f39bbe17",
+      "size": 31671502,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:9435335c",
+      "size": 31472872,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupK.zip"
+    },
+    {
+      "checksum": "adler32:2391b4d5",
+      "size": 33602279,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupL.zip"
+    },
+    {
+      "checksum": "adler32:a751d089",
+      "size": 32623371,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupM.zip"
+    },
+    {
+      "checksum": "adler32:de65e507",
+      "size": 31729304,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupN.zip"
+    },
+    {
+      "checksum": "adler32:db7ea063",
+      "size": 33137194,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupO.zip"
+    },
+    {
+      "checksum": "adler32:60065b8d",
+      "size": 35045624,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupP.zip"
+    },
+    {
+      "checksum": "adler32:df84a9a1",
+      "size": 30432030,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:cc40c2d8",
+      "size": 31537982,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupR.zip"
+    },
+    {
+      "checksum": "adler32:b7c03d8d",
+      "size": 32337412,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupS.zip"
+    },
+    {
+      "checksum": "adler32:60f67034",
+      "size": 31905174,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/6/groupT.zip"
     }
   ],
   "keywords": [
@@ -1269,11 +3501,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:15a2c6b407f608a176a5d24161694c31d9830135",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 7 file\n      index",
-      "size": 1780,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_7_file_index.txt"
+      "checksum": "adler32:3a3e580f",
+      "size": 31823239,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupA.zip"
+    },
+    {
+      "checksum": "adler32:460bcef9",
+      "size": 32636337,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupB.zip"
+    },
+    {
+      "checksum": "adler32:0df8495e",
+      "size": 30558198,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupC.zip"
+    },
+    {
+      "checksum": "adler32:0b6bcc06",
+      "size": 30170637,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupD.zip"
+    },
+    {
+      "checksum": "adler32:9e9fa12d",
+      "size": 34542386,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupE.zip"
+    },
+    {
+      "checksum": "adler32:73d19304",
+      "size": 30815554,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupF.zip"
+    },
+    {
+      "checksum": "adler32:30ac9f4b",
+      "size": 30261171,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupG.zip"
+    },
+    {
+      "checksum": "adler32:f4688b48",
+      "size": 32580076,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupH.zip"
+    },
+    {
+      "checksum": "adler32:77d7e50b",
+      "size": 29477717,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupI.zip"
+    },
+    {
+      "checksum": "adler32:bf8150fb",
+      "size": 32623142,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:c2d545fb",
+      "size": 31801746,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupK.zip"
+    },
+    {
+      "checksum": "adler32:8d40cd12",
+      "size": 33108617,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupL.zip"
+    },
+    {
+      "checksum": "adler32:b20f0aac",
+      "size": 33338702,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupM.zip"
+    },
+    {
+      "checksum": "adler32:212fd319",
+      "size": 30374691,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupN.zip"
+    },
+    {
+      "checksum": "adler32:fa9926e9",
+      "size": 30283491,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupO.zip"
+    },
+    {
+      "checksum": "adler32:20ed1b2b",
+      "size": 30946274,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupP.zip"
+    },
+    {
+      "checksum": "adler32:f0521d83",
+      "size": 31079461,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:429f0584",
+      "size": 33650867,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupR.zip"
+    },
+    {
+      "checksum": "adler32:ad9babcc",
+      "size": 30714484,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupS.zip"
+    },
+    {
+      "checksum": "adler32:32056b46",
+      "size": 33864284,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/7/groupT.zip"
     }
   ],
   "keywords": [
@@ -1321,11 +3646,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:6b0d554e95ce8540ae186a57759a1b99ceb8d0d5",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 8 file\n      index",
-      "size": 1780,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_8_file_index.txt"
+      "checksum": "adler32:6785ba92",
+      "size": 32095569,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupA.zip"
+    },
+    {
+      "checksum": "adler32:59876c48",
+      "size": 30279210,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupB.zip"
+    },
+    {
+      "checksum": "adler32:b2471314",
+      "size": 31956025,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupC.zip"
+    },
+    {
+      "checksum": "adler32:5943786e",
+      "size": 29821676,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupD.zip"
+    },
+    {
+      "checksum": "adler32:f4ae156e",
+      "size": 29288542,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupE.zip"
+    },
+    {
+      "checksum": "adler32:25b3f046",
+      "size": 30946909,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupF.zip"
+    },
+    {
+      "checksum": "adler32:f7a7e05f",
+      "size": 32935203,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupG.zip"
+    },
+    {
+      "checksum": "adler32:f177ebdf",
+      "size": 29189238,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupH.zip"
+    },
+    {
+      "checksum": "adler32:64a261b5",
+      "size": 32151014,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupI.zip"
+    },
+    {
+      "checksum": "adler32:4081fd0b",
+      "size": 32930724,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:9010118b",
+      "size": 32624865,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupK.zip"
+    },
+    {
+      "checksum": "adler32:8a6dd47f",
+      "size": 29834424,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupL.zip"
+    },
+    {
+      "checksum": "adler32:2588b649",
+      "size": 29564064,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupM.zip"
+    },
+    {
+      "checksum": "adler32:33020a71",
+      "size": 30510393,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupN.zip"
+    },
+    {
+      "checksum": "adler32:c8aa565f",
+      "size": 31587180,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupO.zip"
+    },
+    {
+      "checksum": "adler32:b6088da7",
+      "size": 30496904,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupP.zip"
+    },
+    {
+      "checksum": "adler32:669632fd",
+      "size": 26805044,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:21f8bfd2",
+      "size": 29417025,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupR.zip"
+    },
+    {
+      "checksum": "adler32:f2734931",
+      "size": 28865791,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupS.zip"
+    },
+    {
+      "checksum": "adler32:4eb42f3b",
+      "size": 31765379,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/8/groupT.zip"
     }
   ],
   "keywords": [
@@ -1373,11 +3791,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:630d308dfce0ed75f681b64724eb4e2188b47227",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 9 file\n      index",
-      "size": 1780,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_9_file_index.txt"
+      "checksum": "adler32:6b2940ad",
+      "size": 29116283,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupA.zip"
+    },
+    {
+      "checksum": "adler32:f76bbd85",
+      "size": 29314242,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupB.zip"
+    },
+    {
+      "checksum": "adler32:08015c65",
+      "size": 32134518,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupC.zip"
+    },
+    {
+      "checksum": "adler32:cfab63da",
+      "size": 31800243,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupD.zip"
+    },
+    {
+      "checksum": "adler32:67402575",
+      "size": 29992741,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupE.zip"
+    },
+    {
+      "checksum": "adler32:ad4d524f",
+      "size": 28940878,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupF.zip"
+    },
+    {
+      "checksum": "adler32:c058506e",
+      "size": 27517714,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupG.zip"
+    },
+    {
+      "checksum": "adler32:469a2be3",
+      "size": 28398321,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupH.zip"
+    },
+    {
+      "checksum": "adler32:1de60466",
+      "size": 29192753,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupI.zip"
+    },
+    {
+      "checksum": "adler32:89d78859",
+      "size": 26418297,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:ca3ef1eb",
+      "size": 27307942,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupK.zip"
+    },
+    {
+      "checksum": "adler32:f550ee12",
+      "size": 27397604,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupL.zip"
+    },
+    {
+      "checksum": "adler32:f3cfc414",
+      "size": 26806059,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupM.zip"
+    },
+    {
+      "checksum": "adler32:45dbafbd",
+      "size": 26717972,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupN.zip"
+    },
+    {
+      "checksum": "adler32:c903f826",
+      "size": 27157142,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupO.zip"
+    },
+    {
+      "checksum": "adler32:f4f7d566",
+      "size": 26998132,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupP.zip"
+    },
+    {
+      "checksum": "adler32:b8d7a03b",
+      "size": 27369339,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:2a1de676",
+      "size": 28379949,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupR.zip"
+    },
+    {
+      "checksum": "adler32:90a4a7b2",
+      "size": 28746794,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupS.zip"
+    },
+    {
+      "checksum": "adler32:17fffbf7",
+      "size": 29130389,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/9/groupT.zip"
     }
   ],
   "keywords": [
@@ -1425,11 +3936,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:980314b47231068c0eddfc5c1f94e8c6323014aa",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 10 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_10_file_index.txt"
+      "checksum": "adler32:02ac0bbd",
+      "size": 29466047,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupA.zip"
+    },
+    {
+      "checksum": "adler32:4a1b8d12",
+      "size": 27769468,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupB.zip"
+    },
+    {
+      "checksum": "adler32:00a5b2f2",
+      "size": 29161258,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupC.zip"
+    },
+    {
+      "checksum": "adler32:ebfc6322",
+      "size": 29929226,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupD.zip"
+    },
+    {
+      "checksum": "adler32:14da6811",
+      "size": 29558291,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupE.zip"
+    },
+    {
+      "checksum": "adler32:98388b15",
+      "size": 29594866,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupF.zip"
+    },
+    {
+      "checksum": "adler32:925e3f20",
+      "size": 28090713,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupG.zip"
+    },
+    {
+      "checksum": "adler32:073525fe",
+      "size": 26322227,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupH.zip"
+    },
+    {
+      "checksum": "adler32:681ab8e2",
+      "size": 28646367,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupI.zip"
+    },
+    {
+      "checksum": "adler32:ff141d5c",
+      "size": 30653292,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:2a0c5ff2",
+      "size": 29960799,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupK.zip"
+    },
+    {
+      "checksum": "adler32:1eaaa02b",
+      "size": 27674621,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupL.zip"
+    },
+    {
+      "checksum": "adler32:eb887216",
+      "size": 29368377,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupM.zip"
+    },
+    {
+      "checksum": "adler32:b0e1d34a",
+      "size": 28265088,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupN.zip"
+    },
+    {
+      "checksum": "adler32:ceb85e5d",
+      "size": 28107525,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupO.zip"
+    },
+    {
+      "checksum": "adler32:71d8913d",
+      "size": 27371098,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupP.zip"
+    },
+    {
+      "checksum": "adler32:0e84b7e0",
+      "size": 26991180,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:fabfdedf",
+      "size": 32209294,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupR.zip"
+    },
+    {
+      "checksum": "adler32:cdd03363",
+      "size": 27415300,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupS.zip"
+    },
+    {
+      "checksum": "adler32:c13b91a8",
+      "size": 29231827,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/10/groupT.zip"
     }
   ],
   "keywords": [
@@ -1477,11 +4081,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:4f0bf7b6930436cd7730b17c8cb6f9a2d9361b6e",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 11 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_11_file_index.txt"
+      "checksum": "adler32:47dfa9c3",
+      "size": 29046447,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupA.zip"
+    },
+    {
+      "checksum": "adler32:648e2b3f",
+      "size": 27021400,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupB.zip"
+    },
+    {
+      "checksum": "adler32:a78bcd33",
+      "size": 28226672,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupC.zip"
+    },
+    {
+      "checksum": "adler32:1287a4ae",
+      "size": 26546945,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupD.zip"
+    },
+    {
+      "checksum": "adler32:c911cc1f",
+      "size": 29210651,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupE.zip"
+    },
+    {
+      "checksum": "adler32:2a4a88aa",
+      "size": 28782931,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupF.zip"
+    },
+    {
+      "checksum": "adler32:83feb21d",
+      "size": 27365682,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupG.zip"
+    },
+    {
+      "checksum": "adler32:50954bc2",
+      "size": 28400891,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupH.zip"
+    },
+    {
+      "checksum": "adler32:d0da8c97",
+      "size": 27750753,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupI.zip"
+    },
+    {
+      "checksum": "adler32:913cfe84",
+      "size": 28177750,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:960ecbe7",
+      "size": 29231047,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupK.zip"
+    },
+    {
+      "checksum": "adler32:8134258c",
+      "size": 28764582,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupL.zip"
+    },
+    {
+      "checksum": "adler32:09985fe4",
+      "size": 27882744,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupM.zip"
+    },
+    {
+      "checksum": "adler32:e26567da",
+      "size": 28801836,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupN.zip"
+    },
+    {
+      "checksum": "adler32:8e365a80",
+      "size": 28012240,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupO.zip"
+    },
+    {
+      "checksum": "adler32:87ebd458",
+      "size": 26584246,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupP.zip"
+    },
+    {
+      "checksum": "adler32:fba4e412",
+      "size": 28540632,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:2111f210",
+      "size": 28094149,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupR.zip"
+    },
+    {
+      "checksum": "adler32:10852c1e",
+      "size": 28038879,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupS.zip"
+    },
+    {
+      "checksum": "adler32:92235278",
+      "size": 28214087,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/11/groupT.zip"
     }
   ],
   "keywords": [
@@ -1529,11 +4226,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:a0baa82c95bfe51067dc43ac0540244a667765d8",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 12 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_12_file_index.txt"
+      "checksum": "adler32:2ad7e522",
+      "size": 27429390,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupA.zip"
+    },
+    {
+      "checksum": "adler32:78f931dc",
+      "size": 27025432,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupB.zip"
+    },
+    {
+      "checksum": "adler32:e191aea6",
+      "size": 28179852,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupC.zip"
+    },
+    {
+      "checksum": "adler32:3f80b1e5",
+      "size": 29419624,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupD.zip"
+    },
+    {
+      "checksum": "adler32:6b3b7dc1",
+      "size": 26775995,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupE.zip"
+    },
+    {
+      "checksum": "adler32:029724de",
+      "size": 29519971,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupF.zip"
+    },
+    {
+      "checksum": "adler32:45f11533",
+      "size": 27647187,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupG.zip"
+    },
+    {
+      "checksum": "adler32:677a8110",
+      "size": 24921676,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupH.zip"
+    },
+    {
+      "checksum": "adler32:6f213287",
+      "size": 28566101,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupI.zip"
+    },
+    {
+      "checksum": "adler32:75d28fe2",
+      "size": 27443014,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:92072fa0",
+      "size": 27205939,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupK.zip"
+    },
+    {
+      "checksum": "adler32:338dab0b",
+      "size": 31835075,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupL.zip"
+    },
+    {
+      "checksum": "adler32:ef8faa05",
+      "size": 29500576,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupM.zip"
+    },
+    {
+      "checksum": "adler32:56851e25",
+      "size": 30845501,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupN.zip"
+    },
+    {
+      "checksum": "adler32:0c2dcc83",
+      "size": 30168529,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupO.zip"
+    },
+    {
+      "checksum": "adler32:e19a137b",
+      "size": 30405236,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupP.zip"
+    },
+    {
+      "checksum": "adler32:07e8c6e9",
+      "size": 31100706,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:dee67a05",
+      "size": 30377142,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupR.zip"
+    },
+    {
+      "checksum": "adler32:e61d3b6c",
+      "size": 29326992,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupS.zip"
+    },
+    {
+      "checksum": "adler32:70bfd704",
+      "size": 30559845,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/12/groupT.zip"
     }
   ],
   "keywords": [
@@ -1581,11 +4371,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:8139cc68b8114240a0b3b0521d911282b6e55a7c",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 13 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_13_file_index.txt"
+      "checksum": "adler32:31749c8d",
+      "size": 32203300,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupA.zip"
+    },
+    {
+      "checksum": "adler32:ce5540a2",
+      "size": 29747943,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupB.zip"
+    },
+    {
+      "checksum": "adler32:22a1c300",
+      "size": 30056287,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupC.zip"
+    },
+    {
+      "checksum": "adler32:d2259521",
+      "size": 30619678,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupD.zip"
+    },
+    {
+      "checksum": "adler32:28a91167",
+      "size": 28848223,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupE.zip"
+    },
+    {
+      "checksum": "adler32:381e6b64",
+      "size": 28211871,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupF.zip"
+    },
+    {
+      "checksum": "adler32:dcb90708",
+      "size": 31917785,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupG.zip"
+    },
+    {
+      "checksum": "adler32:f51474b3",
+      "size": 27797923,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupH.zip"
+    },
+    {
+      "checksum": "adler32:1a8037a4",
+      "size": 28078741,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupI.zip"
+    },
+    {
+      "checksum": "adler32:22aad466",
+      "size": 30999226,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:67e612b2",
+      "size": 30884444,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupK.zip"
+    },
+    {
+      "checksum": "adler32:f81b02c8",
+      "size": 31783623,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupL.zip"
+    },
+    {
+      "checksum": "adler32:448eacab",
+      "size": 28444257,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupM.zip"
+    },
+    {
+      "checksum": "adler32:cb1e6ac6",
+      "size": 29966571,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupN.zip"
+    },
+    {
+      "checksum": "adler32:c64f061c",
+      "size": 28226634,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupO.zip"
+    },
+    {
+      "checksum": "adler32:cbc46868",
+      "size": 29191308,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupP.zip"
+    },
+    {
+      "checksum": "adler32:1a22e7bd",
+      "size": 28676439,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:d8b68927",
+      "size": 27215445,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupR.zip"
+    },
+    {
+      "checksum": "adler32:2591204a",
+      "size": 30667356,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupS.zip"
+    },
+    {
+      "checksum": "adler32:f654ce83",
+      "size": 31319897,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/13/groupT.zip"
     }
   ],
   "keywords": [
@@ -1633,11 +4516,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:dd4821bde3722e654126d03c662932fee9e174ec",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 14 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_14_file_index.txt"
+      "checksum": "adler32:32d76dbb",
+      "size": 33162023,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupA.zip"
+    },
+    {
+      "checksum": "adler32:81cf12fc",
+      "size": 29070293,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupB.zip"
+    },
+    {
+      "checksum": "adler32:b9c5f18f",
+      "size": 30400761,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupC.zip"
+    },
+    {
+      "checksum": "adler32:f499587c",
+      "size": 30403285,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupD.zip"
+    },
+    {
+      "checksum": "adler32:81c156f9",
+      "size": 31089836,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupE.zip"
+    },
+    {
+      "checksum": "adler32:0024a509",
+      "size": 27577881,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupF.zip"
+    },
+    {
+      "checksum": "adler32:ce071885",
+      "size": 29356443,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupG.zip"
+    },
+    {
+      "checksum": "adler32:f3bba635",
+      "size": 26317945,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupH.zip"
+    },
+    {
+      "checksum": "adler32:0ca4579e",
+      "size": 26286539,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupI.zip"
+    },
+    {
+      "checksum": "adler32:b41c47e5",
+      "size": 28224931,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:376a5068",
+      "size": 28904478,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupK.zip"
+    },
+    {
+      "checksum": "adler32:fa777d83",
+      "size": 30550585,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupL.zip"
+    },
+    {
+      "checksum": "adler32:6f821866",
+      "size": 31819986,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupM.zip"
+    },
+    {
+      "checksum": "adler32:68e376b6",
+      "size": 26282703,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupN.zip"
+    },
+    {
+      "checksum": "adler32:2a1eddc4",
+      "size": 25755892,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupO.zip"
+    },
+    {
+      "checksum": "adler32:c12186bf",
+      "size": 29334982,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupP.zip"
+    },
+    {
+      "checksum": "adler32:0de6da77",
+      "size": 29512105,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:fbef68ad",
+      "size": 28157609,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupR.zip"
+    },
+    {
+      "checksum": "adler32:0df079d8",
+      "size": 29843877,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupS.zip"
+    },
+    {
+      "checksum": "adler32:1eafa688",
+      "size": 29687975,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/14/groupT.zip"
     }
   ],
   "keywords": [
@@ -1685,11 +4661,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:62776aaba5d264ef5c7775f23270180eb1fdd0cb",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 15 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_15_file_index.txt"
+      "checksum": "adler32:0dbed74e",
+      "size": 28332919,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupA.zip"
+    },
+    {
+      "checksum": "adler32:f7bd57d4",
+      "size": 27852269,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupB.zip"
+    },
+    {
+      "checksum": "adler32:c37e26bf",
+      "size": 27320687,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupC.zip"
+    },
+    {
+      "checksum": "adler32:820942d4",
+      "size": 29533574,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupD.zip"
+    },
+    {
+      "checksum": "adler32:eabc37c2",
+      "size": 29058266,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupE.zip"
+    },
+    {
+      "checksum": "adler32:aa5d8daf",
+      "size": 30863508,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupF.zip"
+    },
+    {
+      "checksum": "adler32:19e97608",
+      "size": 28654013,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupG.zip"
+    },
+    {
+      "checksum": "adler32:20c1cebb",
+      "size": 30268404,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupH.zip"
+    },
+    {
+      "checksum": "adler32:ee6617a0",
+      "size": 28736798,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupI.zip"
+    },
+    {
+      "checksum": "adler32:234443c4",
+      "size": 26920503,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:22642546",
+      "size": 31028276,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupK.zip"
+    },
+    {
+      "checksum": "adler32:f3e75102",
+      "size": 31806795,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupL.zip"
+    },
+    {
+      "checksum": "adler32:be52ffa8",
+      "size": 31718939,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupM.zip"
+    },
+    {
+      "checksum": "adler32:81669853",
+      "size": 26523696,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupN.zip"
+    },
+    {
+      "checksum": "adler32:6a4bba14",
+      "size": 28508668,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupO.zip"
+    },
+    {
+      "checksum": "adler32:dd56b454",
+      "size": 29879540,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupP.zip"
+    },
+    {
+      "checksum": "adler32:d952854b",
+      "size": 27264121,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:51820476",
+      "size": 28446974,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupR.zip"
+    },
+    {
+      "checksum": "adler32:c7728b18",
+      "size": 27434206,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupS.zip"
+    },
+    {
+      "checksum": "adler32:88044c67",
+      "size": 28278485,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/15/groupT.zip"
     }
   ],
   "keywords": [
@@ -1737,11 +4806,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:f37829bc4069ef510544ad3c7f62055971ff271e",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 16 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_16_file_index.txt"
+      "checksum": "adler32:e89febeb",
+      "size": 29104481,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupA.zip"
+    },
+    {
+      "checksum": "adler32:4f39e3c1",
+      "size": 28922057,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupB.zip"
+    },
+    {
+      "checksum": "adler32:22da9155",
+      "size": 31196622,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupC.zip"
+    },
+    {
+      "checksum": "adler32:9c0ed803",
+      "size": 30271888,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupD.zip"
+    },
+    {
+      "checksum": "adler32:9b86d285",
+      "size": 27369096,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupE.zip"
+    },
+    {
+      "checksum": "adler32:5bcd8ee3",
+      "size": 28349425,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupF.zip"
+    },
+    {
+      "checksum": "adler32:f7bd2bae",
+      "size": 29289194,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupG.zip"
+    },
+    {
+      "checksum": "adler32:77d19441",
+      "size": 25971987,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupH.zip"
+    },
+    {
+      "checksum": "adler32:fac39b82",
+      "size": 32663877,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupI.zip"
+    },
+    {
+      "checksum": "adler32:0adf2a4f",
+      "size": 27993976,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:c761f164",
+      "size": 30312009,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupK.zip"
+    },
+    {
+      "checksum": "adler32:7f2e7bd4",
+      "size": 29075581,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupL.zip"
+    },
+    {
+      "checksum": "adler32:3a9ad0d8",
+      "size": 27266783,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupM.zip"
+    },
+    {
+      "checksum": "adler32:b5855f84",
+      "size": 27840753,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupN.zip"
+    },
+    {
+      "checksum": "adler32:e2f6b87e",
+      "size": 27012470,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupO.zip"
+    },
+    {
+      "checksum": "adler32:87a48683",
+      "size": 26671221,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupP.zip"
+    },
+    {
+      "checksum": "adler32:296708e8",
+      "size": 25200326,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:01a2bdde",
+      "size": 30953627,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupR.zip"
+    },
+    {
+      "checksum": "adler32:e8943894",
+      "size": 29658503,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupS.zip"
+    },
+    {
+      "checksum": "adler32:bacc2583",
+      "size": 28463904,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/16/groupT.zip"
     }
   ],
   "keywords": [
@@ -1789,11 +4951,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:9432088cd5da72e3684c4f3ef128d16dcc72e7ea",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 17 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_17_file_index.txt"
+      "checksum": "adler32:e078f2e6",
+      "size": 32043151,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupA.zip"
+    },
+    {
+      "checksum": "adler32:ca484e41",
+      "size": 26346850,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupB.zip"
+    },
+    {
+      "checksum": "adler32:45a35664",
+      "size": 30555526,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupC.zip"
+    },
+    {
+      "checksum": "adler32:55605286",
+      "size": 29684052,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupD.zip"
+    },
+    {
+      "checksum": "adler32:4e0cc133",
+      "size": 29953135,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupE.zip"
+    },
+    {
+      "checksum": "adler32:cf2da0bf",
+      "size": 27499917,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupF.zip"
+    },
+    {
+      "checksum": "adler32:f88b7bfd",
+      "size": 27782599,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupG.zip"
+    },
+    {
+      "checksum": "adler32:58e7b11d",
+      "size": 29897470,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupH.zip"
+    },
+    {
+      "checksum": "adler32:ae5f3355",
+      "size": 29800533,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupI.zip"
+    },
+    {
+      "checksum": "adler32:d2cbb696",
+      "size": 32007110,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:d4f1a2c7",
+      "size": 27775545,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupK.zip"
+    },
+    {
+      "checksum": "adler32:ea1b8ffa",
+      "size": 30038916,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupL.zip"
+    },
+    {
+      "checksum": "adler32:50094400",
+      "size": 24413246,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupM.zip"
+    },
+    {
+      "checksum": "adler32:1587ff2c",
+      "size": 30540421,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupN.zip"
+    },
+    {
+      "checksum": "adler32:0808b907",
+      "size": 31426106,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupO.zip"
+    },
+    {
+      "checksum": "adler32:1813c234",
+      "size": 29287910,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupP.zip"
+    },
+    {
+      "checksum": "adler32:0015c76b",
+      "size": 31547522,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:32c7057e",
+      "size": 28749800,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupR.zip"
+    },
+    {
+      "checksum": "adler32:57e8f2cb",
+      "size": 30543500,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupS.zip"
+    },
+    {
+      "checksum": "adler32:3dcc0782",
+      "size": 27936425,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/17/groupT.zip"
     }
   ],
   "keywords": [
@@ -1841,11 +5096,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:a2b8a534f10577127ac01ba55fb8035db35c3a8d",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 18 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_18_file_index.txt"
+      "checksum": "adler32:c9e040cc",
+      "size": 29360765,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupA.zip"
+    },
+    {
+      "checksum": "adler32:05abc2cb",
+      "size": 29392335,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupB.zip"
+    },
+    {
+      "checksum": "adler32:22ac5560",
+      "size": 28998161,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupC.zip"
+    },
+    {
+      "checksum": "adler32:d50394d6",
+      "size": 24465805,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupD.zip"
+    },
+    {
+      "checksum": "adler32:f8183232",
+      "size": 29091502,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupE.zip"
+    },
+    {
+      "checksum": "adler32:b06fcfa1",
+      "size": 27031030,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupF.zip"
+    },
+    {
+      "checksum": "adler32:2ffe5aeb",
+      "size": 28315068,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupG.zip"
+    },
+    {
+      "checksum": "adler32:7ef7c2ca",
+      "size": 28937173,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupH.zip"
+    },
+    {
+      "checksum": "adler32:8cd7edfa",
+      "size": 27114060,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupI.zip"
+    },
+    {
+      "checksum": "adler32:68403df9",
+      "size": 27209069,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:fc77145c",
+      "size": 29791326,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupK.zip"
+    },
+    {
+      "checksum": "adler32:0330ac99",
+      "size": 32523321,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupL.zip"
+    },
+    {
+      "checksum": "adler32:5d4af974",
+      "size": 30747833,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupM.zip"
+    },
+    {
+      "checksum": "adler32:15c0bd52",
+      "size": 30397701,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupN.zip"
+    },
+    {
+      "checksum": "adler32:8eb73700",
+      "size": 29353286,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupO.zip"
+    },
+    {
+      "checksum": "adler32:dae1212d",
+      "size": 27791054,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupP.zip"
+    },
+    {
+      "checksum": "adler32:1aefd791",
+      "size": 28567622,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:a769e23f",
+      "size": 29495546,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupR.zip"
+    },
+    {
+      "checksum": "adler32:e9551f2c",
+      "size": 26736232,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupS.zip"
+    },
+    {
+      "checksum": "adler32:cf77a038",
+      "size": 28885465,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/18/groupT.zip"
     }
   ],
   "keywords": [
@@ -1893,11 +5241,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:aa46e6d6f0f999b861268b6d8180816ba5d2d067",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 19 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_19_file_index.txt"
+      "checksum": "adler32:6354b5ea",
+      "size": 28468874,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupA.zip"
+    },
+    {
+      "checksum": "adler32:9f3afea3",
+      "size": 25643260,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupB.zip"
+    },
+    {
+      "checksum": "adler32:08459b30",
+      "size": 25968498,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupC.zip"
+    },
+    {
+      "checksum": "adler32:f87c20c8",
+      "size": 27414846,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupD.zip"
+    },
+    {
+      "checksum": "adler32:e24e146d",
+      "size": 27182709,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupE.zip"
+    },
+    {
+      "checksum": "adler32:1c4761ea",
+      "size": 28107919,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupF.zip"
+    },
+    {
+      "checksum": "adler32:b9687ce3",
+      "size": 30412999,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupG.zip"
+    },
+    {
+      "checksum": "adler32:ae23278d",
+      "size": 29105102,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupH.zip"
+    },
+    {
+      "checksum": "adler32:b2e2b339",
+      "size": 32109108,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupI.zip"
+    },
+    {
+      "checksum": "adler32:b0a57f00",
+      "size": 28311711,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:5f50757c",
+      "size": 27778455,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupK.zip"
+    },
+    {
+      "checksum": "adler32:485824a9",
+      "size": 30609782,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupL.zip"
+    },
+    {
+      "checksum": "adler32:1c5eb3ad",
+      "size": 29110615,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupM.zip"
+    },
+    {
+      "checksum": "adler32:11591b98",
+      "size": 32249664,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupN.zip"
+    },
+    {
+      "checksum": "adler32:89f53464",
+      "size": 30456054,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupO.zip"
+    },
+    {
+      "checksum": "adler32:fa503c51",
+      "size": 27594363,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupP.zip"
+    },
+    {
+      "checksum": "adler32:e259f91a",
+      "size": 29561324,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:0155ad7a",
+      "size": 29294352,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupR.zip"
+    },
+    {
+      "checksum": "adler32:82720032",
+      "size": 29011260,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupS.zip"
+    },
+    {
+      "checksum": "adler32:185c15b9",
+      "size": 27873043,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/19/groupT.zip"
     }
   ],
   "keywords": [
@@ -1945,11 +5386,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:ba8afd4280353328cc93d19c0980143e1f73d4af",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 20 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_20_file_index.txt"
+      "checksum": "adler32:ec6ae069",
+      "size": 27773731,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupA.zip"
+    },
+    {
+      "checksum": "adler32:76228d5d",
+      "size": 28094651,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupB.zip"
+    },
+    {
+      "checksum": "adler32:e9fcc3c2",
+      "size": 28514584,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupC.zip"
+    },
+    {
+      "checksum": "adler32:0841ac7a",
+      "size": 27437053,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupD.zip"
+    },
+    {
+      "checksum": "adler32:b521384d",
+      "size": 29178664,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupE.zip"
+    },
+    {
+      "checksum": "adler32:a7ec169c",
+      "size": 29498146,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupF.zip"
+    },
+    {
+      "checksum": "adler32:9da9556f",
+      "size": 27442254,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupG.zip"
+    },
+    {
+      "checksum": "adler32:5ff69e23",
+      "size": 28043763,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupH.zip"
+    },
+    {
+      "checksum": "adler32:25dc19e2",
+      "size": 29005793,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupI.zip"
+    },
+    {
+      "checksum": "adler32:0cc343f0",
+      "size": 29763488,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:81475086",
+      "size": 30817326,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupK.zip"
+    },
+    {
+      "checksum": "adler32:5709c605",
+      "size": 30782744,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupL.zip"
+    },
+    {
+      "checksum": "adler32:65246aa4",
+      "size": 29213017,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupM.zip"
+    },
+    {
+      "checksum": "adler32:4c60be80",
+      "size": 27797430,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupN.zip"
+    },
+    {
+      "checksum": "adler32:b5119e9b",
+      "size": 29781200,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupO.zip"
+    },
+    {
+      "checksum": "adler32:11c5011e",
+      "size": 30156926,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupP.zip"
+    },
+    {
+      "checksum": "adler32:6d632de4",
+      "size": 27277903,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:5bef30e0",
+      "size": 28629431,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupR.zip"
+    },
+    {
+      "checksum": "adler32:290e9bfa",
+      "size": 28169116,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupS.zip"
+    },
+    {
+      "checksum": "adler32:34ccb35d",
+      "size": 28799653,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/20/groupT.zip"
     }
   ],
   "keywords": [
@@ -1997,11 +5531,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:ec0bd3a4281303d33e39a8aa57f11bf98a5ea7a6",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 21 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_21_file_index.txt"
+      "checksum": "adler32:df1f1ec2",
+      "size": 28674446,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupA.zip"
+    },
+    {
+      "checksum": "adler32:0a081e83",
+      "size": 29282185,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupB.zip"
+    },
+    {
+      "checksum": "adler32:4c77a398",
+      "size": 28628098,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupC.zip"
+    },
+    {
+      "checksum": "adler32:69cde59f",
+      "size": 28830215,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupD.zip"
+    },
+    {
+      "checksum": "adler32:2500b416",
+      "size": 30459439,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupE.zip"
+    },
+    {
+      "checksum": "adler32:a7ef2dd3",
+      "size": 27282065,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupF.zip"
+    },
+    {
+      "checksum": "adler32:888b5b31",
+      "size": 30287470,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupG.zip"
+    },
+    {
+      "checksum": "adler32:ca700e75",
+      "size": 30318807,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupH.zip"
+    },
+    {
+      "checksum": "adler32:852fe56f",
+      "size": 28981935,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupI.zip"
+    },
+    {
+      "checksum": "adler32:0064c1e2",
+      "size": 27531316,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:b0385e44",
+      "size": 30733059,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupK.zip"
+    },
+    {
+      "checksum": "adler32:facd3d29",
+      "size": 28935776,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupL.zip"
+    },
+    {
+      "checksum": "adler32:526f7a6f",
+      "size": 28534750,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupM.zip"
+    },
+    {
+      "checksum": "adler32:4a79ecf1",
+      "size": 27064425,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupN.zip"
+    },
+    {
+      "checksum": "adler32:24df836d",
+      "size": 26530290,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupO.zip"
+    },
+    {
+      "checksum": "adler32:41014c8f",
+      "size": 27804196,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupP.zip"
+    },
+    {
+      "checksum": "adler32:489fc827",
+      "size": 31697776,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:83b63c3f",
+      "size": 27129277,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupR.zip"
+    },
+    {
+      "checksum": "adler32:69fa8fdd",
+      "size": 28182561,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupS.zip"
+    },
+    {
+      "checksum": "adler32:24e2f39b",
+      "size": 30556033,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/21/groupT.zip"
     }
   ],
   "keywords": [
@@ -2049,11 +5676,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:cc3c0d1859bae8d749b46887189e5901228775f9",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 22 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_22_file_index.txt"
+      "checksum": "adler32:cf7bff4a",
+      "size": 30077316,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupA.zip"
+    },
+    {
+      "checksum": "adler32:0c65897a",
+      "size": 30406718,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupB.zip"
+    },
+    {
+      "checksum": "adler32:6892e239",
+      "size": 26808427,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupC.zip"
+    },
+    {
+      "checksum": "adler32:7beaa4a9",
+      "size": 27201057,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupD.zip"
+    },
+    {
+      "checksum": "adler32:3cc4c059",
+      "size": 29106734,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupE.zip"
+    },
+    {
+      "checksum": "adler32:62a42a53",
+      "size": 26649617,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupF.zip"
+    },
+    {
+      "checksum": "adler32:4c26af1a",
+      "size": 28585223,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupG.zip"
+    },
+    {
+      "checksum": "adler32:27466f15",
+      "size": 28573126,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupH.zip"
+    },
+    {
+      "checksum": "adler32:9ba70e86",
+      "size": 28962261,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupI.zip"
+    },
+    {
+      "checksum": "adler32:431e670e",
+      "size": 28746970,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:19b74f79",
+      "size": 29002818,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupK.zip"
+    },
+    {
+      "checksum": "adler32:2cc71abd",
+      "size": 28562273,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupL.zip"
+    },
+    {
+      "checksum": "adler32:f8de2ae3",
+      "size": 31560222,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupM.zip"
+    },
+    {
+      "checksum": "adler32:bf143766",
+      "size": 28758400,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupN.zip"
+    },
+    {
+      "checksum": "adler32:c16a92f2",
+      "size": 27119363,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupO.zip"
+    },
+    {
+      "checksum": "adler32:7fd2f0c3",
+      "size": 31943294,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupP.zip"
+    },
+    {
+      "checksum": "adler32:ae1ed103",
+      "size": 30837001,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:c43d10bf",
+      "size": 29196925,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupR.zip"
+    },
+    {
+      "checksum": "adler32:a9eb2047",
+      "size": 28411803,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupS.zip"
+    },
+    {
+      "checksum": "adler32:c97dfd2d",
+      "size": 29150470,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/22/groupT.zip"
     }
   ],
   "keywords": [
@@ -2101,11 +5821,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:8d34cd9d9ccd6e04c60ba08ac850a767b76b80b6",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 23 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_23_file_index.txt"
+      "checksum": "adler32:8fdda23a",
+      "size": 29630225,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupA.zip"
+    },
+    {
+      "checksum": "adler32:3acca203",
+      "size": 30982722,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupB.zip"
+    },
+    {
+      "checksum": "adler32:fe003e3d",
+      "size": 30001730,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupC.zip"
+    },
+    {
+      "checksum": "adler32:38037307",
+      "size": 31251815,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupD.zip"
+    },
+    {
+      "checksum": "adler32:1ece7a37",
+      "size": 30373265,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupE.zip"
+    },
+    {
+      "checksum": "adler32:01b225af",
+      "size": 31111701,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupF.zip"
+    },
+    {
+      "checksum": "adler32:b066a35b",
+      "size": 29630244,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupG.zip"
+    },
+    {
+      "checksum": "adler32:2cfe2c82",
+      "size": 29230648,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupH.zip"
+    },
+    {
+      "checksum": "adler32:ab0a2293",
+      "size": 27979169,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupI.zip"
+    },
+    {
+      "checksum": "adler32:f7676d43",
+      "size": 30820474,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:2931acfb",
+      "size": 30363731,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupK.zip"
+    },
+    {
+      "checksum": "adler32:87854ff7",
+      "size": 31668147,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupL.zip"
+    },
+    {
+      "checksum": "adler32:d6576c8d",
+      "size": 29845592,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupM.zip"
+    },
+    {
+      "checksum": "adler32:57d53d58",
+      "size": 31642498,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupN.zip"
+    },
+    {
+      "checksum": "adler32:11e1f9de",
+      "size": 29561473,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupO.zip"
+    },
+    {
+      "checksum": "adler32:7d24c171",
+      "size": 29219967,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupP.zip"
+    },
+    {
+      "checksum": "adler32:57641be8",
+      "size": 31837151,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:2f50d385",
+      "size": 29414155,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupR.zip"
+    },
+    {
+      "checksum": "adler32:40d6286d",
+      "size": 32949527,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupS.zip"
+    },
+    {
+      "checksum": "adler32:0c906878",
+      "size": 30512962,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/23/groupT.zip"
     }
   ],
   "keywords": [
@@ -2153,11 +5966,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:798aa415677d73930155afdfdbf28dc8a385c916",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 24 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_24_file_index.txt"
+      "checksum": "adler32:487305ba",
+      "size": 29909250,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupA.zip"
+    },
+    {
+      "checksum": "adler32:cb4df43b",
+      "size": 29283433,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupB.zip"
+    },
+    {
+      "checksum": "adler32:942c5566",
+      "size": 30973113,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupC.zip"
+    },
+    {
+      "checksum": "adler32:6de8916c",
+      "size": 31032455,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupD.zip"
+    },
+    {
+      "checksum": "adler32:14f93efc",
+      "size": 28901530,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupE.zip"
+    },
+    {
+      "checksum": "adler32:702a8cc9",
+      "size": 29281637,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupF.zip"
+    },
+    {
+      "checksum": "adler32:85eb6138",
+      "size": 30298459,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupG.zip"
+    },
+    {
+      "checksum": "adler32:d4766ee8",
+      "size": 31395358,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupH.zip"
+    },
+    {
+      "checksum": "adler32:5c22e17f",
+      "size": 29368692,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupI.zip"
+    },
+    {
+      "checksum": "adler32:9a0f11b1",
+      "size": 30463007,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:d0b9095f",
+      "size": 30554022,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupK.zip"
+    },
+    {
+      "checksum": "adler32:b632f835",
+      "size": 29671619,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupL.zip"
+    },
+    {
+      "checksum": "adler32:80022119",
+      "size": 30605288,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupM.zip"
+    },
+    {
+      "checksum": "adler32:dda2aa75",
+      "size": 29821478,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupN.zip"
+    },
+    {
+      "checksum": "adler32:ddaef6b3",
+      "size": 29281943,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupO.zip"
+    },
+    {
+      "checksum": "adler32:32097ba8",
+      "size": 28661050,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupP.zip"
+    },
+    {
+      "checksum": "adler32:0bf57d01",
+      "size": 31881830,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:ba66db34",
+      "size": 28651678,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupR.zip"
+    },
+    {
+      "checksum": "adler32:d7f500ca",
+      "size": 27673978,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupS.zip"
+    },
+    {
+      "checksum": "adler32:5a3c18b9",
+      "size": 27402723,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/24/groupT.zip"
     }
   ],
   "keywords": [
@@ -2205,11 +6111,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:21f51eace6cd03b7e1ad086b9ed5b425130e9be3",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 25 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_25_file_index.txt"
+      "checksum": "adler32:b6e470c3",
+      "size": 27250963,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupA.zip"
+    },
+    {
+      "checksum": "adler32:7928c88a",
+      "size": 26255790,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupB.zip"
+    },
+    {
+      "checksum": "adler32:c4f6a2cb",
+      "size": 28165451,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupC.zip"
+    },
+    {
+      "checksum": "adler32:f7c93f1c",
+      "size": 31940778,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupD.zip"
+    },
+    {
+      "checksum": "adler32:1365af22",
+      "size": 29267965,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupE.zip"
+    },
+    {
+      "checksum": "adler32:47c3a87e",
+      "size": 28081214,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupF.zip"
+    },
+    {
+      "checksum": "adler32:a046d36a",
+      "size": 30076956,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupG.zip"
+    },
+    {
+      "checksum": "adler32:b8d4bdb4",
+      "size": 28538518,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupH.zip"
+    },
+    {
+      "checksum": "adler32:4d793a63",
+      "size": 27552634,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupI.zip"
+    },
+    {
+      "checksum": "adler32:31fa9c16",
+      "size": 27067609,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:ab6a0267",
+      "size": 29146659,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupK.zip"
+    },
+    {
+      "checksum": "adler32:071b5676",
+      "size": 29567919,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupL.zip"
+    },
+    {
+      "checksum": "adler32:05bbd996",
+      "size": 28092177,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupM.zip"
+    },
+    {
+      "checksum": "adler32:8a7e4cf3",
+      "size": 27984237,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupN.zip"
+    },
+    {
+      "checksum": "adler32:f3ef7c8f",
+      "size": 30078874,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupO.zip"
+    },
+    {
+      "checksum": "adler32:64a8bb8c",
+      "size": 28487302,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupP.zip"
+    },
+    {
+      "checksum": "adler32:f4dd0916",
+      "size": 26305485,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:def44ab1",
+      "size": 25471851,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupR.zip"
+    },
+    {
+      "checksum": "adler32:14e1b4e6",
+      "size": 27262799,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupS.zip"
+    },
+    {
+      "checksum": "adler32:be10ac83",
+      "size": 25819134,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/25/groupT.zip"
     }
   ],
   "keywords": [
@@ -2257,11 +6256,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:8b86f6d8e90b08475cc5530c820470e1e2ecf8e4",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 26 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_26_file_index.txt"
+      "checksum": "adler32:f4d4e98b",
+      "size": 29342961,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupA.zip"
+    },
+    {
+      "checksum": "adler32:67d502da",
+      "size": 25755034,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupB.zip"
+    },
+    {
+      "checksum": "adler32:88fc663e",
+      "size": 27645484,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupC.zip"
+    },
+    {
+      "checksum": "adler32:c39ec942",
+      "size": 29018825,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupD.zip"
+    },
+    {
+      "checksum": "adler32:03d15051",
+      "size": 26943291,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupE.zip"
+    },
+    {
+      "checksum": "adler32:c3adab6e",
+      "size": 28210279,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupF.zip"
+    },
+    {
+      "checksum": "adler32:058f7605",
+      "size": 29279563,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupG.zip"
+    },
+    {
+      "checksum": "adler32:8a82f194",
+      "size": 29495042,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupH.zip"
+    },
+    {
+      "checksum": "adler32:8ec2cc69",
+      "size": 26808561,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupI.zip"
+    },
+    {
+      "checksum": "adler32:0d76c2a9",
+      "size": 27118251,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:d2b8dbcf",
+      "size": 29794519,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupK.zip"
+    },
+    {
+      "checksum": "adler32:a74494f5",
+      "size": 29810312,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupL.zip"
+    },
+    {
+      "checksum": "adler32:b4d73446",
+      "size": 27792737,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupM.zip"
+    },
+    {
+      "checksum": "adler32:1aed14b6",
+      "size": 27999805,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupN.zip"
+    },
+    {
+      "checksum": "adler32:08aff434",
+      "size": 27153764,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupO.zip"
+    },
+    {
+      "checksum": "adler32:c0506172",
+      "size": 26961940,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupP.zip"
+    },
+    {
+      "checksum": "adler32:46e89bb5",
+      "size": 27618371,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:1a433cf3",
+      "size": 26936582,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupR.zip"
+    },
+    {
+      "checksum": "adler32:cb4ac48e",
+      "size": 29907302,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupS.zip"
+    },
+    {
+      "checksum": "adler32:d305c4e5",
+      "size": 28281691,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/26/groupT.zip"
     }
   ],
   "keywords": [
@@ -2309,11 +6401,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:eca7fcd0135a6c8e4b44c5566078f57603dfb691",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 27 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_27_file_index.txt"
+      "checksum": "adler32:b048db7f",
+      "size": 30293028,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupA.zip"
+    },
+    {
+      "checksum": "adler32:16973a8a",
+      "size": 30462839,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupB.zip"
+    },
+    {
+      "checksum": "adler32:f3ae400e",
+      "size": 27171512,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupC.zip"
+    },
+    {
+      "checksum": "adler32:53220e60",
+      "size": 26427457,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupD.zip"
+    },
+    {
+      "checksum": "adler32:9675784e",
+      "size": 28418333,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupE.zip"
+    },
+    {
+      "checksum": "adler32:8cc362c7",
+      "size": 28631798,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupF.zip"
+    },
+    {
+      "checksum": "adler32:922520d3",
+      "size": 26582096,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupG.zip"
+    },
+    {
+      "checksum": "adler32:185a500e",
+      "size": 28883814,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupH.zip"
+    },
+    {
+      "checksum": "adler32:bd7ae6a4",
+      "size": 29036671,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupI.zip"
+    },
+    {
+      "checksum": "adler32:3f670f2e",
+      "size": 28395556,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:76a6592e",
+      "size": 28787116,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupK.zip"
+    },
+    {
+      "checksum": "adler32:70440a3a",
+      "size": 31193369,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupL.zip"
+    },
+    {
+      "checksum": "adler32:d248e50b",
+      "size": 27737989,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupM.zip"
+    },
+    {
+      "checksum": "adler32:a86a69d7",
+      "size": 27124937,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupN.zip"
+    },
+    {
+      "checksum": "adler32:caf01ed6",
+      "size": 28335042,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupO.zip"
+    },
+    {
+      "checksum": "adler32:627a36e5",
+      "size": 27793286,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupP.zip"
+    },
+    {
+      "checksum": "adler32:39c17f15",
+      "size": 25738158,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:88d0be52",
+      "size": 26055390,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupR.zip"
+    },
+    {
+      "checksum": "adler32:35382fe0",
+      "size": 25223534,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupS.zip"
+    },
+    {
+      "checksum": "adler32:86d0c889",
+      "size": 27491162,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/27/groupT.zip"
     }
   ],
   "keywords": [
@@ -2361,11 +6546,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:0789905c2fd72f8168fad1ca1bb9e73b67155244",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 28 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_28_file_index.txt"
+      "checksum": "adler32:12032cec",
+      "size": 31193150,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupA.zip"
+    },
+    {
+      "checksum": "adler32:573ba9a5",
+      "size": 29443266,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupB.zip"
+    },
+    {
+      "checksum": "adler32:8d119ced",
+      "size": 27859385,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupC.zip"
+    },
+    {
+      "checksum": "adler32:48a2e50e",
+      "size": 27241665,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupD.zip"
+    },
+    {
+      "checksum": "adler32:55b9f436",
+      "size": 28975610,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupE.zip"
+    },
+    {
+      "checksum": "adler32:3dbc980c",
+      "size": 26439393,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupF.zip"
+    },
+    {
+      "checksum": "adler32:028ae04d",
+      "size": 26237301,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupG.zip"
+    },
+    {
+      "checksum": "adler32:87267b18",
+      "size": 25463814,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupH.zip"
+    },
+    {
+      "checksum": "adler32:4109ef8a",
+      "size": 27747307,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupI.zip"
+    },
+    {
+      "checksum": "adler32:e2de0e13",
+      "size": 26353676,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:07d304ee",
+      "size": 28750865,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupK.zip"
+    },
+    {
+      "checksum": "adler32:d4687a8d",
+      "size": 27229648,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupL.zip"
+    },
+    {
+      "checksum": "adler32:69238b4e",
+      "size": 26422811,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupM.zip"
+    },
+    {
+      "checksum": "adler32:97021f7c",
+      "size": 27335766,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupN.zip"
+    },
+    {
+      "checksum": "adler32:4d319cf8",
+      "size": 27743575,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupO.zip"
+    },
+    {
+      "checksum": "adler32:3075d874",
+      "size": 27314100,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupP.zip"
+    },
+    {
+      "checksum": "adler32:3c6acf16",
+      "size": 28492221,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:06ca3b2b",
+      "size": 31700521,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupR.zip"
+    },
+    {
+      "checksum": "adler32:d9ab4dce",
+      "size": 26692652,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupS.zip"
+    },
+    {
+      "checksum": "adler32:66357d49",
+      "size": 26618226,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/28/groupT.zip"
     }
   ],
   "keywords": [
@@ -2413,11 +6691,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:d84f5e76e97d5f33de89cffc669080ed3504d39f",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 29 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_29_file_index.txt"
+      "checksum": "adler32:ef045077",
+      "size": 28259910,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupA.zip"
+    },
+    {
+      "checksum": "adler32:f5201bd4",
+      "size": 30360132,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupB.zip"
+    },
+    {
+      "checksum": "adler32:cf19310b",
+      "size": 27887967,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupC.zip"
+    },
+    {
+      "checksum": "adler32:d41b36fa",
+      "size": 27587825,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupD.zip"
+    },
+    {
+      "checksum": "adler32:f3e047a7",
+      "size": 27483338,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupE.zip"
+    },
+    {
+      "checksum": "adler32:696b259f",
+      "size": 27596724,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupF.zip"
+    },
+    {
+      "checksum": "adler32:d4d16a24",
+      "size": 29194912,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupG.zip"
+    },
+    {
+      "checksum": "adler32:f27d8751",
+      "size": 24474448,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupH.zip"
+    },
+    {
+      "checksum": "adler32:6b579475",
+      "size": 27443114,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupI.zip"
+    },
+    {
+      "checksum": "adler32:74d848ec",
+      "size": 30969588,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:c3ed296c",
+      "size": 30688521,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupK.zip"
+    },
+    {
+      "checksum": "adler32:1c836614",
+      "size": 30232153,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupL.zip"
+    },
+    {
+      "checksum": "adler32:142b4200",
+      "size": 28928839,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupM.zip"
+    },
+    {
+      "checksum": "adler32:e537f8dc",
+      "size": 29362032,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupN.zip"
+    },
+    {
+      "checksum": "adler32:d5bf0068",
+      "size": 28449140,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupO.zip"
+    },
+    {
+      "checksum": "adler32:beae4b63",
+      "size": 28231018,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupP.zip"
+    },
+    {
+      "checksum": "adler32:cc76eecb",
+      "size": 27083919,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:79621099",
+      "size": 27519892,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupR.zip"
+    },
+    {
+      "checksum": "adler32:164ce62e",
+      "size": 29062917,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupS.zip"
+    },
+    {
+      "checksum": "adler32:48ee61e1",
+      "size": 32668838,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/29/groupT.zip"
     }
   ],
   "keywords": [
@@ -2465,11 +6836,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:9a148ef491aa24ce3e38819428f461367bf6ddcf",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 30 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_30_file_index.txt"
+      "checksum": "adler32:6a2711ed",
+      "size": 32481653,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupA.zip"
+    },
+    {
+      "checksum": "adler32:f4005481",
+      "size": 30643486,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupB.zip"
+    },
+    {
+      "checksum": "adler32:7d0c5661",
+      "size": 28558164,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupC.zip"
+    },
+    {
+      "checksum": "adler32:c5b3669f",
+      "size": 28857245,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupD.zip"
+    },
+    {
+      "checksum": "adler32:794b442a",
+      "size": 28930260,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupE.zip"
+    },
+    {
+      "checksum": "adler32:ce5fb41c",
+      "size": 30404310,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupF.zip"
+    },
+    {
+      "checksum": "adler32:19ad6f71",
+      "size": 30094407,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupG.zip"
+    },
+    {
+      "checksum": "adler32:c9157cd1",
+      "size": 32525001,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupH.zip"
+    },
+    {
+      "checksum": "adler32:34ff2987",
+      "size": 29813848,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupI.zip"
+    },
+    {
+      "checksum": "adler32:46a10810",
+      "size": 29357350,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:17abbef4",
+      "size": 28010937,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupK.zip"
+    },
+    {
+      "checksum": "adler32:c2f673d8",
+      "size": 28757323,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupL.zip"
+    },
+    {
+      "checksum": "adler32:4fe77589",
+      "size": 31612233,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupM.zip"
+    },
+    {
+      "checksum": "adler32:6a1355ce",
+      "size": 30681159,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupN.zip"
+    },
+    {
+      "checksum": "adler32:8181369f",
+      "size": 30858111,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupO.zip"
+    },
+    {
+      "checksum": "adler32:564dd2bd",
+      "size": 30533229,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupP.zip"
+    },
+    {
+      "checksum": "adler32:a204594d",
+      "size": 29625764,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:843ed757",
+      "size": 31503594,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupR.zip"
+    },
+    {
+      "checksum": "adler32:12c2391d",
+      "size": 31184051,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupS.zip"
+    },
+    {
+      "checksum": "adler32:f0cc504b",
+      "size": 29107705,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/30/groupT.zip"
     }
   ],
   "keywords": [
@@ -2517,11 +6981,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:17d95e1592c4698aa3e70eae21c9ccd991d60f58",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 31 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_31_file_index.txt"
+      "checksum": "adler32:3f851f73",
+      "size": 33448624,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupA.zip"
+    },
+    {
+      "checksum": "adler32:367d86f6",
+      "size": 28936239,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupB.zip"
+    },
+    {
+      "checksum": "adler32:73527f59",
+      "size": 30131550,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupC.zip"
+    },
+    {
+      "checksum": "adler32:d1607923",
+      "size": 32184718,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupD.zip"
+    },
+    {
+      "checksum": "adler32:03fa328d",
+      "size": 28669680,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupE.zip"
+    },
+    {
+      "checksum": "adler32:95f59e2d",
+      "size": 29958089,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupF.zip"
+    },
+    {
+      "checksum": "adler32:61fb6066",
+      "size": 29456872,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupG.zip"
+    },
+    {
+      "checksum": "adler32:22f4b073",
+      "size": 28325272,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupH.zip"
+    },
+    {
+      "checksum": "adler32:3108f0cd",
+      "size": 26345217,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupI.zip"
+    },
+    {
+      "checksum": "adler32:04e94205",
+      "size": 30341706,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:3af4b8ea",
+      "size": 28588493,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupK.zip"
+    },
+    {
+      "checksum": "adler32:bf593bac",
+      "size": 29839505,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupL.zip"
+    },
+    {
+      "checksum": "adler32:74e23084",
+      "size": 31028449,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupM.zip"
+    },
+    {
+      "checksum": "adler32:f4dd0909",
+      "size": 30700501,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupN.zip"
+    },
+    {
+      "checksum": "adler32:7d4971c7",
+      "size": 28702350,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupO.zip"
+    },
+    {
+      "checksum": "adler32:b88a76d1",
+      "size": 33780657,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupP.zip"
+    },
+    {
+      "checksum": "adler32:a1927f46",
+      "size": 31553316,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:74ee33e6",
+      "size": 28552800,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupR.zip"
+    },
+    {
+      "checksum": "adler32:f9827208",
+      "size": 28496517,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupS.zip"
+    },
+    {
+      "checksum": "adler32:90eba662",
+      "size": 31352140,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/31/groupT.zip"
     }
   ],
   "keywords": [
@@ -2569,11 +7126,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:7f048f83ed52158e32e09366c34eba8be99f1e87",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 32 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_32_file_index.txt"
+      "checksum": "adler32:99f2e9a2",
+      "size": 31867661,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupA.zip"
+    },
+    {
+      "checksum": "adler32:d481a69c",
+      "size": 28146365,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupB.zip"
+    },
+    {
+      "checksum": "adler32:bdf1b086",
+      "size": 28738462,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupC.zip"
+    },
+    {
+      "checksum": "adler32:b0cadae4",
+      "size": 24943626,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupD.zip"
+    },
+    {
+      "checksum": "adler32:9cb70591",
+      "size": 26886996,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupE.zip"
+    },
+    {
+      "checksum": "adler32:a75e18ce",
+      "size": 27615180,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupF.zip"
+    },
+    {
+      "checksum": "adler32:99e3a721",
+      "size": 28844883,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupG.zip"
+    },
+    {
+      "checksum": "adler32:b85b0a5d",
+      "size": 27967948,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupH.zip"
+    },
+    {
+      "checksum": "adler32:73f833e6",
+      "size": 25734067,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupI.zip"
+    },
+    {
+      "checksum": "adler32:bf1448c6",
+      "size": 29253909,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:1fabc081",
+      "size": 27765497,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupK.zip"
+    },
+    {
+      "checksum": "adler32:923d2362",
+      "size": 26937193,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupL.zip"
+    },
+    {
+      "checksum": "adler32:957cf173",
+      "size": 28766371,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupM.zip"
+    },
+    {
+      "checksum": "adler32:950862b4",
+      "size": 30138306,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupN.zip"
+    },
+    {
+      "checksum": "adler32:c27c7e0b",
+      "size": 27679308,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupO.zip"
+    },
+    {
+      "checksum": "adler32:71348d15",
+      "size": 28573504,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupP.zip"
+    },
+    {
+      "checksum": "adler32:8ccca8d5",
+      "size": 28739964,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:323a2cd4",
+      "size": 27827644,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupR.zip"
+    },
+    {
+      "checksum": "adler32:cb4a9ddd",
+      "size": 29274364,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupS.zip"
+    },
+    {
+      "checksum": "adler32:d8aac89f",
+      "size": 29925397,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/32/groupT.zip"
     }
   ],
   "keywords": [
@@ -2621,11 +7271,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:659b0fd0dcbe85dbb82af5c47887396016c2f928",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 33 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_33_file_index.txt"
+      "checksum": "adler32:0b5cd225",
+      "size": 25072447,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupA.zip"
+    },
+    {
+      "checksum": "adler32:39451eb8",
+      "size": 26372410,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupB.zip"
+    },
+    {
+      "checksum": "adler32:8e3d08a5",
+      "size": 26981291,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupC.zip"
+    },
+    {
+      "checksum": "adler32:0544bd44",
+      "size": 27794414,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupD.zip"
+    },
+    {
+      "checksum": "adler32:6d99a2ad",
+      "size": 28802074,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupE.zip"
+    },
+    {
+      "checksum": "adler32:39da99cd",
+      "size": 26256136,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupF.zip"
+    },
+    {
+      "checksum": "adler32:99e6610a",
+      "size": 26048374,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupG.zip"
+    },
+    {
+      "checksum": "adler32:50b23339",
+      "size": 27291106,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupH.zip"
+    },
+    {
+      "checksum": "adler32:b0a392c7",
+      "size": 25563541,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupI.zip"
+    },
+    {
+      "checksum": "adler32:49a8c9ab",
+      "size": 27403474,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:06767b10",
+      "size": 31386814,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupK.zip"
+    },
+    {
+      "checksum": "adler32:a6214581",
+      "size": 28916509,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupL.zip"
+    },
+    {
+      "checksum": "adler32:ddb10451",
+      "size": 29679866,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupM.zip"
+    },
+    {
+      "checksum": "adler32:405db33c",
+      "size": 30835803,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupN.zip"
+    },
+    {
+      "checksum": "adler32:98ee26ba",
+      "size": 30135234,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupO.zip"
+    },
+    {
+      "checksum": "adler32:14276bd4",
+      "size": 29393844,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupP.zip"
+    },
+    {
+      "checksum": "adler32:a0e81d56",
+      "size": 29112507,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:f9b264d6",
+      "size": 30128744,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupR.zip"
+    },
+    {
+      "checksum": "adler32:dcca822b",
+      "size": 27712487,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupS.zip"
+    },
+    {
+      "checksum": "adler32:7c7cf609",
+      "size": 28236656,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/33/groupT.zip"
     }
   ],
   "keywords": [
@@ -2673,11 +7416,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:6cb709ad361941d79a1e19a0d0cf79a8987d251d",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 34 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_34_file_index.txt"
+      "checksum": "adler32:9b182840",
+      "size": 29599080,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupA.zip"
+    },
+    {
+      "checksum": "adler32:536c64fc",
+      "size": 29209294,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupB.zip"
+    },
+    {
+      "checksum": "adler32:9d9ede0d",
+      "size": 31773599,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupC.zip"
+    },
+    {
+      "checksum": "adler32:c64770e5",
+      "size": 25936478,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupD.zip"
+    },
+    {
+      "checksum": "adler32:2bc4c00c",
+      "size": 31237672,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupE.zip"
+    },
+    {
+      "checksum": "adler32:6c65f699",
+      "size": 30102353,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupF.zip"
+    },
+    {
+      "checksum": "adler32:a88bdf6b",
+      "size": 25871892,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupG.zip"
+    },
+    {
+      "checksum": "adler32:8b309f50",
+      "size": 27544584,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupH.zip"
+    },
+    {
+      "checksum": "adler32:ba33cc6b",
+      "size": 28547202,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupI.zip"
+    },
+    {
+      "checksum": "adler32:52ceaec0",
+      "size": 28942889,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:479cf0e1",
+      "size": 28643461,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupK.zip"
+    },
+    {
+      "checksum": "adler32:30ef5dc1",
+      "size": 27753612,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupL.zip"
+    },
+    {
+      "checksum": "adler32:073be5de",
+      "size": 28480360,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupM.zip"
+    },
+    {
+      "checksum": "adler32:d32f727c",
+      "size": 26285020,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupN.zip"
+    },
+    {
+      "checksum": "adler32:a7855589",
+      "size": 29236073,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupO.zip"
+    },
+    {
+      "checksum": "adler32:d748b6e0",
+      "size": 29332515,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupP.zip"
+    },
+    {
+      "checksum": "adler32:590f9166",
+      "size": 28261040,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:13953a16",
+      "size": 28942529,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupR.zip"
+    },
+    {
+      "checksum": "adler32:2fa4fcee",
+      "size": 25398961,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupS.zip"
+    },
+    {
+      "checksum": "adler32:1f8acf2f",
+      "size": 27840209,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/34/groupT.zip"
     }
   ],
   "keywords": [
@@ -2725,11 +7561,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:8d2c79fb300f8a2b98b326790c4eccd3c7bdb540",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 35 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_35_file_index.txt"
+      "checksum": "adler32:2f9248c1",
+      "size": 29791304,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupA.zip"
+    },
+    {
+      "checksum": "adler32:e459069d",
+      "size": 26824377,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupB.zip"
+    },
+    {
+      "checksum": "adler32:937ee052",
+      "size": 28486888,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupC.zip"
+    },
+    {
+      "checksum": "adler32:058c9534",
+      "size": 31157351,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupD.zip"
+    },
+    {
+      "checksum": "adler32:cf0b07e2",
+      "size": 27957462,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupE.zip"
+    },
+    {
+      "checksum": "adler32:caafe292",
+      "size": 24967169,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupF.zip"
+    },
+    {
+      "checksum": "adler32:9e675f21",
+      "size": 25712582,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupG.zip"
+    },
+    {
+      "checksum": "adler32:cbdec24c",
+      "size": 26477017,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupH.zip"
+    },
+    {
+      "checksum": "adler32:baf967e5",
+      "size": 27279657,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupI.zip"
+    },
+    {
+      "checksum": "adler32:db199a64",
+      "size": 28979754,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:2de71a80",
+      "size": 30266879,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupK.zip"
+    },
+    {
+      "checksum": "adler32:a2340ea9",
+      "size": 29957961,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupL.zip"
+    },
+    {
+      "checksum": "adler32:e05fcf6e",
+      "size": 31951767,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupM.zip"
+    },
+    {
+      "checksum": "adler32:7c118309",
+      "size": 29591786,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupN.zip"
+    },
+    {
+      "checksum": "adler32:4e0c07be",
+      "size": 30539584,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupO.zip"
+    },
+    {
+      "checksum": "adler32:2b267621",
+      "size": 32697905,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupP.zip"
+    },
+    {
+      "checksum": "adler32:30fae528",
+      "size": 30841834,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:4f418cd2",
+      "size": 29357955,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupR.zip"
+    },
+    {
+      "checksum": "adler32:a87328e0",
+      "size": 30366345,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupS.zip"
+    },
+    {
+      "checksum": "adler32:73c961a4",
+      "size": 27662345,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/35/groupT.zip"
     }
   ],
   "keywords": [
@@ -2777,11 +7706,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:66e8b679a551005812fc59e17f0a0e3e1a6a9112",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 36 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_36_file_index.txt"
+      "checksum": "adler32:212c79be",
+      "size": 29708172,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupA.zip"
+    },
+    {
+      "checksum": "adler32:b610352d",
+      "size": 29333802,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupB.zip"
+    },
+    {
+      "checksum": "adler32:9fc539ac",
+      "size": 29785053,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupC.zip"
+    },
+    {
+      "checksum": "adler32:3f566b9b",
+      "size": 25681994,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupD.zip"
+    },
+    {
+      "checksum": "adler32:a901d623",
+      "size": 28408445,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupE.zip"
+    },
+    {
+      "checksum": "adler32:92bfa779",
+      "size": 29178616,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupF.zip"
+    },
+    {
+      "checksum": "adler32:35b99243",
+      "size": 26935604,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupG.zip"
+    },
+    {
+      "checksum": "adler32:8f13d4c2",
+      "size": 27812952,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupH.zip"
+    },
+    {
+      "checksum": "adler32:ff8db788",
+      "size": 32110962,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupI.zip"
+    },
+    {
+      "checksum": "adler32:9750d8c6",
+      "size": 30035677,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:e5de1934",
+      "size": 31785243,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupK.zip"
+    },
+    {
+      "checksum": "adler32:9555f06d",
+      "size": 30188371,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupL.zip"
+    },
+    {
+      "checksum": "adler32:986da565",
+      "size": 31010072,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupM.zip"
+    },
+    {
+      "checksum": "adler32:34e17fcd",
+      "size": 29318151,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupN.zip"
+    },
+    {
+      "checksum": "adler32:146d24c7",
+      "size": 28645427,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupO.zip"
+    },
+    {
+      "checksum": "adler32:7f62400f",
+      "size": 28407024,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupP.zip"
+    },
+    {
+      "checksum": "adler32:d10275e8",
+      "size": 27905299,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:225f4274",
+      "size": 27934708,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupR.zip"
+    },
+    {
+      "checksum": "adler32:9f74b127",
+      "size": 28081395,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupS.zip"
+    },
+    {
+      "checksum": "adler32:be1481a2",
+      "size": 27926551,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/36/groupT.zip"
     }
   ],
   "keywords": [
@@ -2829,11 +7851,104 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:66f59db29957b2e61b5f6cef083ca1049d853c11",
-      "description": "ATLAS Masterclass ZPath 2015 dataset 37 file\n      index",
-      "size": 1800,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/file-indexes/ATLAS_MasterclassDatasets_ZPath_2015_dataset_37_file_index.txt"
+      "checksum": "adler32:940cc4b3",
+      "size": 27906622,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupA.zip"
+    },
+    {
+      "checksum": "adler32:b29b3141",
+      "size": 27828924,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupB.zip"
+    },
+    {
+      "checksum": "adler32:f0602f61",
+      "size": 27979553,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupC.zip"
+    },
+    {
+      "checksum": "adler32:da22a964",
+      "size": 28469778,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupD.zip"
+    },
+    {
+      "checksum": "adler32:83010c92",
+      "size": 31415719,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupE.zip"
+    },
+    {
+      "checksum": "adler32:a62b2cde",
+      "size": 32607193,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupF.zip"
+    },
+    {
+      "checksum": "adler32:e64b35fd",
+      "size": 30170679,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupG.zip"
+    },
+    {
+      "checksum": "adler32:83d1afd6",
+      "size": 26952244,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupH.zip"
+    },
+    {
+      "checksum": "adler32:7cb127f1",
+      "size": 29930669,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupI.zip"
+    },
+    {
+      "checksum": "adler32:0d7c5c52",
+      "size": 29517242,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupJ.zip"
+    },
+    {
+      "checksum": "adler32:e3cfd39c",
+      "size": 29249697,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupK.zip"
+    },
+    {
+      "checksum": "adler32:29eba780",
+      "size": 27634954,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupL.zip"
+    },
+    {
+      "checksum": "adler32:ed84aa94",
+      "size": 28848602,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupM.zip"
+    },
+    {
+      "checksum": "adler32:f9768408",
+      "size": 30429486,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupN.zip"
+    },
+    {
+      "checksum": "adler32:40295a5d",
+      "size": 32239262,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupO.zip"
+    },
+    {
+      "checksum": "adler32:35e1c282",
+      "size": 31182696,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupP.zip"
+    },
+    {
+      "checksum": "adler32:67f8b604",
+      "size": 27808659,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupQ.zip"
+    },
+    {
+      "checksum": "adler32:2f9f56ad",
+      "size": 31134424,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupR.zip"
+    },
+    {
+      "checksum": "adler32:fb794e54",
+      "size": 29465112,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupS.zip"
+    },
+    {
+      "checksum": "adler32:eb783554",
+      "size": 27905291,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/MasterclassDatasets/ZPath/2015/37/groupT.zip"
     }
   ],
   "keywords": [
@@ -2889,11 +8004,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:43be755b0921911f9f6e6fc8c4cd66cdb26b29b6",
-      "description": "DataEgamma file index",
-      "size": 94,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/DataEgamma_file_index.txt"
+      "checksum": "adler32:2df1e37e",
+      "size": 746284873,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/Data/DataEgamma.root"
     }
   ],
   "license": {
@@ -2963,11 +8076,9 @@
   "experiment": "ATLAS",
   "files": [
     {
-      "checksum": "sha1:0e3c8b09b2ec2d03cd93c8ba4aef3dfdc1cafd2d",
-      "description": "DataMuons file index",
-      "size": 93,
-      "type": "index",
-      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/file-indexes/DataMuons_file_index.txt"
+      "checksum": "adler32:a44ac4fe",
+      "size": 619800948,
+      "uri": "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2016-07-29/Data/DataMuons.root"
     }
   ],
   "license": {


### PR DESCRIPTION
* Changes `atlas-derived-datasets` records by removing the index files and
  attaching the asset files directly. This is sufficient for this collection
  containing relatively low number of files. (addresses #2093)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>