### PR TITLE
records: updated opera author lists

### DIFF
--- a/cernopendata/modules/fixtures/data/records/opera-author-list-multiplicity.json
+++ b/cernopendata/modules/fixtures/data/records/opera-author-list-multiplicity.json
@@ -10,7 +10,7 @@
         "name": "Guler, Ali Murat"
       },
       {
-        "affiliation": "Middle East Tech. U., Ankara",
+        "affiliation": "Middle East Tech. U., Ankara and Ankara U.",
         "name": "Kamiscioglu, Cagin"
       },
       {
@@ -30,15 +30,15 @@
         "name": "Pessard, Henri"
       },
       {
-        "affiliation": "Bari U.",
+        "affiliation": "Bari U. and INFN, Bari",
         "name": "De Serio, Marilisa"
       },
       {
-        "affiliation": "Bari U.",
+        "affiliation": "Bari U. and INFN, Bari",
         "name": "Muciaccia, Maria Teresa"
       },
       {
-        "affiliation": "Bari U.",
+        "affiliation": "Bari U. and INFN, Bari",
         "name": "Paparella, Luigi"
       },
       {
@@ -46,7 +46,7 @@
         "name": "Pastore, Alessandra"
       },
       {
-        "affiliation": "Bari U.",
+        "affiliation": "Bari U. and INFN, Bari",
         "name": "Simone, Saverio"
       },
       {
@@ -62,7 +62,7 @@
         "name": "Ariga, Akitaka"
       },
       {
-        "affiliation": "Bern U., LHEP",
+        "affiliation": "Bern U., LHEP and Kyushu U.",
         "name": "Ariga, Tomoko"
       },
       {
@@ -78,7 +78,7 @@
         "name": "Di Ferdinando, Donato"
       },
       {
-        "affiliation": "INFN, Bologna",
+        "affiliation": "INFN, Bologna and Bologna U.",
         "name": "Fornari, Federico"
       },
       {
@@ -86,7 +86,7 @@
         "name": "Mandrioli, Gianni"
       },
       {
-        "affiliation": "INFN, Bologna",
+        "affiliation": "INFN, Bologna and Bologna U.",
         "name": "Mauri, Nicoletta"
       },
       {
@@ -94,11 +94,11 @@
         "name": "Patrizii, Laura"
       },
       {
-        "affiliation": "INFN, Bologna",
+        "affiliation": "INFN, Bologna and Bologna U.",
         "name": "Pasqualini, Laura"
       },
       {
-        "affiliation": "INFN, Bologna",
+        "affiliation": "INFN, Bologna and Bologna U.",
         "name": "Pozzato, Michele"
       },
       {
@@ -254,7 +254,7 @@
         "name": "Okateva, Natalia"
       },
       {
-        "affiliation": "Lebedev Inst.",
+        "affiliation": "Lebedev Inst. and Moscow Phys. Eng. Inst.",
         "name": "Polukhina, Natalia"
       },
       {
@@ -330,7 +330,7 @@
         "name": "Aleksandrov, Aleksandar"
       },
       {
-        "affiliation": "INFN, Naples",
+        "affiliation": "INFN, Naples and Naples U.",
         "name": "Buonaura, Annarita"
       },
       {
@@ -342,7 +342,7 @@
         "name": "Consiglio, Lucia"
       },
       {
-        "affiliation": "INFN, Naples",
+        "affiliation": "INFN, Naples and Naples U.",
         "name": "De Lellis, Giovanni"
       },
       {
@@ -350,19 +350,19 @@
         "name": "Di Crescenzo, Antonia"
       },
       {
-        "affiliation": "INFN, Naples",
+        "affiliation": "INFN, Naples and Naples U.",
         "name": "Galati, Giuliana"
       },
       {
-        "affiliation": "INFN, Naples",
+        "affiliation": "INFN, Naples and Naples U.",
         "name": "Lauria, Adele"
       },
       {
-        "affiliation": "INFN, Naples",
+        "affiliation": "INFN, Naples and Naples U.",
         "name": "Montesi, Maria Cristina"
       },
       {
-        "affiliation": "INFN, Naples",
+        "affiliation": "INFN, Naples and Naples U.",
         "name": "Strolin, Paolo Emilio"
       },
       {
@@ -382,7 +382,7 @@
         "name": "Bertolin, Alessandro"
       },
       {
-        "affiliation": "INFN, Padua",
+        "affiliation": "INFN, Padua and Padua U.",
         "name": "Brugnera, Riccardo"
       },
       {
@@ -390,7 +390,7 @@
         "name": "Dusini, Stefano"
       },
       {
-        "affiliation": "INFN, Padua",
+        "affiliation": "INFN, Padua and Padua U.",
         "name": "Garfagnini, Alberto"
       },
       {
@@ -398,8 +398,8 @@
         "name": "Kose, Umut"
       },
       {
-        "affiliation": "INFN, Padua",
-        "name": "Fulvio Laudisio"
+        "affiliation": "INFN, Padua and Padua U.",
+        "name": "Laudisio, Fulvio"
       },
       {
         "affiliation": "INFN, Padua",
@@ -418,7 +418,7 @@
         "name": "Roda, Marco"
       },
       {
-        "affiliation": "INFN, Padua",
+        "affiliation": "INFN, Padua and Padua U.",
         "name": "Sirignano, Chiara"
       },
       {
@@ -525,7 +525,7 @@
       "Author-Lists"
     ],
     "date_created": "2010-2012",
-    "date_published": "2017",
+    "date_published": "2018",
     "distribution": {
       "formats": [
         "pdf"
@@ -541,7 +541,7 @@
     ],
     "publisher": "CERN Open Data Portal",
     "recid": "452",
-    "title": "OPERA author list for the 2017 data release",
+    "title": "OPERA author list for the release of multiplicity studies",
     "type": {
       "primary": "Documentation",
       "secondary": [

--- a/cernopendata/modules/fixtures/data/records/opera-author-list-tau.json
+++ b/cernopendata/modules/fixtures/data/records/opera-author-list-tau.json
@@ -1,0 +1,568 @@
+[
+  {
+    "authors": [
+      {
+        "affiliation": "Aichi U. ",
+        "name": "Kodama, Koichi"
+      },
+      {
+        "affiliation": "Middle East Tech. U., Ankara",
+        "name": "Guler, Ali Murat"
+      },
+      {
+        "affiliation": "Middle East Tech. U., Ankara and Ankara U.",
+        "name": "Kamiscioglu, Cagin"
+      },
+      {
+        "affiliation": "Middle East Tech. U., Ankara",
+        "name": "Kamiscioglu, Mustafa"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "name": "del Amo Sanchez, Pablo"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "name": "Duchesneau, Dominique"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "name": "Favier, Jean"
+      },
+      {
+        "affiliation": "Annecy, LAPP",
+        "name": "Pessard, Henri"
+      },
+      {
+        "affiliation": "Bari U. and INFN, Bari",
+        "name": "De Serio, Marilisa"
+      },
+      {
+        "affiliation": "Bari U. and INFN, Bari",
+        "name": "Muciaccia, Maria Teresa"
+      },
+      {
+        "affiliation": "Bari U. and INFN, Bari",
+        "name": "Paparella, Luigi"
+      },
+      {
+        "affiliation": "Bari U.",
+        "name": "Pastore, Alessandra"
+      },
+      {
+        "affiliation": "Bari U. and INFN, Bari",
+        "name": "Simone, Saverio"
+      },
+      {
+        "affiliation": "INFN, Bari",
+        "name": "Fini, Rosa Anna"
+      },
+      {
+        "affiliation": "Bern U., LHEP",
+        "name": "Ereditato, Antonio"
+      },
+      {
+        "affiliation": "Bern U., LHEP",
+        "name": "Ariga, Akitaka"
+      },
+      {
+        "affiliation": "Bern U., LHEP and Kyushu U.",
+        "name": "Ariga, Tomoko"
+      },
+      {
+        "affiliation": "Bern U., LHEP",
+        "name": "Kreslo, Igor"
+      },
+      {
+        "affiliation": "Bern U., LHEP",
+        "name": "Pistillo, Ciro"
+      },
+      {
+        "affiliation": "Bern U., LHEP",
+        "name": "Tufanli, Sehran"
+      },
+      {
+        "affiliation": "Bern U., LHEP",
+        "name": "Vuilleumier, Jean-Luc"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "name": "Di Ferdinando, Donato"
+      },
+      {
+        "affiliation": "INFN, Bologna and Bologna U.",
+        "name": "Fornari, Federico"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "name": "Mandrioli, Gianni"
+      },
+      {
+        "affiliation": "INFN, Bologna and Bologna U.",
+        "name": "Mauri, Nicoletta"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "name": "Patrizii, Laura"
+      },
+      {
+        "affiliation": "INFN, Bologna and Bologna U.",
+        "name": "Pasqualini, Laura"
+      },
+      {
+        "affiliation": "INFN, Bologna and Bologna U.",
+        "name": "Pozzato, Michele"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "name": "Sirri, Gabriele"
+      },
+      {
+        "affiliation": "INFN, Bologna",
+        "name": "Tenti, Matteo"
+      },
+      {
+        "affiliation": "Brussels U., IIHE",
+        "name": "Vilain, Pierre"
+      },
+      {
+        "affiliation": "Brussels U., IIHE",
+        "name": "Wilquet, Gaston"
+      },
+      {
+        "affiliation": "Hamburg U.",
+        "name": "Ebert, Joachim"
+      },
+      {
+        "affiliation": "Hamburg U.",
+        "name": "Hagner, Caren"
+      },
+      {
+        "affiliation": "Hamburg U.",
+        "name": "Hollnagel, Annika"
+      },
+      {
+        "affiliation": "Hamburg U.",
+        "name": "Wonsak, Björn"
+      },
+      {
+        "affiliation": "Moscow, INR",
+        "name": "Agafonova, Natalia"
+      },
+      {
+        "affiliation": "Moscow, INR",
+        "name": "Malgin, Alexei"
+      },
+      {
+        "affiliation": "Moscow, INR",
+        "name": "Matveev, Vitaly"
+      },
+      {
+        "affiliation": "Moscow, INR",
+        "name": "Ryazhskaya, Olga"
+      },
+      {
+        "affiliation": "Moscow, INR",
+        "name": "Shakirianova, Irina"
+      },
+      {
+        "affiliation": "Higher Sch. of Economics, Moscow and INFN, Naples",
+        "name": "Ustyuzhanin, Andrey"
+      },
+      {
+        "affiliation": "Dubna, JINR",
+        "name": "Chukanov, Artem"
+      },
+      {
+        "affiliation": "Dubna, JINR",
+        "name": "Dmitrievsky, Sergey"
+      },
+      {
+        "affiliation": "Dubna, JINR",
+        "name": "Gornushkin, Yuri"
+      },
+      {
+        "affiliation": "Dubna, JINR",
+        "name": "Olchevsky, Alexander"
+      },
+      {
+        "affiliation": "Dubna, JINR",
+        "name": "Sadovsky, Andrey"
+      },
+      {
+        "affiliation": "Dubna, JINR",
+        "name": "Sotnikov, Albert Petrovich"
+      },
+      {
+        "affiliation": "Dubna, JINR",
+        "name": "Vasina, Svetlana"
+      },
+      {
+        "affiliation": "Gyeongsang Natl. U.",
+        "name": "Kim, Seung Hwan"
+      },
+      {
+        "affiliation": "Gyeongsang Natl. U.",
+        "name": "Park, Byung Do"
+      },
+      {
+        "affiliation": "Gyeongsang Natl. U.",
+        "name": "Yoon, Chun Sil"
+      },
+      {
+        "affiliation": "Kobe U.",
+        "name": "Aoki, Shigeki"
+      },
+      {
+        "affiliation": "Kobe U.",
+        "name": "Hara, Testuya"
+      },
+      {
+        "affiliation": "Kobe U.",
+        "name": "Mizutani, Fukashi"
+      },
+      {
+        "affiliation": "Kobe U.",
+        "name": "Ozaki, Kazuhiko"
+      },
+      {
+        "affiliation": "Kobe U.",
+        "name": "Shibayama, Emi"
+      },
+      {
+        "affiliation": "Kobe U.",
+        "name": "Takahashi, Shigeru"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "name": "Paoloni, Alessandro"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "name": "Spinetti, Mario"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "name": "Votano, Lucia"
+      },
+      {
+        "affiliation": "Milan Bicocca U.",
+        "name": "Terranova, Francesco"
+      },
+      {
+        "affiliation": "Gran Sasso",
+        "name": "D'Ambrosio, Nicola"
+      },
+      {
+        "affiliation": "Gran Sasso",
+        "name": "Di Marco, Natalia"
+      },
+      {
+        "affiliation": "Gran Sasso",
+        "name": "Schembri, Andrea"
+      },
+      {
+        "affiliation": "GSSI, Aquila",
+        "name": "Gentile, Valerio"
+      },
+      {
+        "affiliation": "Lebedev Inst.",
+        "name": "Chernyavskiy, Mikhail"
+      },
+      {
+        "affiliation": "Lebedev Inst.",
+        "name": "Gorbunov, Sergei"
+      },
+      {
+        "affiliation": "Lebedev Inst.",
+        "name": "Okateva, Natalia"
+      },
+      {
+        "affiliation": "Lebedev Inst. and Moscow Phys. Eng. Inst.",
+        "name": "Polukhina, Natalia"
+      },
+      {
+        "affiliation": "Lebedev Inst.",
+        "name": "Starkov, Nikolai"
+      },
+      {
+        "affiliation": "Lebedev Inst.",
+        "name": "Shchedrina, Tatiana"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Fukuda, Tomokazu"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Hayakawa, Takashi"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Ishiguro, Katsuya"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Kitagawa, Naomasa"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Komatsu, Masahiro"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Miyanishi, Motoaki"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Morishima, Kunihiro"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Naganawa, Naotaka"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Naka, Tatsuhiro"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Nakamura, Mitsuhiro"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Nakano, Takashi"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Niwa, Kimio"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Rokujo, Hiroki"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Sato, Osamu"
+      },
+      {
+        "affiliation": "Nagoya U.",
+        "name": "Shiraishi, Takuya"
+      },
+      {
+        "affiliation": "INFN, Naples",
+        "name": "Aleksandrov, Aleksandar"
+      },
+      {
+        "affiliation": "INFN, Naples and Naples U.",
+        "name": "Buonaura, Annarita"
+      },
+      {
+        "affiliation": "INFN, Naples",
+        "name": "Buontempo, Salvatore"
+      },
+      {
+        "affiliation": "INFN, Naples",
+        "name": "Consiglio, Lucia"
+      },
+      {
+        "affiliation": "INFN, Naples and Naples U.",
+        "name": "De Lellis, Giovanni"
+      },
+      {
+        "affiliation": "INFN, Naples",
+        "name": "Di Crescenzo, Antonia"
+      },
+      {
+        "affiliation": "INFN, Naples and Naples U.",
+        "name": "Galati, Giuliana"
+      },
+      {
+        "affiliation": "INFN, Naples and Naples U.",
+        "name": "Iuliano, Antonio"
+      },
+      {
+        "affiliation": "INFN, Naples and Naples U.",
+        "name": "Lauria, Adele"
+      },
+      {
+        "affiliation": "INFN, Naples and Naples U.",
+        "name": "Montesi, Maria Cristina"
+      },
+      {
+        "affiliation": "INFN, Naples and Naples U.",
+        "name": "Strolin, Paolo Emilio"
+      },
+      {
+        "affiliation": "INFN, Naples",
+        "name": "Tioukov, Valeri"
+      },
+      {
+        "affiliation": "INFN, Naples",
+        "name": "Voevodina, Elena"
+      },
+      {
+        "affiliation": "Nihon U., Narashino",
+        "name": "Mikado, Shoji"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "name": "Bertolin, Alessandro"
+      },
+      {
+        "affiliation": "INFN, Padua and Padua U.",
+        "name": "Brugnera, Riccardo"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "name": "Dusini, Stefano"
+      },
+      {
+        "affiliation": "INFN, Padua and Padua U.",
+        "name": "Garfagnini, Alberto"
+      },
+      {
+        "affiliation": "CERN",
+        "name": "Kose, Umut"
+      },
+      {
+        "affiliation": "INFN, Padua and Padua U.",
+        "name": "Laudisio, Fulvio"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "name": "Longhin, Andrea"
+      },
+      {
+        "affiliation": "Padua Observ.",
+        "name": "Medinaceli, Eduardo"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "name": "Pupilli, Fabio"
+      },
+      {
+        "affiliation": "Liverpool U.",
+        "name": "Roda, Marco"
+      },
+      {
+        "affiliation": "INFN, Padua and Padua U.",
+        "name": "Sirignano, Chiara"
+      },
+      {
+        "affiliation": "INFN, Padua",
+        "name": "Stanco, Luca"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "name": "Gustavino, Carlo"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "name": "Loverre, Pier Ferruccio"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "name": "Monacelli, Piero"
+      },
+      {
+        "affiliation": "INFN, Rome",
+        "name": "Rosa, Giovanni"
+      },
+      {
+        "affiliation": "Salerno U. and INFN, Salerno",
+        "name": "Grella, Giuseppe"
+      },
+      {
+        "affiliation": "Salerno U. and INFN, Salerno",
+        "name": "Bozza, Cristiano"
+      },
+      {
+        "affiliation": "Salerno U.",
+        "name": "Stellacci, Simona Maria"
+      },
+      {
+        "affiliation": "Strasbourg, IPHC",
+        "name": "Jollet, Cecile"
+      },
+      {
+        "affiliation": "Strasbourg, IPHC",
+        "name": "Meregaglia, Anselmo"
+      },
+      {
+        "affiliation": "Strasbourg, IPHC",
+        "name": "Dracos, Marcos"
+      },
+      {
+        "affiliation": "SINP, Moscow",
+        "name": "Anokhina, Anna"
+      },
+      {
+        "affiliation": "SINP, Moscow",
+        "name": "Dzhatdoev, Timur"
+      },
+      {
+        "affiliation": "SINP, Moscow",
+        "name": "Podgrudkov, Dmitry Abramovich"
+      },
+      {
+        "affiliation": "SINP, Moscow",
+        "name": "Roganova, Tatiana Mikhaylovna"
+      },
+      {
+        "affiliation": "Technion",
+        "name": "Goldberg, Jacques"
+      },
+      {
+        "affiliation": "Toho U.",
+        "name": "Matsuo, Toshihiro"
+      },
+      {
+        "affiliation": "Toho U.",
+        "name": "Ogawa, Satoru"
+      },
+      {
+        "affiliation": "Toho U.",
+        "name": "Shibuya, Hiroshi"
+      },
+      {
+        "affiliation": "Boskovic Inst., Zagreb",
+        "name": "Klicek, Budimir"
+      },
+      {
+        "affiliation": "Boskovic Inst., Zagreb",
+        "name": "Stipcevic, Mario"
+      },
+      {
+        "affiliation": "Boskovic Inst., Zagreb",
+        "name": "Jakovcic, Kresimir"
+      },
+      {
+        "affiliation": "Boskovic Inst., Zagreb",
+        "name": "Ljubicic, Tonko Ante"
+      },
+      {
+        "affiliation": "Boskovic Inst., Zagreb",
+        "name": "Malenica, Marko"
+      }
+    ],
+    "collaboration": {
+      "name": "OPERA collaboration"
+    },
+    "collections": [
+      "Author-Lists"
+    ],
+    "date_created": "2010-2012",
+    "date_published": "2018",
+    "experiment": "OPERA",
+    "publisher": "CERN Open Data Portal",
+    "recid": "454",
+    "title": "OPERA author list for the release of tau appearance studies",
+    "type": {
+      "primary": "Documentation",
+      "secondary": [
+        "Authors"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
* Adds a second author list
* Makes additions to the first author list based on the new document provided (inclusion of second affiliations for some authors)

Signed-off-by: Artemis Lavasa <artemis.lavasa@cern.ch>
