### PR TITLE
docs: updates to the About ATLAS page

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ FROM centos:7
 # Install CERN Open Data Portal web node pre-requisites:
 RUN yum update -y && \
     yum install -y \
+        ca-certificates \
         curl \
         git \
         rlwrap \

--- a/cernopendata/modules/fixtures/data/docs/atlas-about/atlas-about.md
+++ b/cernopendata/modules/fixtures/data/docs/atlas-about/atlas-about.md
@@ -1,7 +1,54 @@
-ATLAS (A Toroidal LHC ApparatuS) is one of the two general-purpose detectors at the LHC, the other being CMS. Both detectors are geared towards covering a large range of physics produced in proton collisions such as the search for the Higgs Boson or Vector Boson Scattering.
+**[ATLAS](https://atlas.cern)** (A Toroidal LHC ApparatuS) is one of the four major experiments at the [Large Hadron Collider](http://home.web.cern.ch/topics/large-hadron-collider) (LHC) at [CERN](https://home.cern). It is a general-purpose particle physics experiment run by an international collaboration and, together with [CMS](https://cms.cern), is designed to exploit the full discovery potential and the vast range of physics opportunities that the LHC provides.
 
-## About ATLAS Data
+[ATLAS](https://atlas.cern)'s scientific exploration uses precision measurement to push the frontiers of knowledge by seeking answers to fundamental questions such as: What are the basic building blocks of matter? What are the fundamental forces of nature? Could there be a greater underlying symmetry to our universe?
 
-The available dataset is derived from actual data recored by ATLAS during the 2011 run. There are 6 packages of 1000 events each totalling 6000 events. These events have been preselected to provide a high amount of interesting physics events. The data are saved in an XML format that can be read with the event display program MINERVA. A python-based framework for the analysis of the data is in the works.
+ATLAS physicists test the predictions of the [Standard Model](https://home.cern/about/physics/standard-model), which encapsulates our current understanding of what the building blocks of matter are and how they interact. These studies can lead to ground-breaking discoveries, such as that of the Higgs boson, physics beyond the Standard Model and the development of new theories to better describe our universe.
 
-The dataset from the ATLAS Higgs Machine Learning Challenge is also available. The Challenge, which ran from May to September 2014, was to develop an algorithm that improved the detection of the Higgs boson signal. Participants applied and developed cutting-edge Machine Learning techniques, which have been shown to be better than existing traditional high-energy physics tools. The dataset that was available to Challenge participants through the Kaggle platform is now available on the CERN Open Data Portal to allow further studies.
+For more about the ATLAS Collaboration, the experiment, the physics and its members, please visit our [Official Site](https://atlas.cern/discover/experiment).
+
+
+## About [ATLAS Open Data](http://opendata.atlas.cern)
+
+**The ATLAS Collaboration's current approach on the release of datasets is intended for Education, Training and Outreach activities around the World**.
+In order to fulfil that objective, the **[ATLAS Open Data project](http://opendata.atlas.cern) was created**.
+
+[ATLAS Open Data](http://opendata.atlas.cern) project aims to provide data and tools to high-school, masters and undergraduate students, to help educate them in physics analysis techniques used in experimental particle physics. Sharing data collected by the [ATLAS](https://atlas.cern) experiment aims to generate excitement and enthusiasm for fundamental research, inspiring physicists of the future.
+
+[International Masterclasses](http://physicsmasterclasses.org/) introduce particle physics to high-school students and have been running very successfully for the last 20 years.
+ATLAS data [were first used in 2011](https://www.interactions.org/press-release/high-school-students-analyse-first-time-real-lhc-data), and 8 TeV ATLAS Open Data in 2015.
+Inspired by the success of International Masterclasses, a new [ATLAS Open Data](http://opendata.atlas.cern) initiative [was launched in 2016](http://atlas.cern/updates/atlas-news/explore-lhc-data-new-atlas-educational-platform).
+
+ The target audience is physics undergraduate and masters students, but may also include advanced high-school students or indeed anyone with some basic understanding of particle physics and coding experience. A comprehensive **educational platform was developed featuring a new 8 TeV dataset and a set of educational tools at a more advanced level. The objectives of this initiative are to provide**:
+
+* 8 TeV proton–proton data collected by ATLAS plus associated simulated data.
+* 13 TeV proton–proton data collected by ATLAS plus associated simulated data.
+* Tools and software of varying technical difficulty to analyse the data.
+* An educational platform providing easy access to the data, software and tools with documentation in the form of step-by-step instructions for users.
+
+
+You can find usage instructions, examples, applications and suggestions in the several [ATLAS Open Data](http://opendata.atlas.cern) online Books:
+
+* Book in the [**Get Started**](http://opendata.atlas.cern/visualisations/documentation.php) section
+* Book in the [**Web Analysis**](http://opendata.atlas.cern/webanalysis/documentation.php) section
+* Book in the [**Data & Tools**](http://opendata.atlas.cern/extendedanalysis/documentation.php) section
+* ATLAS [document on **public 8 TeV datasets**](https://cds.cern.ch/record/2203649).
+
+
+**With the collaboration of the [CERN Open Data](http://opendata.cern.ch)** team, we aim to publish, preserve and document real and simulated datasets, software and virtual machines, web and desktop applications, and up-to-date exercises and documentation.
+
+The ideal scenario is to have all the [ATLAS Open Data](http://opendata.atlas.cern) resources replicated in both sites. We will do our best to reach this objective.
+
+
+## <a name="atlas-disclaimer">Disclaimer</a>
+
+* **The [ATLAS Open Data](http://opendata.atlas.cern) are released under the [Creative Commons CC0 waiver](http://creativecommons.org/publicdomain/zero/1.0/)**.
+Neither ATLAS nor CERN endorses any works, scientific or otherwise, produced using these data, even if available on, or linked from, this nor the ATLAS portal.
+* All data sets will have a unique [DOI](https://en.wikipedia.org/wiki/Digital_object_identifier) that you are requested to cite in any applications or publications.
+* Despite being processed, the high-level primary datasets remain complex, and selection criteria need to be applied in order to analyse them, requiring some understanding of particle physics and detector functioning. The large majority of the data cannot be viewed in simple data tables for spreadsheet-based analyses.
+* No further development is foreseen for either the data released or the software version needed to analyse them.
+    * The analysis methods and software have evolved since the released data were recorded.
+    * More advanced techniques are used with recent data, but the software is not compatible out-of-the-box with older data samples.
+
+## <a name="atlas-policies">Policies</a>
+
+* [ATLAS Open Access policy](/record/413)


### PR DESCRIPTION
installation: ca-certificates
    
* Update ``ca-certificates`` package in order to fix Travis CI installation
  issues with some repository mirrors ("Cannot retrieve metalink for repository:
  epel/x86_64") that I am not observing locally.
    
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>