### PR TITLE
records: CMS 2011 collision datasets rich index files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2011A.json
@@ -31,17 +31,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:a0c48ed090c7e5d88d8a4c73b5e99f2ab188f957",
+      "checksum": "adler32:70cf4527",
+      "description": "BTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 270,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_BTag_AOD_12Oct2013-v1_00000_file_index.json"
+    },
+    {
+      "checksum": "adler32:441122c7",
       "description": "BTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 122,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_BTag_AOD_12Oct2013-v1_00000_file_index.txt"
     },
     {
-      "checksum": "sha1:b9ca7077636e006d44469ef878810cc716352458",
+      "checksum": "adler32:6cfccce7",
+      "description": "BTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 131274,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_BTag_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:f787654f",
       "description": "BTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 59536,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_BTag_AOD_12Oct2013-v1_20000_file_index.txt"
     }
   ],
@@ -144,17 +158,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:d16e00934a0775800419307f920e73a2de2d641d",
+      "checksum": "adler32:d8e853ac",
+      "description": "DoubleElectron AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 278723,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_DoubleElectron_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:c60078ad",
       "description": "DoubleElectron AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 131868,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_DoubleElectron_AOD_12Oct2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:15d2d9bc6623459b19fa847696c370df0371be00",
+      "checksum": "adler32:ecec5bff",
+      "description": "DoubleElectron AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 194744,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_DoubleElectron_AOD_12Oct2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "adler32:7070ac66",
       "description": "DoubleElectron AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 92136,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_DoubleElectron_AOD_12Oct2013-v1_20001_file_index.txt"
     }
   ],
@@ -257,24 +285,45 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:b68dbc3c1edae7266bccd66d97beca0fbacd2b58",
+      "checksum": "adler32:072715e1",
+      "description": "DoubleMu AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
+      "size": 272729,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_DoubleMu_AOD_12Oct2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "adler32:63627e87",
       "description": "DoubleMu AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
       "size": 125874,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_DoubleMu_AOD_12Oct2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:b5d3224005f3e04f7850106effe9094f3e0f2812",
+      "checksum": "adler32:94db3ed7",
+      "description": "DoubleMu AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
+      "size": 87089,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_DoubleMu_AOD_12Oct2013-v1_10001_file_index.json"
+    },
+    {
+      "checksum": "adler32:83438a22",
       "description": "DoubleMu AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
       "size": 40194,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_DoubleMu_AOD_12Oct2013-v1_10001_file_index.txt"
     },
     {
-      "checksum": "sha1:63868d0bf6e804eede62bc76a068c6ba5200c01a",
+      "checksum": "adler32:80178318",
+      "description": "DoubleMu AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
+      "size": 16262,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_DoubleMu_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:6a0b9263",
       "description": "DoubleMu AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
       "size": 7560,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_DoubleMu_AOD_12Oct2013-v1_20000_file_index.txt"
     }
   ],
@@ -377,24 +426,45 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:33d6a81033c220475e79a2d205e7eabe5f741e79",
+      "checksum": "adler32:a7896ec4",
+      "description": "ElectronHad AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
+      "size": 277934,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/ElectronHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_ElectronHad_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:43767a71",
       "description": "ElectronHad AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
       "size": 129903,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/ElectronHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_ElectronHad_AOD_12Oct2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:292e6653536afbc73a7473dd61ef68bffb1dda90",
+      "checksum": "adler32:14fe60c3",
+      "description": "ElectronHad AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
+      "size": 276002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/ElectronHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_ElectronHad_AOD_12Oct2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "adler32:42dd7092",
       "description": "ElectronHad AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
       "size": 129000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/ElectronHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_ElectronHad_AOD_12Oct2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:9a4707792323a271c9f5e8c289099152b0094b99",
+      "checksum": "adler32:0353d062",
+      "description": "ElectronHad AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
+      "size": 2762,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/ElectronHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_ElectronHad_AOD_12Oct2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "adler32:c17679a0",
       "description": "ElectronHad AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
       "size": 1290,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/ElectronHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_ElectronHad_AOD_12Oct2013-v1_20002_file_index.txt"
     }
   ],
@@ -465,8 +535,6 @@
   }
 }
 ,
-{}
-,
 {
   "abstract": {
     "description": "HT primary dataset in AOD format from RunA of 2011. Run period from run number 160404 to 173692."
@@ -499,38 +567,73 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:deba99194537dfda1f2f14e6b56e090bd240cfae",
+      "checksum": "adler32:6ce6ab0e",
+      "description": "HT AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
+      "size": 2672,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_00000_file_index.json"
+    },
+    {
+      "checksum": "adler32:37615446",
       "description": "HT AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
       "size": 1200,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_00000_file_index.txt"
     },
     {
-      "checksum": "sha1:c0569d916a2947c12d90716655dc72e1db927837",
+      "checksum": "adler32:0af930ce",
       "description": "HT AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
-      "size": 119880,
-      "type": "index",
+      "size": 266468,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:ba30a363",
+      "description": "HT AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
+      "size": 119760,
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:9bf5cc770c7928f10ecd033c4c6c2c74d8550eb4",
+      "checksum": "adler32:f9f398b7",
+      "description": "HT AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
+      "size": 267002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "adler32:3b46e5e8",
       "description": "HT AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
       "size": 120000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:29502f2240b71e831566b1d1d528fc3bef51c3a1",
+      "checksum": "adler32:6f8dac66",
+      "description": "HT AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
+      "size": 267002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "adler32:edfeeafe",
       "description": "HT AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
       "size": 120000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_20002_file_index.txt"
     },
     {
-      "checksum": "sha1:e3993012d4acc21e9733aa9bda3d45f744349660",
+      "checksum": "adler32:edbc741f",
+      "description": "HT AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
+      "size": 230690,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_20003_file_index.json"
+    },
+    {
+      "checksum": "adler32:f063e354",
       "description": "HT AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
       "size": 103680,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_20003_file_index.txt"
     }
   ],
@@ -633,24 +736,45 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:a321882fee80e7ff984d2bf8f7fef05743874253",
+      "checksum": "adler32:b2e9589c",
+      "description": "Jet AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
+      "size": 1341,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Jet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Jet_AOD_12Oct2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "adler32:0972ace0",
       "description": "Jet AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
       "size": 605,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Jet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Jet_AOD_12Oct2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:2cec22eb597b0b15cbd4cbdc63ca7f2ca2e2c9fd",
+      "checksum": "adler32:a6124665",
+      "description": "Jet AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
+      "size": 268267,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Jet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Jet_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:c288b526",
       "description": "Jet AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
       "size": 121121,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Jet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Jet_AOD_12Oct2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:7bb035660170644945866a5c73af32a0903b9e0a",
+      "checksum": "adler32:8cf47b2c",
+      "description": "Jet AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
+      "size": 58158,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Jet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Jet_AOD_12Oct2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "adler32:afa75e45",
       "description": "Jet AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
       "size": 26257,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Jet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Jet_AOD_12Oct2013-v1_20001_file_index.txt"
     }
   ],
@@ -753,10 +877,17 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:56002be740bb7baa43b2e78cf1615fd6c3a3237a",
+      "checksum": "adler32:c2838af4",
+      "description": "MET AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
+      "size": 196446,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MET/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MET_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:46d65aad",
       "description": "MET AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
       "size": 88693,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MET/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MET_AOD_12Oct2013-v1_20000_file_index.txt"
     }
   ],
@@ -859,17 +990,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:6acff68db6bf485c327d9dbd088be5882973c7ea",
+      "checksum": "adler32:339c45c5",
+      "description": "METBTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 273,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/METBTag/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_METBTag_AOD_12Oct2013-v1_00000_file_index.json"
+    },
+    {
+      "checksum": "adler32:b8b32387",
       "description": "METBTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 125,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/METBTag/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_METBTag_AOD_12Oct2013-v1_00000_file_index.txt"
     },
     {
-      "checksum": "sha1:0d2fdd4e1860e971a5116f5a393dabf1298d0195",
+      "checksum": "adler32:a6a3c90a",
+      "description": "METBTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 82146,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/METBTag/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_METBTag_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:80f73cb1",
       "description": "METBTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 37750,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/METBTag/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_METBTag_AOD_12Oct2013-v1_20000_file_index.txt"
     }
   ],
@@ -972,45 +1117,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:2c682da64ed60d2ef694478ae0c353a1f1cc566b",
+      "checksum": "adler32:2245a5a2",
+      "description": "MinimumBias AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 275725,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MinimumBias_AOD_12Oct2013-v1_00000_file_index.json"
+    },
+    {
+      "checksum": "adler32:ff0fac6c",
       "description": "MinimumBias AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 128871,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MinimumBias_AOD_12Oct2013-v1_00000_file_index.txt"
     },
     {
-      "checksum": "sha1:036491763d4e1510ad0bcc960c9865341fb952ca",
+      "checksum": "adler32:e1ec42a7",
+      "description": "MinimumBias AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 49130,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MinimumBias_AOD_12Oct2013-v1_00001_file_index.json"
+    },
+    {
+      "checksum": "adler32:cf485790",
       "description": "MinimumBias AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 22962,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MinimumBias_AOD_12Oct2013-v1_00001_file_index.txt"
     },
     {
-      "checksum": "sha1:20f017a181ca64e7a5495d08ce44218787603cb4",
+      "checksum": "adler32:dfdaebbd",
+      "description": "MinimumBias AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 14623,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MinimumBias_AOD_12Oct2013-v1_010000_file_index.json"
+    },
+    {
+      "checksum": "adler32:f1eddea9",
       "description": "MinimumBias AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 6890,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MinimumBias_AOD_12Oct2013-v1_010000_file_index.txt"
     },
     {
-      "checksum": "sha1:5797c05fd452ee7cd10229c2f769f49936ad88c6",
+      "checksum": "adler32:45375c56",
+      "description": "MinimumBias AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 275713,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MinimumBias_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:853d8c9e",
       "description": "MinimumBias AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 128871,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MinimumBias_AOD_12Oct2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:9ef968bdeebf15fcb9f15a640dd72b09295ee459",
+      "checksum": "adler32:6cdf1744",
+      "description": "MinimumBias AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 194030,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MinimumBias_AOD_12Oct2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "adler32:66bbe50f",
       "description": "MinimumBias AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 90687,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MinimumBias_AOD_12Oct2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:76c66fa1183b75b9082f8dc15eada697e1c87af3",
+      "checksum": "adler32:5e46a11f",
+      "description": "MinimumBias AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 5504,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MinimumBias_AOD_12Oct2013-v1_210000_file_index.json"
+    },
+    {
+      "checksum": "adler32:e1f8f8db",
       "description": "MinimumBias AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 2600,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MinimumBias_AOD_12Oct2013-v1_210000_file_index.txt"
     }
   ],
@@ -1113,17 +1300,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:1b1a9715174006645087999914bafa7af8d4e21e",
+      "checksum": "adler32:0462f54f",
+      "description": "MuEG AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 268733,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuEG/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuEG_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:a058e08f",
       "description": "MuEG AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 121878,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuEG/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuEG_AOD_12Oct2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:52458bae24cbf9ba55490fe42c9ae9f2c6afe494",
+      "checksum": "adler32:5231b178",
+      "description": "MuEG AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 82316,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuEG/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuEG_AOD_12Oct2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "adler32:180f9fd8",
       "description": "MuEG AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 37332,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuEG/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuEG_AOD_12Oct2013-v1_20001_file_index.txt"
     }
   ],
@@ -1226,24 +1427,45 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:0cc63529a098a7ef1a5739df27fa741098ab8fe5",
+      "checksum": "adler32:a8d50017",
+      "description": "MuHad AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
+      "size": 262684,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuHad_AOD_12Oct2013-v1_00000_file_index.json"
+    },
+    {
+      "checksum": "adler32:ef90d5a1",
       "description": "MuHad AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
       "size": 119679,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuHad_AOD_12Oct2013-v1_00000_file_index.txt"
     },
     {
-      "checksum": "sha1:1bfa3fbc9012133c04ba109967e93c5608984556",
+      "checksum": "adler32:e14c05d8",
+      "description": "MuHad AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
+      "size": 269732,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuHad_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:7bae6f6f",
       "description": "MuHad AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
       "size": 122877,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuHad_AOD_12Oct2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:683aca0ef0d1b913871d54bec836c1a33fc24c67",
+      "checksum": "adler32:f0756bbe",
+      "description": "MuHad AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
+      "size": 170372,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuHad_AOD_12Oct2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "adler32:8297e6eb",
       "description": "MuHad AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
       "size": 77613,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuHad_AOD_12Oct2013-v1_20001_file_index.txt"
     }
   ],
@@ -1346,31 +1568,59 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:05e16bf76319fb72efa33378c8b704aee2630c02",
+      "checksum": "adler32:09a4c4d1",
+      "description": "MuOnia AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
+      "size": 269647,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuOnia/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuOnia_AOD_12Oct2013-v1_00000_file_index.json"
+    },
+    {
+      "checksum": "adler32:488fb635",
       "description": "MuOnia AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
       "size": 123380,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuOnia/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuOnia_AOD_12Oct2013-v1_00000_file_index.txt"
     },
     {
-      "checksum": "sha1:a2025157420a78ddb6e396dbf2230a7f9104bc1c",
+      "checksum": "adler32:e5ab8024",
+      "description": "MuOnia AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
+      "size": 203793,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuOnia/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuOnia_AOD_12Oct2013-v1_00001_file_index.json"
+    },
+    {
+      "checksum": "adler32:df53dc26",
       "description": "MuOnia AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
       "size": 93248,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuOnia/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuOnia_AOD_12Oct2013-v1_00001_file_index.txt"
     },
     {
-      "checksum": "sha1:89851c27c70e0830db6e06971e9d5e007d73228b",
+      "checksum": "adler32:03f88a06",
+      "description": "MuOnia AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
+      "size": 135361,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuOnia/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuOnia_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:99f2bc91",
       "description": "MuOnia AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
       "size": 62000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuOnia/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuOnia_AOD_12Oct2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:9efe3eee3537695cb937cf685fa32bc671f77679",
+      "checksum": "adler32:78f7f245",
+      "description": "MuOnia AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
+      "size": 13820,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuOnia/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuOnia_AOD_12Oct2013-v1_210000_file_index.json"
+    },
+    {
+      "checksum": "adler32:20522827",
       "description": "MuOnia AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
       "size": 6375,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuOnia/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MuOnia_AOD_12Oct2013-v1_210000_file_index.txt"
     }
   ],
@@ -1473,31 +1723,59 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:2112bd17649f9749a05a0a8dfea4d37ce9e43d3c",
+      "checksum": "adler32:d34f2f51",
+      "description": "MultiJet AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
+      "size": 272729,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MultiJet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MultiJet_AOD_12Oct2013-v1_00000_file_index.json"
+    },
+    {
+      "checksum": "adler32:b2dd1e55",
       "description": "MultiJet AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
       "size": 125874,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MultiJet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MultiJet_AOD_12Oct2013-v1_00000_file_index.txt"
     },
     {
-      "checksum": "sha1:bfdfb903569f4f692dab8ba518318d0bfc8970a9",
+      "checksum": "adler32:3dcbf2ed",
+      "description": "MultiJet AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
+      "size": 34400,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MultiJet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MultiJet_AOD_12Oct2013-v1_00001_file_index.json"
+    },
+    {
+      "checksum": "adler32:fd8f0c15",
       "description": "MultiJet AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
       "size": 15876,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MultiJet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MultiJet_AOD_12Oct2013-v1_00001_file_index.txt"
     },
     {
-      "checksum": "sha1:fbf1c18b0fb44944244c94d88fe81caa521106a2",
+      "checksum": "adler32:ad0bcb52",
+      "description": "MultiJet AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
+      "size": 543545,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MultiJet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MultiJet_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:75324fbc",
       "description": "MultiJet AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
       "size": 251748,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MultiJet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MultiJet_AOD_12Oct2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:7c36d42c2e660fe35e4432fe504a4e327848d28e",
+      "checksum": "adler32:4de3fd22",
+      "description": "MultiJet AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
+      "size": 166856,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MultiJet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MultiJet_AOD_12Oct2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "adler32:3aac2206",
       "description": "MultiJet AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
       "size": 77364,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MultiJet/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_MultiJet_AOD_12Oct2013-v1_20001_file_index.txt"
     }
   ],
@@ -1600,38 +1878,73 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:7f40079aa4a451df8615910082a9107631aa08d8",
+      "checksum": "adler32:b1bcd2a7",
+      "description": "Photon AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
+      "size": 815,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Photon/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Photon_AOD_12Oct2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "adler32:54d16ba7",
       "description": "Photon AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
       "size": 372,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Photon/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Photon_AOD_12Oct2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:b7e68474a13ca713f7a692a7e2f95b65fd713073",
+      "checksum": "adler32:e9354719",
+      "description": "Photon AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
+      "size": 274,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Photon/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Photon_AOD_12Oct2013-v1_110000_file_index.json"
+    },
+    {
+      "checksum": "adler32:dc552441",
       "description": "Photon AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
       "size": 125,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Photon/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Photon_AOD_12Oct2013-v1_110000_file_index.txt"
     },
     {
-      "checksum": "sha1:6a93f5c22c6e540286f50aad4b0406ff196ba3c1",
+      "checksum": "adler32:7647de7d",
+      "description": "Photon AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
+      "size": 277192,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Photon/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Photon_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:9fb1b452",
       "description": "Photon AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
       "size": 126852,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Photon/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Photon_AOD_12Oct2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:582500f371322cad7397cc7d5524a04baf52db5a",
+      "checksum": "adler32:c156b7aa",
+      "description": "Photon AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
+      "size": 271002,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Photon/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Photon_AOD_12Oct2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "adler32:3f678961",
       "description": "Photon AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
       "size": 124000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Photon/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Photon_AOD_12Oct2013-v1_20001_file_index.txt"
     },
     {
-      "checksum": "sha1:ab0fe6e53f98b5966b9a061a35b46bf1a7f90372",
+      "checksum": "adler32:9bda8ae4",
+      "description": "Photon AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
+      "size": 227371,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Photon/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Photon_AOD_12Oct2013-v1_20002_file_index.json"
+    },
+    {
+      "checksum": "adler32:f881f70a",
       "description": "Photon AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
       "size": 104036,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Photon/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Photon_AOD_12Oct2013-v1_20002_file_index.txt"
     }
   ],
@@ -1734,17 +2047,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:f61e5d7bc3360ea939aa8f3864c2fb88e941e4c7",
+      "checksum": "adler32:e1c9b849",
+      "description": "PhotonHad AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 98305,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/PhotonHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_PhotonHad_AOD_12Oct2013-v1_00000_file_index.json"
+    },
+    {
+      "checksum": "adler32:2f00c51f",
       "description": "PhotonHad AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 45593,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/PhotonHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_PhotonHad_AOD_12Oct2013-v1_00000_file_index.txt"
     },
     {
-      "checksum": "sha1:281574b87f124b8ddcf7102652df92d4119642cd",
+      "checksum": "adler32:80037b6c",
+      "description": "PhotonHad AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 198378,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/PhotonHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_PhotonHad_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:c5698604",
       "description": "PhotonHad AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 91948,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/PhotonHad/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_PhotonHad_AOD_12Oct2013-v1_20000_file_index.txt"
     }
   ],
@@ -1847,24 +2174,45 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:b5718a04bed44b4a9667789ee9bc60a208f7a0c8",
+      "checksum": "adler32:507b6647",
+      "description": "SingleElectron AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
+      "size": 7204,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleElectron/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleElectron_AOD_12Oct2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "adler32:70ecf57b",
       "description": "SingleElectron AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
       "size": 3432,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleElectron/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleElectron_AOD_12Oct2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:9243e3158f3761d6774b708d3727b6f8c444724b",
+      "checksum": "adler32:7d176350",
+      "description": "SingleElectron AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
+      "size": 287864,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleElectron/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleElectron_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:6133dbd4",
       "description": "SingleElectron AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
       "size": 136224,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleElectron/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleElectron_AOD_12Oct2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:f64294f570ae605021659bfa9507274e68d109f2",
+      "checksum": "adler32:ddcf17ca",
+      "description": "SingleElectron AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
+      "size": 135038,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleElectron/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleElectron_AOD_12Oct2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "adler32:d2f51507",
       "description": "SingleElectron AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
       "size": 63888,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleElectron/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleElectron_AOD_12Oct2013-v1_20001_file_index.txt"
     }
   ],
@@ -1967,31 +2315,59 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:3f3f5846d19b15bb5ee52e8d0cbf2bb84b5fa868",
+      "checksum": "adler32:6fc13e5e",
+      "description": "SingleMu AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
+      "size": 512532,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleMu_AOD_12Oct2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "adler32:e2fc908b",
       "description": "SingleMu AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
       "size": 237132,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleMu_AOD_12Oct2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:83c8e6c2a0ac613eb9313a57c71aec9772aa0c11",
+      "checksum": "adler32:8c4205c9",
+      "description": "SingleMu AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
+      "size": 77807,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleMu_AOD_12Oct2013-v1_10001_file_index.json"
+    },
+    {
+      "checksum": "adler32:ceabca7d",
       "description": "SingleMu AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
       "size": 35910,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleMu_AOD_12Oct2013-v1_10001_file_index.txt"
     },
     {
-      "checksum": "sha1:1f3f572817c6f380943ed48195454b578aa2f6db",
+      "checksum": "adler32:a42417fb",
+      "description": "SingleMu AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
+      "size": 273001,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleMu_AOD_12Oct2013-v1_20000_file_index.json"
+    },
+    {
+      "checksum": "adler32:b5031097",
       "description": "SingleMu AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
       "size": 126000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleMu_AOD_12Oct2013-v1_20000_file_index.txt"
     },
     {
-      "checksum": "sha1:9c2876f18b4256c56a6e36523369359d5ffb2cef",
+      "checksum": "adler32:4b184f6b",
+      "description": "SingleMu AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
+      "size": 220859,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleMu_AOD_12Oct2013-v1_20001_file_index.json"
+    },
+    {
+      "checksum": "adler32:eed8cb98",
       "description": "SingleMu AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
       "size": 101934,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_SingleMu_AOD_12Oct2013-v1_20001_file_index.txt"
     }
   ],
@@ -2094,10 +2470,17 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:c05201f7947a7797225d459be1cae4c636f8a573",
+      "checksum": "adler32:d1947d76",
+      "description": "Tau AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
+      "size": 211454,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Tau/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Tau_AOD_12Oct2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "adler32:e47b4287",
       "description": "Tau AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
       "size": 95469,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Tau/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_Tau_AOD_12Oct2013-v1_10000_file_index.txt"
     }
   ],
@@ -2199,17 +2582,31 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:6849f05c4cdf49ac92bac1ec1de3095a222db665",
+      "checksum": "adler32:f5f4674b",
+      "description": "TauPlusX AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
+      "size": 273821,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/TauPlusX/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_TauPlusX_AOD_12Oct2013-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "adler32:d03c3a0a",
       "description": "TauPlusX AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
       "size": 126378,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/TauPlusX/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_TauPlusX_AOD_12Oct2013-v1_10000_file_index.txt"
     },
     {
-      "checksum": "sha1:7623fcfd0166521fdc3f1ffe6b34a2d5abd739f3",
+      "checksum": "adler32:2287eb18",
+      "description": "TauPlusX AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
+      "size": 114662,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/TauPlusX/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_TauPlusX_AOD_12Oct2013-v1_10001_file_index.json"
+    },
+    {
+      "checksum": "adler32:5e515c42",
       "description": "TauPlusX AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
       "size": 52920,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/TauPlusX/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_TauPlusX_AOD_12Oct2013-v1_10001_file_index.txt"
     }
   ],


### PR DESCRIPTION
* Adds rich index files (TXT, JSON) to `cms-primary-datasets-Run2011A`
  records. (addresses #2093)

* Removes empty record (coming from a conversion of a deleted dataset that was
  never officially released).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>