### PR TITLE
records: topic becomes categories

### DIFF
--- a/cernopendata/config.py
+++ b/cernopendata/config.py
@@ -303,9 +303,12 @@ RECORDS_REST_FACETS = {
             collision_energy=dict(terms=dict(
                 field='collision_information.energy.keyword',
                 order=dict(_term='asc'))),
-            topic_category=dict(terms=dict(
-                field='topic.category.keyword',
-                order=dict(_term='asc'))),
+            category=dict(terms=dict(
+                field='categories.primary.keyword',
+                order=dict(_term='asc')),
+                aggs=dict(subcategory=dict(terms=dict(
+                          field="categories.secondary.keyword",
+                          order=dict(_term='asc'))))),
         ),
         'post_filters': dict(
             experiment=terms_filter('experiment.keyword'),
@@ -317,7 +320,8 @@ RECORDS_REST_FACETS = {
             collision_type=terms_filter('collision_information.type.keyword'),
             collision_energy=terms_filter('collision_information.energy'
                                           '.keyword'),
-            topic_category=terms_filter('topic.category.keyword'),
+            category=terms_filter('categories.primary.keyword'),
+            subcategory=terms_filter('categories.secondary.keyword'),
             file_type=terms_filter('distribution.formats.keyword'),
             collections=terms_filter('collections.keyword'),
         ),

--- a/cernopendata/jsonschemas/records/record-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/record-v1.0.0.json
@@ -100,6 +100,26 @@
       },
       "type": "array"
     },
+    "categories": {
+      "properties": {
+        "primary": {
+          "description": "Primary category of the simulated dataset or related asset",
+          "type": "string"
+        },
+        "secondary": {
+          "items": {
+            "description": "The secondary category of the simulated dataset of related asset",
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "source": {
+          "description": "The authority who attributed the category",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "cms_confdb_id": {
       "description": "the cms_confdb_id (applies to CMS records)",
       "type": "string"
@@ -449,17 +469,6 @@
     "title_additional": {
       "description": "A more descriptive, human-readble title",
       "type": "string"
-    },
-    "topic": {
-      "properties": {
-        "category": {
-          "type": "string"
-        },
-        "source": {
-          "type": "string"
-        }
-      },
-      "type": "object"
     },
     "type": {
       "properties": {

--- a/cernopendata/mappings/records/record-v1.0.0.json
+++ b/cernopendata/mappings/records/record-v1.0.0.json
@@ -20,6 +20,26 @@
             }
           }
         },
+        "categories": {
+          "properties": {
+            "primary": {
+              "fields": {
+                "keyword": {
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            },
+            "secondary": {
+              "fields": {
+                "keyword": {
+                  "type": "keyword"
+                }
+              },
+              "type": "text"
+            }
+          }
+        },
         "collections": {
           "fields": {
             "keyword": {
@@ -99,18 +119,6 @@
             }
           },
           "type": "text"
-        },
-        "topic": {
-          "properties": {
-            "category": {
-              "fields": {
-                "keyword": {
-                  "type": "keyword"
-                }
-              },
-              "type": "text"
-            }
-          }
         },
         "type": {
           "properties": {

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
@@ -4,6 +4,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-550_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -90,10 +97,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-550_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-550_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -122,6 +125,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-550_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -196,10 +206,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-550_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-550_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -228,6 +234,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -314,10 +327,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -346,6 +355,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -432,10 +448,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -464,6 +476,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -538,10 +557,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -570,6 +585,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-600_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -656,10 +678,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-600_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-600_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -688,6 +706,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-600_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -774,10 +799,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-600_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-600_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -806,6 +827,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -892,10 +920,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -924,6 +948,13 @@
       "description": "\n          <p>Simulated dataset ZZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -997,10 +1028,6 @@
     },
     "title": "/ZZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset ZZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -1029,6 +1056,13 @@
       "description": "\n          <p>Simulated dataset ZZJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -1114,10 +1148,6 @@
     },
     "title": "/ZZJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -1146,6 +1176,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-650_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -1232,10 +1269,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-650_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-650_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -1264,6 +1297,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-650_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -1362,10 +1402,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-650_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-650_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -1394,6 +1430,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-700_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -1468,10 +1511,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-700_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-700_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -1500,6 +1539,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-700_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -1598,10 +1644,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-700_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-700_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -1630,6 +1672,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-750_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -1716,10 +1765,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-750_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-750_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -1748,6 +1793,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-800_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -1834,10 +1886,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-800_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-800_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -1866,6 +1914,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-800_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -1952,10 +2007,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-800_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-800_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -1984,6 +2035,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-850_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -2058,10 +2116,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-850_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-850_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -2090,6 +2144,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-900_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -2188,10 +2249,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-900_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-900_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -2220,6 +2277,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-900_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -2318,10 +2382,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-900_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-900_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -2350,6 +2410,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-950_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -2424,10 +2491,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-950_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-950_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -2456,6 +2519,13 @@
       "description": "\n          <p>Simulated dataset Graviton2PH6ToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Exotica",
+      "secondary": [
+        "Gravitons"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -2530,10 +2600,6 @@
     },
     "title": "/Graviton2PH6ToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Graviton2PH6ToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -2562,6 +2628,13 @@
       "description": "\n          <p>Simulated dataset Higgs0MToGGTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -2648,10 +2721,6 @@
     },
     "title": "/Higgs0MToGGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0MToGGTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -2680,6 +2749,13 @@
       "description": "\n          <p>Simulated dataset Higgs0MToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -2754,10 +2830,6 @@
     },
     "title": "/Higgs0MToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset Higgs0MToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -2786,6 +2858,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -2872,10 +2951,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -2904,6 +2979,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -2990,10 +3072,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -3022,6 +3100,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -3108,10 +3193,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -3140,6 +3221,13 @@
       "description": "\n          <p>Simulated dataset Higgs0Mf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -3226,10 +3314,6 @@
     },
     "title": "/Higgs0Mf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0Mf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -3258,6 +3342,13 @@
       "description": "\n          <p>Simulated dataset Higgs0PMToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -3332,10 +3423,6 @@
     },
     "title": "/Higgs0PMToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset Higgs0PMToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -3364,6 +3451,13 @@
       "description": "\n          <p>Simulated dataset Higgs0PMToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -3450,10 +3544,6 @@
     },
     "title": "/Higgs0PMToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0PMToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -3482,6 +3572,13 @@
       "description": "\n          <p>Simulated dataset JJHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -3556,10 +3653,6 @@
     },
     "title": "/JJHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset JJHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -3588,6 +3681,13 @@
       "description": "\n          <p>Simulated dataset JJHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -3686,10 +3786,6 @@
     },
     "title": "/JJHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset JJHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -3718,6 +3814,13 @@
       "description": "\n          <p>Simulated dataset JJHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -3792,10 +3895,6 @@
     },
     "title": "/JJHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset JJHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -3824,6 +3923,13 @@
       "description": "\n          <p>Simulated dataset JJHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -3898,10 +4004,6 @@
     },
     "title": "/JJHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset JJHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -3930,6 +4032,13 @@
       "description": "\n          <p>Simulated dataset JJHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -4028,10 +4137,6 @@
     },
     "title": "/JJHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset JJHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -4060,6 +4165,10 @@
       "description": "\n          <p>Simulated dataset JPsiToMuMu_2MuPEtaFilter_7TeV-pythia6-evtgen-v2 in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -4169,10 +4278,6 @@
     },
     "title": "/JPsiToMuMu_2MuPEtaFilter_7TeV-pythia6-evtgen-v2/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset JPsiToMuMu_2MuPEtaFilter_7TeV-pythia6-evtgen-v2 in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -4201,6 +4306,10 @@
       "description": "\n          <p>Simulated dataset LambdaBToJPsiLambda_lambdaFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -4287,10 +4396,6 @@
     },
     "title": "/LambdaBToJPsiLambda_lambdaFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset LambdaBToJPsiLambda_lambdaFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -4319,6 +4424,10 @@
       "description": "\n          <p>Simulated dataset LambdaBToLambdaJpsi_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -4393,10 +4502,6 @@
     },
     "title": "/LambdaBToLambdaJpsi_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset LambdaBToLambdaJpsi_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -4425,6 +4530,10 @@
       "description": "\n          <p>Simulated dataset LambdaBToLambdaMuMu_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -4499,10 +4608,6 @@
     },
     "title": "/LambdaBToLambdaMuMu_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset LambdaBToLambdaMuMu_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -4531,6 +4636,10 @@
       "description": "\n          <p>Simulated dataset LambdaBToLambdaPsi_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -4605,10 +4714,6 @@
     },
     "title": "/LambdaBToLambdaPsi_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset LambdaBToLambdaPsi_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -4637,6 +4742,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-0to5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -4710,10 +4822,6 @@
     },
     "title": "/QCD_Pt-0to5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-0to5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -4742,6 +4850,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -4815,10 +4930,6 @@
     },
     "title": "/QCD_Pt-1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -4847,6 +4958,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-1000to1400_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -4920,10 +5038,6 @@
     },
     "title": "/QCD_Pt-1000to1400_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-1000to1400_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -4952,6 +5066,13 @@
       "description": "\n          <p>Simulated dataset ZZJetsTo4L_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -5037,10 +5158,6 @@
     },
     "title": "/ZZJetsTo4L_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZJetsTo4L_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -5069,6 +5186,13 @@
       "description": "\n          <p>Simulated dataset ZZTo2e2muJJ_Contin_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -5155,10 +5279,6 @@
     },
     "title": "/ZZTo2e2muJJ_Contin_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo2e2muJJ_Contin_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -5187,6 +5307,13 @@
       "description": "\n          <p>Simulated dataset ZZTo2e2mu_7TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -5309,10 +5436,6 @@
     },
     "title": "/ZZTo2e2mu_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo2e2mu_7TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -5341,6 +5464,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -5427,10 +5557,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -5459,6 +5585,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-120to170_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -5532,10 +5665,6 @@
     },
     "title": "/QCD_Pt-120to170_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-120to170_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -5564,6 +5693,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-120to170_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -5637,10 +5773,6 @@
     },
     "title": "/QCD_Pt-120to170_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-120to170_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -5669,6 +5801,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -5743,10 +5882,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -5775,6 +5910,13 @@
       "description": "\n          <p>Simulated dataset VBFHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -5849,10 +5991,6 @@
     },
     "title": "/VBFHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -5881,6 +6019,13 @@
       "description": "\n          <p>Simulated dataset VBFHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -5967,10 +6112,6 @@
     },
     "title": "/VBFHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset VBFHiggs0MToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -5999,6 +6140,13 @@
       "description": "\n          <p>Simulated dataset VBFHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -6073,10 +6221,6 @@
     },
     "title": "/VBFHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -6105,6 +6249,13 @@
       "description": "\n          <p>Simulated dataset VBFHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -6179,10 +6330,6 @@
     },
     "title": "/VBFHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -6211,6 +6358,13 @@
       "description": "\n          <p>Simulated dataset Tbar_TuneZ2_tW-channel-DS_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -6284,10 +6438,6 @@
     },
     "title": "/Tbar_TuneZ2_tW-channel-DS_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Tbar_TuneZ2_tW-channel-DS_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -6316,6 +6466,13 @@
       "description": "\n          <p>Simulated dataset Tbar_TuneZ2_tW-channel-DR_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -6389,10 +6546,6 @@
     },
     "title": "/Tbar_TuneZ2_tW-channel-DR_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Tbar_TuneZ2_tW-channel-DR_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -6421,6 +6574,13 @@
       "description": "\n          <p>Simulated dataset T_TuneZ2_tW-channel-DS_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -6495,10 +6655,6 @@
     },
     "title": "/T_TuneZ2_tW-channel-DS_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset T_TuneZ2_tW-channel-DS_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -6527,6 +6683,13 @@
       "description": "\n          <p>Simulated dataset T_TuneZ2_t-channel_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -6601,10 +6764,6 @@
     },
     "title": "/T_TuneZ2_t-channel_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset T_TuneZ2_t-channel_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -6633,6 +6792,13 @@
       "description": "\n          <p>Simulated dataset TTbarH_HToZZTo4L_M-130_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -6706,10 +6872,6 @@
     },
     "title": "/TTbarH_HToZZTo4L_M-130_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset TTbarH_HToZZTo4L_M-130_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -6738,6 +6900,13 @@
       "description": "\n          <p>Simulated dataset TT_weights_CT10_TuneZ2_7TeV-powheg-pythia-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -6825,10 +6994,6 @@
     },
     "title": "/TT_weights_CT10_TuneZ2_7TeV-powheg-pythia-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset TT_weights_CT10_TuneZ2_7TeV-powheg-pythia-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -6857,6 +7022,13 @@
       "description": "\n          <p>Simulated dataset TTTo2L2Nu2B_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -6931,10 +7103,6 @@
     },
     "title": "/TTTo2L2Nu2B_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTTo2L2Nu2B_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -6963,6 +7131,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_matchingup_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -7063,10 +7238,6 @@
     },
     "title": "/TTJets_MSDecays_matchingup_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_matchingup_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -7095,6 +7266,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_matchingdown_mt172_5_7TeV-madgraph in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -7169,10 +7347,6 @@
     },
     "title": "/TTJets_MSDecays_matchingdown_mt172_5_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_matchingdown_mt172_5_7TeV-madgraph in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -7201,6 +7375,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -7287,10 +7468,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -7319,6 +7496,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-1400to1800_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -7392,10 +7576,6 @@
     },
     "title": "/QCD_Pt-1400to1800_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-1400to1800_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -7424,6 +7604,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-15to20_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -7509,10 +7696,6 @@
     },
     "title": "/QCD_Pt-15to20_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-15to20_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -7541,6 +7724,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-15to30_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -7698,10 +7888,6 @@
     },
     "title": "/QCD_Pt-15to30_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-15to30_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -7730,6 +7916,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-170to250_EMEnriched_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -7803,10 +7996,6 @@
     },
     "title": "/QCD_Pt-170to250_EMEnriched_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-170to250_EMEnriched_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -7835,6 +8024,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-170to300_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -7908,10 +8104,6 @@
     },
     "title": "/QCD_Pt-170to300_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-170to300_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -7940,6 +8132,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-170to300_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -8013,10 +8212,6 @@
     },
     "title": "/QCD_Pt-170to300_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-170to300_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -8045,6 +8240,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-1800_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -8118,10 +8320,6 @@
     },
     "title": "/QCD_Pt-1800_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-1800_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -8150,6 +8348,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-20_MuEnrichedPt-10_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -8223,10 +8428,6 @@
     },
     "title": "/QCD_Pt-20_MuEnrichedPt-10_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-20_MuEnrichedPt-10_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -8255,6 +8456,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-20_MuEnrichedPt-15_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -8328,10 +8536,6 @@
     },
     "title": "/QCD_Pt-20_MuEnrichedPt-15_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-20_MuEnrichedPt-15_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -8360,6 +8564,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-20to30_BCtoE_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -8433,10 +8644,6 @@
     },
     "title": "/QCD_Pt-20to30_BCtoE_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-20to30_BCtoE_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -8465,6 +8672,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-20to30_EMEnriched_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -8538,10 +8752,6 @@
     },
     "title": "/QCD_Pt-20to30_EMEnriched_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-20to30_EMEnriched_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -8570,6 +8780,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-20to30_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -8643,10 +8860,6 @@
     },
     "title": "/QCD_Pt-20to30_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-20to30_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -8675,6 +8888,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-250to350_EMEnriched_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -8748,10 +8968,6 @@
     },
     "title": "/QCD_Pt-250to350_EMEnriched_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-250to350_EMEnriched_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -8780,6 +8996,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-300to470_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -8853,10 +9076,6 @@
     },
     "title": "/QCD_Pt-300to470_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-300to470_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -8885,6 +9104,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -8959,10 +9185,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -8991,6 +9213,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -9065,10 +9294,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -9097,6 +9322,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -9183,10 +9415,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -9215,6 +9443,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -9289,10 +9524,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -9321,6 +9552,13 @@
       "description": "\n          <p>Simulated dataset ZZTo2e2mu_mll4_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -9419,10 +9657,6 @@
     },
     "title": "/ZZTo2e2mu_mll4_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo2e2mu_mll4_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -9451,6 +9685,13 @@
       "description": "\n          <p>Simulated dataset Tbar_TuneZ2_t-channel_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -9524,10 +9765,6 @@
     },
     "title": "/Tbar_TuneZ2_t-channel_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Tbar_TuneZ2_t-channel_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -9556,6 +9793,10 @@
       "description": "\n          <p>Simulated dataset BuToKMuMu_BFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -9642,10 +9883,6 @@
     },
     "title": "/BuToKMuMu_BFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset BuToKMuMu_BFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -9674,6 +9911,10 @@
       "description": "\n          <p>Simulated dataset BuToKstarJPsiV2_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -9748,10 +9989,6 @@
     },
     "title": "/BuToKstarJPsiV2_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset BuToKstarJPsiV2_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -9780,6 +10017,10 @@
       "description": "\n          <p>Simulated dataset BuToKstarMuMuV2_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -9866,10 +10107,6 @@
     },
     "title": "/BuToKstarMuMuV2_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset BuToKstarMuMuV2_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -9898,6 +10135,10 @@
       "description": "\n          <p>Simulated dataset BuToKstarPsi2SV2_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -9972,10 +10213,6 @@
     },
     "title": "/BuToKstarPsi2SV2_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset BuToKstarPsi2SV2_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -10004,6 +10241,10 @@
       "description": "\n          <p>Simulated dataset BuToPsiK_KFilter_TuneZ2star_SVS_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -10090,10 +10331,6 @@
     },
     "title": "/BuToPsiK_KFilter_TuneZ2star_SVS_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset BuToPsiK_KFilter_TuneZ2star_SVS_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -10122,6 +10359,13 @@
       "description": "\n          <p>Simulated dataset DY1JetToLL_M-10To50_TuneZ2_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "Drell-Yan"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -10231,10 +10475,6 @@
     },
     "title": "/DY1JetToLL_M-10To50_TuneZ2_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset DY1JetToLL_M-10To50_TuneZ2_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -10263,6 +10503,13 @@
       "description": "\n          <p>Simulated dataset DY2Jets_M-10To50_TuneZ2_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "Drell-Yan"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -10432,10 +10679,6 @@
     },
     "title": "/DY2Jets_M-10To50_TuneZ2_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset DY2Jets_M-10To50_TuneZ2_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -10464,6 +10707,13 @@
       "description": "\n          <p>Simulated dataset DY3Jets_M-10To50_TuneZ2_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "Drell-Yan"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -10573,10 +10823,6 @@
     },
     "title": "/DY3Jets_M-10To50_TuneZ2_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset DY3Jets_M-10To50_TuneZ2_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -10605,6 +10851,13 @@
       "description": "\n          <p>Simulated dataset DY4Jets_M-10To50_TuneZ2_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "Drell-Yan"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -10690,10 +10943,6 @@
     },
     "title": "/DY4Jets_M-10To50_TuneZ2_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset DY4Jets_M-10To50_TuneZ2_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -10722,6 +10971,13 @@
       "description": "\n          <p>Simulated dataset DYJetsToLL_M-10To50_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "Drell-Yan"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -10795,10 +11051,6 @@
     },
     "title": "/DYJetsToLL_M-10To50_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset DYJetsToLL_M-10To50_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -10827,6 +11079,13 @@
       "description": "\n          <p>Simulated dataset DYJetsToLL_M-50_7TeV-madgraph-pythia6-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "Drell-Yan"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -10997,10 +11256,6 @@
     },
     "title": "/DYJetsToLL_M-50_7TeV-madgraph-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset DYJetsToLL_M-50_7TeV-madgraph-pythia6-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -11029,6 +11284,13 @@
       "description": "\n          <p>Simulated dataset DYJetsToLL_TuneZ2_M-50_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "Drell-Yan"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -11294,10 +11556,6 @@
     },
     "title": "/DYJetsToLL_TuneZ2_M-50_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset DYJetsToLL_TuneZ2_M-50_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -11326,6 +11584,13 @@
       "description": "\n          <p>Simulated dataset GJet_Pt-20_doubleEMEnriched_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -11399,10 +11664,6 @@
     },
     "title": "/GJet_Pt-20_doubleEMEnriched_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GJet_Pt-20_doubleEMEnriched_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -11431,6 +11692,13 @@
       "description": "\n          <p>Simulated dataset GJets_TuneZ2_100_HT_200_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -11504,10 +11772,6 @@
     },
     "title": "/GJets_TuneZ2_100_HT_200_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v3/AODSIM",
     "title_additional": "Simulated dataset GJets_TuneZ2_100_HT_200_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -11536,6 +11800,13 @@
       "description": "\n          <p>Simulated dataset GJets_TuneZ2_200_HT_inf_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -11621,10 +11892,6 @@
     },
     "title": "/GJets_TuneZ2_200_HT_inf_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GJets_TuneZ2_200_HT_inf_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -11653,6 +11920,13 @@
       "description": "\n          <p>Simulated dataset GJets_TuneZ2_40_HT_100_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -11726,10 +12000,6 @@
     },
     "title": "/GJets_TuneZ2_40_HT_100_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GJets_TuneZ2_40_HT_100_7TeV-madgraph in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -11758,6 +12028,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo2L2Lprime_Contin_7TeV-gg2vv315-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -11868,10 +12145,6 @@
     },
     "title": "/GluGluTo2L2Lprime_Contin_7TeV-gg2vv315-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo2L2Lprime_Contin_7TeV-gg2vv315-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -11900,6 +12173,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo2L2Lprime_H_M-125p6_7TeV-gg2vv315-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -11974,10 +12254,6 @@
     },
     "title": "/GluGluTo2L2Lprime_H_M-125p6_7TeV-gg2vv315-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo2L2Lprime_H_M-125p6_7TeV-gg2vv315-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -12006,6 +12282,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo2e2mu_Contin_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -12116,10 +12399,6 @@
     },
     "title": "/GluGluTo2e2mu_Contin_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo2e2mu_Contin_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -12148,6 +12427,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo2e2mu_SMH_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -12258,10 +12544,6 @@
     },
     "title": "/GluGluTo2e2mu_SMH_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo2e2mu_SMH_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -12290,6 +12572,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo4L_Contin_7TeV-gg2vv315-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -12388,10 +12677,6 @@
     },
     "title": "/GluGluTo4L_Contin_7TeV-gg2vv315-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo4L_Contin_7TeV-gg2vv315-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -12420,6 +12705,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo4L_H_M-125p6_7TeV-gg2vv315-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -12494,10 +12786,6 @@
     },
     "title": "/GluGluTo4L_H_M-125p6_7TeV-gg2vv315-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo4L_H_M-125p6_7TeV-gg2vv315-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -12526,6 +12814,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo4e_Contin_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -12600,10 +12895,6 @@
     },
     "title": "/GluGluTo4e_Contin_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo4e_Contin_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -12632,6 +12923,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo4e_SMH_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -12706,10 +13004,6 @@
     },
     "title": "/GluGluTo4e_SMH_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset GluGluTo4e_SMH_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -12738,6 +13032,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo4mu_Contin_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -12824,10 +13125,6 @@
     },
     "title": "/GluGluTo4mu_Contin_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo4mu_Contin_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -12856,6 +13153,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo4mu_SMH_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -12954,10 +13258,6 @@
     },
     "title": "/GluGluTo4mu_SMH_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo4mu_SMH_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -12986,6 +13286,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -13072,10 +13379,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -13104,6 +13407,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -13190,10 +13500,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-200_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -13222,6 +13528,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -13296,10 +13609,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-225_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -13328,6 +13637,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -13414,10 +13730,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -13446,6 +13758,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -13520,10 +13839,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -13552,6 +13867,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -13638,10 +13960,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-300_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -13670,6 +13988,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -13756,10 +14081,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-350_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -13788,6 +14109,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -13874,10 +14202,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-400_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -13906,6 +14230,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -13992,10 +14323,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-450_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -14024,6 +14351,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -14098,10 +14432,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-500_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -14130,6 +14460,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -14216,10 +14553,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-550_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -14248,6 +14581,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -14334,10 +14674,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-600_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -14366,6 +14702,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -14452,10 +14795,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-650_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -14484,6 +14823,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -14570,10 +14916,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-700_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -14602,6 +14944,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -14688,10 +15037,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-800_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -14720,6 +15065,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -14806,10 +15158,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Nu_M-900_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -14838,6 +15186,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -14912,10 +15267,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -14944,6 +15295,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -15018,10 +15376,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -15050,6 +15404,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -15124,10 +15485,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -15156,6 +15513,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -15230,10 +15594,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -15262,6 +15622,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -15336,10 +15703,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -15368,6 +15731,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -15442,10 +15812,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -15474,6 +15840,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -15548,10 +15921,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -15580,6 +15949,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -15654,10 +16030,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -15686,6 +16058,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -15760,10 +16139,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -15792,6 +16167,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -15866,10 +16248,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -15898,6 +16276,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -15972,10 +16357,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -16004,6 +16385,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -16078,10 +16466,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -16110,6 +16494,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -16184,10 +16575,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -16216,6 +16603,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -16290,10 +16684,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -16322,6 +16712,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -16396,10 +16793,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -16428,6 +16821,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -16502,10 +16902,6 @@
     },
     "title": "/GluGluToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -16534,6 +16930,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-1000_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -16620,10 +17023,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-1000_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-1000_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -16652,6 +17051,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-125_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -16726,10 +17132,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-125_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-125_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -16758,6 +17160,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-125_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -16832,10 +17241,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-125_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-125_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -16864,6 +17269,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-126_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -16938,10 +17350,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-126_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-126_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -16970,6 +17378,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-126_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -17056,10 +17471,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-126_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-126_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -17088,6 +17499,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-190_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -17174,10 +17592,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-190_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-190_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -17206,6 +17620,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-200_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -17304,10 +17725,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-200_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-200_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -17336,6 +17753,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-225_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -17422,10 +17846,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-225_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-225_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -17454,6 +17874,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-250_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -17528,10 +17955,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-250_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-250_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -17560,6 +17983,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-250_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -17634,10 +18064,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-250_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-250_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -17666,6 +18092,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-275_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -17752,10 +18185,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-275_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-275_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -17784,6 +18213,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-300_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -17858,10 +18294,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-300_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-300_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -17890,6 +18322,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-300_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -17976,10 +18415,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-300_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-300_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -18008,6 +18443,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-350_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -18082,10 +18524,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-350_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-350_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -18114,6 +18552,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-350_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -18188,10 +18633,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-350_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-350_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -18220,6 +18661,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-400_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -18294,10 +18742,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-400_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-400_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -18326,6 +18770,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-400_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -18400,10 +18851,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-400_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-400_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -18432,6 +18879,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-450_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -18518,10 +18972,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-450_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-450_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -18550,6 +19000,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-450_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -18648,10 +19105,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-450_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-450_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -18680,6 +19133,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-500_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -18766,10 +19226,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-500_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-500_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -18798,6 +19254,13 @@
       "description": "\n          <p>Simulated dataset TTbarH_HToZZTo4L_M-180_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -18871,10 +19334,6 @@
     },
     "title": "/TTbarH_HToZZTo4L_M-180_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTbarH_HToZZTo4L_M-180_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -18903,6 +19362,13 @@
       "description": "\n          <p>Simulated dataset TTbarH_HToZZTo4L_M-160_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -18976,10 +19442,6 @@
     },
     "title": "/TTbarH_HToZZTo4L_M-160_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTbarH_HToZZTo4L_M-160_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -19008,6 +19470,13 @@
       "description": "\n          <p>Simulated dataset TTbarH_HToZZTo4L_M-115_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -19081,10 +19550,6 @@
     },
     "title": "/TTbarH_HToZZTo4L_M-115_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTbarH_HToZZTo4L_M-115_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -19113,6 +19578,13 @@
       "description": "\n          <p>Simulated dataset TTbarH_HToZZTo4L_M-120_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -19186,10 +19658,6 @@
     },
     "title": "/TTbarH_HToZZTo4L_M-120_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset TTbarH_HToZZTo4L_M-120_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -19218,6 +19686,13 @@
       "description": "\n          <p>Simulated dataset TTbarH_HToZZTo4L_M-125_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -19291,10 +19766,6 @@
     },
     "title": "/TTbarH_HToZZTo4L_M-125_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTbarH_HToZZTo4L_M-125_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -19323,6 +19794,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -19397,10 +19875,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -19429,6 +19903,13 @@
       "description": "\n          <p>Simulated dataset VBFHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -19503,10 +19984,6 @@
     },
     "title": "/VBFHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset VBFHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -19535,6 +20012,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-300to470_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -19608,10 +20092,6 @@
     },
     "title": "/QCD_Pt-300to470_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-300to470_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -19640,6 +20120,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -19714,10 +20201,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -19746,6 +20229,13 @@
       "description": "\n          <p>Simulated dataset VBFHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -19820,10 +20310,6 @@
     },
     "title": "/VBFHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -19852,6 +20338,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -19926,10 +20419,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -19958,6 +20447,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-30to50_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -20031,10 +20527,6 @@
     },
     "title": "/QCD_Pt-30to50_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-30to50_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -20063,6 +20555,10 @@
       "description": "\n          <p>Simulated dataset Bd2JpsiKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -20137,10 +20633,6 @@
     },
     "title": "/Bd2JpsiKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset Bd2JpsiKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -20169,6 +20661,10 @@
       "description": "\n          <p>Simulated dataset Bd2KstarMuMu_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -20243,10 +20739,6 @@
     },
     "title": "/Bd2KstarMuMu_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset Bd2KstarMuMu_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -20275,6 +20767,10 @@
       "description": "\n          <p>Simulated dataset Bd2Psi2SKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -20349,10 +20845,6 @@
     },
     "title": "/Bd2Psi2SKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset Bd2Psi2SKstar_EtaPtFilter_TuneZ2star_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -20381,6 +20873,10 @@
       "description": "\n          <p>Simulated dataset BuToJPsiKV2_2MuPtEtaFilterKPtEtaFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -20467,10 +20963,6 @@
     },
     "title": "/BuToJPsiKV2_2MuPtEtaFilterKPtEtaFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset BuToJPsiKV2_2MuPtEtaFilterKPtEtaFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -20499,6 +20991,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo2L2Lprime_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -20621,10 +21120,6 @@
     },
     "title": "/GluGluTo2L2Lprime_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo2L2Lprime_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -20653,6 +21148,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo2e2mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -20775,10 +21277,6 @@
     },
     "title": "/GluGluTo2e2mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo2e2mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -20807,6 +21305,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo2e2mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -20905,10 +21410,6 @@
     },
     "title": "/GluGluTo2e2mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo2e2mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -20937,6 +21438,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo4L_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -21011,10 +21519,6 @@
     },
     "title": "/GluGluTo4L_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo4L_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -21043,6 +21547,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo4e_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -21129,10 +21640,6 @@
     },
     "title": "/GluGluTo4e_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo4e_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -21161,6 +21668,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo4e_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -21259,10 +21773,6 @@
     },
     "title": "/GluGluTo4e_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo4e_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -21291,6 +21801,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo4mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -21365,10 +21882,6 @@
     },
     "title": "/GluGluTo4mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo4mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -21397,6 +21910,13 @@
       "description": "\n          <p>Simulated dataset GluGluTo4mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -21483,10 +22003,6 @@
     },
     "title": "/GluGluTo4mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluTo4mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -21515,6 +22031,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-1000_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -21613,10 +22136,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-1000_7TeV-minloHJJ-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-1000_7TeV-minloHJJ-pythia6-tauola in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -21645,6 +22164,13 @@
       "description": "\n          <p>Simulated dataset Graviton2BPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Exotica",
+      "secondary": [
+        "Gravitons"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -21719,10 +22245,6 @@
     },
     "title": "/Graviton2BPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Graviton2BPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -21751,6 +22273,13 @@
       "description": "\n          <p>Simulated dataset Graviton2HPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Exotica",
+      "secondary": [
+        "Gravitons"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -21849,10 +22378,6 @@
     },
     "title": "/Graviton2HPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Graviton2HPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -21881,6 +22406,13 @@
       "description": "\n          <p>Simulated dataset Graviton2MH10qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Exotica",
+      "secondary": [
+        "Gravitons"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -21967,10 +22499,6 @@
     },
     "title": "/Graviton2MH10qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Graviton2MH10qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -21999,6 +22527,13 @@
       "description": "\n          <p>Simulated dataset Graviton2PH2qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Exotica",
+      "secondary": [
+        "Gravitons"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -22073,10 +22608,6 @@
     },
     "title": "/Graviton2PH2qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Graviton2PH2qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -22105,6 +22636,13 @@
       "description": "\n          <p>Simulated dataset Graviton2PH3qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Exotica",
+      "secondary": [
+        "Gravitons"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -22179,10 +22717,6 @@
     },
     "title": "/Graviton2PH3qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Graviton2PH3qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -22211,6 +22745,13 @@
       "description": "\n          <p>Simulated dataset Higgs0L1f01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -22297,10 +22838,6 @@
     },
     "title": "/Higgs0L1f01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0L1f01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -22329,6 +22866,13 @@
       "description": "\n          <p>Simulated dataset Higgs0L1f05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -22427,10 +22971,6 @@
     },
     "title": "/Higgs0L1f05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0L1f05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -22459,6 +22999,13 @@
       "description": "\n          <p>Simulated dataset Higgs0PHf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -22533,10 +23080,6 @@
     },
     "title": "/Higgs0PHf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0PHf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -22565,6 +23108,13 @@
       "description": "\n          <p>Simulated dataset Higgs0PHf01ph90ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -22639,10 +23189,6 @@
     },
     "title": "/Higgs0PHf01ph90ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0PHf01ph90ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -22671,6 +23217,13 @@
       "description": "\n          <p>Simulated dataset Higgs0PHf033ph0Mf033ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -22757,10 +23310,6 @@
     },
     "title": "/Higgs0PHf033ph0Mf033ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0PHf033ph0Mf033ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -22789,6 +23338,13 @@
       "description": "\n          <p>Simulated dataset Higgs0PHf05ph0Mf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -22887,10 +23443,6 @@
     },
     "title": "/Higgs0PHf05ph0Mf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0PHf05ph0Mf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -22919,6 +23471,13 @@
       "description": "\n          <p>Simulated dataset Higgs0PHf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -23005,10 +23564,6 @@
     },
     "title": "/Higgs0PHf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0PHf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -23037,6 +23592,13 @@
       "description": "\n          <p>Simulated dataset Higgs0PHf05ph180ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -23123,10 +23685,6 @@
     },
     "title": "/Higgs0PHf05ph180ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0PHf05ph180ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -23155,6 +23713,13 @@
       "description": "\n          <p>Simulated dataset Higgs0PMToZZf05GGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -23265,10 +23830,6 @@
     },
     "title": "/Higgs0PMToZZf05GGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0PMToZZf05GGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -23297,6 +23858,13 @@
       "description": "\n          <p>Simulated dataset Higgs0PMToZZf05ZGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -23371,10 +23939,6 @@
     },
     "title": "/Higgs0PMToZZf05ZGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0PMToZZf05ZGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -23403,6 +23967,13 @@
       "description": "\n          <p>Simulated dataset Higgs0PMToZZfZGfGGfTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -23477,10 +24048,6 @@
     },
     "title": "/Higgs0PMToZZfZGfGGfTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Higgs0PMToZZfZGfGGfTo4L_M-125p6_7TeV-powheg15-JHUgenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -23509,6 +24076,13 @@
       "description": "\n          <p>Simulated dataset JJHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -23595,10 +24169,6 @@
     },
     "title": "/JJHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset JJHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -23627,6 +24197,10 @@
       "description": "\n          <p>Simulated dataset LambdaBToLambdaPsi_JpsiPiPiPPi_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -23701,10 +24275,6 @@
     },
     "title": "/LambdaBToLambdaPsi_JpsiPiPiPPi_EtaPtFilter_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset LambdaBToLambdaPsi_JpsiPiPiPPi_EtaPtFilter_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -23733,6 +24303,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-115_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -23819,10 +24396,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-115_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-115_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -23851,6 +24424,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-122_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -23925,10 +24505,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-122_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-122_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -23957,6 +24533,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-125_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -24031,10 +24614,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-125_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-125_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -24063,6 +24642,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-126_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -24173,10 +24759,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-126_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-126_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -24205,6 +24787,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-130_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -24315,10 +24904,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-130_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-130_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -24347,6 +24932,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-185_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -24433,10 +25025,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-185_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-185_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -24465,6 +25053,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_dileptonic_central_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -24553,10 +25148,6 @@
     },
     "title": "/TTJets_MSDecays_dileptonic_central_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_dileptonic_central_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -24585,6 +25176,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "SM Systematic Variations"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -24661,10 +25259,6 @@
     },
     "title": "/TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -24693,6 +25287,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -24769,10 +25370,6 @@
     },
     "title": "/TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6_ext1-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -24801,6 +25398,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_dileptonic_matchingup_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -24889,10 +25493,6 @@
     },
     "title": "/TTJets_MSDecays_dileptonic_matchingup_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_dileptonic_matchingup_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -24921,6 +25521,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_dileptonic_mt166_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -24997,10 +25604,6 @@
     },
     "title": "/TTJets_MSDecays_dileptonic_mt166_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_dileptonic_mt166_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -25029,6 +25632,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_dileptonic_mt178_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -25129,10 +25739,6 @@
     },
     "title": "/TTJets_MSDecays_dileptonic_mt178_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_dileptonic_mt178_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -25161,6 +25767,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_dileptonic_scaledown_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -25237,10 +25850,6 @@
     },
     "title": "/TTJets_MSDecays_dileptonic_scaledown_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v3/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_dileptonic_scaledown_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -25269,6 +25878,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_dileptonic_scaleup_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -25357,10 +25973,6 @@
     },
     "title": "/TTJets_MSDecays_dileptonic_scaleup_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_dileptonic_scaleup_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -25389,6 +26001,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_scaledown_TuneZ2star_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -25501,10 +26120,6 @@
     },
     "title": "/TTJets_MSDecays_scaledown_TuneZ2star_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_scaledown_TuneZ2star_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -25533,6 +26148,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_scaledown_mt172_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -25645,10 +26267,6 @@
     },
     "title": "/TTJets_MSDecays_scaledown_mt172_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_scaledown_mt172_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -25677,6 +26295,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_scaleup_TuneZ2star_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -25789,10 +26414,6 @@
     },
     "title": "/TTJets_MSDecays_scaleup_TuneZ2star_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_scaleup_TuneZ2star_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -25821,6 +26442,10 @@
       "description": "\n          <p>Simulated dataset Upsilon1SToMuMu_2MuEtaFilter_tuneD6T_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "B physics and Quarkonia",
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -25906,10 +26531,6 @@
     },
     "title": "/Upsilon1SToMuMu_2MuEtaFilter_tuneD6T_7TeV-pythia6-evtgen/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Upsilon1SToMuMu_2MuEtaFilter_tuneD6T_7TeV-pythia6-evtgen in AODSIM format for 2011 collision data (B-physics)",
-    "topic": {
-      "category": "B-physics",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -25938,6 +26559,13 @@
       "description": "\n          <p>Simulated dataset VBFHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -26012,10 +26640,6 @@
     },
     "title": "/VBFHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -26044,6 +26668,13 @@
       "description": "\n          <p>Simulated dataset VBFHiggs0Mf05ph0ToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -26130,10 +26761,6 @@
     },
     "title": "/VBFHiggs0Mf05ph0ToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFHiggs0Mf05ph0ToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -26162,6 +26789,13 @@
       "description": "\n          <p>Simulated dataset VBFHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -26236,10 +26870,6 @@
     },
     "title": "/VBFHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -26268,6 +26898,13 @@
       "description": "\n          <p>Simulated dataset VBFHiggs0PHToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -26342,10 +26979,6 @@
     },
     "title": "/VBFHiggs0PHToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFHiggs0PHToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -26374,6 +27007,13 @@
       "description": "\n          <p>Simulated dataset WHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -26448,10 +27088,6 @@
     },
     "title": "/WHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -26480,6 +27116,13 @@
       "description": "\n          <p>Simulated dataset ZHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -26566,10 +27209,6 @@
     },
     "title": "/ZHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset ZHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -26598,6 +27237,13 @@
       "description": "\n          <p>Simulated dataset ZZTo2e2muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -26720,10 +27366,6 @@
     },
     "title": "/ZZTo2e2muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo2e2muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -26752,6 +27394,13 @@
       "description": "\n          <p>Simulated dataset ZZTo2e2muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -26850,10 +27499,6 @@
     },
     "title": "/ZZTo2e2muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo2e2muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -26882,6 +27527,13 @@
       "description": "\n          <p>Simulated dataset ZZTo2e2muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -26980,10 +27632,6 @@
     },
     "title": "/ZZTo2e2muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo2e2muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -27012,6 +27660,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4eJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -27086,10 +27741,6 @@
     },
     "title": "/ZZTo4eJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4eJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -27118,6 +27769,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4eJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -27204,10 +27862,6 @@
     },
     "title": "/ZZTo4eJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4eJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -27236,6 +27890,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4eJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -27346,10 +28007,6 @@
     },
     "title": "/ZZTo4eJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4eJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -27378,6 +28035,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -27476,10 +28140,6 @@
     },
     "title": "/ZZTo4muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -27508,6 +28168,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -27594,10 +28261,6 @@
     },
     "title": "/ZZTo4muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -27626,6 +28289,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -27724,10 +28394,6 @@
     },
     "title": "/ZZTo4muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset ZZTo4muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -27756,6 +28422,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -27842,10 +28515,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -27874,6 +28543,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-30to50_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -27947,10 +28623,6 @@
     },
     "title": "/QCD_Pt-30to50_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-30to50_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -27979,6 +28651,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-30to80_BCtoE_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -28052,10 +28731,6 @@
     },
     "title": "/QCD_Pt-30to80_BCtoE_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-30to80_BCtoE_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -28084,6 +28759,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-30to80_EMEnriched_TuneZ2_7TeV-pythia in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -28169,10 +28851,6 @@
     },
     "title": "/QCD_Pt-30to80_EMEnriched_TuneZ2_7TeV-pythia/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-30to80_EMEnriched_TuneZ2_7TeV-pythia in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -28201,6 +28879,13 @@
       "description": "\n          <p>Simulated dataset ZHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -28275,10 +28960,6 @@
     },
     "title": "/ZHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -28307,6 +28988,13 @@
       "description": "\n          <p>Simulated dataset ZHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -28381,10 +29069,6 @@
     },
     "title": "/ZHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -28413,6 +29097,13 @@
       "description": "\n          <p>Simulated dataset TTJets_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -28547,10 +29238,6 @@
     },
     "title": "/TTJets_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -28579,6 +29266,13 @@
       "description": "\n          <p>Simulated dataset GluGluToHToZZTo4L_M-500_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -28653,10 +29347,6 @@
     },
     "title": "/GluGluToHToZZTo4L_M-500_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset GluGluToHToZZTo4L_M-500_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -28685,6 +29375,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -28771,10 +29468,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-275_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -28803,6 +29496,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -28877,10 +29577,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -28909,6 +29605,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-350_EMEnriched_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -28982,10 +29685,6 @@
     },
     "title": "/QCD_Pt-350_EMEnriched_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-350_EMEnriched_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -29014,6 +29713,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -29088,10 +29794,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -29120,6 +29822,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-470to600_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -29193,10 +29902,6 @@
     },
     "title": "/QCD_Pt-470to600_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-470to600_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -29225,6 +29930,13 @@
       "description": "\n          <p>Simulated dataset ZZTo2e2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -29311,10 +30023,6 @@
     },
     "title": "/ZZTo2e2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo2e2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -29343,6 +30051,13 @@
       "description": "\n          <p>Simulated dataset ZZTo2e2tau_mll4_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -29429,10 +30144,6 @@
     },
     "title": "/ZZTo2e2tau_mll4_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo2e2tau_mll4_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -29461,6 +30172,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-470to600_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -29534,10 +30252,6 @@
     },
     "title": "/QCD_Pt-470to600_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-470to600_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -29566,6 +30280,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-50to80_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -29639,10 +30360,6 @@
     },
     "title": "/QCD_Pt-50to80_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-50to80_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -29671,6 +30388,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-50to80_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -29744,10 +30468,6 @@
     },
     "title": "/QCD_Pt-50to80_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-50to80_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -29776,6 +30496,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-5to15_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -29849,10 +30576,6 @@
     },
     "title": "/QCD_Pt-5to15_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-5to15_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -29881,6 +30604,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-600to800_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -29954,10 +30684,6 @@
     },
     "title": "/QCD_Pt-600to800_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-600to800_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -29986,6 +30712,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-600to800_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -30059,10 +30792,6 @@
     },
     "title": "/QCD_Pt-600to800_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-600to800_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -30091,6 +30820,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-800to1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -30164,10 +30900,6 @@
     },
     "title": "/QCD_Pt-800to1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-800to1000_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -30196,6 +30928,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-800to1000_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -30269,10 +31008,6 @@
     },
     "title": "/QCD_Pt-800to1000_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-800to1000_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -30301,6 +31036,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-80to120_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -30374,10 +31116,6 @@
     },
     "title": "/QCD_Pt-80to120_MuEnrichedPt5_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-80to120_MuEnrichedPt5_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -30406,6 +31144,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-80to120_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -30479,10 +31224,6 @@
     },
     "title": "/QCD_Pt-80to120_TuneZ2_7TeV_pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-80to120_TuneZ2_7TeV_pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -30511,6 +31252,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-80to170_BCtoE_TuneZ2_7TeV-pythia in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -30584,10 +31332,6 @@
     },
     "title": "/QCD_Pt-80to170_BCtoE_TuneZ2_7TeV-pythia/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-80to170_BCtoE_TuneZ2_7TeV-pythia in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -30616,6 +31360,13 @@
       "description": "\n          <p>Simulated dataset QCD_Pt-80to170_EMEnriched_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "QCD"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -30689,10 +31440,6 @@
     },
     "title": "/QCD_Pt-80to170_EMEnriched_TuneZ2_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset QCD_Pt-80to170_EMEnriched_TuneZ2_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -30721,6 +31468,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-120_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -30795,10 +31549,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-120_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-120_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -30827,6 +31577,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-124_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -30901,10 +31658,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-124_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-124_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -30933,6 +31686,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-128_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -31007,10 +31767,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-128_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-128_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -31039,6 +31795,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-135_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -31113,10 +31876,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-135_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-135_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -31145,6 +31904,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-140_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -31231,10 +31997,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-140_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-140_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -31263,6 +32025,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-145_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -31337,10 +32106,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-145_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-145_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -31369,6 +32134,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-150_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -31467,10 +32239,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-150_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-150_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -31499,6 +32267,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-160_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -31609,10 +32384,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-160_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-160_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -31641,6 +32412,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -31715,10 +32493,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -31747,6 +32521,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -31833,10 +32614,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -31865,6 +32642,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-170_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -31939,10 +32723,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-170_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-170_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -31971,6 +32751,13 @@
       "description": "\n          <p>Simulated dataset ZZTo2mu2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -32045,10 +32832,6 @@
     },
     "title": "/ZZTo2mu2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo2mu2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -32077,6 +32860,13 @@
       "description": "\n          <p>Simulated dataset ZZTo2mu2tau_mll4_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -32163,10 +32953,6 @@
     },
     "title": "/ZZTo2mu2tau_mll4_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo2mu2tau_mll4_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -32195,6 +32981,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -32269,10 +33062,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -32301,6 +33090,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -32375,10 +33171,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -32407,6 +33199,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -32481,10 +33280,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -32513,6 +33308,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -32587,10 +33389,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -32619,6 +33417,13 @@
       "description": "\n          <p>Simulated dataset ZHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -32717,10 +33522,6 @@
     },
     "title": "/ZHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -32749,6 +33550,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -32823,10 +33631,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -32855,6 +33659,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -32941,10 +33752,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -32973,6 +33780,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -33047,10 +33861,6 @@
     },
     "title": "/VBFToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -33079,6 +33889,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo4L_M-250_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -33153,10 +33970,6 @@
     },
     "title": "/VBFToHToZZTo4L_M-250_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo4L_M-250_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -33185,6 +33998,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-175_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -33259,10 +34079,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-175_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-175_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -33291,6 +34107,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4eJJ_Contin_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -33389,10 +34212,6 @@
     },
     "title": "/ZZTo4eJJ_Contin_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4eJJ_Contin_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -33421,6 +34240,13 @@
       "description": "\n          <p>Simulated dataset TTbarH_HToZZTo4L_M-200_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -33506,10 +34332,6 @@
     },
     "title": "/TTbarH_HToZZTo4L_M-200_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTbarH_HToZZTo4L_M-200_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -33538,6 +34360,13 @@
       "description": "\n          <p>Simulated dataset TTbarH_HToZZTo4L_M-140_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -33611,10 +34440,6 @@
     },
     "title": "/TTbarH_HToZZTo4L_M-140_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTbarH_HToZZTo4L_M-140_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -33643,6 +34468,13 @@
       "description": "\n          <p>Simulated dataset TT_weights_CT10_AUET2_7TeV-powheg-herwig in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -33741,10 +34573,6 @@
     },
     "title": "/TT_weights_CT10_AUET2_7TeV-powheg-herwig/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset TT_weights_CT10_AUET2_7TeV-powheg-herwig in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -33773,6 +34601,13 @@
       "description": "\n          <p>Simulated dataset T_TuneZ2_s-channel_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -33859,10 +34694,6 @@
     },
     "title": "/T_TuneZ2_s-channel_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset T_TuneZ2_s-channel_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -33891,6 +34722,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo4L_M-275_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -33965,10 +34803,6 @@
     },
     "title": "/VBFToHToZZTo4L_M-275_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo4L_M-275_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -33997,6 +34831,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo4L_M-300_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -34083,10 +34924,6 @@
     },
     "title": "/VBFToHToZZTo4L_M-300_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo4L_M-300_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -34115,6 +34952,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo4L_M-350_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -34201,10 +35045,6 @@
     },
     "title": "/VBFToHToZZTo4L_M-350_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo4L_M-350_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -34233,6 +35073,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo4L_M-450_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -34319,10 +35166,6 @@
     },
     "title": "/VBFToHToZZTo4L_M-450_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo4L_M-450_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -34351,6 +35194,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo4L_M-550_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -34425,10 +35275,6 @@
     },
     "title": "/VBFToHToZZTo4L_M-550_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo4L_M-550_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -34457,6 +35303,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo4L_M-600_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -34531,10 +35384,6 @@
     },
     "title": "/VBFToHToZZTo4L_M-600_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo4L_M-600_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -34563,6 +35412,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo4L_M-900_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -34649,10 +35505,6 @@
     },
     "title": "/VBFToHToZZTo4L_M-900_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo4L_M-900_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -34681,6 +35533,13 @@
       "description": "\n          <p>Simulated dataset VBF_ToHToZZTo4L_M-115_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -34755,10 +35614,6 @@
     },
     "title": "/VBF_ToHToZZTo4L_M-115_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBF_ToHToZZTo4L_M-115_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -34787,6 +35642,13 @@
       "description": "\n          <p>Simulated dataset VBF_ToHToZZTo4L_M-120_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -34861,10 +35723,6 @@
     },
     "title": "/VBF_ToHToZZTo4L_M-120_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBF_ToHToZZTo4L_M-120_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -34893,6 +35751,13 @@
       "description": "\n          <p>Simulated dataset VBF_ToHToZZTo4L_M-125_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -34967,10 +35832,6 @@
     },
     "title": "/VBF_ToHToZZTo4L_M-125_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBF_ToHToZZTo4L_M-125_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -34999,6 +35860,13 @@
       "description": "\n          <p>Simulated dataset VBF_ToHToZZTo4L_M-130_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -35073,10 +35941,6 @@
     },
     "title": "/VBF_ToHToZZTo4L_M-130_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBF_ToHToZZTo4L_M-130_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -35105,6 +35969,13 @@
       "description": "\n          <p>Simulated dataset VBF_ToHToZZTo4L_M-140_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -35179,10 +36050,6 @@
     },
     "title": "/VBF_ToHToZZTo4L_M-140_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBF_ToHToZZTo4L_M-140_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -35211,6 +36078,13 @@
       "description": "\n          <p>Simulated dataset VBF_ToHToZZTo4L_M-150_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -35285,10 +36159,6 @@
     },
     "title": "/VBF_ToHToZZTo4L_M-150_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBF_ToHToZZTo4L_M-150_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -35317,6 +36187,13 @@
       "description": "\n          <p>Simulated dataset VBF_ToHToZZTo4L_M-160_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -35391,10 +36268,6 @@
     },
     "title": "/VBF_ToHToZZTo4L_M-160_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBF_ToHToZZTo4L_M-160_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -35423,6 +36296,13 @@
       "description": "\n          <p>Simulated dataset VBF_ToHToZZTo4L_M-170_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -35497,10 +36377,6 @@
     },
     "title": "/VBF_ToHToZZTo4L_M-170_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBF_ToHToZZTo4L_M-170_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -35529,6 +36405,13 @@
       "description": "\n          <p>Simulated dataset VBF_ToHToZZTo4L_M-180_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -35603,10 +36486,6 @@
     },
     "title": "/VBF_ToHToZZTo4L_M-180_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBF_ToHToZZTo4L_M-180_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -35635,6 +36514,13 @@
       "description": "\n          <p>Simulated dataset VBF_ToHToZZTo4L_M-190_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -35709,10 +36595,6 @@
     },
     "title": "/VBF_ToHToZZTo4L_M-190_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBF_ToHToZZTo4L_M-190_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -35741,6 +36623,13 @@
       "description": "\n          <p>Simulated dataset VBF_ToHToZZTo4L_M-200_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -35815,10 +36704,6 @@
     },
     "title": "/VBF_ToHToZZTo4L_M-200_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBF_ToHToZZTo4L_M-200_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -35847,6 +36732,13 @@
       "description": "\n          <p>Simulated dataset W1Jet_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -35932,10 +36824,6 @@
     },
     "title": "/W1Jet_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset W1Jet_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -35964,6 +36852,13 @@
       "description": "\n          <p>Simulated dataset W2Jets_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -36037,10 +36932,6 @@
     },
     "title": "/W2Jets_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset W2Jets_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -36069,6 +36960,13 @@
       "description": "\n          <p>Simulated dataset W3Jets_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -36154,10 +37052,6 @@
     },
     "title": "/W3Jets_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset W3Jets_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -36186,6 +37080,13 @@
       "description": "\n          <p>Simulated dataset W4Jets_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Exclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -36259,10 +37160,6 @@
     },
     "title": "/W4Jets_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset W4Jets_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Exclusive)",
-    "topic": {
-      "category": "SM Exclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -36291,6 +37188,13 @@
       "description": "\n          <p>Simulated dataset WH_HToZZTo4L_M-110_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -36364,10 +37268,6 @@
     },
     "title": "/WH_HToZZTo4L_M-110_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WH_HToZZTo4L_M-110_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -36396,6 +37296,13 @@
       "description": "\n          <p>Simulated dataset WH_HToZZTo4L_M-115_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -36481,10 +37388,6 @@
     },
     "title": "/WH_HToZZTo4L_M-115_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WH_HToZZTo4L_M-115_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -36513,6 +37416,13 @@
       "description": "\n          <p>Simulated dataset WH_HToZZTo4L_M-120_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -36598,10 +37508,6 @@
     },
     "title": "/WH_HToZZTo4L_M-120_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WH_HToZZTo4L_M-120_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -36630,6 +37536,13 @@
       "description": "\n          <p>Simulated dataset WH_HToZZTo4L_M-125_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -36703,10 +37616,6 @@
     },
     "title": "/WH_HToZZTo4L_M-125_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WH_HToZZTo4L_M-125_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -36735,6 +37644,13 @@
       "description": "\n          <p>Simulated dataset WH_HToZZTo4L_M-126_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -36808,10 +37724,6 @@
     },
     "title": "/WH_HToZZTo4L_M-126_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WH_HToZZTo4L_M-126_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -36840,6 +37752,13 @@
       "description": "\n          <p>Simulated dataset WH_HToZZTo4L_M-130_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -36913,10 +37832,6 @@
     },
     "title": "/WH_HToZZTo4L_M-130_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WH_HToZZTo4L_M-130_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -36945,6 +37860,13 @@
       "description": "\n          <p>Simulated dataset WH_HToZZTo4L_M-140_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -37018,10 +37940,6 @@
     },
     "title": "/WH_HToZZTo4L_M-140_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WH_HToZZTo4L_M-140_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -37050,6 +37968,13 @@
       "description": "\n          <p>Simulated dataset WH_HToZZTo4L_M-150_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -37135,10 +38060,6 @@
     },
     "title": "/WH_HToZZTo4L_M-150_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WH_HToZZTo4L_M-150_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -37167,6 +38088,13 @@
       "description": "\n          <p>Simulated dataset WH_HToZZTo4L_M-160_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -37252,10 +38180,6 @@
     },
     "title": "/WH_HToZZTo4L_M-160_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WH_HToZZTo4L_M-160_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -37284,6 +38208,13 @@
       "description": "\n          <p>Simulated dataset WH_HToZZTo4L_M-180_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -37357,10 +38288,6 @@
     },
     "title": "/WH_HToZZTo4L_M-180_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset WH_HToZZTo4L_M-180_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -37389,6 +38316,13 @@
       "description": "\n          <p>Simulated dataset WH_HToZZTo4L_M-200_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -37462,10 +38396,6 @@
     },
     "title": "/WH_HToZZTo4L_M-200_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WH_HToZZTo4L_M-200_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -37494,6 +38424,13 @@
       "description": "\n          <p>Simulated dataset WHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -37568,10 +38505,6 @@
     },
     "title": "/WHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -37600,6 +38533,13 @@
       "description": "\n          <p>Simulated dataset WHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -37686,10 +38626,6 @@
     },
     "title": "/WHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -37718,6 +38654,13 @@
       "description": "\n          <p>Simulated dataset WHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -37804,10 +38747,6 @@
     },
     "title": "/WHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -37836,6 +38775,13 @@
       "description": "\n          <p>Simulated dataset WHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -37910,10 +38856,6 @@
     },
     "title": "/WHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -37942,6 +38884,13 @@
       "description": "\n          <p>Simulated dataset WHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -38028,10 +38977,6 @@
     },
     "title": "/WHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -38060,6 +39005,13 @@
       "description": "\n          <p>Simulated dataset WHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -38134,10 +39086,6 @@
     },
     "title": "/WHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -38166,6 +39114,13 @@
       "description": "\n          <p>Simulated dataset WHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -38252,10 +39207,6 @@
     },
     "title": "/WHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -38284,6 +39235,13 @@
       "description": "\n          <p>Simulated dataset WJetsToLNu_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -38393,10 +39351,6 @@
     },
     "title": "/WJetsToLNu_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WJetsToLNu_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -38425,6 +39379,13 @@
       "description": "\n          <p>Simulated dataset WWJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -38498,10 +39459,6 @@
     },
     "title": "/WWJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset WWJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -38530,6 +39487,13 @@
       "description": "\n          <p>Simulated dataset WW_TuneZ2_7TeV_pythia6_tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -38604,10 +39568,6 @@
     },
     "title": "/WW_TuneZ2_7TeV_pythia6_tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WW_TuneZ2_7TeV_pythia6_tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -38636,6 +39596,13 @@
       "description": "\n          <p>Simulated dataset WZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -38721,10 +39688,6 @@
     },
     "title": "/WZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -38753,6 +39716,13 @@
       "description": "\n          <p>Simulated dataset ZHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -38827,10 +39797,6 @@
     },
     "title": "/ZHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v2/AODSIM",
     "title_additional": "Simulated dataset ZHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -38859,6 +39825,13 @@
       "description": "\n          <p>Simulated dataset T_TuneZ2_tW-channel-DR_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -38945,10 +39918,6 @@
     },
     "title": "/T_TuneZ2_tW-channel-DR_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset T_TuneZ2_tW-channel-DR_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -38977,6 +39946,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_matchingdown_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -39089,10 +40065,6 @@
     },
     "title": "/TTJets_MSDecays_matchingdown_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_matchingdown_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -39121,6 +40093,13 @@
       "description": "\n          <p>Simulated dataset WZJetsTo3LNu_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -39194,10 +40173,6 @@
     },
     "title": "/WZJetsTo3LNu_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WZJetsTo3LNu_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -39226,6 +40201,13 @@
       "description": "\n          <p>Simulated dataset WZ_TuneZ2_7TeV_pythia6_tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -39300,10 +40282,6 @@
     },
     "title": "/WZ_TuneZ2_7TeV_pythia6_tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset WZ_TuneZ2_7TeV_pythia6_tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -39332,6 +40310,13 @@
       "description": "\n          <p>Simulated dataset ZGToNuNuG_TuneZ2_7TeV-madgraph in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -39405,10 +40390,6 @@
     },
     "title": "/ZGToNuNuG_TuneZ2_7TeV-madgraph/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZGToNuNuG_TuneZ2_7TeV-madgraph in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -39437,6 +40418,13 @@
       "description": "\n          <p>Simulated dataset ZH_HToZZTo4L_M-110_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -39510,10 +40498,6 @@
     },
     "title": "/ZH_HToZZTo4L_M-110_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZH_HToZZTo4L_M-110_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -39542,6 +40526,13 @@
       "description": "\n          <p>Simulated dataset VBFHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -39616,10 +40607,6 @@
     },
     "title": "/VBFHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -39648,6 +40635,13 @@
       "description": "\n          <p>Simulated dataset ZH_HToZZTo4L_M-115_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -39733,10 +40727,6 @@
     },
     "title": "/ZH_HToZZTo4L_M-115_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZH_HToZZTo4L_M-115_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -39765,6 +40755,13 @@
       "description": "\n          <p>Simulated dataset ZH_HToZZTo4L_M-120_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -39850,10 +40847,6 @@
     },
     "title": "/ZH_HToZZTo4L_M-120_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZH_HToZZTo4L_M-120_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -39882,6 +40875,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4e_7TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -39956,10 +40956,6 @@
     },
     "title": "/ZZTo4e_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4e_7TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -39988,6 +40984,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4e_mll4_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -40122,10 +41125,6 @@
     },
     "title": "/ZZTo4e_mll4_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4e_mll4_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -40154,6 +41153,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4muJJ_Contin_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -40228,10 +41234,6 @@
     },
     "title": "/ZZTo4muJJ_Contin_7TeV-phantom-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4muJJ_Contin_7TeV-phantom-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -40260,6 +41262,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4mu_7TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -40334,10 +41343,6 @@
     },
     "title": "/ZZTo4mu_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4mu_7TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -40366,6 +41371,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4mu_mll4_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -40452,10 +41464,6 @@
     },
     "title": "/ZZTo4mu_mll4_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4mu_mll4_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -40484,6 +41492,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4tau_7TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -40594,10 +41609,6 @@
     },
     "title": "/ZZTo4tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4tau_7TeV_mll8_mZZ95-160-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -40626,6 +41637,13 @@
       "description": "\n          <p>Simulated dataset ZZTo4tau_mll4_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -40712,10 +41730,6 @@
     },
     "title": "/ZZTo4tau_mll4_7TeV-powheg-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZTo4tau_mll4_7TeV-powheg-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -40744,6 +41758,13 @@
       "description": "\n          <p>Simulated dataset ZZ_TuneZ2_7TeV_pythia6_tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ElectroWeak"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -40818,10 +41839,6 @@
     },
     "title": "/ZZ_TuneZ2_7TeV_pythia6_tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZZ_TuneZ2_7TeV_pythia6_tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -40850,6 +41867,13 @@
       "description": "\n          <p>Simulated dataset TTbarH_HToZZTo4L_M-150_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -40923,10 +41947,6 @@
     },
     "title": "/TTbarH_HToZZTo4L_M-150_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTbarH_HToZZTo4L_M-150_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -40955,6 +41975,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-180_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -41029,10 +42056,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-180_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-180_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -41061,6 +42084,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -41135,10 +42165,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-250_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -41167,6 +42193,13 @@
       "description": "\n          <p>Simulated dataset ZH_HToZZTo4L_M-125_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -41240,10 +42273,6 @@
     },
     "title": "/ZH_HToZZTo4L_M-125_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZH_HToZZTo4L_M-125_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -41272,6 +42301,13 @@
       "description": "\n          <p>Simulated dataset SMHiggsToZZTo4L_M-200_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -41358,10 +42394,6 @@
     },
     "title": "/SMHiggsToZZTo4L_M-200_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset SMHiggsToZZTo4L_M-200_7TeV-powheg15-JHUgenV3-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -41390,6 +42422,13 @@
       "description": "\n          <p>Simulated dataset VBFToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -41476,10 +42515,6 @@
     },
     "title": "/VBFToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFToHToZZTo2L2Nu_M-1000_7TeV-powheg15-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -41508,6 +42543,13 @@
       "description": "\n          <p>Simulated dataset ZH_HToZZTo4L_M-126_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -41581,10 +42623,6 @@
     },
     "title": "/ZH_HToZZTo4L_M-126_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZH_HToZZTo4L_M-126_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -41613,6 +42651,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_central_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -41689,10 +42734,6 @@
     },
     "title": "/TTJets_MSDecays_central_TuneZ2_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_central_TuneZ2_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -41721,6 +42762,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_mass169_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -41833,10 +42881,6 @@
     },
     "title": "/TTJets_MSDecays_mass169_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_mass169_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -41865,6 +42909,13 @@
       "description": "\n          <p>Simulated dataset ZH_HToZZTo4L_M-130_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -41938,10 +42989,6 @@
     },
     "title": "/ZH_HToZZTo4L_M-130_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZH_HToZZTo4L_M-130_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -41970,6 +43017,13 @@
       "description": "\n          <p>Simulated dataset ZH_HToZZTo4L_M-140_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -42043,10 +43097,6 @@
     },
     "title": "/ZH_HToZZTo4L_M-140_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZH_HToZZTo4L_M-140_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -42075,6 +43125,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_mass171_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -42175,10 +43232,6 @@
     },
     "title": "/TTJets_MSDecays_mass171_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_mass171_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -42207,6 +43260,13 @@
       "description": "\n          <p>Simulated dataset ZH_HToZZTo4L_M-150_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -42280,10 +43340,6 @@
     },
     "title": "/ZH_HToZZTo4L_M-150_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZH_HToZZTo4L_M-150_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -42312,6 +43368,13 @@
       "description": "\n          <p>Simulated dataset ZH_HToZZTo4L_M-160_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -42397,10 +43460,6 @@
     },
     "title": "/ZH_HToZZTo4L_M-160_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZH_HToZZTo4L_M-160_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -42429,6 +43488,13 @@
       "description": "\n          <p>Simulated dataset ZH_HToZZTo4L_M-180_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -42502,10 +43568,6 @@
     },
     "title": "/ZH_HToZZTo4L_M-180_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZH_HToZZTo4L_M-180_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -42534,6 +43596,13 @@
       "description": "\n          <p>Simulated dataset ZH_HToZZTo4L_M-200_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -42619,10 +43688,6 @@
     },
     "title": "/ZH_HToZZTo4L_M-200_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZH_HToZZTo4L_M-200_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -42651,6 +43716,13 @@
       "description": "\n          <p>Simulated dataset ZHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -42725,10 +43797,6 @@
     },
     "title": "/ZHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -42757,6 +43825,13 @@
       "description": "\n          <p>Simulated dataset ZHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -42831,10 +43906,6 @@
     },
     "title": "/ZHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -42863,6 +43934,13 @@
       "description": "\n          <p>Simulated dataset ZHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -42937,10 +44015,6 @@
     },
     "title": "/ZHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset ZHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4 in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -42969,6 +44043,13 @@
       "description": "\n          <p>Simulated dataset Tbar_TuneZ2_s-channel_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -43055,10 +44136,6 @@
     },
     "title": "/Tbar_TuneZ2_s-channel_7TeV-powheg-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Tbar_TuneZ2_s-channel_7TeV-powheg-tauola in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -43087,6 +44164,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_mass173_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -43199,10 +44283,6 @@
     },
     "title": "/TTJets_MSDecays_mass173_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_mass173_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -43231,6 +44311,13 @@
       "description": "\n          <p>Simulated dataset TTbarH_HToZZTo4L_M-126_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -43328,10 +44415,6 @@
     },
     "title": "/TTbarH_HToZZTo4L_M-126_7TeV-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTbarH_HToZZTo4L_M-126_7TeV-pythia6 in AODSIM format for 2011 collision data (SM Higgs)",
-    "topic": {
-      "category": "SM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -43360,6 +44443,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_mass175_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -43484,10 +44574,6 @@
     },
     "title": "/TTJets_MSDecays_mass175_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_mass175_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -43516,6 +44602,13 @@
       "description": "\n          <p>Simulated dataset VBFHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Higgs Physics",
+      "secondary": [
+        "Beyond Standard Model"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -43590,10 +44683,6 @@
     },
     "title": "/VBFHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset VBFHiggs0PToGG_M-125p6_7TeV-JHUGenV4-pythia6-tauola in AODSIM format for 2011 collision data (BSM Higgs)",
-    "topic": {
-      "category": "BSM Higgs",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -43622,6 +44711,13 @@
       "description": "\n          <p>Simulated dataset Vector1MToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Exotica",
+      "secondary": [
+        "Miscellaneous"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -43697,10 +44793,6 @@
     },
     "title": "/Vector1MToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset Vector1MToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6 in AODSIM format for 2011 collision data (SM Inclusive)",
-    "topic": {
-      "category": "SM Inclusive",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -43729,6 +44821,13 @@
       "description": "\n          <p>Simulated dataset TTJets_MSDecays_scaleup_mt172_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)</p>\n          <p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p>\n        "
     },
     "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "ttbar"
+      ],
+      "source": "CMS Collaboration"
+    },
     "collaboration": {
       "name": "CMS collaboration",
       "recid": "451"
@@ -43817,10 +44916,6 @@
     },
     "title": "/TTJets_MSDecays_scaleup_mt172_5_7TeV-madgraph-tauola/Summer11LegDR-PU_S13_START53_LV6-v1/AODSIM",
     "title_additional": "Simulated dataset TTJets_MSDecays_scaleup_mt172_5_7TeV-madgraph-tauola in AODSIM format for 2011 collision data (SM Systematic Variations)",
-    "topic": {
-      "category": "SM Systematic Variations",
-      "source": "CMS Collaboration"
-    },
     "type": {
       "primary": "Dataset",
       "secondary": [

--- a/cernopendata/templates/cernopendata/search.html
+++ b/cernopendata/templates/cernopendata/search.html
@@ -61,7 +61,7 @@
                      <div class="card-body content-style">
                          <invenio-search-facets
                           order="type,experiment,year,file_type,
-                          collision_type,collision_energy,topic_category,
+                          collision_type,collision_energy,category,
                           run,keywords"
                           template="{{ url_for('static', filename='templates/cernopendata_search_ui/facets.html') }}">
                          </invenio-search-facets>


### PR DESCRIPTION
* Changes record structure from `topic` to `categories` with a possibility of
  having one primary and several secondary categories.  Amends JSON data model
  and Elasticsearch mappings and indexes accordingly.  (closes #2475)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
