### PR TITLE
records: fix CMS MC pileup links

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010.json
@@ -42,9 +42,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "710",
     "run_period": [
@@ -434,9 +431,6 @@
     },
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
-    },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "715",
@@ -1842,9 +1836,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "733",
     "run_period": [
@@ -1922,9 +1913,6 @@
     },
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
-    },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "734",
@@ -2004,9 +1992,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "735",
     "run_period": [
@@ -2085,9 +2070,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "736",
     "run_period": [
@@ -2165,9 +2147,6 @@
     },
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
-    },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "737",
@@ -2325,9 +2304,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "739",
     "run_period": [
@@ -2406,9 +2382,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "740",
     "run_period": [
@@ -2486,9 +2459,6 @@
     },
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
-    },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "741",
@@ -2731,9 +2701,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "744",
     "run_period": [
@@ -2811,9 +2778,6 @@
     },
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
-    },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "745",
@@ -6793,9 +6757,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "796",
     "run_period": [
@@ -6873,9 +6834,6 @@
     },
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
-    },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "797",
@@ -6955,9 +6913,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "798",
     "run_period": [
@@ -7035,9 +6990,6 @@
     },
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
-    },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "799",
@@ -7117,9 +7069,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "800",
     "run_period": [
@@ -7197,9 +7146,6 @@
     },
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
-    },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "801",
@@ -7279,9 +7225,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "802",
     "run_period": [
@@ -7359,9 +7302,6 @@
     },
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
-    },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "803",
@@ -7441,9 +7381,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "804",
     "run_period": [
@@ -7521,9 +7458,6 @@
     },
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
-    },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "805",
@@ -7603,9 +7537,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "806",
     "run_period": [
@@ -7683,9 +7614,6 @@
     },
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
-    },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "807",
@@ -7765,9 +7693,6 @@
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
     },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
-    },
     "publisher": "CERN Open Data Portal",
     "recid": "808",
     "run_period": [
@@ -7845,9 +7770,6 @@
     },
     "note": {
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2010."
-    },
-    "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p><p>The pile-up dataset used is <a href=\"/record/None\">/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM</a>.</p><p>E7TeV_ProbDist_2010Data_BX156</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "809",

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2012.json
@@ -80,7 +80,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7299",
@@ -201,7 +207,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7682",
@@ -308,7 +320,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7683",
@@ -408,7 +426,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7685",
@@ -508,7 +532,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7687",
@@ -615,7 +645,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7688",
@@ -722,7 +758,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7689",
@@ -829,7 +871,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7690",
@@ -936,7 +984,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7691",
@@ -1043,7 +1097,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7692",
@@ -1164,7 +1224,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7693",
@@ -1271,7 +1337,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7694",
@@ -1375,7 +1447,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7717",
@@ -1482,7 +1560,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7718",
@@ -1673,7 +1757,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7719",
@@ -1780,7 +1870,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7720",
@@ -1887,7 +1983,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7721",
@@ -2008,7 +2110,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7722",
@@ -2115,7 +2223,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7723",
@@ -2362,7 +2476,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7724",
@@ -2483,7 +2603,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7725",
@@ -2604,7 +2730,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7726",
@@ -2725,7 +2857,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7727",
@@ -2846,7 +2984,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7728",
@@ -2953,7 +3097,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7729",
@@ -3088,7 +3238,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7730",
@@ -3209,7 +3365,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7731",
@@ -3316,7 +3478,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7732",
@@ -3423,7 +3591,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7733",
@@ -3544,7 +3718,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7734",
@@ -3665,7 +3845,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7735",
@@ -3828,7 +4014,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7736",
@@ -3935,7 +4127,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7737",
@@ -4042,7 +4240,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7738",
@@ -4149,7 +4353,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7739",
@@ -4256,7 +4466,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7740",
@@ -4377,7 +4593,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7741",
@@ -4526,7 +4748,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7742",
@@ -4647,7 +4875,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7743",
@@ -4768,7 +5002,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7744",
@@ -4875,7 +5115,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7745",
@@ -4982,7 +5228,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7746",
@@ -5086,7 +5338,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7752",
@@ -5193,7 +5451,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7755",
@@ -5300,7 +5564,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7756",
@@ -5407,7 +5677,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7757",
@@ -5514,7 +5790,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7758",
@@ -5635,7 +5917,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7759",
@@ -5742,7 +6030,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7760",
@@ -5849,7 +6143,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7761",
@@ -5956,7 +6256,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7762",
@@ -6077,7 +6383,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7763",
@@ -6184,7 +6496,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7764",
@@ -6305,7 +6623,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7767",
@@ -6454,7 +6778,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7774",
@@ -6575,7 +6905,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7775",
@@ -6710,7 +7046,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7777",
@@ -6831,7 +7173,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7778",
@@ -6938,7 +7286,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7779",
@@ -7059,7 +7413,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7780",
@@ -7187,7 +7547,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7783",
@@ -7308,7 +7674,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7803",
@@ -7429,7 +7801,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7804",
@@ -7550,7 +7928,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7805",
@@ -7657,7 +8041,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7809",
@@ -7764,7 +8154,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7810",
@@ -7871,7 +8267,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7811",
@@ -7978,7 +8380,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7812",
@@ -8085,7 +8493,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7813",
@@ -8192,7 +8606,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7814",
@@ -8299,7 +8719,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7815",
@@ -8406,7 +8832,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7816",
@@ -8513,7 +8945,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7817",
@@ -8634,7 +9072,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7819",
@@ -8755,7 +9199,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7820",
@@ -8876,7 +9326,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7821",
@@ -8990,7 +9446,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7823",
@@ -9125,7 +9587,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7824",
@@ -9232,7 +9700,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7825",
@@ -9353,7 +9827,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7827",
@@ -9474,7 +9954,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7828",
@@ -9595,7 +10081,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7829",
@@ -9702,7 +10194,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7865",
@@ -9823,7 +10321,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7866",
@@ -9930,7 +10434,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7867",
@@ -10037,7 +10547,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7868",
@@ -10144,7 +10660,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7869",
@@ -10251,7 +10773,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7870",
@@ -10358,7 +10886,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7871",
@@ -10465,7 +10999,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7872",
@@ -10586,7 +11126,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7873",
@@ -10707,7 +11253,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7874",
@@ -10814,7 +11366,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7877",
@@ -10935,7 +11493,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7900",
@@ -11056,7 +11620,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7901",
@@ -11163,7 +11733,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7902",
@@ -11270,7 +11846,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7903",
@@ -11377,7 +11959,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7904",
@@ -11484,7 +12072,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7905",
@@ -11591,7 +12185,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7906",
@@ -11698,7 +12298,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7977",
@@ -11805,7 +12411,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "7986",
@@ -11926,7 +12538,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8000",
@@ -12033,7 +12651,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8001",
@@ -12140,7 +12764,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8063",
@@ -12261,7 +12891,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8064",
@@ -12368,7 +13004,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8100",
@@ -12489,7 +13131,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8103",
@@ -12610,7 +13258,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8104",
@@ -12731,7 +13385,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8116",
@@ -12852,7 +13512,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8169",
@@ -12973,7 +13639,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8215",
@@ -13080,7 +13752,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8216",
@@ -13187,7 +13865,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8261",
@@ -13294,7 +13978,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8262",
@@ -13401,7 +14091,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8263",
@@ -13508,7 +14204,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8264",
@@ -13615,7 +14317,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8265",
@@ -13722,7 +14430,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8266",
@@ -13829,7 +14543,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8267",
@@ -13936,7 +14656,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8268",
@@ -14043,7 +14769,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8272",
@@ -14164,7 +14896,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8286",
@@ -14285,7 +15023,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8287",
@@ -14406,7 +15150,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8288",
@@ -14527,7 +15277,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8289",
@@ -14634,7 +15390,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8290",
@@ -14755,7 +15517,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8291",
@@ -14876,7 +15644,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8292",
@@ -14997,7 +15771,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8293",
@@ -15118,7 +15898,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8294",
@@ -15239,7 +16025,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8295",
@@ -15360,7 +16152,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8480",
@@ -15467,7 +16265,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8481",
@@ -15588,7 +16392,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8482",
@@ -15695,7 +16505,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8483",
@@ -15816,7 +16632,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8484",
@@ -15937,7 +16759,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8485",
@@ -16055,7 +16883,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8847",
@@ -16162,7 +16996,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8870",
@@ -16283,7 +17123,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8871",
@@ -16390,7 +17236,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8872",
@@ -16497,7 +17349,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8873",
@@ -16604,7 +17462,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8874",
@@ -16711,7 +17575,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8875",
@@ -16818,7 +17688,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8876",
@@ -16925,7 +17801,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8877",
@@ -17032,7 +17914,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8878",
@@ -17139,7 +18027,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8879",
@@ -17246,7 +18140,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8880",
@@ -17367,7 +18267,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8881",
@@ -17488,7 +18394,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8882",
@@ -17595,7 +18507,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8883",
@@ -18080,7 +18998,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8884",
@@ -18187,7 +19111,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8885",
@@ -18308,7 +19238,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8886",
@@ -18471,7 +19407,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8887",
@@ -18578,7 +19520,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8888",
@@ -18713,7 +19661,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8889",
@@ -18820,7 +19774,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8890",
@@ -18927,7 +19887,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8891",
@@ -19034,7 +20000,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8893",
@@ -19141,7 +20113,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8894",
@@ -19248,7 +20226,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8895",
@@ -19355,7 +20339,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8896",
@@ -19462,7 +20452,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8897",
@@ -19709,7 +20705,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8898",
@@ -19816,7 +20818,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "8899",
@@ -19923,7 +20931,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9356",
@@ -20030,7 +21044,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9437",
@@ -20137,7 +21157,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9438",
@@ -20244,7 +21270,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9439",
@@ -20351,7 +21383,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9444",
@@ -20458,7 +21496,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9445",
@@ -20579,7 +21623,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9446",
@@ -20700,7 +21750,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9447",
@@ -20807,7 +21863,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9452",
@@ -20928,7 +21990,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9457",
@@ -21049,7 +22117,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9518",
@@ -21156,7 +22230,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9519",
@@ -21305,7 +22385,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9527",
@@ -21412,7 +22498,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9536",
@@ -21519,7 +22611,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9537",
@@ -21640,7 +22738,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9538",
@@ -21761,7 +22865,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9539",
@@ -21903,7 +23013,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9549",
@@ -22010,7 +23126,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9567",
@@ -22117,7 +23239,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9568",
@@ -22252,7 +23380,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9576",
@@ -22373,7 +23507,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9577",
@@ -22480,7 +23620,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9578",
@@ -22587,7 +23733,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9579",
@@ -22694,7 +23846,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9580",
@@ -22801,7 +23959,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9581",
@@ -22950,7 +24114,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9582",
@@ -23071,7 +24241,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9583",
@@ -23178,7 +24354,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9584",
@@ -23299,7 +24481,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9585",
@@ -23406,7 +24594,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9586",
@@ -23625,7 +24819,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9588",
@@ -23732,7 +24932,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9600",
@@ -23867,7 +25073,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9601",
@@ -24002,7 +25214,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9602",
@@ -24123,7 +25341,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9603",
@@ -24230,7 +25454,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9604",
@@ -24351,7 +25581,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9605",
@@ -24472,7 +25708,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9606",
@@ -24593,7 +25835,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9607",
@@ -24700,7 +25948,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9619",
@@ -24807,7 +26061,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9620",
@@ -24914,7 +26174,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9634",
@@ -25021,7 +26287,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9635",
@@ -25128,7 +26400,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9640",
@@ -25277,7 +26555,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9641",
@@ -25398,7 +26682,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9648",
@@ -25505,7 +26795,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9665",
@@ -25626,7 +26922,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9666",
@@ -25747,7 +27049,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9667",
@@ -25854,7 +27162,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9668",
@@ -25961,7 +27275,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9669",
@@ -26082,7 +27402,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9671",
@@ -26189,7 +27515,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9672",
@@ -26296,7 +27628,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9702",
@@ -26424,7 +27762,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9713",
@@ -26531,7 +27875,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9714",
@@ -26638,7 +27988,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9743",
@@ -26745,7 +28101,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9748",
@@ -26852,7 +28214,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9790",
@@ -26959,7 +28327,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9793",
@@ -27094,7 +28468,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9863",
@@ -27229,7 +28609,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9864",
@@ -27350,7 +28736,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9865",
@@ -27471,7 +28863,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9866",
@@ -27592,7 +28990,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9885",
@@ -27734,7 +29138,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9896",
@@ -27841,7 +29251,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9914",
@@ -27948,7 +29364,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9915",
@@ -28069,7 +29491,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9924",
@@ -28176,7 +29604,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9929",
@@ -28311,7 +29745,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9937",
@@ -28432,7 +29872,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9938",
@@ -28539,7 +29985,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9939",
@@ -28674,7 +30126,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9940",
@@ -28781,7 +30239,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9941",
@@ -28902,7 +30366,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9945",
@@ -29009,7 +30479,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9946",
@@ -29130,7 +30606,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9967",
@@ -29251,7 +30733,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9968",
@@ -29358,7 +30846,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9969",
@@ -29465,7 +30959,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9970",
@@ -29572,7 +31072,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9971",
@@ -29679,7 +31185,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9972",
@@ -29786,7 +31298,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9973",
@@ -29890,7 +31408,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9974",
@@ -29997,7 +31521,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9977",
@@ -30118,7 +31648,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9978",
@@ -30225,7 +31761,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9983",
@@ -30329,7 +31871,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9984",
@@ -30436,7 +31984,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9986",
@@ -30571,7 +32125,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9987",
@@ -30678,7 +32238,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9988",
@@ -30785,7 +32351,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "9990",
@@ -30906,7 +32478,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10024",
@@ -31027,7 +32605,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10033",
@@ -31148,7 +32732,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10034",
@@ -31269,7 +32859,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10035",
@@ -31376,7 +32972,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10036",
@@ -31483,7 +33085,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10037",
@@ -31590,7 +33198,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10038",
@@ -31711,7 +33325,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10039",
@@ -31818,7 +33438,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10040",
@@ -31939,7 +33565,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10041",
@@ -32046,7 +33678,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10042",
@@ -32167,7 +33805,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10043",
@@ -32274,7 +33918,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10044",
@@ -32381,7 +34031,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10045",
@@ -32488,7 +34144,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10046",
@@ -32595,7 +34257,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10047",
@@ -32702,7 +34370,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10048",
@@ -32823,7 +34497,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10051",
@@ -32930,7 +34610,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10052",
@@ -33051,7 +34737,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10053",
@@ -33158,7 +34850,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10054",
@@ -33265,7 +34963,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10058",
@@ -33372,7 +35076,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10059",
@@ -33493,7 +35203,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10060",
@@ -33600,7 +35316,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10061",
@@ -33721,7 +35443,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10062",
@@ -33828,7 +35556,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10063",
@@ -33949,7 +35683,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10064",
@@ -34056,7 +35796,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10065",
@@ -34163,7 +35909,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10068",
@@ -34270,7 +36022,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10069",
@@ -34391,7 +36149,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10070",
@@ -34498,7 +36262,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10071",
@@ -34605,7 +36375,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10074",
@@ -34712,7 +36488,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10075",
@@ -34833,7 +36615,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10076",
@@ -34940,7 +36728,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10077",
@@ -35044,7 +36838,13 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2012."
     },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/about/CMS-Pileup-Simulation\">pile-up events</a> are added to the simulated event in this step.</p>"
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
+      "links": [
+        {
+          "recid": "37",
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
     },
     "publisher": "CERN Open Data Portal",
     "recid": "10078",

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
@@ -78,10 +78,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -187,10 +187,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -308,10 +308,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -429,10 +429,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -538,10 +538,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -659,10 +659,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -780,10 +780,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -901,10 +901,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -1009,10 +1009,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -1129,10 +1129,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -1250,10 +1250,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -1383,10 +1383,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -1492,10 +1492,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -1625,10 +1625,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -1746,10 +1746,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -1867,10 +1867,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -1988,10 +1988,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -2097,10 +2097,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -2230,10 +2230,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -2363,10 +2363,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -2472,10 +2472,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -2581,10 +2581,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -2702,10 +2702,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -2811,10 +2811,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -2932,10 +2932,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -3053,10 +3053,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -3174,10 +3174,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -3295,10 +3295,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -3404,10 +3404,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -3525,10 +3525,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -3634,10 +3634,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -3767,10 +3767,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -3876,10 +3876,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -3985,10 +3985,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -4118,10 +4118,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -4259,10 +4259,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -4377,10 +4377,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -4483,10 +4483,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -4589,10 +4589,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -4695,10 +4695,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -4803,10 +4803,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -4911,10 +4911,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -5019,10 +5019,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -5139,10 +5139,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -5260,10 +5260,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -5417,10 +5417,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -5538,10 +5538,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -5646,10 +5646,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -5754,10 +5754,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -5863,10 +5863,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -5972,10 +5972,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -6093,10 +6093,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -6202,10 +6202,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -6311,10 +6311,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -6419,10 +6419,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -6527,10 +6527,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -6636,10 +6636,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -6745,10 +6745,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -6853,10 +6853,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -6975,10 +6975,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -7084,10 +7084,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -7219,10 +7219,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -7328,10 +7328,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -7449,10 +7449,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -7557,10 +7557,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -7677,10 +7677,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -7869,10 +7869,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -7977,10 +7977,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -8085,10 +8085,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -8193,10 +8193,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -8301,10 +8301,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -8409,10 +8409,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -8517,10 +8517,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -8625,10 +8625,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -8733,10 +8733,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -8841,10 +8841,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -8949,10 +8949,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -9057,10 +9057,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -9166,10 +9166,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -9275,10 +9275,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -9396,10 +9396,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -9505,10 +9505,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -9638,10 +9638,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -9746,10 +9746,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -9864,10 +9864,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -9970,10 +9970,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -10088,10 +10088,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -10194,10 +10194,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -10312,10 +10312,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -10456,10 +10456,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -10660,10 +10660,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -10804,10 +10804,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -10924,10 +10924,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -11032,10 +11032,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -11237,10 +11237,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -11537,10 +11537,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -11645,10 +11645,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -11753,10 +11753,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -11873,10 +11873,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -11981,10 +11981,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -12126,10 +12126,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -12235,10 +12235,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -12380,10 +12380,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -12525,10 +12525,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -12658,10 +12658,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -12767,10 +12767,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -12876,10 +12876,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -12985,10 +12985,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -13106,10 +13106,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -13239,10 +13239,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -13360,10 +13360,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -13481,10 +13481,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -13590,10 +13590,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -13711,10 +13711,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -13820,10 +13820,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -13941,10 +13941,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -14062,10 +14062,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -14183,10 +14183,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -14304,10 +14304,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -14413,10 +14413,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -14534,10 +14534,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -14655,10 +14655,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -14776,10 +14776,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -14897,10 +14897,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -15018,10 +15018,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -15139,10 +15139,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -15248,10 +15248,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -15357,10 +15357,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -15466,10 +15466,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -15575,10 +15575,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -15684,10 +15684,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -15793,10 +15793,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -15902,10 +15902,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -16011,10 +16011,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -16120,10 +16120,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -16229,10 +16229,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -16338,10 +16338,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -16447,10 +16447,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -16556,10 +16556,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -16665,10 +16665,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -16774,10 +16774,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -16883,10 +16883,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -17004,10 +17004,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -17113,10 +17113,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -17222,10 +17222,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -17331,10 +17331,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -17452,10 +17452,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -17573,10 +17573,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -17706,10 +17706,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -17827,10 +17827,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -17936,10 +17936,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -18045,10 +18045,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -18166,10 +18166,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -18275,10 +18275,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -18396,10 +18396,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -18505,10 +18505,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -18614,10 +18614,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -18723,10 +18723,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -18832,10 +18832,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -18953,10 +18953,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -19086,10 +19086,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -19207,10 +19207,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -19315,10 +19315,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -19423,10 +19423,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -19531,10 +19531,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -19639,10 +19639,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -19747,10 +19747,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -19856,10 +19856,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -19965,10 +19965,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -20073,10 +20073,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -20182,10 +20182,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -20291,10 +20291,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -20400,10 +20400,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -20508,10 +20508,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -20614,10 +20614,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -20720,10 +20720,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -20826,10 +20826,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -20944,10 +20944,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -21101,10 +21101,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -21258,10 +21258,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -21391,10 +21391,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -21500,10 +21500,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -21621,10 +21621,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -21754,10 +21754,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -21863,10 +21863,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -21984,10 +21984,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -22117,10 +22117,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -22226,10 +22226,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -22359,10 +22359,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -22480,10 +22480,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -22589,10 +22589,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -22698,10 +22698,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -22819,10 +22819,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -22952,10 +22952,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -23061,10 +23061,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -23170,10 +23170,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -23291,10 +23291,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -23424,10 +23424,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -23545,10 +23545,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -23666,10 +23666,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -23811,10 +23811,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -23920,10 +23920,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -24029,10 +24029,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -24150,10 +24150,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -24256,10 +24256,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -24377,10 +24377,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -24486,10 +24486,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -24595,10 +24595,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -24740,10 +24740,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -24885,10 +24885,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -25006,10 +25006,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -25129,10 +25129,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -25240,10 +25240,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -25351,10 +25351,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -25474,10 +25474,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -25585,10 +25585,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -25720,10 +25720,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -25831,10 +25831,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -25954,10 +25954,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -26101,10 +26101,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -26248,10 +26248,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -26395,10 +26395,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -26512,10 +26512,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -26621,10 +26621,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -26742,10 +26742,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -26851,10 +26851,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -26960,10 +26960,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -27069,10 +27069,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -27190,10 +27190,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -27347,10 +27347,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -27480,10 +27480,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -27613,10 +27613,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -27722,10 +27722,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -27843,10 +27843,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -27988,10 +27988,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -28121,10 +28121,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -28242,10 +28242,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -28375,10 +28375,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -28496,10 +28496,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -28604,10 +28604,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -28712,10 +28712,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -28832,10 +28832,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -28941,10 +28941,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -29050,10 +29050,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -29219,10 +29219,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -29328,10 +29328,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -29449,10 +29449,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -29558,10 +29558,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -29666,10 +29666,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -29775,10 +29775,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -29883,10 +29883,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -30004,10 +30004,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -30125,10 +30125,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -30233,10 +30233,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -30341,10 +30341,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -30449,10 +30449,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -30557,10 +30557,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -30665,10 +30665,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -30773,10 +30773,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -30881,10 +30881,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -30989,10 +30989,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -31097,10 +31097,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -31205,10 +31205,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -31313,10 +31313,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -31421,10 +31421,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -31530,10 +31530,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -31639,10 +31639,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -31748,10 +31748,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -31857,10 +31857,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -31978,10 +31978,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -32087,10 +32087,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -32220,10 +32220,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -32365,10 +32365,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -32474,10 +32474,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -32595,10 +32595,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -32704,10 +32704,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -32813,10 +32813,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -32934,10 +32934,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -33043,10 +33043,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -33152,10 +33152,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -33261,10 +33261,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -33370,10 +33370,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -33503,10 +33503,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -33612,10 +33612,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -33733,10 +33733,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -33842,10 +33842,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -33951,10 +33951,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -34060,10 +34060,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -34193,10 +34193,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -34313,10 +34313,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -34421,10 +34421,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -34554,10 +34554,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -34675,10 +34675,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -34784,10 +34784,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -34905,10 +34905,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -35026,10 +35026,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -35147,10 +35147,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -35256,10 +35256,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -35365,10 +35365,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -35486,10 +35486,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -35595,10 +35595,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -35704,10 +35704,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -35813,10 +35813,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -35922,10 +35922,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -36031,10 +36031,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -36140,10 +36140,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -36249,10 +36249,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -36358,10 +36358,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -36467,10 +36467,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -36576,10 +36576,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -36685,10 +36685,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -36805,10 +36805,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -36913,10 +36913,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -37033,10 +37033,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -37141,10 +37141,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -37249,10 +37249,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -37369,10 +37369,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -37489,10 +37489,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -37597,10 +37597,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -37705,10 +37705,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -37813,10 +37813,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -37921,10 +37921,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -38041,10 +38041,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -38161,10 +38161,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -38269,10 +38269,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -38377,10 +38377,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -38486,10 +38486,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -38607,10 +38607,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -38728,10 +38728,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -38837,10 +38837,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -38958,10 +38958,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -39067,10 +39067,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -39188,10 +39188,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -39332,10 +39332,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -39440,10 +39440,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -39549,10 +39549,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -39669,10 +39669,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -39778,10 +39778,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -39899,10 +39899,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -40046,10 +40046,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -40154,10 +40154,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -40263,10 +40263,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -40371,10 +40371,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -40479,10 +40479,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -40588,10 +40588,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -40708,10 +40708,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -40828,10 +40828,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -40937,10 +40937,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -41106,10 +41106,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -41215,10 +41215,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -41324,10 +41324,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -41445,10 +41445,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -41590,10 +41590,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -41711,10 +41711,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -41820,10 +41820,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -41928,10 +41928,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -42037,10 +42037,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -42146,10 +42146,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -42254,10 +42254,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -42375,10 +42375,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -42496,10 +42496,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -42604,10 +42604,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -42715,10 +42715,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -42862,10 +42862,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -42970,10 +42970,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -43078,10 +43078,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -43213,10 +43213,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -43321,10 +43321,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -43441,10 +43441,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -43549,10 +43549,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -43669,10 +43669,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -43778,10 +43778,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -43887,10 +43887,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -43996,10 +43996,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -44117,10 +44117,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -44264,10 +44264,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -44396,10 +44396,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -44555,10 +44555,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -44664,10 +44664,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -44774,10 +44774,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -44897,10 +44897,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]
@@ -44999,10 +44999,10 @@
       "description": "These simulated datasets correspond to the collision data collected by the CMS experiment in 2011."
     },
     "pileup": {
-      "description": " <p> To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step. </p> ",
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "3600",
+          "recid": "36",
           "title": "/MinBias_TuneZ2_7TeV-pythia6/Summer11Leg-START53_LV4-v1/GEN-SIM"
         }
       ]

--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -200,7 +200,11 @@
             <p>{{ record.methodology.description | safe}}</p>
             {{ link_list(record.methodology.links) }}
             {% if record.pileup %}
-            <p>{{ record.pileup.description | safe}}</p>
+              <p>{{ record.pileup.description | safe}}</p>
+              {% if record.pileup.links %}
+                <p>The pile-up dataset is:</p>
+                {{ link_list(record.pileup.links) }}
+              {% endif %}
             {% endif %}
        </div>
     </div>


### PR DESCRIPTION
* Fixes CMS MC pileup record information and links. (closes #2497)
    
Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
