### PR TITLE
templates: update of the ATLAS Public URL

### DIFF
--- a/cernopendata/templates/cernopendata_theme/footer.html
+++ b/cernopendata/templates/cernopendata_theme/footer.html
@@ -8,7 +8,7 @@
                                                 width="55" height="55"></a>
           </li>
           <li class="list-inline-item">
-            <a href="http://atlas.ch"><img src="{{ url_for('static', filename='img/atlas.gif') }}" alt="" width="55"
+            <a href="https://atlas.cern"><img src="{{ url_for('static', filename='img/atlas.gif') }}" alt="" width="55"
                                            height="55"></a>
           </li>
           <li class="list-inline-item">


### PR DESCRIPTION
* Updates the ATLAS Public URL in the page footer.
  (closes #2387)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>