### PR TITLE
records: addition of ORCID iDs

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-ana-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-ana-Run2011A.json
@@ -9,7 +9,8 @@
         "name": "Rodriguez Marrero, Ana"
       },
       {
-        "name": "Lassila-Perini, Kati"
+        "name": "Lassila-Perini, Kati",
+        "orcid": "0000-0002-5502-1795"
       }
     ],
     "collections": [
@@ -97,7 +98,8 @@
         "name": "Rodriguez Marrero, Ana"
       },
       {
-        "name": "Lassila-Perini, Kati"
+        "name": "Lassila-Perini, Kati",
+        "orcid": "0000-0002-5502-1795"
       }
     ],
     "collections": [

--- a/cernopendata/modules/fixtures/data/records/cms-tools-reco.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-reco.json
@@ -6,7 +6,8 @@
     "accelerator": "CERN-LHC",
     "authors": [
       {
-        "name": "Lassila-Perini, Kati"
+        "name": "Lassila-Perini, Kati",
+        "orcid": "0000-0002-5502-1795"
       }
     ],
     "collections": [
@@ -70,7 +71,8 @@
     "accelerator": "CERN-LHC",
     "authors": [
       {
-        "name": "Lassila-Perini, Kati"
+        "name": "Lassila-Perini, Kati",
+        "orcid": "0000-0002-5502-1795"
       }
     ],
     "collections": [


### PR DESCRIPTION
* This is the first test for populating already-existing records with ORCID iDs. These iDs will need to be added to the DOI metadata as well. (closes #2419)

Signed-off-by: Artemis Lavasa <artemis.lavasa@cern.ch>

