### PR TITLE
glossary: fix "see also" terms

### DIFF
--- a/cernopendata/modules/fixtures/data/terms/terms.json
+++ b/cernopendata/modules/fixtures/data/terms/terms.json
@@ -20,13 +20,13 @@
     ],
     "see_also": [
       {
-        "term": "primary"
+        "term": "Primary"
       },
       {
-        "term": "reconstruction"
+        "term": "Reconstruction"
       },
       {
-        "term": "tag"
+        "term": "Tag"
       }
     ],
     "term": [
@@ -109,10 +109,10 @@
         "term": "Luminosity"
       },
       {
-        "term": "barn"
+        "term": "Barn"
       },
       {
-        "term": "hadron"
+        "term": "Hadron"
       }
     ],
     "term": [
@@ -151,13 +151,13 @@
     ],
     "see_also": [
       {
-        "term": "primary"
+        "term": "Primary"
       },
       {
-        "term": "tag"
+        "term": "Tag"
       },
       {
-        "term": "condition"
+        "term": "Condition"
       }
     ],
     "term": [
@@ -184,13 +184,13 @@
     ],
     "see_also": [
       {
-        "term": "hadron"
+        "term": "Hadron"
       },
       {
-        "term": "quark"
+        "term": "Quark"
       },
       {
-        "term": "gluon"
+        "term": "Gluon"
       }
     ],
     "term": [
@@ -213,13 +213,13 @@
     ],
     "see_also": [
       {
-        "term": "muon"
+        "term": "Muon"
       },
       {
-        "term": "proton"
+        "term": "Proton"
       },
       {
-        "term": "neutrino"
+        "term": "Neutrino"
       }
     ],
     "term": [
@@ -248,7 +248,7 @@
     ],
     "see_also": [
       {
-        "term": "proton"
+        "term": "Proton"
       },
       {
         "term": "Pile-up"
@@ -257,7 +257,7 @@
         "term": "Cross section"
       },
       {
-        "term": "ion"
+        "term": "Ion"
       }
     ],
     "term": [
@@ -282,19 +282,19 @@
     ],
     "see_also": [
       {
-        "term": "monte carlo"
+        "term": "Monte Carlo"
       },
       {
-        "term": "primary"
+        "term": "Primary"
       },
       {
-        "term": "derived"
+        "term": "Derived"
       },
       {
         "term": "Les Houches Event file"
       },
       {
-        "term": "pythia"
+        "term": "Pythia"
       }
     ],
     "term": [
@@ -322,10 +322,10 @@
     ],
     "see_also": [
       {
-        "term": "quark"
+        "term": "Quark"
       },
       {
-        "term": "photon"
+        "term": "Photon"
       }
     ],
     "term": [
@@ -350,19 +350,19 @@
     ],
     "see_also": [
       {
-        "term": "proton"
+        "term": "Proton"
       },
       {
-        "term": "quark"
+        "term": "Quark"
       },
       {
-        "term": "jet"
+        "term": "Jet"
       },
       {
         "term": "Parton"
       },
       {
-        "term": "ion"
+        "term": "Ion"
       }
     ],
     "term": [
@@ -387,16 +387,16 @@
     ],
     "see_also": [
       {
-        "term": "proton"
+        "term": "Proton"
       },
       {
-        "term": "quark"
+        "term": "Quark"
       },
       {
-        "term": "jet"
+        "term": "Jet"
       },
       {
-        "term": "ion"
+        "term": "Ion"
       }
     ],
     "term": [
@@ -421,13 +421,13 @@
     ],
     "see_also": [
       {
-        "term": "proton"
+        "term": "Proton"
       },
       {
-        "term": "quark"
+        "term": "Quark"
       },
       {
-        "term": "hadron"
+        "term": "Hadron"
       }
     ],
     "term": [
@@ -456,13 +456,13 @@
     ],
     "see_also": [
       {
-        "term": "generator"
+        "term": "Generator"
       },
       {
         "term": "Events"
       },
       {
-        "term": "reconstruction"
+        "term": "Reconstruction"
       }
     ],
     "term": [
@@ -491,10 +491,10 @@
         "term": "Events"
       },
       {
-        "term": "barn"
+        "term": "Barn"
       },
       {
-        "term": "lumisection"
+        "term": "Lumisection"
       }
     ],
     "term": [
@@ -535,7 +535,7 @@
   {
     "anchor": "Monte Carlo",
     "category": "generic",
-    "definition": "Refers to computational algorithms based on numerical random samplings that is used in simulation programs for generating the particle collisions and for simulating of particle interactions in the detector material. Often used as a synonym for simulated data.",
+    "definition": "\u201cMonte Carlo\u201d refers to computational algorithms based on numerical random samplings. It is used in simulation programs for generating the particle collisions and for simulation of particle interactions in the detector material. Often used as a synonym for simulated data.",
     "links": [
       {
         "text": "Read more on Wikipedia",
@@ -544,21 +544,22 @@
     ],
     "see_also": [
       {
-        "term": "generator"
+        "term": "Generator"
       },
       {
-        "term": "primary"
+        "term": "Primary"
       },
       {
-        "term": "derived"
+        "term": "Derived"
       },
       {
-        "term": "condition"
+        "term": "Condition"
       }
     ],
     "term": [
       "Monte Carlo",
       "MonteCarlo",
+      "MC",
       "monte carlo"
     ],
     "type": {
@@ -577,10 +578,10 @@
     ],
     "see_also": [
       {
-        "term": "electron"
+        "term": "Electron"
       },
       {
-        "term": "neutrino"
+        "term": "Neutrino"
       }
     ],
     "term": [
@@ -605,10 +606,10 @@
     ],
     "see_also": [
       {
-        "term": "muon"
+        "term": "Muon"
       },
       {
-        "term": "neutrino"
+        "term": "Neutrino"
       }
     ],
     "term": [
@@ -633,13 +634,13 @@
     ],
     "see_also": [
       {
-        "term": "hadron"
+        "term": "Hadron"
       },
       {
-        "term": "proton"
+        "term": "Proton"
       },
       {
-        "term": "quark"
+        "term": "Quark"
       }
     ],
     "term": [
@@ -691,7 +692,7 @@
     ],
     "see_also": [
       {
-        "term": "gluon"
+        "term": "Gluon"
       }
     ],
     "term": [
@@ -720,7 +721,7 @@
     ],
     "see_also": [
       {
-        "term": "reconstruction"
+        "term": "Reconstruction"
       },
       {
         "term": "Cross section"
@@ -729,7 +730,7 @@
         "term": "Events"
       },
       {
-        "term": "primary"
+        "term": "Primary"
       }
     ],
     "term": [
@@ -754,10 +755,10 @@
     ],
     "see_also": [
       {
-        "term": "generator"
+        "term": "Generator"
       },
       {
-        "term": "monte carlo"
+        "term": "Monte Carlo"
       }
     ],
     "term": [
@@ -801,19 +802,19 @@
         "term": "AOD"
       },
       {
-        "term": "reconstruction"
+        "term": "Reconstruction"
       },
       {
-        "term": "tag"
+        "term": "Tag"
       },
       {
-        "term": "derived"
+        "term": "Derived"
       },
       {
-        "term": "trigger"
+        "term": "Trigger"
       },
       {
-        "term": "condition"
+        "term": "Condition"
       }
     ],
     "term": [
@@ -838,13 +839,13 @@
     ],
     "see_also": [
       {
-        "term": "hadron"
+        "term": "Hadron"
       },
       {
-        "term": "electron"
+        "term": "Electron"
       },
       {
-        "term": "jet"
+        "term": "Jet"
       }
     ],
     "term": [
@@ -873,10 +874,10 @@
     ],
     "see_also": [
       {
-        "term": "hadron"
+        "term": "Hadron"
       },
       {
-        "term": "jet"
+        "term": "Jet"
       }
     ],
     "term": [
@@ -899,16 +900,16 @@
     ],
     "see_also": [
       {
-        "term": "hadron"
+        "term": "Hadron"
       },
       {
-        "term": "proton"
+        "term": "Proton"
       },
       {
-        "term": "jet"
+        "term": "Jet"
       },
       {
-        "term": "gluon"
+        "term": "Gluon"
       }
     ],
     "term": [
@@ -933,13 +934,13 @@
     ],
     "see_also": [
       {
-        "term": "quark"
+        "term": "Quark"
       },
       {
-        "term": "hadron"
+        "term": "Hadron"
       },
       {
-        "term": "gluon"
+        "term": "Gluon"
       }
     ],
     "term": [
@@ -981,10 +982,10 @@
         "term": "AOD"
       },
       {
-        "term": "primary"
+        "term": "Primary"
       },
       {
-        "term": "tag"
+        "term": "Tag"
       }
     ],
     "term": [
@@ -1061,13 +1062,13 @@
     ],
     "see_also": [
       {
-        "term": "reconstruction"
+        "term": "Reconstruction"
       },
       {
         "term": "AOD"
       },
       {
-        "term": "primary"
+        "term": "Primary"
       }
     ],
     "term": [
@@ -1098,13 +1099,13 @@
     ],
     "see_also": [
       {
-        "term": "generator"
+        "term": "Generator"
       },
       {
-        "term": "primary"
+        "term": "Primary"
       },
       {
-        "term": "derived"
+        "term": "Derived"
       }
     ],
     "term": [


### PR DESCRIPTION
PR #2483 changed all entries to start with uppercase, but the references
in "see also" were not updated. This commit fixes it.

Adds a new 'term' for Monte Carlo: "MC". Improves MC definition
