### PR TITLE
records: CMS 2010 collision datasets rich index files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets.json
@@ -31,45 +31,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:8bc4211afc79335b32c29b3c5c83414c907e808e",
+      "checksum": "adler32:72ce7bd5",
+      "description": "BTau AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 168328,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:ae6e2ee6",
       "description": "BTau AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 76875,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:2b0c56c2131d1e77e33c24b05fb0ace4c3f2a9a8",
+      "checksum": "adler32:ea75eb17",
+      "description": "BTau AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 96106,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0001_file_index.json"
+    },
+    {
+      "checksum": "adler32:25a76061",
       "description": "BTau AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 43911,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0001_file_index.txt"
     },
     {
-      "checksum": "sha1:7411de0e41f2777afd9cd2f60ff2d93895dc44d5",
+      "checksum": "adler32:a0bf3ab7",
+      "description": "BTau AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 140536,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:f71daa97",
       "description": "BTau AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 64206,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:d1a7fdf03178a9b96e31f26e0113afd0b386ef91",
+      "checksum": "adler32:c7a212df",
+      "description": "BTau AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 121759,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0003_file_index.json"
+    },
+    {
+      "checksum": "adler32:f700cb91",
       "description": "BTau AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 55596,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0003_file_index.txt"
     },
     {
-      "checksum": "sha1:c65e5a1e7bf08847b854d39cd9e30267142b32c8",
+      "checksum": "adler32:6adc7235",
+      "description": "BTau AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 125005,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0004_file_index.json"
+    },
+    {
+      "checksum": "adler32:7a9d893f",
       "description": "BTau AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 57072,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0004_file_index.txt"
     },
     {
-      "checksum": "sha1:e4513e16f362d54abca56dc25a0aae3a1e471dd7",
+      "checksum": "adler32:ad5e2d35",
+      "description": "BTau AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 133581,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0005_file_index.json"
+    },
+    {
+      "checksum": "adler32:89c50ab4",
       "description": "BTau AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 61008,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_BTau_AOD_Apr21ReReco-v1_0005_file_index.txt"
     }
   ],
@@ -172,38 +214,73 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:48b917c1c36ab97a72837fd66f902a3a5b238d01",
+      "checksum": "adler32:8feda990",
+      "description": "ZeroBias AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
+      "size": 21064,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:9e34629c",
       "description": "ZeroBias AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
       "size": 9779,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:3a86952eb5df0f8c112d31ef5ff6d6a9cf83a140",
+      "checksum": "adler32:c04352bf",
+      "description": "ZeroBias AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
+      "size": 7126,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0001_file_index.json"
+    },
+    {
+      "checksum": "adler32:c6aed778",
       "description": "ZeroBias AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
       "size": 3302,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0001_file_index.txt"
     },
     {
-      "checksum": "sha1:35874edd9f1c5661fe9a17ddd44da2c87e04733a",
+      "checksum": "adler32:d88a7e2a",
+      "description": "ZeroBias AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
+      "size": 4380,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:31545bf1",
       "description": "ZeroBias AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
       "size": 2032,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:96e59aaa389eac28130d5835c768d489be7266b5",
+      "checksum": "adler32:1ff13722",
+      "description": "ZeroBias AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
+      "size": 4097,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0006_file_index.json"
+    },
+    {
+      "checksum": "adler32:2a8937ee",
       "description": "ZeroBias AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
       "size": 1905,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0006_file_index.txt"
     },
     {
-      "checksum": "sha1:d5652ff5f8ff2af79bc54d886c8cb7817328635c",
+      "checksum": "adler32:df1920a0",
+      "description": "ZeroBias AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
+      "size": 1095,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0008_file_index.json"
+    },
+    {
+      "checksum": "adler32:7aa79750",
       "description": "ZeroBias AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
       "size": 508,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/ZeroBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_ZeroBias_AOD_Apr21ReReco-v1_0008_file_index.txt"
     }
   ],
@@ -306,31 +383,59 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:e6788af65eafed782c6b7f9bc575ade90078131c",
+      "checksum": "adler32:dfd12717",
+      "description": "Commissioning AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
+      "size": 133487,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:3ac40fb3",
       "description": "Commissioning AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
       "size": 63228,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:ca4d9018f949bfc6361ec83399c56158465ea43e",
+      "checksum": "adler32:96fd94cc",
+      "description": "Commissioning AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
+      "size": 558,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:a96b502b",
       "description": "Commissioning AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
       "size": 264,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:db26ce03a74804561c715d6038d1815d344e748d",
+      "checksum": "adler32:27cbf597",
+      "description": "Commissioning AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
+      "size": 21964,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0003_file_index.json"
+    },
+    {
+      "checksum": "adler32:aa2b67be",
       "description": "Commissioning AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
       "size": 10428,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0003_file_index.txt"
     },
     {
-      "checksum": "sha1:06adb6cadf67ef1fa3ac6fcf3d48349df19068fe",
+      "checksum": "adler32:50b114b4",
+      "description": "Commissioning AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
+      "size": 5840,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0004_file_index.json"
+    },
+    {
+      "checksum": "adler32:5ce54ad1",
       "description": "Commissioning AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
       "size": 2772,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Commissioning/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Commissioning_AOD_Apr21ReReco-v1_0004_file_index.txt"
     }
   ],
@@ -433,45 +538,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:c0f1f2f83b5f3babd22633e051b9b75c16e9c5fc",
+      "checksum": "adler32:f1817ce9",
+      "description": "EGMonitor AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 121072,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:45b9aa25",
       "description": "EGMonitor AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 56448,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:40709297d18de06979f998188538b7269300f9bf",
+      "checksum": "adler32:4047241c",
+      "description": "EGMonitor AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 18634,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0001_file_index.json"
+    },
+    {
+      "checksum": "adler32:7a291df2",
       "description": "EGMonitor AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 8704,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0001_file_index.txt"
     },
     {
-      "checksum": "sha1:1eb3143ce8fcafc34798071c393207f62aa022f2",
+      "checksum": "adler32:e419eb89",
+      "description": "EGMonitor AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 25210,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:a2f0b3be",
       "description": "EGMonitor AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 11776,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:24e8ee09b6d197bbaf38ee567245d224957d881f",
+      "checksum": "adler32:f6cc75bc",
+      "description": "EGMonitor AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 27676,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0003_file_index.json"
+    },
+    {
+      "checksum": "adler32:d0cb09af",
       "description": "EGMonitor AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 12928,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0003_file_index.txt"
     },
     {
-      "checksum": "sha1:ddcc5ef5dc30f22c51a6ae16d13ede6fc424e2e6",
+      "checksum": "adler32:e6a4290a",
+      "description": "EGMonitor AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 7948,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0004_file_index.json"
+    },
+    {
+      "checksum": "adler32:8d5650a8",
       "description": "EGMonitor AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 3712,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0004_file_index.txt"
     },
     {
-      "checksum": "sha1:50662bc9d206fdd5032cfbd913dd7679c2993f50",
+      "checksum": "adler32:d345d180",
+      "description": "EGMonitor AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 13428,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0005_file_index.json"
+    },
+    {
+      "checksum": "adler32:48e14d57",
       "description": "EGMonitor AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 6272,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_EGMonitor_AOD_Apr21ReReco-v1_0005_file_index.txt"
     }
   ],
@@ -574,45 +721,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:dea5e984b15fd7f2472cca34c0f173382dc5ccb1",
+      "checksum": "adler32:d1e3cf91",
+      "description": "Electron AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 231629,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:d3e0a449",
       "description": "Electron AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 107569,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:ff13d826efb5d05eb7cb2f585c08d0b82447bc8a",
+      "checksum": "adler32:84a1f330",
+      "description": "Electron AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 168805,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0001_file_index.json"
+    },
+    {
+      "checksum": "adler32:6ef080e0",
       "description": "Electron AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 78359,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0001_file_index.txt"
     },
     {
-      "checksum": "sha1:7725a2b4ed57297973d375e15828924c4a2e3fd8",
+      "checksum": "adler32:f640d6fa",
+      "description": "Electron AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 128816,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:1f8cdfc5",
       "description": "Electron AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 59817,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:372d143c485195feaa3d8a5e5fd371fb2b291061",
+      "checksum": "adler32:22b18f13",
+      "description": "Electron AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 121788,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0003_file_index.json"
+    },
+    {
+      "checksum": "adler32:11c0097d",
       "description": "Electron AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 56515,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0003_file_index.txt"
     },
     {
-      "checksum": "sha1:a8b38b806bdf2c47afe7c15c4e5316f8cdc30a87",
+      "checksum": "adler32:10b00be4",
+      "description": "Electron AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 129079,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0004_file_index.json"
+    },
+    {
+      "checksum": "adler32:ba060251",
       "description": "Electron AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 59944,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0004_file_index.txt"
     },
     {
-      "checksum": "sha1:d86d1c56e90dc9e86762a943dbe2a64a0b066800",
+      "checksum": "adler32:285a34c5",
+      "description": "Electron AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 98157,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0005_file_index.json"
+    },
+    {
+      "checksum": "adler32:211e43c0",
       "description": "Electron AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 45593,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Electron_AOD_Apr21ReReco-v1_0005_file_index.txt"
     }
   ],
@@ -715,45 +904,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:9eb1ff9e465d34e9d1130fca8b0b044d3960f963",
+      "checksum": "adler32:0d6ebe30",
+      "description": "Jet AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 170474,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:2737f1f7",
       "description": "Jet AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 77470,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:6d703e5d19d461689b3d86981155d1d091a36f08",
+      "checksum": "adler32:a933b350",
+      "description": "Jet AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 83999,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0001_file_index.json"
+    },
+    {
+      "checksum": "adler32:57cadf79",
       "description": "Jet AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 38186,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0001_file_index.txt"
     },
     {
-      "checksum": "sha1:1bdd024e5b593659abc8e35c956b26cb46aa5d9f",
+      "checksum": "adler32:523a47eb",
+      "description": "Jet AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 46421,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:46aa39f8",
       "description": "Jet AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 21106,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:9167b285d5eb44e6e8c8bf5226b2e449b2bebb84",
+      "checksum": "adler32:98a65832",
+      "description": "Jet AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 66049,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0003_file_index.json"
+    },
+    {
+      "checksum": "adler32:28787935",
       "description": "Jet AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 30012,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0003_file_index.txt"
     },
     {
-      "checksum": "sha1:2f687cfd0fa9c102973df8b67711b8ba1c2cdeb5",
+      "checksum": "adler32:53b5ad4f",
+      "description": "Jet AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 41833,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0004_file_index.json"
+    },
+    {
+      "checksum": "adler32:141add3b",
       "description": "Jet AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 19032,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0004_file_index.txt"
     },
     {
-      "checksum": "sha1:6a24eca75f074cc53f2505c61a55e5c01a138a73",
+      "checksum": "adler32:e68aaace",
+      "description": "Jet AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 37918,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0005_file_index.json"
+    },
+    {
+      "checksum": "adler32:f6a0c677",
       "description": "Jet AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 17202,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Jet_AOD_Apr21ReReco-v1_0005_file_index.txt"
     }
   ],
@@ -856,45 +1087,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:47c56d21dbbb07252d8c8def35bf02728b169c9c",
+      "checksum": "adler32:1491b7bf",
+      "description": "Photon AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 205672,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:290e595b",
       "description": "Photon AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 94750,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:122f35127765ede51f9fac5232acf61972dfc29e",
+      "checksum": "adler32:7936822a",
+      "description": "Photon AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 120877,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0001_file_index.json"
+    },
+    {
+      "checksum": "adler32:a3fef6d1",
       "description": "Photon AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 55750,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0001_file_index.txt"
     },
     {
-      "checksum": "sha1:76843508666f4b3d78ef253207182a26b65cb0da",
+      "checksum": "adler32:7d7e6f5c",
+      "description": "Photon AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 90698,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:091aac31",
       "description": "Photon AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 41750,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:7fb784b02e8f47b4ae967e4e03d88f0693fec920",
+      "checksum": "adler32:f8149bbd",
+      "description": "Photon AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 167630,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0003_file_index.json"
+    },
+    {
+      "checksum": "adler32:f5f20281",
       "description": "Photon AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 77250,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0003_file_index.txt"
     },
     {
-      "checksum": "sha1:70d1787739a67262069e5b603d65c67b3c68bb88",
+      "checksum": "adler32:d818519a",
+      "description": "Photon AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 101317,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0004_file_index.json"
+    },
+    {
+      "checksum": "adler32:aa3758d4",
       "description": "Photon AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 46625,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0004_file_index.txt"
     },
     {
-      "checksum": "sha1:0a62a817931fc31be49d257e9c24f857566eb734",
+      "checksum": "adler32:b8539a3d",
+      "description": "Photon AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 77297,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0005_file_index.json"
+    },
+    {
+      "checksum": "adler32:6e3684e4",
       "description": "Photon AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 35625,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Photon_AOD_Apr21ReReco-v1_0005_file_index.txt"
     }
   ],
@@ -997,31 +1270,59 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:a31dff15d059bc7ef127ef6cbecf272d0d7c8297",
+      "checksum": "adler32:a3ac785d",
+      "description": "MultiJet AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
+      "size": 169645,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MultiJet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:ccf2b310",
       "description": "MultiJet AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
       "size": 78740,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MultiJet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:13094fa056cd704e5516d869e7cf1b24d4955337",
+      "checksum": "adler32:02080d91",
+      "description": "MultiJet AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
+      "size": 154669,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MultiJet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0001_file_index.json"
+    },
+    {
+      "checksum": "adler32:d401b513",
       "description": "MultiJet AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
       "size": 71882,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MultiJet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0001_file_index.txt"
     },
     {
-      "checksum": "sha1:80ef3fa81cfac36c7cd7528654eef1ca1da8db9c",
+      "checksum": "adler32:67be11c2",
+      "description": "MultiJet AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
+      "size": 159488,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MultiJet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:02103c64",
       "description": "MultiJet AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
       "size": 74041,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MultiJet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:4210cfa21536cadf4bf13caf0cf24774323f6113",
+      "checksum": "adler32:3f17eef1",
+      "description": "MultiJet AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
+      "size": 102006,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MultiJet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0003_file_index.json"
+    },
+    {
+      "checksum": "adler32:c9f8300c",
       "description": "MultiJet AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
       "size": 47371,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MultiJet/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MultiJet_AOD_Apr21ReReco-v1_0003_file_index.txt"
     }
   ],
@@ -1124,10 +1425,17 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:c080e7631241885012c498df0dae1947f57c2e3e",
+      "checksum": "adler32:a6b82cee",
+      "description": "MuMonitor AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
+      "size": 89350,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuMonitor_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:8855b33c",
       "description": "MuMonitor AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
       "size": 41600,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuMonitor_AOD_Apr21ReReco-v1_0000_file_index.txt"
     }
   ],
@@ -1230,52 +1538,101 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:ff7950e3f5e1bc7b6f25bd16ccfbb574057a8097",
+      "checksum": "adler32:09653cdc",
+      "description": "MinimumBias AOD dataset file index (1 of 7) for access to data via CMS virtual machine",
+      "size": 153122,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:79064f5d",
       "description": "MinimumBias AOD dataset file index (1 of 7) for access to data via CMS virtual machine",
       "size": 71890,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:276b04a5598fad94e41f3788baa7903bcedd3770",
+      "checksum": "adler32:92518324",
+      "description": "MinimumBias AOD dataset file index (2 of 7) for access to data via CMS virtual machine",
+      "size": 73049,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0001_file_index.json"
+    },
+    {
+      "checksum": "adler32:85164311",
       "description": "MinimumBias AOD dataset file index (2 of 7) for access to data via CMS virtual machine",
       "size": 34320,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0001_file_index.txt"
     },
     {
-      "checksum": "sha1:5cb21c1d375efc8834327e1cd70aec9d75551e73",
+      "checksum": "adler32:d23d7c8e",
+      "description": "MinimumBias AOD dataset file index (3 of 7) for access to data via CMS virtual machine",
+      "size": 69093,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:543b2430",
       "description": "MinimumBias AOD dataset file index (3 of 7) for access to data via CMS virtual machine",
       "size": 32500,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:02c90193f611de0aafd321d383e3e635ab8dccdb",
+      "checksum": "adler32:226b25af",
+      "description": "MinimumBias AOD dataset file index (4 of 7) for access to data via CMS virtual machine",
+      "size": 3047,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0003_file_index.json"
+    },
+    {
+      "checksum": "adler32:56ceadf1",
       "description": "MinimumBias AOD dataset file index (4 of 7) for access to data via CMS virtual machine",
       "size": 1430,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0003_file_index.txt"
     },
     {
-      "checksum": "sha1:f2d5d18c387acb5405bd4b2e777bba3a5cfb6ecd",
+      "checksum": "adler32:39a5cacc",
+      "description": "MinimumBias AOD dataset file index (5 of 7) for access to data via CMS virtual machine",
+      "size": 80995,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0004_file_index.json"
+    },
+    {
+      "checksum": "adler32:5fd4b7c0",
       "description": "MinimumBias AOD dataset file index (5 of 7) for access to data via CMS virtual machine",
       "size": 38090,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0004_file_index.txt"
     },
     {
-      "checksum": "sha1:a08bc5d3e63a9eab6c86367fd233f2dd136e5a68",
+      "checksum": "adler32:c40d9d64",
+      "description": "MinimumBias AOD dataset file index (6 of 7) for access to data via CMS virtual machine",
+      "size": 37282,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0005_file_index.json"
+    },
+    {
+      "checksum": "adler32:18fc9b90",
       "description": "MinimumBias AOD dataset file index (6 of 7) for access to data via CMS virtual machine",
       "size": 17550,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0005_file_index.txt"
     },
     {
-      "checksum": "sha1:b546fc81d76db88c21b4a54e5c01670a0f26ef1e",
+      "checksum": "adler32:dae18ddf",
+      "description": "MinimumBias AOD dataset file index (7 of 7) for access to data via CMS virtual machine",
+      "size": 16010,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0006_file_index.json"
+    },
+    {
+      "checksum": "adler32:98d9d913",
       "description": "MinimumBias AOD dataset file index (7 of 7) for access to data via CMS virtual machine",
       "size": 7540,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MinimumBias_AOD_Apr21ReReco-v1_0006_file_index.txt"
     }
   ],
@@ -1378,45 +1735,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:e6236fbddb54069f4842adee8fff2b832f4fdaca",
+      "checksum": "adler32:86d4c839",
+      "description": "JetMETTauMonitor AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 99152,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:82256b61",
       "description": "JetMETTauMonitor AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 47520,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:549558dfbf26e45136f72f9d395c3f764b38b8bb",
+      "checksum": "adler32:399f4179",
+      "description": "JetMETTauMonitor AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 7896,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0001_file_index.json"
+    },
+    {
+      "checksum": "adler32:735a7caa",
       "description": "JetMETTauMonitor AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 3780,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0001_file_index.txt"
     },
     {
-      "checksum": "sha1:8e482404ea6246bea982966d51618b9f4d3b7cf4",
+      "checksum": "adler32:da6de9fc",
+      "description": "JetMETTauMonitor AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 37094,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:6dc132ac",
       "description": "JetMETTauMonitor AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 17820,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:d4505f2a5c8f6580fc7424ab21c35b7ea1374fd9",
+      "checksum": "adler32:9cd669ac",
+      "description": "JetMETTauMonitor AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 11804,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0003_file_index.json"
+    },
+    {
+      "checksum": "adler32:78bec106",
       "description": "JetMETTauMonitor AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 5670,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0003_file_index.txt"
     },
     {
-      "checksum": "sha1:4721790cdb6324ce9059fa8b22d3a6807d256da1",
+      "checksum": "adler32:ccb7dd75",
+      "description": "JetMETTauMonitor AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 13209,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0004_file_index.json"
+    },
+    {
+      "checksum": "adler32:f5d88bef",
       "description": "JetMETTauMonitor AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 6345,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0004_file_index.txt"
     },
     {
-      "checksum": "sha1:a8132adb74c777a84d997bcfb1c18dfd2f682657",
+      "checksum": "adler32:b0debdf5",
+      "description": "JetMETTauMonitor AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 18892,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0005_file_index.json"
+    },
+    {
+      "checksum": "adler32:d8d1bc68",
       "description": "JetMETTauMonitor AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 9045,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_JetMETTauMonitor_AOD_Apr21ReReco-v1_0005_file_index.txt"
     }
   ],
@@ -1519,45 +1918,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:588235ac347a51a2bc5d2c2efc81fae7f465477b",
+      "checksum": "adler32:348a3dff",
+      "description": "METFwd AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 176419,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:1fbc6363",
       "description": "METFwd AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 81250,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:c4ab8e366cdb678c0efbae67091392471434db8b",
+      "checksum": "adler32:1398a8ee",
+      "description": "METFwd AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 74004,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0001_file_index.json"
+    },
+    {
+      "checksum": "adler32:14773d8d",
       "description": "METFwd AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 34125,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0001_file_index.txt"
     },
     {
-      "checksum": "sha1:3ab6ddabda503f67f76eed27fd27614fea02c160",
+      "checksum": "adler32:886cb7a7",
+      "description": "METFwd AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 57456,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:d2be74ac",
       "description": "METFwd AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 26500,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:02c6c1f0d0c4929493230f0c2df94a513e41e3b2",
+      "checksum": "adler32:030597b9",
+      "description": "METFwd AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 93514,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0003_file_index.json"
+    },
+    {
+      "checksum": "adler32:7978973a",
       "description": "METFwd AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 43125,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0003_file_index.txt"
     },
     {
-      "checksum": "sha1:049c8ea2dda4f4104603dd5dbcb5371115cac03f",
+      "checksum": "adler32:dfa52925",
+      "description": "METFwd AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 49063,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0004_file_index.json"
+    },
+    {
+      "checksum": "adler32:0b7a05c9",
       "description": "METFwd AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 22625,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0004_file_index.txt"
     },
     {
-      "checksum": "sha1:e84dd2b2f3c1609d78b3be6cf01f25908534d263",
+      "checksum": "adler32:22e094b5",
+      "description": "METFwd AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 45549,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0005_file_index.json"
+    },
+    {
+      "checksum": "adler32:d9b127d5",
       "description": "METFwd AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 21000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_METFwd_AOD_Apr21ReReco-v1_0005_file_index.txt"
     }
   ],
@@ -1660,46 +2101,116 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:fdec040dd6998b49b94447e79f5d662939105629",
-      "description": "MuOnia AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "checksum": "adler32:2b00ef1a",
+      "description": "MuOnia AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
+      "size": 141358,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:77885d20",
+      "description": "MuOnia AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
       "size": 65125,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:8ab4f807b8aa6e4346f77463db2c1ae553b35e92",
-      "description": "MuOnia AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "checksum": "adler32:30cc22f9",
+      "description": "MuOnia AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
+      "size": 97691,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0001_file_index.json"
+    },
+    {
+      "checksum": "adler32:4e3c12fd",
+      "description": "MuOnia AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
       "size": 45000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0001_file_index.txt"
     },
     {
-      "checksum": "sha1:070a5fc2c59bc661ce3e24aa9398eb00578f8882",
-      "description": "MuOnia AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "checksum": "adler32:973517eb",
+      "description": "MuOnia AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
+      "size": 70271,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:60e07bf7",
+      "description": "MuOnia AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
       "size": 32375,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:6957af95c5ec37aa7e243711a4c0435bbc2a2549",
-      "description": "MuOnia AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "checksum": "adler32:b0a0a8b3",
+      "description": "MuOnia AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
+      "size": 109833,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0003_file_index.json"
+    },
+    {
+      "checksum": "adler32:4b0d9a69",
+      "description": "MuOnia AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
       "size": 50625,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0003_file_index.txt"
     },
     {
-      "checksum": "sha1:9aa98611840847b8cf7370422344cf9f0ca906ea",
-      "description": "MuOnia AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "checksum": "adler32:f08a655b",
+      "description": "MuOnia AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
+      "size": 99846,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0004_file_index.json"
+    },
+    {
+      "checksum": "adler32:cf88400b",
+      "description": "MuOnia AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
       "size": 46000,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0004_file_index.txt"
     },
     {
-      "checksum": "sha1:1e0ae2b9e5af7ecd6986a9fdff31be30042187d9",
-      "description": "MuOnia AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "checksum": "adler32:b6322b84",
+      "description": "MuOnia AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
+      "size": 76200,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0005_file_index.json"
+    },
+    {
+      "checksum": "adler32:89d5ab05",
+      "description": "MuOnia AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
       "size": 35125,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_0005_file_index.txt"
+    },
+    {
+      "checksum": "adler32:5b62c04c",
+      "description": "MuOnia AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
+      "size": 185129,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_10000_file_index.json"
+    },
+    {
+      "checksum": "adler32:d0ebef13",
+      "description": "MuOnia AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
+      "size": 85680,
+      "type": "index.txt",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_10000_file_index.txt"
+    },
+    {
+      "checksum": "adler32:92a8063c",
+      "description": "MuOnia AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
+      "size": 11701,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_10001_file_index.json"
+    },
+    {
+      "checksum": "adler32:c2394512",
+      "description": "MuOnia AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
+      "size": 5418,
+      "type": "index.txt",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_MuOnia_AOD_Apr21ReReco-v1_10001_file_index.txt"
     }
   ],
   "license": {
@@ -1801,45 +2312,87 @@
   "experiment": "CMS",
   "files": [
     {
-      "checksum": "sha1:77282b365e04665e2b901dbe017a7cb6828984e9",
+      "checksum": "adler32:85e137b9",
+      "description": "Mu AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
+      "size": 188299,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0000_file_index.json"
+    },
+    {
+      "checksum": "adler32:1869eb93",
       "description": "Mu AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
       "size": 85184,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0000_file_index.txt"
     },
     {
-      "checksum": "sha1:f373cec0faab939381d098e27f6dedb41c2ebdf4",
+      "checksum": "adler32:16124659",
+      "description": "Mu AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
+      "size": 130461,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0001_file_index.json"
+    },
+    {
+      "checksum": "adler32:b7d4e5a8",
       "description": "Mu AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
       "size": 59048,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0001_file_index.txt"
     },
     {
-      "checksum": "sha1:3881ae2e3190a205ef43236527d0419e03978d75",
+      "checksum": "adler32:0f13357c",
+      "description": "Mu AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
+      "size": 109992,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0002_file_index.json"
+    },
+    {
+      "checksum": "adler32:512c2674",
       "description": "Mu AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
       "size": 49731,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0002_file_index.txt"
     },
     {
-      "checksum": "sha1:b73339510e879832b9554922ed4b4c04785f61e1",
+      "checksum": "adler32:1dfbed43",
+      "description": "Mu AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
+      "size": 147779,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0003_file_index.json"
+    },
+    {
+      "checksum": "adler32:aeddd265",
       "description": "Mu AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
       "size": 66792,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0003_file_index.txt"
     },
     {
-      "checksum": "sha1:42b755bd2ba7337b4269bb2bf902fc9e443be640",
+      "checksum": "adler32:5de6b56d",
+      "description": "Mu AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
+      "size": 103506,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0004_file_index.json"
+    },
+    {
+      "checksum": "adler32:3748d874",
       "description": "Mu AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
       "size": 46827,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0004_file_index.txt"
     },
     {
-      "checksum": "sha1:d799b79f968343080f90f961d82abab00cd357c0",
+      "checksum": "adler32:3bc75911",
+      "description": "Mu AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
+      "size": 116871,
+      "type": "index.json",
+      "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0005_file_index.json"
+    },
+    {
+      "checksum": "adler32:9dd0ca64",
       "description": "Mu AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
       "size": 52877,
-      "type": "index",
+      "type": "index.txt",
       "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/AOD/Apr21ReReco-v1/file-indexes/CMS_Run2010B_Mu_AOD_Apr21ReReco-v1_0005_file_index.txt"
     }
   ],


### PR DESCRIPTION
* Adds rich index files (TXT, JSON) to `cms-primary-datasets` records.
  (addresses #2093)

* Adds previously forgotten 10000 and 10001 volumes to the MuOnia dataset.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>