### PR TITLE
Installation: bump markdown engines version.

### DIFF
--- a/DEVELOPING.rst
+++ b/DEVELOPING.rst
@@ -45,8 +45,31 @@ The portal uses `Python-markdown <https://python-markdown.github.io/>`_ for
 Markdown rendering. There are `some differences
 <https://python-markdown.github.io/#differences>`_ between this implementation
 and the `syntax rules <https://daringfireball.net/projects/markdown/syntax>`_,
-mainly concerning lists. You must always use 4 spaces (or a tab) for indentation
-and the same character (-, *, +, numbers) for items list.
+mainly concerning lists:
+
+* You must always use 4 spaces (or a tab) for indentation and the same
+  character (-, *, +, numbers) for items list.
+* To add a Table Of Contents to a document place the identifier ``[TOC]``
+  where you want it to be.
+
+The following extensions are enabled:
+
+* `markdown.extensions.attr_list <https://python-markdown.github.io/extensions/attr_list/>`_
+* `markdown.extensions.tables <https://python-markdown.github.io/extensions/tables/>`_
+* `markdown.extensions.toc <https://python-markdown.github.io/extensions/toc/>`_
+* `pymdownx.magiclink <https://facelessuser.github.io/pymdown-extensions/extensions/magiclink/>`_
+* `pymdownx.betterem <https://facelessuser.github.io/pymdown-extensions/extensions/betterem/>`_
+* `pymdownx.tilde <https://facelessuser.github.io/pymdown-extensions/extensions/tilde/>`_
+* `pymdownx.emoji <https://facelessuser.github.io/pymdown-extensions/extensions/emoji/>`_
+* `pymdownx.tasklist <https://facelessuser.github.io/pymdown-extensions/extensions/tasklist/>`_
+* `pymdownx.superfences <https://facelessuser.github.io/pymdown-extensions/extensions/superfences/>`_
+* `mdx_math <https://pypi.org/project/python-markdown-math/>`_
+
+Working with LaTeX
+------------------
+
+LaTeX is enabled with the `mdx_math` extension. Inline equations are between
+single ``$``, e.g. ``$E = m c^2$``. For standalone math, use ``\[...\]``.
 
 Working with docs
 -----------------

--- a/cernopendata/modules/fixtures/data/docs/cms-guide-for-education/cms-guide-for-education.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-for-education/cms-guide-for-education.md
@@ -1,12 +1,11 @@
 This page will guide you through contents of the CMS Open Data collections that are meant for educational use (or for physics enthusiasts!). It is roughly broken down into three levels of difficulty:
 
-* Beginner: *Visualise collisions*
-* Intermediate: *Make histograms with collision data*
-* Advanced: *Dive deeper into the data*
+* Beginner: [*Visualise collisions*](#visualise-collisions)
+* Intermediate: [*Make histograms with collision data*](#make-histograms-with-collision-data)
+* Advanced: [*Dive deeper into the data*](#dive-deeper-into-the-data)
 
----
 
-#### Visualise collisions
+## Visualise collisions
 
 If you are new to particle physics, your time is limited, or you want to do something online fairly quickly, have a look at visual displays of real particle collisions. For example, here are collision events which contributed to the discovery of the Higgs boson in 2012:
 
@@ -34,9 +33,8 @@ You can also download these files directly from the records on this portal.
 
 To learn how to use the [CMS event display](/visualise/events/cms), click on `Need help?` link on the top right side of the screen. For suggestions for classroom activities see [Tutorials and worksheets for CMS Event Display](/record/5103).
 
----
 
-#### Make histograms with collision data
+## Make histograms with collision data
 
 You can get an overview of our education resources through [this search query](/search?page=1&size=20&q=learning%20school%20education&experiment=CMS) with your keyword of interest (you can change the pre-defined keywords here). Here are some highlights:
 
@@ -49,9 +47,9 @@ You can get an overview of our education resources through [this search query](/
     * [Analysing CMS Open Data in Jupyter using **R**](/record/5102), with a brief intro to the R programming language
 * All applications mentioned above use open data in simplified CSV (comma-separated values) format. See [all available CSV datasets](/search?page=1&size=20&q=&type=Dataset&experiment=CMS&subtype=Derived&file_type=csv), which have been extracted directly from the original collision datasets.
     * If you are interested in producing your own selection of open data in CSV format, see [example software ](/record/552) for the processing step.
----
 
-#### Dive deeper into the data
+
+## Dive deeper into the data
 
 If you want a more detailed understanding of particle physics or an introduction aimed at the university level, take a look at some of the other resources in [this search query](/search?page=1&size=20&q=&keywords=education&experiment=CMS).
 

--- a/cernopendata/modules/markdown/ext.py
+++ b/cernopendata/modules/markdown/ext.py
@@ -95,7 +95,9 @@ class CernopendataMarkdown(object):
         # GitHub Flavored Markdown.
         # github extension is deprecated, workaround is to use other extensions
         # https://facelessuser.github.io/pymdown-extensions/faq/
+        pymd_extensions.append('markdown.extensions.attr_list')
         pymd_extensions.append('markdown.extensions.tables')
+        pymd_extensions.append('markdown.extensions.toc')
         pymd_extensions.append('pymdownx.magiclink')
         pymd_extensions.append('pymdownx.betterem')
         pymd_extensions.append('pymdownx.tilde')
@@ -110,6 +112,11 @@ class CernopendataMarkdown(object):
         # For config format see:
         # https://pythonhosted.org/Markdown/reference.html#extension_configs
         pymd_extension_configs = {
+            'markdown.extensions.toc.': {
+                'anchorlink': True,
+                'permalink': True,
+                'toc_depth': 3
+            },
             'pymdownx.tilde': {
                 'subscript': True
             },

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -86,7 +86,7 @@ jupyter-core==4.3.0
 kombu==4.1.0
 lxml==4.1.0
 Mako==1.0.7
-Markdown==2.6.11
+Markdown==3.0.1
 MarkupSafe==1.0
 marshmallow==2.14.0
 mistune==0.7.4
@@ -110,7 +110,7 @@ ptyprocess==0.5.2
 py==1.4.34
 pydocstyle==2.1.1
 Pygments==2.2.0
-pymdown-extensions==5.0.0
+pymdown-extensions==6.0.0
 pyPEG2==2.15.2
 pytest==3.2.3
 pytest-cache==1.0


### PR DESCRIPTION
- python-markdown 2.6.11 -> 3.0.1
- pymdown-extensions 5.0.0 -> 6.0.0

Add extensions:
- markdown.extensions.attr_list
- markdown.extensions.toc

fix #1842

Update DEVELOPING.rst with markdown and latex tips


To add a Table Of Contents to a document place the identifier `[TOC]`  where you want it to be. It will translate all the headers into a Table Of Contents with the appropriate links.
