### PR TITLE
Fixes typo in the description of record 1802

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-2012.json
@@ -51,7 +51,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n      <p> These files are needed when running a CMSSW job on the Open Data VM. They are automatically read from the /cvmfs/cms-opendata-conddb.cern.ch runtime, you do not need to download these files from here separately.</p>\n      <p>START53_LVA1 is to be used with the simulated data.</p>\n  <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p>\n    <p>For 2012 CMS collision data see:</p>",
+      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n      <p> These files are needed when running a CMSSW job on the Open Data VM. They are automatically read from the /cvmfs/cms-opendata-conddb.cern.ch runtime, you do not need to download these files from here separately.</p>\n      <p>START53_V27 is to be used with the simulated data.</p>\n  <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p>\n    <p>For 2012 CMS collision data see:</p>",
       "links": [
         {
           "recid": "1803"

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2011A.json
@@ -44,7 +44,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n      <p> These files are needed when running a CMSSW job on the Open Data VM. They are automatically read from the /cvmfs/cms-opendata-conddb.cern.ch runtime, you do not need to download these files from here separately.</p>\n      <p>START53_LVA1 is to be used with the simulated data.</p>\n    <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p>\n        <p>For 2011 CMS collision data see:</p>",
+      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n      <p> These files are needed when running a CMSSW job on the Open Data VM. They are automatically read from the /cvmfs/cms-opendata-conddb.cern.ch runtime, you do not need to download these files from here separately.</p>\n      <p>START53_LV6A1 is to be used with the simulated data.</p>\n    <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p>\n        <p>For 2011 CMS collision data see:</p>",
       "links": [
         {
           "recid": "1801"


### PR DESCRIPTION
START53_LVA1 -> START53_LV6A1


