### PR TITLE
nginx: disable uwsgi mod buffering for nginx

### DIFF
--- a/nginx/cernopendata.conf
+++ b/nginx/cernopendata.conf
@@ -74,6 +74,8 @@ server {
         uwsgi_no_cache $nocache;
         uwsgi_cache cache_web_files;
         uwsgi_cache_key $host$uri$is_args$args;
+        uwsgi_buffering off;
+        uwsgi_request_buffering off;
         uwsgi_cache_valid 200 301 302 30m;
         uwsgi_cache_lock on;
         uwsgi_cache_use_stale updating;


### PR DESCRIPTION
* uwsgi nginx module sets a buffer by default see
  http://nginx.org/en/docs/http/ngx_http_uwsgi_module.html#uwsgi_request_buffering.
  For a client takes normally a lot of time to consume it, so in certain
  occassions the uwsgi process would time out and only a chunk of the
  file would be downloaded (the chunk that corresponds with the default
  size of the buffer) (closes #2427).