### PR TITLE
Fixtures: enrich json with secondary category

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cod-privacy-policy/cod-privacy-policy.json
+++ b/cernopendata/modules/fixtures/data/docs/cod-privacy-policy/cod-privacy-policy.json
@@ -10,7 +10,8 @@
     "slug": "privacy-policy",
     "title": "CERN Open Data Privacy Policy",
     "type": {
-      "primary": "Documentation"
+      "primary": "Documentation",
+      "secondary": ["Policy"]
     }
   }
 ]

--- a/cernopendata/modules/fixtures/data/records/cms-open-data-instructions.json
+++ b/cernopendata/modules/fixtures/data/records/cms-open-data-instructions.json
@@ -172,7 +172,7 @@
     "title": "CMS Pile-up Simulation",
     "type": {
       "primary": "Documentation",
-      "secondary": []
+      "secondary": ["Guide"]
     }
   },
   {
@@ -201,7 +201,7 @@
     "title": "CMS Simulated Dataset Names",
     "type": {
       "primary": "Documentation",
-      "secondary": []
+      "secondary": ["Guide"]
     }
   },
   {

--- a/cernopendata/modules/fixtures/data/records/lhcb-antimatter-matters-2017.json
+++ b/cernopendata/modules/fixtures/data/records/lhcb-antimatter-matters-2017.json
@@ -51,7 +51,7 @@
     "title": "Matter Antimatter Differences (B meson decays to three hadrons) - Data Files",
     "type": {
       "primary": "Dataset",
-      "secondary": []
+      "secondary": ["Collision"]
     },
     "usage": {
       "description": "The data files can be accessed using ROOT.",

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -65,6 +65,14 @@ if [ "${whitespace_found_p}" != "0" ]; then
     exit 1
 fi
 
+# check for empty secondary type in fixtures
+for file in $(find cernopendata/modules/fixtures/data/{records,docs}/ -name "*.json"); do
+    secondaries=$(jq '.[].type.secondary' $file -c | sort | uniq)
+    if echo $secondaries | grep -q -e '\[\]' -e "null"; then
+        echo "[Warning] empty type.secondary field in $file"
+    fi
+done
+
 # do we need to continue?
 if [[ "$@" = *"--check-fixtures-only"* ]]; then
     exit 0


### PR DESCRIPTION
Fix #2442

- Dataset:
   - `Matter Antimatter Differences (B meson decays to three hadrons) - Data Files `
       http://opendata.cern.ch/record/4900
       -> Collision
- Documentation:
   - `CERN Open Data Privacy Policy `
       http://opendata.cern.ch/docs/privacy-policy
       -> Policy
   - `CMS Pile-up Simulation`
       http://opendata.cern.ch/record/70
       -> Guide
   - `CMS Simulated Dataset Names`
       http://opendata.cern.ch/record/71
       -> Guide
