### PR TITLE
docs: categorisation of MC datasets

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/simulated-dataset-categories/simulated-dataset-categories.json
+++ b/cernopendata/modules/fixtures/data/docs/simulated-dataset-categories/simulated-dataset-categories.json
@@ -1,0 +1,22 @@
+[
+  {
+    "body": {
+      "content": "simulated-dataset-categories.md",
+      "format": "md"
+    },
+    "short_description": {
+      "content": "Description of the simulated dataset categories used in the CERN Open Data Portal."
+    },
+    "slug": "simulated-dataset-categories",
+    "tags": [
+      "Getting Started"
+    ],
+    "title": "Simulated Dataset Categories",
+    "type": {
+      "primary": "Documentation",
+      "secondary": [
+        "Guide"
+      ]
+    }
+  }
+]

--- a/cernopendata/modules/fixtures/data/docs/simulated-dataset-categories/simulated-dataset-categories.md
+++ b/cernopendata/modules/fixtures/data/docs/simulated-dataset-categories/simulated-dataset-categories.md
@@ -1,0 +1,87 @@
+The CERN Open Data Portal classifies each simulated dataset in one category or
+subcategory. The scheme used here follows closely the
+[CMS Physics Publications](https://cms-results.web.cern.ch/cms-results/public-results/publications/)
+and
+[ATLAS Physics Analysis Groups & Summary Plots ](https://twiki.cern.ch/twiki/bin/view/AtlasPublic/WebHome#Physics%20Analysis%20Groups%20%20Summary)
+structures.
+
+## Categories
+
+- B Physics and Quarkonia
+- Higgs Physics
+    - Standard Model
+    - Beyond Standard Model
+- Standard Model
+    - Drell-Yan
+    - ElectroWeak
+    - Forward and Small-x QCD Physics
+    - Minimum Bias
+    - QCD
+    - ttbar
+    - Miscalleneous
+- Heavy-Ion Physics
+- Beyond 2 Generations
+- Exotica
+    - Colorons, Axigluons, Diquarks
+    - Contact Interaction
+    - Dark Matter
+    - Excited Fermions
+    - Extra Dimensions
+    - Gravitons
+    - Heavy Fermions, Heavy Righ-Handed Neutrinos
+    - Heavy Gauge Bosons
+    - Leptoquarks
+    - Resonances
+    - Miscalleneous
+- Supersymmetry
+- Physics Modelling
+
+
+## Description
+
+Please find below the description of each category.
+
+### B Physics and Quarkonia
+
+Datasets for bottom and charm quarks production:
+
+- Heavy-quark hadron production, decay and properties.
+- Quarkonia properties.
+
+### Higgs Physics
+
+Datasets related Higgs Boson physics including Standard Model and (N)MSSM.
+
+### Standard Model Physics
+
+Datasets for jet, vector-boson production and production of vector-bosons with associated jets:
+
+- Drell Yan and Z/W production (including additional jets).
+- Multi vector-boson production.
+- Forward and small-X physics (including difractive processes).
+- Processes for ttbar production.
+- Inclusive and multi-jet production.
+
+### Heavy-Ion Physics
+
+Datasets for p-Pb, Pb-Pb collisions, and p-p reference set.
+
+### Beyond 2 Generations
+
+Datasets for new heavy particles, including heavy resonances like Z' and W', diboson resonances, heavy partners of top quark (with vector-like VLQ properties).
+
+### Exotica
+
+Datasets for non-supersymmetric physics beyond the Standard Model: Extra Dimensions, mini Black Holes, Dark Matter, extended Higgs models, Compositeness.
+
+### Supersymmetry
+
+Datasets for production of supersymmetric (SUSY) particles including both R-parity conserving and violating scenarios. ((N)MSSM Higgs boson production is under _Higgs Physics_)
+
+### Physics Modeling
+
+Datasets for Monte Carlo generator studies and tuning, as well as Standard Model Systematic Variations.
+
+---
+
+A word of advice: the categorisation is done automatically. It might happen that one dataset is misscategorised.


### PR DESCRIPTION
New page with description of the categories for MC datasets.

Latest categorisation results for CMS datasets:
- https://hpascoal.web.cern.ch/hpascoal/tmp/2018-11-29-results/
- https://hpascoal.web.cern.ch/hpascoal/tmp/2018-11-29-categorisation/