### PR TITLE
glosary: 

### DIFF
--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -37,7 +37,7 @@
     }
   },
   {
-    "anchor": "barn",
+    "anchor": "Barn",
     "category": "generic",
     "definition": "Barn is a unit of area, used to express cross sections, and is equivalent to $10^{-24}$ cm². The inverse femtobarn ($fb^{-1}$) is the typical unit used for time-integrated Luminosity.",
     "links": [
@@ -117,14 +117,16 @@
     ],
     "term": [
       "Cross section",
-      "cross section"
+      "Cross sections",
+      "cross section",
+      "cross sections"
     ],
     "type": {
       "primary": "Glossary"
     }
   },
   {
-    "anchor": "derived",
+    "anchor": "Derived",
     "category": "specific",
     "definition": "Contains data that have been derived from the primary datasets. The data may be reduced in the sense that (a) only part of the information is kept or (b) only part of the events are selected.",
     "experiment": [
@@ -160,7 +162,11 @@
     ],
     "term": [
       "Derived Dataset",
-      "Derived Datasets"
+      "Derived Datasets",
+      "Derived dataset",
+      "Derived datasets",
+      "derived dataset",
+      "derived datasets"
     ],
     "type": {
       "primary": "Glossary"
@@ -196,7 +202,7 @@
     }
   },
   {
-    "anchor": "electron",
+    "anchor": "Electron",
     "category": "generic",
     "definition": "A stable elementary particle belonging to the first generation of the \u201clepton\u201d family of particles. It has a -1 electrical charge, while its anti-particle, the anti-electron or positron, has a +1 electrical charge. Atoms are made of electrons orbiting positively charged nuclei. An electron has a mass of $\\sim 0.5 MeV/c^2$, or about $1/1836$ times the mass of a proton.",
     "links": [
@@ -218,6 +224,8 @@
     ],
     "term": [
       "Electron",
+      "electron",
+      "electrons",
       "Electrons"
     ],
     "type": {
@@ -263,7 +271,7 @@
     }
   },
   {
-    "anchor": "generator",
+    "anchor": "Generator",
     "category": "generic",
     "definition": "Simulation programs used to generate particle collisions.",
     "links": [
@@ -291,9 +299,11 @@
     ],
     "term": [
       "Event generator",
+      "Event Generator",
       "Event generators",
       "event generators",
       "Generator",
+      "generator",
       "Generators"
     ],
     "type": {
@@ -301,7 +311,7 @@
     }
   },
   {
-    "anchor": "gluon",
+    "anchor": "Gluon",
     "category": "generic",
     "definition": "An elementary particle belonging to the \u201cboson\u201d family of particles. It is the carrier of the strong force that binds quarks together to form hadrons. It is massless and has no electrical charge but has a property known as \u201ccolour charge\u201d.",
     "links": [
@@ -320,14 +330,16 @@
     ],
     "term": [
       "Gluon",
-      "Gluons"
+      "Gluons",
+      "gluon",
+      "gluons"
     ],
     "type": {
       "primary": "Glossary"
     }
   },
   {
-    "anchor": "hadron",
+    "anchor": "Hadron",
     "category": "generic",
     "definition": "A composite particle made of two or more quarks. There are two sub-categories of hadrons: \u201cbaryons\u201d, such as protons and neutrons, are made of three quarks (or three anti-quarks), while \u201cmesons\u201d are made of a quark and an anti-quark. Atomic nuclei can also be considered hadrons, since they are also fundamentally made of quarks. The LHC collides two species of hadrons: protons and lead nuclei (also called lead ions). Hadrons produced in collisions typically cluster together to form particle jets in the detectors.",
     "links": [
@@ -364,7 +376,7 @@
     }
   },
   {
-    "anchor": "ion",
+    "anchor": "Ion",
     "category": "generic",
     "definition": "An ion is an atom or a molecule in which the number of electrons is not the same as the number of protons. In the context of the LHC, the term \u201cheavy ion\u201d refers to the nuclei of heavy atoms such as lead.",
     "links": [
@@ -389,14 +401,16 @@
     ],
     "term": [
       "Ion",
-      "Ions"
+      "ion",
+      "Ions",
+      "ions"
     ],
     "type": {
       "primary": "Glossary"
     }
   },
   {
-    "anchor": "jet",
+    "anchor": "Jet",
     "category": "generic",
     "definition": "A jet is a shower of hadrons, which originate from a quark or a gluon, clustered together after being produced in particle collisions.",
     "links": [
@@ -417,8 +431,10 @@
       }
     ],
     "term": [
-      "Particle jet",
-      "Particle jets"
+      "jet",
+      "jets",
+      "Jet",
+      "Jets"
     ],
     "type": {
       "primary": "Glossary"
@@ -490,7 +506,7 @@
     }
   },
   {
-    "anchor": "lumisection",
+    "anchor": "Lumisection",
     "category": "specific",
     "definition": "A lumi section is a fixed time period in data taking, approximately 24 seconds.",
     "experiment": [
@@ -517,7 +533,7 @@
     }
   },
   {
-    "anchor": "monte carlo",
+    "anchor": "Monte Carlo",
     "category": "generic",
     "definition": "Refers to computational algorithms based on numerical random samplings that is used in simulation programs for generating the particle collisions and for simulating of particle interactions in the detector material. Often used as a synonym for simulated data.",
     "links": [
@@ -541,14 +557,16 @@
       }
     ],
     "term": [
-      "Monte Carlo"
+      "Monte Carlo",
+      "MonteCarlo",
+      "monte carlo"
     ],
     "type": {
       "primary": "Glossary"
     }
   },
   {
-    "anchor": "muon",
+    "anchor": "Muon",
     "category": "generic",
     "definition": "An elementary particle belonging to the second generation of the \u201clepton\u201d family of particles. It has a -1 electrical charge, while its anti-particle, the anti-muon, has a +1 electrical charge. A muon\u2019s properties are similar to those of an electron but it is around 200 times more massive. It is represented by the Greek letter \u201c$\\mu$\u201d.",
     "links": [
@@ -567,14 +585,16 @@
     ],
     "term": [
       "Muon",
-      "Muons"
+      "Muons",
+      "muon",
+      "muons"
     ],
     "type": {
       "primary": "Glossary"
     }
   },
   {
-    "anchor": "neutrino",
+    "anchor": "Neutrino",
     "category": "generic",
     "definition": "An elementary particle belonging to the \u201clepton\u201d family of particles. Neutrinos and their anti-particles, anti-neutrinos, have no charge, although measurements show that they are not massless. Neutrinos rarely interact with matter: they can fly through lightyears of lead without coming to a stop. Therefore, they cannot be detected directly by the particle detectors at the LHC: their presence has to be inferred by detecting and measuring every other particle produced in the collisions and then applying conservation laws. Neutrinos are recorded as \u201cmissing transverse energy\u201d or MET, although MET could also be a sign of previously undiscovered, non-interacting particles.",
     "links": [
@@ -593,7 +613,9 @@
     ],
     "term": [
       "Neutrino",
-      "Neutrinos"
+      "Neutrinos",
+      "neutrino",
+      "neutrinos"
     ],
     "type": {
       "primary": "Glossary"
@@ -658,7 +680,7 @@
     }
   },
   {
-    "anchor": "photon",
+    "anchor": "Photon",
     "category": "generic",
     "definition": "A stable elementary particle belonging to the \u201cboson\u201d family of particles. Called the \u201cquantum\u201d of light, the photon is the carrier of the electromagnetic force and is massless with no electrical charge. It is represented by the Greek letter \u201c$\\gamma$\u201d.",
     "links": [
@@ -674,7 +696,9 @@
     ],
     "term": [
       "Photon",
-      "Photons"
+      "Photons",
+      "photon",
+      "photons"
     ],
     "type": {
       "primary": "Glossary"
@@ -740,14 +764,16 @@
       "Pythia",
       "pythia",
       "Pythia6",
-      "Pythia8"
+      "Pythia8",
+      "pythia6",
+      "pythia8"
     ],
     "type": {
       "primary": "Glossary"
     }
   },
   {
-    "anchor": "primary",
+    "anchor": "Primary",
     "category": "specific",
     "definition": "Datasets prepared after trigger selections, with no further selection criteria applied. On this portal, primary datasets refer to \u201creconstructed data\u201d.",
     "experiment": [
@@ -792,14 +818,16 @@
     ],
     "term": [
       "Primary Dataset",
-      "Primary Datasets"
+      "Primary Datasets",
+      "primary dataset",
+      "primary datasets"
     ],
     "type": {
       "primary": "Glossary"
     }
   },
   {
-    "anchor": "proton",
+    "anchor": "Proton",
     "category": "generic",
     "definition": "A stable composite particle belonging to the \u201chadron\u201d family of particles, made of two up quarks and a down quark. It has a +1 electrical charge and is found in the nuclei of atoms. A proton has a mass of $\\sim 938 MeV/c^2$, or about 1836 times the mass of an electron. Protons are one of the species of particles collided at the LHC.",
     "links": [
@@ -821,7 +849,9 @@
     ],
     "term": [
       "Proton",
-      "Protons"
+      "Protons",
+      "proton",
+      "protons"
     ],
     "type": {
       "primary": "Glossary"
@@ -858,7 +888,7 @@
     }
   },
   {
-    "anchor": "quark",
+    "anchor": "Quark",
     "category": "generic",
     "definition": "An elementary particle that comes in six flavours: up, charm and top (all with +2/3 electrical charge) and down, strange and bottom (all with -1/3 electrical charge). Quarks also have a property known as \u201ccolour charge\u201d and cannot exist freely because of a phenomenon called \u201ccolour confinement\u201d: they are held together by gluons to form hadrons.",
     "links": [
@@ -883,7 +913,9 @@
     ],
     "term": [
       "Quark",
-      "Quarks"
+      "Quarks",
+      "quark",
+      "quarks"
     ],
     "type": {
       "primary": "Glossary"
@@ -921,7 +953,7 @@
     }
   },
   {
-    "anchor": "reconstruction",
+    "anchor": "Reconstruction",
     "category": "specific",
     "definition": "Fragmented data from various sub-detectors are processed or \u201creconstructed\u201d to provide coherent information about individual physics objects such as electrons or particle jets. Reconstruction involves putting together information from different sub-detectors into a coherent representation of every particle collision. However, the format for the first tier of reconstructed data is often too huge for meaningful analysis, and is converted into a lighter format, such as the AOD format for CMS.",
     "experiment": [
@@ -967,10 +999,19 @@
   {
     "anchor": "Run",
     "category": "specific",
-    "definition": "The data collected by CMS in a given year are divided into sets called \u201cRuns\u201d. For example, the data from 2010 were divided into \u201cRunA\u201d and \u201cRunB\u201d, the latter being from the second part of the year.",
+    "definition": "The data collected by an experiment in a given year are divided into sets called \u201cRuns\u201d. For example, the data from 2010 were divided into \u201cRunA\u201d and \u201cRunB\u201d, the latter being from the second part of the year.",
     "experiment": [
       {
         "name": "CMS"
+      },
+      {
+        "name": "ATLAS"
+      },
+      {
+        "name": "ALICE"
+      },
+      {
+        "name": "LHCb"
       }
     ],
     "links": [
@@ -1004,7 +1045,7 @@
     }
   },
   {
-    "anchor": "tag",
+    "anchor": "Tag",
     "category": "specific",
     "definition": "A Global Tag is a coherent collection of records of additional data needed by the reconstruction and analysis software. These records are stored in the Condition Database. Condition data include non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for the simulation/reconstruction/analysis software.",
     "experiment": [
@@ -1032,6 +1073,8 @@
     "term": [
       "Global Tag",
       "Global Tags",
+      "global tag",
+      "global tags",
       "Condition Data",
       "Condition Database"
     ],
@@ -1040,7 +1083,7 @@
     }
   },
   {
-    "anchor": "trigger",
+    "anchor": "Trigger",
     "category": "generic",
     "definition": "A system that determines which particle collisions are stored in primary datasets and which ones are discarded. The triggering is done first by a lower-level hardware-based trigger (L1) and then by the High-Level Trigger (HLT) on a computing farm.",
     "links": [
@@ -1067,6 +1110,8 @@
     "term": [
       "Trigger",
       "Triggers",
+      "trigger",
+      "triggers",
       "L1",
       "HLT"
     ],


### PR DESCRIPTION
- All entries start with uppercase
- Add more terms to match the plural forms

The entry for [lumisection](http://opendata-dev.cern.ch/glossary/lumisection) lists only `CMS` experiment in the `See also` list. This gives the impression that this concept is CMS-specific, but [TOTEM also uses](https://twiki.cern.ch/twiki/bin/view/TOTEM/CompCMSbril#Terminology) and possibly other experiments. Should I remove `CMS` from the list?