### PR TITLE
Glossary: more terms

### DIFF
--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -355,7 +355,9 @@
     ],
     "term": [
       "Hadron",
-      "Hadrons"
+      "hadron",
+      "Hadrons",
+      "hadrons"
     ],
     "type": {
       "primary": "Glossary"
@@ -852,6 +854,37 @@
     "term": [
       "Quark",
       "Quarks"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
+    "anchor": "Quarkonia",
+    "category": "generic",
+    "definition": "Quarkonium (pl. quarkonia) is a bound state of a heavy quark and it's own anti-quark. It is a neutral particle and the antiparticle of itself.",
+    "links": [
+      {
+        "text": "Read more on Wikipedia",
+        "url": "https://en.wikipedia.org/wiki/Quarkonium"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "quark"
+      },
+      {
+        "term": "hadron"
+      },
+      {
+        "term": "gluon"
+      }
+    ],
+    "term": [
+      "quarkonia",
+      "Quarkonia",
+      "quarkonium",
+      "Quarkonium"
     ],
     "type": {
       "primary": "Glossary"

--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -503,6 +503,34 @@
     }
   },
   {
+    "anchor": "Pile-up",
+    "category": "generic",
+    "definition": "Pile-up is the effect of multiple interactions per beam crossing and/or the effects of events overlay. These so called minimum bias events or pile-up add a non-negligible level of background to the response of the detector system. At high luminosities several separate events are likely to occur at the same bunch crossing.",
+    "links": [
+      {
+        "text": "Read more on CMS WorkBook",
+        "url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideSimulation"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "reconstruction"
+      },
+      {
+        "term": "primary"
+      }
+    ],
+    "term": [
+      "Pileup",
+      "pileup",
+      "Pile-up",
+      "pile-up"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
     "anchor": "Pythia",
     "category": "generic",
     "definition": "Pythia is a General Purpose Event Generator.",

--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -147,7 +147,7 @@
     ],
     "see_also": [
       {
-        "term": "montecarlo"
+        "term": "monte carlo"
       },
       {
         "term": "primary"
@@ -156,50 +156,15 @@
         "term": "derived"
       },
       {
-        "term": "condition"
+        "term": "pythia"
       }
     ],
     "term": [
       "Event generator",
       "Event generators",
+      "event generators",
       "Generator",
       "Generators"
-    ],
-    "type": {
-      "primary": "Glossary"
-    }
-  },
-  {
-    "anchor": "tag",
-    "category": "specific",
-    "definition": "A Global Tag is a coherent collection of records of additional data needed by the reconstruction and analysis software. These records are stored in the Condition Database. Condition data include non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for the simulation/reconstruction/analysis software.",
-    "experiment": [
-      {
-        "name": "CMS"
-      }
-    ],
-    "links": [
-      {
-        "text": "Read more about CMS Global Tags",
-        "url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions"
-      }
-    ],
-    "see_also": [
-      {
-        "term": "reconstruction"
-      },
-      {
-        "term": "AOD"
-      },
-      {
-        "term": "primary"
-      }
-    ],
-    "term": [
-      "Global Tag",
-      "Global Tags",
-      "Condition Data",
-      "Condition Database"
     ],
     "type": {
       "primary": "Glossary"
@@ -296,6 +261,35 @@
     }
   },
   {
+    "anchor": "jet",
+    "category": "generic",
+    "definition": "A jet is a shower of hadrons, which originate from a quark or a gluon, clustered together after being produced in particle collisions.",
+    "links": [
+      {
+        "text": "Read more on Wikipedia",
+        "url": "https://en.wikipedia.org/wiki/Jet_%28particle_physics%29"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "proton"
+      },
+      {
+        "term": "quark"
+      },
+      {
+        "term": "hadron"
+      }
+    ],
+    "term": [
+      "Particle jet",
+      "Particle jets"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
     "anchor": "lumisection",
     "category": "specific",
     "definition": "A lumi section is a fixed time period in data taking, approximately 24 seconds.",
@@ -313,7 +307,7 @@
     }
   },
   {
-    "anchor": "montecarlo",
+    "anchor": "monte carlo",
     "category": "generic",
     "definition": "Refers to computational algorithms based on numerical random samplings that is used in simulation programs for generating the particle collisions and for simulating of particle interactions in the detector material. Often used as a synonym for simulated data.",
     "links": [
@@ -396,35 +390,6 @@
     }
   },
   {
-    "anchor": "jet",
-    "category": "generic",
-    "definition": "A jet is a shower of hadrons, which originate from a quark or a gluon, clustered together after being produced in particle collisions.",
-    "links": [
-      {
-        "text": "Read more on Wikipedia",
-        "url": "https://en.wikipedia.org/wiki/Jet_%28particle_physics%29"
-      }
-    ],
-    "see_also": [
-      {
-        "term": "proton"
-      },
-      {
-        "term": "quark"
-      },
-      {
-        "term": "hadron"
-      }
-    ],
-    "term": [
-      "Particle jet",
-      "Particle jets"
-    ],
-    "type": {
-      "primary": "Glossary"
-    }
-  },
-  {
     "anchor": "PAT",
     "category": "specific",
     "definition": "Stands for Physics Analysis Toolkit, and provides easy access to algorithms developed by the CMS Physics Object Groups (POGs) in the framework of CMS Software (CMSSW), suitable for most CMS analyses.",
@@ -469,6 +434,34 @@
     "term": [
       "Photon",
       "Photons"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
+    "anchor": "Pythia",
+    "category": "generic",
+    "definition": "Pythia is a General Purpose Event Generator.",
+    "links": [
+      {
+        "text": "Official website",
+        "url": "http://home.thep.lu.se/~torbjorn/Pythia.html"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "generator"
+      },
+      {
+        "term": "monte carlo"
+      }
+    ],
+    "term": [
+      "Pythia",
+      "pythia",
+      "Pythia6",
+      "Pythia8"
     ],
     "type": {
       "primary": "Glossary"
@@ -624,6 +617,7 @@
     ],
     "term": [
       "Reconstruction",
+      "reconstruction",
       "Reconstructions"
     ],
     "type": {
@@ -664,6 +658,42 @@
       "Run2012B",
       "Run2012C",
       "Run2012D"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
+    "anchor": "tag",
+    "category": "specific",
+    "definition": "A Global Tag is a coherent collection of records of additional data needed by the reconstruction and analysis software. These records are stored in the Condition Database. Condition data include non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for the simulation/reconstruction/analysis software.",
+    "experiment": [
+      {
+        "name": "CMS"
+      }
+    ],
+    "links": [
+      {
+        "text": "Read more about CMS Global Tags",
+        "url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "reconstruction"
+      },
+      {
+        "term": "AOD"
+      },
+      {
+        "term": "primary"
+      }
+    ],
+    "term": [
+      "Global Tag",
+      "Global Tags",
+      "Condition Data",
+      "Condition Database"
     ],
     "type": {
       "primary": "Glossary"

--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -64,6 +64,32 @@
     }
   },
   {
+    "anchor": "Cross section",
+    "category": "generic",
+    "definition": "The \u201dcross section\u201d (σ) of an interaction between two particles is the transverse area that measures the probability of a collision, or scattering. It is also possible to specify this value in terms of a final-state variable, such as energy or particle angle, in what is called \u201ddifferential cross section\u201d. The sum of the differential cross section over all variables is called the \u201dtotal cross section\u201d.",
+    "links": [
+      {
+        "text": "Read more on Wikipedia",
+        "url": "https://en.wikipedia.org/wiki/Cross_section_(physics)"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "Events"
+      },
+      {
+        "term": "hadron"
+      }
+    ],
+    "term": [
+      "Cross section",
+      "cross section"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
     "anchor": "derived",
     "category": "specific",
     "definition": "Contains data that have been derived from the primary datasets. The data may be reduced in the sense that (a) only part of the information is kept or (b) only part of the events are selected.",
@@ -180,6 +206,9 @@
       },
       {
         "term": "Pile-up"
+      },
+      {
+        "term": "Cross section"
       },
       {
         "term": "ion"
@@ -582,6 +611,9 @@
     "see_also": [
       {
         "term": "reconstruction"
+      },
+      {
+        "term": "Cross section"
       },
       {
         "term": "Events"

--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -828,6 +828,36 @@
     }
   },
   {
+    "anchor": "Pseudorapidity",
+    "category": "generic",
+    "definition": "The pseudorapidity η is a coordinate that describes the angle of a particle (or jet) produced in an event relative to the beam axis. It is calculated as $\\eta = - \\ln \\left ( \\tan \\frac{\\theta}{2} \\right )$, with $\\theta$ the angle between the three-momentum and the beam axis. $\\eta = 0$ means the produced particle/jet is perpendicular to the beam axis. While a higher pseudorapidity means it is closer to the beam.",
+    "links": [
+      {
+        "text": "Read more on Wikipedia, ",
+        "url": "https://en.wikipedia.org/wiki/Pseudorapidity"
+      },
+      {
+        "text": "or the article Forward Physics at the LHC",
+        "url": "https://arxiv.org/abs/0708.0551"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "hadron"
+      },
+      {
+        "term": "jet"
+      }
+    ],
+    "term": [
+      "Pseudorapidity",
+      "pseudorapidity"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
     "anchor": "quark",
     "category": "generic",
     "definition": "An elementary particle that comes in six flavours: up, charm and top (all with +2/3 electrical charge) and down, strange and bottom (all with -1/3 electrical charge). Quarks also have a property known as \u201ccolour charge\u201d and cannot exist freely because of a phenomenon called \u201ccolour confinement\u201d: they are held together by gluons to form hadrons.",

--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -217,6 +217,9 @@
         "term": "jet"
       },
       {
+        "term": "Parton"
+      },
+      {
         "term": "ion"
       }
     ],
@@ -384,6 +387,37 @@
     "term": [
       "Neutrino",
       "Neutrinos"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
+    "anchor": "Parton",
+    "category": "generic",
+    "definition": "The Parton Model is a model to describe hadrons. Any hadron can be considered to be composed by partons.",
+    "links": [
+      {
+        "text": "Read more on Wikipedia",
+        "url": "https://en.wikipedia.org/wiki/Parton_(particle_physics)"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "hadron"
+      },
+      {
+        "term": "proton"
+      },
+      {
+        "term": "quark"
+      }
+    ],
+    "term": [
+      "parton",
+      "Parton",
+      "partons",
+      "Partons"
     ],
     "type": {
       "primary": "Glossary"

--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -37,6 +37,34 @@
     }
   },
   {
+    "anchor": "barn",
+    "category": "generic",
+    "definition": "Barn is a unit of area, used to express cross sections, and is equivalent to $10^{-24}$ cm². The inverse femtobarn ($fb^{-1}$) is the typical unit used for time-integrated Luminosity.",
+    "links": [
+      {
+        "text": "Read more in Wikipedia",
+        "url": "https://en.wikipedia.org/wiki/Barn_(unit)"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "Cross section"
+      },
+      {
+        "term": "Luminosity"
+      }
+    ],
+    "term": [
+      "Barn",
+      "barn",
+      "Femtobarn",
+      "femtobarn"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
     "anchor": "CMSSW",
     "category": "specific",
     "definition": "Stands for CMS Software and refers to (1) the so-called \u201cOffline\u201d software needed to simulate, reconstruct and analyse CMS data, and (2) the \u201cOnline\u201d software needed for data selection and storage.",
@@ -79,6 +107,9 @@
       },
       {
         "term": "Luminosity"
+      },
+      {
+        "term": "barn"
       },
       {
         "term": "hadron"
@@ -199,8 +230,12 @@
     "definition": "An event is a collision of the beams. In the LHC, it is primarily a collision of protons, but it can also use beams of ions.",
     "links": [
       {
-        "text": "Read more on Wikipedia",
+        "text": "Read more on Wikipedia, ",
         "url": "https://en.wikipedia.org/wiki/Event_(particle_physics)"
+      },
+      {
+        "text": "Read more on Guide to the CMS Trigger System",
+        "url": "/docs/cms-guide-trigger-system"
       }
     ],
     "see_also": [
@@ -423,7 +458,7 @@
   {
     "anchor": "Luminosity",
     "category": "generic",
-    "definition": "The Luminosity (L) indicates the number of events per time per cross section. The \u201dIntegrated Luminosity\u201d is the sum of the luminosity over time.",
+    "definition": "The Luminosity (L) indicates the number of events per time per cross section. The \u201dIntegrated Luminosity\u201d is the sum of the luminosity over time, and is typically measured in units of inverse femtobarn.",
     "links": [
       {
         "text": "Read more on Wikipedia,",
@@ -436,6 +471,9 @@
       },
       {
         "term": "Events"
+      },
+      {
+        "term": "barn"
       },
       {
         "term": "lumisection"
@@ -646,8 +684,12 @@
     "definition": "Pile-up is the effect of multiple interactions per beam crossing and/or the effects of events overlay. These so called minimum bias events or pile-up add a non-negligible level of background to the response of the detector system. At high luminosities several separate events are likely to occur at the same bunch crossing.",
     "links": [
       {
-        "text": "Read more on CMS WorkBook",
+        "text": "Read more on CMS WorkBook, ",
         "url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideSimulation"
+      },
+      {
+        "text": "Read more on CMS Pile-up Simulation",
+        "url": "/docs/cms-guide-pileup-simulation"
       }
     ],
     "see_also": [
@@ -940,8 +982,12 @@
     "definition": "A system that determines which particle collisions are stored in primary datasets and which ones are discarded. The triggering is done first by a lower-level hardware-based trigger (L1) and then by the High-Level Trigger (HLT) on a computing farm.",
     "links": [
       {
-        "text": "Read more on Wikipedia",
+        "text": "Read more on Wikipedia, ",
         "url": "https://en.wikipedia.org/wiki/Trigger_%28particle_physics%29"
+      },
+      {
+        "text": "Read more on Guide to the CMS Trigger System",
+        "url": "/docs/cms-guide-trigger-system"
       }
     ],
     "see_also": [

--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -165,6 +165,37 @@
     }
   },
   {
+    "anchor": "Events",
+    "category": "generic",
+    "definition": "An event is a collision of the beams. In the LHC, it is primarily a collision of protons, but it can also use beams of ions.",
+    "links": [
+      {
+        "text": "Read more on Wikipedia",
+        "url": "https://en.wikipedia.org/wiki/Event_(particle_physics)"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "proton"
+      },
+      {
+        "term": "Pile-up"
+      },
+      {
+        "term": "ion"
+      }
+    ],
+    "term": [
+      "Event",
+      "event",
+      "Events",
+      "events"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
     "anchor": "generator",
     "category": "generic",
     "definition": "Simulation programs used to generate particle collisions.",
@@ -517,6 +548,9 @@
         "term": "reconstruction"
       },
       {
+        "term": "Events"
+      },
+      {
         "term": "primary"
       }
     ],
@@ -613,7 +647,7 @@
   {
     "anchor": "proton",
     "category": "generic",
-    "definition": "A stable composite particle belonging to the \u201chadron\u201d family of particles, made of two up quarks and a down quark. It has a +1 electrical charge and is found in the nuclei of atoms. A proton has a mass of ~938 MeV/c<sup>2</sup>, or about 1836 times the mass of an electron. Protons are one of the species of particles collided at the LHC.",
+    "definition": "A stable composite particle belonging to the \u201chadron\u201d family of particles, made of two up quarks and a down quark. It has a +1 electrical charge and is found in the nuclei of atoms. A proton has a mass of $\\sim 938 MeV/c^2$, or about 1836 times the mass of an electron. Protons are one of the species of particles collided at the LHC.",
     "links": [
       {
         "text": "Read more on Wikipedia",

--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -138,7 +138,7 @@
   {
     "anchor": "electron",
     "category": "generic",
-    "definition": "A stable elementary particle belonging to the first generation of the \u201clepton\u201d family of particles. It has a $-$1 electrical charge, while its anti-particle, the anti-electron or positron, has a +1 electrical charge. Atoms are made of electrons orbiting positively charged nuclei. An electron has a mass of ~0.5 MeV/c$^2$, or about 1/1836 times the mass of a proton.",
+    "definition": "A stable elementary particle belonging to the first generation of the \u201clepton\u201d family of particles. It has a -1 electrical charge, while its anti-particle, the anti-electron or positron, has a +1 electrical charge. Atoms are made of electrons orbiting positively charged nuclei. An electron has a mass of $\\sim 0.5 MeV/c^2$, or about $1/1836$ times the mass of a proton.",
     "links": [
       {
         "text": "Read more on Wikipedia",
@@ -214,6 +214,9 @@
       },
       {
         "term": "derived"
+      },
+      {
+        "term": "Les Houches Event file"
       },
       {
         "term": "pythia"
@@ -347,6 +350,39 @@
     "term": [
       "Particle jet",
       "Particle jets"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
+    "anchor": "Les Houches Event file",
+    "category": "generic",
+    "definition": "The Les Houches Event file format is a standard in event generators to define event listings in a common language.",
+    "links": [
+      {
+        "text": "Read more on Wikipedia,",
+        "url": "https://en.wikipedia.org/wiki/Les_Houches_Accords"
+      },
+      {
+        "text": "Les Houches Event Format paper",
+        "url": "https://arxiv.org/abs/hep-ph/0609017"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "generator"
+      },
+      {
+        "term": "Events"
+      },
+      {
+        "term": "reconstruction"
+      }
+    ],
+    "term": [
+      "LHE",
+      "Les Houches"
     ],
     "type": {
       "primary": "Glossary"

--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -78,6 +78,9 @@
         "term": "Events"
       },
       {
+        "term": "Luminosity"
+      },
+      {
         "term": "hadron"
       }
     ],
@@ -418,6 +421,35 @@
     }
   },
   {
+    "anchor": "Luminosity",
+    "category": "generic",
+    "definition": "The Luminosity (L) indicates the number of events per time per cross section. The \u201dIntegrated Luminosity\u201d is the sum of the luminosity over time.",
+    "links": [
+      {
+        "text": "Read more on Wikipedia,",
+        "url": "https://en.wikipedia.org/wiki/Luminosity_(scattering_theory)"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "Cross section"
+      },
+      {
+        "term": "Events"
+      },
+      {
+        "term": "lumisection"
+      }
+    ],
+    "term": [
+      "luminosity",
+      "Luminosity"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
     "anchor": "lumisection",
     "category": "specific",
     "definition": "A lumi section is a fixed time period in data taking, approximately 24 seconds.",
@@ -426,8 +458,18 @@
         "name": "CMS"
       }
     ],
+    "see_also": [
+      {
+        "term": "Cross section"
+      },
+      {
+        "term": "Events"
+      }
+    ],
     "term": [
       "Lumi section",
+      "lumi section",
+      "Lumisection",
       "lumisection"
     ],
     "type": {

--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -107,6 +107,35 @@
     }
   },
   {
+    "anchor": "Drell-Yan",
+    "category": "generic",
+    "definition": "In hadron-hadron scattering, the Drell-Yan process produces a pair of oppositely charged leptons. This happens by the annihilation of a quark from one hadron with an antiquark from another hadron, which then creates a virtual photon or Z boson that decays into the lepton pair.",
+    "links": [
+      {
+        "text": "Read more on Wikipedia",
+        "url": "https://en.wikipedia.org/wiki/Drell-Yan_process"
+      }
+    ],
+    "see_also": [
+      {
+        "term": "hadron"
+      },
+      {
+        "term": "quark"
+      },
+      {
+        "term": "gluon"
+      }
+    ],
+    "term": [
+      "Drell–Yan",
+      "Drell-Yan process"
+    ],
+    "type": {
+      "primary": "Glossary"
+    }
+  },
+  {
     "anchor": "electron",
     "category": "generic",
     "definition": "A stable elementary particle belonging to the first generation of the \u201clepton\u201d family of particles. It has a $-$1 electrical charge, while its anti-particle, the anti-electron or positron, has a +1 electrical charge. Atoms are made of electrons orbiting positively charged nuclei. An electron has a mass of ~0.5 MeV/c$^2$, or about 1/1836 times the mass of a proton.",
@@ -199,7 +228,7 @@
   {
     "anchor": "hadron",
     "category": "generic",
-    "definition": "A composite particle made of two or more quarks. There are two sub-categories of hadrons: \u201cbaryons\u201d such as protons and neutrons are made of three quarks (or three anti-quarks), while \u201cmesons\u201d are made of a quark and an anti-quark. Atomic nuclei can also be considered hadrons, since they are also fundamentally made of quarks. The LHC collides two species of hadrons: protons and lead nuclei (also called lead ions). Hadrons produced in collisions typically cluster together to form particle jets in the detectors.",
+    "definition": "A composite particle made of two or more quarks. There are two sub-categories of hadrons: \u201cbaryons\u201d, such as protons and neutrons, are made of three quarks (or three anti-quarks), while \u201cmesons\u201d are made of a quark and an anti-quark. Atomic nuclei can also be considered hadrons, since they are also fundamentally made of quarks. The LHC collides two species of hadrons: protons and lead nuclei (also called lead ions). Hadrons produced in collisions typically cluster together to form particle jets in the detectors.",
     "links": [
       {
         "text": "Read more on Wikipedia",
@@ -343,7 +372,7 @@
   {
     "anchor": "muon",
     "category": "generic",
-    "definition": "An elementary particle belonging to the second generation of the \u201clepton\u201d family of particles. It has a $-$1 electrical charge, while its anti-particle, the anti-muon, has a +1 electrical charge. A muon\u2019s properties are similar to those of an electron but it is around 200 times more massive. It is represented by the Greek letter \u201c$\\mu$\u201d.",
+    "definition": "An elementary particle belonging to the second generation of the \u201clepton\u201d family of particles. It has a -1 electrical charge, while its anti-particle, the anti-muon, has a +1 electrical charge. A muon\u2019s properties are similar to those of an electron but it is around 200 times more massive. It is represented by the Greek letter \u201c$\\mu$\u201d.",
     "links": [
       {
         "text": "Read more on Wikipedia",
@@ -585,7 +614,7 @@
   {
     "anchor": "quark",
     "category": "generic",
-    "definition": "An elementary particle that comes in six flavours: up, charm and top (all with +2/3 electrical charge) and down, strange and bottom (all with $-$1/3 electrical charge). Quarks also have a property known as \u201ccolour charge\u201d and cannot exist freely because of a phenomenon called \u201ccolour confinement\u201d: they are held together by gluons to form hadrons.",
+    "definition": "An elementary particle that comes in six flavours: up, charm and top (all with +2/3 electrical charge) and down, strange and bottom (all with -1/3 electrical charge). Quarks also have a property known as \u201ccolour charge\u201d and cannot exist freely because of a phenomenon called \u201ccolour confinement\u201d: they are held together by gluons to form hadrons.",
     "links": [
       {
         "text": "Read more on Wikipedia",


### PR DESCRIPTION
Add more items to glossary.

Some of the entries start with upper case letter, some with lower case letter. Should we uniformise this? The alphabetical ordering of the portal is case sensitive.

Do we need more items there as well?

Fix #1920