### PR TITLE
records: fix Run2010B run period in CMS dataset titles

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-csv-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-csv-files.json
@@ -205,7 +205,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.B8MR.C4A2",
       "recid": "14",
-      "title": "/Mu/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/Mu/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],

--- a/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana.json
@@ -52,7 +52,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.B8MR.C4A2",
       "recid": "14",
-      "title": "/Mu/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/Mu/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     },
     {
@@ -65,7 +65,7 @@
   "system_details": {
     "release": "CMSSW_4_2_8"
   },
-  "title": "Muons and electrons in PAT candidate format derived from /Mu/Run-2010B-Apr21ReReco-v1/AOD primary dataset",
+  "title": "Muons and electrons in PAT candidate format derived from /Mu/Run2010B-Apr21ReReco-v1/AOD primary dataset",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -143,7 +143,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.PDY4.7H2H",
       "recid": "4",
-      "title": "/Electron/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/Electron/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     },
     {
@@ -156,7 +156,7 @@
   "system_details": {
     "release": "CMSSW_4_2_8"
   },
-  "title": "Muons and electrons in PAT candidate format derived from /Electron/Run-2010B-Apr21ReReco-v1/AOD primary dataset",
+  "title": "Muons and electrons in PAT candidate format derived from /Electron/Run2010B-Apr21ReReco-v1/AOD primary dataset",
   "type": {
     "primary": "Dataset",
     "secondary": [

--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files.json
@@ -1,7 +1,7 @@
 [
 {
   "abstract": {
-    "description": "Sample event set from /BTau/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /BTau/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -50,7 +50,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.A342.9982",
       "recid": "1",
-      "title": "/BTau/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/BTau/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -59,7 +59,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /BTau/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /BTau/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -79,7 +79,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /EGMonitor/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /EGMonitor/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -128,7 +128,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.93E7.64SK",
       "recid": "3",
-      "title": "/EGMonitor/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/EGMonitor/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -137,7 +137,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /EGMonitor/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /EGMonitor/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -157,7 +157,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /Electron/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /Electron/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -206,7 +206,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.PDY4.7H2H",
       "recid": "4",
-      "title": "/Electron/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/Electron/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -215,7 +215,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /Electron/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /Electron/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -235,7 +235,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /Jet/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /Jet/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -284,7 +284,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.3S7F.2E9W",
       "recid": "5",
-      "title": "/Jet/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/Jet/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -293,7 +293,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /Jet/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /Jet/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -313,7 +313,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /JetMETTauMonitor/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /JetMETTauMonitor/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -362,7 +362,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.WV7H.T2B8",
       "recid": "6",
-      "title": "/JetMETTauMonitor/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/JetMETTauMonitor/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -371,7 +371,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /JetMETTauMonitor/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /JetMETTauMonitor/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -391,7 +391,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /METFwd/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /METFwd/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -440,7 +440,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.GSK4.32RS",
       "recid": "7",
-      "title": "/METFwd/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/METFwd/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -449,7 +449,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /METFwd/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /METFwd/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -469,7 +469,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /Mu/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /Mu/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -518,7 +518,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.B8MR.C4A2",
       "recid": "14",
-      "title": "/Mu/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/Mu/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -527,7 +527,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /Mu/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /Mu/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -547,7 +547,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /MuMonitor/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /MuMonitor/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -596,7 +596,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.KYMN.CR5R",
       "recid": "9",
-      "title": "/MuMonitor/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/MuMonitor/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -605,7 +605,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /MuMonitor/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /MuMonitor/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -625,7 +625,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /MuOnia/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /MuOnia/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -674,7 +674,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.TME9.7FP2",
       "recid": "10",
-      "title": "/MuOnia/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/MuOnia/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -683,7 +683,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /MuOnia/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /MuOnia/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -703,7 +703,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /MultiJet/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /MultiJet/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -752,7 +752,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.QAJC.TR8V",
       "recid": "11",
-      "title": "/MultiJet/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/MultiJet/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -761,7 +761,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /MultiJet/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /MultiJet/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -781,7 +781,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /Photon/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /Photon/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -830,7 +830,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.QKAX.PSW6",
       "recid": "12",
-      "title": "/Photon/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/Photon/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -839,7 +839,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /Photon/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /Photon/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -859,7 +859,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /Commissioning/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /Commissioning/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -908,7 +908,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.VTD5.V7Y3",
       "recid": "2",
-      "title": "/Commissioning/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/Commissioning/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -917,7 +917,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /Commissioning/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /Commissioning/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -937,7 +937,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /MinimumBias/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /MinimumBias/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -986,7 +986,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.6BPY.XFRQ",
       "recid": "8",
-      "title": "/MinimumBias/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/MinimumBias/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -995,7 +995,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /MinimumBias/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /MinimumBias/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [
@@ -1015,7 +1015,7 @@
 ,
 {
   "abstract": {
-    "description": "Sample event set from /ZeroBias/Run-2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
+    "description": "Sample event set from /ZeroBias/Run2010B-Apr21ReReco-v1/AOD primary dataset in json format readable from the browser-based 3d event display"
   },
   "accelerator": "CERN-LHC",
   "authors": [
@@ -1064,7 +1064,7 @@
     {
       "doi": "10.7483/OPENDATA.CMS.ACV6.SYP3",
       "recid": "13",
-      "title": "/ZeroBias/Run-2010B-Apr21ReReco-v1/AOD",
+      "title": "/ZeroBias/Run2010B-Apr21ReReco-v1/AOD",
       "type": "isChildOf"
     }
   ],
@@ -1073,7 +1073,7 @@
     "global_tag": "GR_R_42_V25::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "Event display file derived from /ZeroBias/Run-2010B-Apr21ReReco-v1/AOD",
+  "title": "Event display file derived from /ZeroBias/Run2010B-Apr21ReReco-v1/AOD",
   "type": {
     "primary": "Dataset",
     "secondary": [

--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets.json
@@ -91,7 +91,7 @@
   "recid": "1",
   "relations": [
     {
-      "title": "/BTau/Run-2010B-v1/RAW",
+      "title": "/BTau/Run2010B-v1/RAW",
       "type": "isChildOf"
     }
   ],
@@ -100,8 +100,8 @@
     "global_tag": "FT_R_42_V10A::All",
     "release": "CMSSW_4_2_8"
   },
-  "title": "/BTau/Run-2010B-Apr21ReReco-v1/AOD",
-  "title_additional": "BTau primary dataset in AOD format from RunB of 2010 (/BTau/Run-2010B-Apr21ReReco-v1/AOD)",
+  "title": "/BTau/Run2010B-Apr21ReReco-v1/AOD",
+  "title_additional": "BTau primary dataset in AOD format from RunB of 2010 (/BTau/Run2010B-Apr21ReReco-v1/AOD)",
   "type": {
     "primary": "Dataset",
     "secondary": [


### PR DESCRIPTION
* Fixes CMS dataset titles that were using `Run-2010B` instead of `Run2010B`.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>