### PR TITLE
records: CMS 2011 HT file addition

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2011A.json
@@ -577,16 +577,16 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_00000_file_index.txt"
       },
       {
-        "checksum": "adler32:0af930ce",
+        "checksum": "adler32:0ede7548",
         "description": "HT AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
-        "size": 266468,
+        "size": 266735,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "adler32:ba30a363",
+        "checksum": "adler32:5c4bc585",
         "description": "HT AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
-        "size": 119760,
+        "size": 119880,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/AOD/12Oct2013-v1/file-indexes/CMS_Run2011A_HT_AOD_12Oct2013-v1_20000_file_index.txt"
       },


### PR DESCRIPTION
* Amends fixtures for the CMS 2011 HT collision dataset following up the
  recovery of a missing file. (closes #2324)
    
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
