### PR TITLE
records: date_created is a list

### DIFF
--- a/cernopendata/jsonschemas/records/record-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/record-v1.0.0.json
@@ -174,8 +174,11 @@
       "type": "array"
     },
     "date_created": {
-      "description": "The year the resource was created or the data-taking year for datasets",
-      "type": "string"
+      "items": {
+        "description": "The data-taking year during which the collision data or for which the simulated data, software and other assets were produced",
+        "type": "string"
+      },
+      "type": "array"
     },
     "date_published": {
       "description": "The year of publication on the portal",

--- a/cernopendata/modules/fixtures/data/records/alice-reconstructed-data.json
+++ b/cernopendata/modules/fixtures/data/records/alice-reconstructed-data.json
@@ -14,7 +14,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -82,7 +84,9 @@
       "energy": "2.76TeV",
       "type": "PbPb"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -150,7 +154,9 @@
       "energy": "2.76TeV",
       "type": "PbPb"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -218,7 +224,9 @@
       "energy": "2.76TeV",
       "type": "PbPb"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -286,7 +294,9 @@
       "energy": "2.76TeV",
       "type": "PbPb"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -354,7 +364,9 @@
       "energy": "2.76TeV",
       "type": "PbPb"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -422,7 +434,9 @@
       "energy": "2.76TeV",
       "type": "PbPb"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -490,7 +504,9 @@
       "energy": "2.76TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -558,7 +574,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -626,7 +644,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -694,7 +714,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -762,7 +784,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -830,7 +854,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -898,7 +924,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/atlas-all-samples.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-all-samples.json
@@ -14,7 +14,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "number_files": 1,

--- a/cernopendata/modules/fixtures/data/records/atlas-derived-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-derived-datasets.json
@@ -10,7 +10,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2014",
     "distribution": {
@@ -156,7 +158,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2014",
     "distribution": {
@@ -302,7 +306,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2014",
     "distribution": {
@@ -448,7 +454,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2014",
     "distribution": {
@@ -594,7 +602,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2014",
     "distribution": {
@@ -740,7 +750,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2014",
     "distribution": {
@@ -886,7 +898,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -1032,7 +1046,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -1178,7 +1194,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -1324,7 +1342,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -1470,7 +1490,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -1616,7 +1638,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -1762,7 +1786,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -1908,7 +1934,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -2054,7 +2082,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -2200,7 +2230,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -2346,7 +2378,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -2492,7 +2526,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -2638,7 +2674,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -2784,7 +2822,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -2930,7 +2970,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -3076,7 +3118,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -3222,7 +3266,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -3368,7 +3414,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -3514,7 +3562,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -3660,7 +3710,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -3806,7 +3858,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -3952,7 +4006,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -4098,7 +4154,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -4244,7 +4302,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -4390,7 +4450,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -4536,7 +4598,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -4682,7 +4746,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -4828,7 +4894,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -4974,7 +5042,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -5120,7 +5190,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -5266,7 +5338,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -5412,7 +5486,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -5558,7 +5634,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -5704,7 +5782,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -5850,7 +5930,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -5996,7 +6078,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -6142,7 +6226,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -6288,7 +6374,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -6434,7 +6522,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -6580,7 +6670,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -6726,7 +6818,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -6872,7 +6966,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -7018,7 +7114,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -7164,7 +7262,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -7310,7 +7410,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -7456,7 +7558,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -7602,7 +7706,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -7748,7 +7854,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -7894,7 +8002,9 @@
     "collections": [
       "ATLAS-Derived-Datasets"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2015",
     "distribution": {
@@ -8044,7 +8154,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2016",
     "distribution": {
@@ -8117,7 +8229,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2016",
     "distribution": {

--- a/cernopendata/modules/fixtures/data/records/atlas-simulated-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-simulated-datasets.json
@@ -14,7 +14,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -90,7 +92,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -166,7 +170,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -242,7 +248,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -318,7 +326,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -394,7 +404,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -470,7 +482,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -546,7 +560,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -622,7 +638,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -698,7 +716,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -774,7 +794,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -850,7 +872,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -926,7 +950,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1002,7 +1028,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1078,7 +1106,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1154,7 +1184,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1230,7 +1262,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1306,7 +1340,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1382,7 +1418,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1458,7 +1496,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1534,7 +1574,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1610,7 +1652,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1686,7 +1730,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1762,7 +1808,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1838,7 +1886,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1914,7 +1964,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1990,7 +2042,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2066,7 +2120,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2142,7 +2198,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2218,7 +2276,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2294,7 +2354,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2370,7 +2432,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2446,7 +2510,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2522,7 +2588,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2598,7 +2666,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2674,7 +2744,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2750,7 +2822,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2826,7 +2900,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2902,7 +2978,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2978,7 +3056,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3054,7 +3134,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3130,7 +3212,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/atlas-tools.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-tools.json
@@ -60,7 +60,9 @@
     "collections": [
       "ATLAS-Tools"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -121,7 +123,9 @@
     "collections": [
       "ATLAS-Tools"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "experiment": "ATLAS",
     "files": [
@@ -170,7 +174,9 @@
     "collections": [
       "ATLAS-Tools"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "experiment": "ATLAS",
     "files": [
@@ -219,7 +225,9 @@
     "collections": [
       "ATLAS-Tools"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "experiment": "ATLAS",
     "files": [
@@ -268,7 +276,9 @@
     "collections": [
       "ATLAS-Tools"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2016",
     "experiment": "ATLAS",
     "license": {

--- a/cernopendata/modules/fixtures/data/records/cms-author-list-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-author-list-2012.json
@@ -19847,7 +19847,9 @@
     "collections": [
       "Author-Lists"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-author-list-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-author-list-Run2011A.json
@@ -19847,7 +19847,9 @@
     "collections": [
       "Author-Lists"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-author-list.json
+++ b/cernopendata/modules/fixtures/data/records/cms-author-list.json
@@ -19022,7 +19022,9 @@
     "collections": [
       "Author-Lists"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-2012.json
@@ -16,7 +16,9 @@
     "collections": [
       "CMS-Condition-Data"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -69,7 +71,9 @@
     "collections": [
       "CMS-Condition-Data"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2010B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2010B.json
@@ -11,7 +11,9 @@
     "collections": [
       "CMS-Condition-Data"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2011A.json
@@ -16,7 +16,9 @@
     "collections": [
       "CMS-Condition-Data"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "files": [
@@ -61,7 +63,9 @@
     "collections": [
       "CMS-Condition-Data"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "files": [

--- a/cernopendata/modules/fixtures/data/records/cms-configuration-files-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-configuration-files-2012.json
@@ -16,7 +16,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -69,7 +71,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -122,7 +126,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -175,7 +181,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -228,7 +236,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -281,7 +291,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -334,7 +346,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -387,7 +401,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -440,7 +456,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -493,7 +511,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -546,7 +566,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -599,7 +621,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -652,7 +676,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -705,7 +731,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -758,7 +786,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -811,7 +841,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -864,7 +896,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -917,7 +951,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -970,7 +1006,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1023,7 +1061,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1076,7 +1116,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1129,7 +1171,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1182,7 +1226,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1235,7 +1281,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1288,7 +1336,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1341,7 +1391,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1394,7 +1446,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1447,7 +1501,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1500,7 +1556,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1553,7 +1611,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1606,7 +1666,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1659,7 +1721,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1712,7 +1776,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1765,7 +1831,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1818,7 +1886,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1871,7 +1941,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1924,7 +1996,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1977,7 +2051,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2030,7 +2106,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2083,7 +2161,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2136,7 +2216,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2189,7 +2271,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2242,7 +2326,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2295,7 +2381,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2348,7 +2436,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2401,7 +2491,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2454,7 +2546,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2507,7 +2601,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2560,7 +2656,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2613,7 +2711,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2666,7 +2766,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2719,7 +2821,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2772,7 +2876,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2825,7 +2931,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2878,7 +2986,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2931,7 +3041,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2984,7 +3096,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3037,7 +3151,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3090,7 +3206,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3143,7 +3261,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3196,7 +3316,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3249,7 +3371,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3302,7 +3426,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3355,7 +3481,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3408,7 +3536,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3461,7 +3591,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3514,7 +3646,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3567,7 +3701,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3620,7 +3756,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3673,7 +3811,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3726,7 +3866,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3779,7 +3921,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3832,7 +3976,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3885,7 +4031,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3938,7 +4086,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -3991,7 +4141,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4044,7 +4196,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4097,7 +4251,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4150,7 +4306,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4203,7 +4361,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4256,7 +4416,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4309,7 +4471,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4362,7 +4526,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4415,7 +4581,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4468,7 +4636,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4521,7 +4691,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4574,7 +4746,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4627,7 +4801,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4680,7 +4856,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4733,7 +4911,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4786,7 +4966,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4839,7 +5021,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4892,7 +5076,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4945,7 +5131,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -4998,7 +5186,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5051,7 +5241,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5104,7 +5296,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5157,7 +5351,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5210,7 +5406,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5263,7 +5461,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5316,7 +5516,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5369,7 +5571,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5422,7 +5626,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5475,7 +5681,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5528,7 +5736,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5581,7 +5791,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5634,7 +5846,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5687,7 +5901,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5740,7 +5956,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5793,7 +6011,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5846,7 +6066,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5899,7 +6121,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -5952,7 +6176,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6005,7 +6231,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6058,7 +6286,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6111,7 +6341,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6164,7 +6396,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6217,7 +6451,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6270,7 +6506,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6323,7 +6561,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6376,7 +6616,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6429,7 +6671,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6482,7 +6726,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6535,7 +6781,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6588,7 +6836,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6641,7 +6891,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6694,7 +6946,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6747,7 +7001,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6800,7 +7056,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6853,7 +7111,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6906,7 +7166,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -6959,7 +7221,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7012,7 +7276,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7065,7 +7331,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7118,7 +7386,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7171,7 +7441,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7224,7 +7496,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7277,7 +7551,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7330,7 +7606,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7383,7 +7661,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7436,7 +7716,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7489,7 +7771,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7542,7 +7826,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7595,7 +7881,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7648,7 +7936,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7701,7 +7991,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7754,7 +8046,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7807,7 +8101,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7860,7 +8156,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7913,7 +8211,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -7966,7 +8266,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8019,7 +8321,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8072,7 +8376,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8125,7 +8431,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8178,7 +8486,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8231,7 +8541,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8284,7 +8596,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8337,7 +8651,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8390,7 +8706,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8443,7 +8761,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8496,7 +8816,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8549,7 +8871,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8602,7 +8926,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8655,7 +8981,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8708,7 +9036,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8761,7 +9091,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8814,7 +9146,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8867,7 +9201,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8920,7 +9256,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -8973,7 +9311,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9026,7 +9366,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9079,7 +9421,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9132,7 +9476,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9185,7 +9531,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9238,7 +9586,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9291,7 +9641,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9344,7 +9696,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9397,7 +9751,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9450,7 +9806,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9503,7 +9861,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9556,7 +9916,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9609,7 +9971,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9662,7 +10026,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9715,7 +10081,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9768,7 +10136,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9821,7 +10191,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9874,7 +10246,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9927,7 +10301,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -9980,7 +10356,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10033,7 +10411,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10086,7 +10466,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10139,7 +10521,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10192,7 +10576,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10245,7 +10631,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10298,7 +10686,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10351,7 +10741,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10404,7 +10796,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10457,7 +10851,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10510,7 +10906,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10563,7 +10961,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10616,7 +11016,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10669,7 +11071,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10722,7 +11126,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10775,7 +11181,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10828,7 +11236,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10881,7 +11291,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10934,7 +11346,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -10987,7 +11401,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11040,7 +11456,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11093,7 +11511,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11146,7 +11566,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11199,7 +11621,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11252,7 +11676,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11305,7 +11731,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11358,7 +11786,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11411,7 +11841,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11464,7 +11896,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11517,7 +11951,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11570,7 +12006,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11623,7 +12061,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11676,7 +12116,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11729,7 +12171,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11782,7 +12226,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11835,7 +12281,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11888,7 +12336,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11941,7 +12391,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -11994,7 +12446,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12047,7 +12501,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12100,7 +12556,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12153,7 +12611,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12206,7 +12666,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12259,7 +12721,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12312,7 +12776,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12365,7 +12831,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12418,7 +12886,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12471,7 +12941,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12524,7 +12996,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12577,7 +13051,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12630,7 +13106,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12683,7 +13161,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12736,7 +13216,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12789,7 +13271,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12842,7 +13326,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12895,7 +13381,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -12948,7 +13436,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13001,7 +13491,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13054,7 +13546,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13107,7 +13601,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13160,7 +13656,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13213,7 +13711,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13266,7 +13766,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13319,7 +13821,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13372,7 +13876,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13425,7 +13931,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13478,7 +13986,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13531,7 +14041,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13584,7 +14096,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13637,7 +14151,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13690,7 +14206,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13743,7 +14261,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13796,7 +14316,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13849,7 +14371,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13902,7 +14426,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -13955,7 +14481,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14008,7 +14536,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14061,7 +14591,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14114,7 +14646,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14167,7 +14701,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14220,7 +14756,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14273,7 +14811,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14326,7 +14866,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14379,7 +14921,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14432,7 +14976,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14485,7 +15031,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14538,7 +15086,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14591,7 +15141,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14644,7 +15196,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14697,7 +15251,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14750,7 +15306,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14803,7 +15361,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14856,7 +15416,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14909,7 +15471,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -14962,7 +15526,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15015,7 +15581,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15068,7 +15636,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15121,7 +15691,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15174,7 +15746,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15227,7 +15801,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15280,7 +15856,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15333,7 +15911,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15386,7 +15966,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15439,7 +16021,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15492,7 +16076,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15545,7 +16131,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15598,7 +16186,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15651,7 +16241,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15704,7 +16296,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15757,7 +16351,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15810,7 +16406,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -15863,7 +16461,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-configuration-files-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-configuration-files-Run2011A.json
@@ -15,7 +15,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -62,7 +64,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -109,7 +113,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -156,7 +162,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -203,7 +211,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -250,7 +260,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -297,7 +309,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -344,7 +358,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -391,7 +407,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -438,7 +456,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -485,7 +505,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -532,7 +554,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -579,7 +603,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -626,7 +652,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -673,7 +701,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -720,7 +750,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -767,7 +799,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -814,7 +848,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -861,7 +897,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -908,7 +946,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -955,7 +995,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1002,7 +1044,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1049,7 +1093,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1096,7 +1142,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1143,7 +1191,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1190,7 +1240,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1237,7 +1289,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1284,7 +1338,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1331,7 +1387,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1378,7 +1436,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1425,7 +1485,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1472,7 +1534,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1519,7 +1583,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1566,7 +1632,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1613,7 +1681,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1660,7 +1730,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1707,7 +1779,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1754,7 +1828,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1801,7 +1877,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1848,7 +1926,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1895,7 +1975,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1942,7 +2024,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1989,7 +2073,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2036,7 +2122,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2083,7 +2171,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2130,7 +2220,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2177,7 +2269,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2224,7 +2318,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2271,7 +2367,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2318,7 +2416,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2365,7 +2465,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2412,7 +2514,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2459,7 +2563,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2506,7 +2612,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2553,7 +2661,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2600,7 +2710,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2647,7 +2759,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2694,7 +2808,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2741,7 +2857,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2788,7 +2906,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2835,7 +2955,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2882,7 +3004,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2929,7 +3053,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2976,7 +3102,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3023,7 +3151,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3070,7 +3200,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3117,7 +3249,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3164,7 +3298,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3211,7 +3347,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3258,7 +3396,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3305,7 +3445,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3352,7 +3494,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3399,7 +3543,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3446,7 +3592,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3493,7 +3641,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3540,7 +3690,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3587,7 +3739,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3634,7 +3788,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3681,7 +3837,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3728,7 +3886,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3775,7 +3935,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3822,7 +3984,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3869,7 +4033,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3916,7 +4082,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3963,7 +4131,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4010,7 +4180,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4057,7 +4229,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4104,7 +4278,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4151,7 +4327,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4198,7 +4376,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4245,7 +4425,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4292,7 +4474,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4339,7 +4523,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4386,7 +4572,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4433,7 +4621,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4480,7 +4670,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4527,7 +4719,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4574,7 +4768,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4621,7 +4817,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4668,7 +4866,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4715,7 +4915,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4762,7 +4964,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4809,7 +5013,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4856,7 +5062,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4903,7 +5111,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4950,7 +5160,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4997,7 +5209,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5044,7 +5258,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5091,7 +5307,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5138,7 +5356,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5185,7 +5405,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5232,7 +5454,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5279,7 +5503,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5326,7 +5552,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5373,7 +5601,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5420,7 +5650,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5467,7 +5699,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5514,7 +5748,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5561,7 +5797,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5608,7 +5846,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5655,7 +5895,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5702,7 +5944,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5749,7 +5993,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5796,7 +6042,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5843,7 +6091,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5890,7 +6140,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5937,7 +6189,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5984,7 +6238,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6031,7 +6287,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6078,7 +6336,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6125,7 +6385,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6172,7 +6434,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6219,7 +6483,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6266,7 +6532,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6313,7 +6581,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6360,7 +6630,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6407,7 +6679,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6454,7 +6728,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6501,7 +6777,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6548,7 +6826,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6595,7 +6875,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6642,7 +6924,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6689,7 +6973,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6736,7 +7022,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6783,7 +7071,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6830,7 +7120,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6877,7 +7169,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6924,7 +7218,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6971,7 +7267,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7018,7 +7316,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7065,7 +7365,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7112,7 +7414,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7159,7 +7463,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7206,7 +7512,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7253,7 +7561,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7300,7 +7610,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7347,7 +7659,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7394,7 +7708,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7441,7 +7757,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7488,7 +7806,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7535,7 +7855,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7582,7 +7904,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7629,7 +7953,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7676,7 +8002,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7723,7 +8051,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7770,7 +8100,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7817,7 +8149,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7864,7 +8198,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7911,7 +8247,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7958,7 +8296,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8005,7 +8345,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8052,7 +8394,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8099,7 +8443,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8146,7 +8492,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8193,7 +8541,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8240,7 +8590,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8287,7 +8639,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8334,7 +8688,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8381,7 +8737,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8428,7 +8786,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8475,7 +8835,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8522,7 +8884,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8569,7 +8933,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8616,7 +8982,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8663,7 +9031,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8710,7 +9080,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8757,7 +9129,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8804,7 +9178,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8851,7 +9227,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8898,7 +9276,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8945,7 +9325,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8992,7 +9374,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9039,7 +9423,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9086,7 +9472,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9133,7 +9521,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9180,7 +9570,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9227,7 +9619,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9274,7 +9668,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9321,7 +9717,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9368,7 +9766,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9415,7 +9815,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9462,7 +9864,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9509,7 +9913,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9556,7 +9962,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9603,7 +10011,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9650,7 +10060,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9697,7 +10109,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9744,7 +10158,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9791,7 +10207,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9838,7 +10256,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9885,7 +10305,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9932,7 +10354,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9979,7 +10403,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10026,7 +10452,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10073,7 +10501,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10120,7 +10550,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10167,7 +10599,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10214,7 +10648,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10261,7 +10697,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10308,7 +10746,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10355,7 +10795,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10402,7 +10844,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10449,7 +10893,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10496,7 +10942,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10543,7 +10991,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10590,7 +11040,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10637,7 +11089,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10684,7 +11138,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10731,7 +11187,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10778,7 +11236,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10825,7 +11285,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10872,7 +11334,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10919,7 +11383,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10966,7 +11432,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11013,7 +11481,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11060,7 +11530,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11107,7 +11579,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11154,7 +11628,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11201,7 +11677,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11248,7 +11726,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11295,7 +11775,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11342,7 +11824,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11389,7 +11873,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11436,7 +11922,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11483,7 +11971,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11530,7 +12020,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11577,7 +12069,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11624,7 +12118,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11671,7 +12167,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11718,7 +12216,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11765,7 +12265,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11812,7 +12314,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11859,7 +12363,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11906,7 +12412,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11953,7 +12461,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12000,7 +12510,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12047,7 +12559,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12094,7 +12608,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12141,7 +12657,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12188,7 +12706,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12235,7 +12755,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12282,7 +12804,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12329,7 +12853,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12376,7 +12902,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12423,7 +12951,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12470,7 +13000,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12517,7 +13049,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12564,7 +13098,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12611,7 +13147,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12658,7 +13196,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12705,7 +13245,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12752,7 +13294,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12799,7 +13343,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12846,7 +13392,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12893,7 +13441,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12940,7 +13490,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12987,7 +13539,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13034,7 +13588,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13081,7 +13637,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13128,7 +13686,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13175,7 +13735,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13222,7 +13784,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13269,7 +13833,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13316,7 +13882,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13363,7 +13931,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13410,7 +13980,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13457,7 +14029,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13504,7 +14078,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13551,7 +14127,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13598,7 +14176,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13645,7 +14225,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13692,7 +14274,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13739,7 +14323,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13786,7 +14372,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13833,7 +14421,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13880,7 +14470,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13927,7 +14519,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13974,7 +14568,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14021,7 +14617,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14068,7 +14666,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14115,7 +14715,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14162,7 +14764,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14209,7 +14813,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14256,7 +14862,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14303,7 +14911,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14350,7 +14960,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14397,7 +15009,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14444,7 +15058,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14491,7 +15107,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14538,7 +15156,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14585,7 +15205,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14632,7 +15254,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14679,7 +15303,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14726,7 +15352,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14773,7 +15401,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14820,7 +15450,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14867,7 +15499,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14914,7 +15548,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14961,7 +15597,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15008,7 +15646,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15055,7 +15695,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15102,7 +15744,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15149,7 +15793,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15196,7 +15842,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15243,7 +15891,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15290,7 +15940,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15337,7 +15989,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15384,7 +16038,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15431,7 +16087,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15478,7 +16136,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15525,7 +16185,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15572,7 +16234,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15619,7 +16283,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15666,7 +16332,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15713,7 +16381,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15760,7 +16430,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15807,7 +16479,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15854,7 +16528,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15901,7 +16577,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15948,7 +16626,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15995,7 +16675,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16042,7 +16724,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16089,7 +16773,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16136,7 +16822,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16183,7 +16871,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16230,7 +16920,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16277,7 +16969,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16324,7 +17018,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16371,7 +17067,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16418,7 +17116,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16465,7 +17165,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16512,7 +17214,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16559,7 +17263,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16606,7 +17312,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16653,7 +17361,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16700,7 +17410,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16747,7 +17459,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16794,7 +17508,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16841,7 +17557,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16888,7 +17606,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16935,7 +17655,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16982,7 +17704,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17029,7 +17753,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17076,7 +17802,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17123,7 +17851,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17170,7 +17900,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17217,7 +17949,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17264,7 +17998,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17311,7 +18047,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17358,7 +18096,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17405,7 +18145,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17452,7 +18194,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17499,7 +18243,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17546,7 +18292,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17593,7 +18341,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17640,7 +18390,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17687,7 +18439,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17734,7 +18488,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17781,7 +18537,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17828,7 +18586,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17875,7 +18635,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17922,7 +18684,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17969,7 +18733,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18016,7 +18782,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18063,7 +18831,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18110,7 +18880,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18157,7 +18929,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18204,7 +18978,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18251,7 +19027,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18298,7 +19076,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18345,7 +19125,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18392,7 +19174,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18439,7 +19223,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18486,7 +19272,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18533,7 +19321,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18580,7 +19370,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18627,7 +19419,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18674,7 +19468,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18721,7 +19517,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18768,7 +19566,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18815,7 +19615,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18862,7 +19664,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18909,7 +19713,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18956,7 +19762,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19003,7 +19811,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19050,7 +19860,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19097,7 +19909,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19144,7 +19958,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19191,7 +20007,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19238,7 +20056,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19285,7 +20105,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19332,7 +20154,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19379,7 +20203,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19426,7 +20252,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19473,7 +20301,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19520,7 +20350,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19567,7 +20399,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19614,7 +20448,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19661,7 +20497,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19708,7 +20546,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19755,7 +20595,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19802,7 +20644,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19849,7 +20693,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19896,7 +20742,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19943,7 +20791,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19990,7 +20840,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20037,7 +20889,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20084,7 +20938,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20131,7 +20987,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20178,7 +21036,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20225,7 +21085,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20272,7 +21134,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-csv-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-csv-files.json
@@ -50,7 +50,9 @@
         "variable": "nBJets"
       }
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2015",
     "distribution": {
       "formats": [
@@ -119,7 +121,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana-Run2011A.json
@@ -12,7 +12,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -110,7 +112,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-pattuples-ana.json
@@ -12,7 +12,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -110,7 +112,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-dimuon-spectrum-2011.json
+++ b/cernopendata/modules/fixtures/data/records/cms-dimuon-spectrum-2011.json
@@ -21,7 +21,10 @@
     "collections": [
       "CMS-Validation-Utilities"
     ],
-    "date_created": "2011-2012",
+    "date_created": [
+      "2011",
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2011A.json
@@ -16,7 +16,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -95,7 +97,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -174,7 +178,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -253,7 +259,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -332,7 +340,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -411,7 +421,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -490,7 +502,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -569,7 +583,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -648,7 +664,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -727,7 +745,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -806,7 +826,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -885,7 +907,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -964,7 +988,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1043,7 +1069,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1122,7 +1150,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1201,7 +1231,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1280,7 +1312,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1359,7 +1393,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1438,7 +1474,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012B.json
@@ -16,7 +16,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -94,7 +96,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -172,7 +176,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -250,7 +256,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -328,7 +336,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -406,7 +416,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -484,7 +496,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -562,7 +576,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -640,7 +656,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -718,7 +736,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -796,7 +816,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -874,7 +896,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -952,7 +976,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1030,7 +1056,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1108,7 +1136,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1186,7 +1216,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1264,7 +1296,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1342,7 +1376,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1420,7 +1456,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1498,7 +1536,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1576,7 +1616,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1654,7 +1696,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1732,7 +1776,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1810,7 +1856,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1888,7 +1936,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {

--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012C.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012C.json
@@ -16,7 +16,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -94,7 +96,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -172,7 +176,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -250,7 +256,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -328,7 +336,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -406,7 +416,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -484,7 +496,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -562,7 +576,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -640,7 +656,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -718,7 +736,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -796,7 +816,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -874,7 +896,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -952,7 +976,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1030,7 +1056,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1108,7 +1136,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1186,7 +1216,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1264,7 +1296,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1342,7 +1376,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1420,7 +1456,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1498,7 +1536,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1576,7 +1616,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1654,7 +1696,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1732,7 +1776,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1810,7 +1856,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1888,7 +1936,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {

--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files.json
@@ -16,7 +16,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -95,7 +97,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -174,7 +178,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -253,7 +259,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -332,7 +340,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -411,7 +421,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -490,7 +502,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -569,7 +583,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -648,7 +664,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -727,7 +745,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -806,7 +826,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -885,7 +907,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -964,7 +988,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -1043,7 +1069,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-hamburg-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-hamburg-files.json
@@ -15,7 +15,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2012",
     "distribution": {
       "formats": [
@@ -71,7 +73,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2012",
     "distribution": {
       "formats": [
@@ -127,7 +131,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2012",
     "distribution": {
       "formats": [
@@ -183,7 +189,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2012",
     "distribution": {
       "formats": [
@@ -239,7 +247,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2012",
     "distribution": {
       "formats": [
@@ -295,7 +305,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2012",
     "distribution": {
       "formats": [
@@ -351,7 +363,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2012",
     "distribution": {
       "formats": [
@@ -407,7 +421,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2012",
     "distribution": {
       "formats": [
@@ -463,7 +479,9 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2012",
     "distribution": {
       "formats": [
@@ -519,7 +537,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2012",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-hlt-2011-configuration-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-hlt-2011-configuration-files.json
@@ -14,7 +14,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -60,7 +62,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -106,7 +110,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -152,7 +158,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -198,7 +206,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -244,7 +254,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -290,7 +302,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -336,7 +350,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -382,7 +398,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -428,7 +446,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -474,7 +494,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -520,7 +542,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -566,7 +590,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -612,7 +638,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -658,7 +686,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -704,7 +734,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -750,7 +782,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -796,7 +830,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -842,7 +878,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -888,7 +926,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -934,7 +974,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -980,7 +1022,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1026,7 +1070,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1072,7 +1118,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1118,7 +1166,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1164,7 +1214,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1210,7 +1262,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1256,7 +1310,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1302,7 +1358,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1348,7 +1406,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1394,7 +1454,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1440,7 +1502,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1486,7 +1550,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1532,7 +1598,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1578,7 +1646,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1624,7 +1694,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1670,7 +1742,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1716,7 +1790,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1762,7 +1838,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1808,7 +1886,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1854,7 +1934,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1900,7 +1982,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1946,7 +2030,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1992,7 +2078,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2038,7 +2126,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2084,7 +2174,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2130,7 +2222,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2176,7 +2270,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2222,7 +2318,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2268,7 +2366,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2314,7 +2414,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2360,7 +2462,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2406,7 +2510,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2452,7 +2558,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2498,7 +2606,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2544,7 +2654,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2590,7 +2702,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2636,7 +2750,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2682,7 +2798,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2728,7 +2846,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2774,7 +2894,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2820,7 +2942,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2866,7 +2990,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2912,7 +3038,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2958,7 +3086,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3004,7 +3134,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3050,7 +3182,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3096,7 +3230,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3142,7 +3278,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3188,7 +3326,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3234,7 +3374,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3280,7 +3422,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3326,7 +3470,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3372,7 +3518,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3418,7 +3566,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3464,7 +3614,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3510,7 +3662,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3556,7 +3710,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3602,7 +3758,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3648,7 +3806,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3694,7 +3854,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3740,7 +3902,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3786,7 +3950,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3832,7 +3998,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3878,7 +4046,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-hlt-configuration-files-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-hlt-configuration-files-2012.json
@@ -15,7 +15,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -64,7 +66,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -113,7 +117,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -162,7 +168,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -211,7 +219,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -260,7 +270,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -309,7 +321,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -358,7 +372,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -407,7 +423,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -456,7 +474,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -505,7 +525,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -554,7 +576,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -603,7 +627,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -652,7 +678,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -701,7 +729,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -750,7 +780,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -799,7 +831,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -848,7 +882,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -897,7 +933,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -946,7 +984,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -995,7 +1035,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1044,7 +1086,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1093,7 +1137,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1142,7 +1188,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1191,7 +1239,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1240,7 +1290,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1289,7 +1341,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1338,7 +1392,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1387,7 +1443,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1436,7 +1494,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1485,7 +1545,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1534,7 +1596,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1583,7 +1647,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1632,7 +1698,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1681,7 +1749,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1730,7 +1800,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1779,7 +1851,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1828,7 +1902,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1877,7 +1953,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1926,7 +2004,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1975,7 +2055,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2024,7 +2106,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2073,7 +2157,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2122,7 +2208,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2171,7 +2259,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2220,7 +2310,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2269,7 +2361,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-hlt-trigger-paths-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-hlt-trigger-paths-2012.json
@@ -15,7 +15,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -48,7 +50,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -81,7 +85,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -114,7 +120,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -147,7 +155,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -180,7 +190,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -213,7 +225,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -246,7 +260,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -279,7 +295,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -312,7 +330,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -345,7 +365,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -378,7 +400,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -411,7 +435,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -444,7 +470,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -477,7 +505,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -510,7 +540,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -543,7 +575,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -576,7 +610,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -609,7 +645,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -642,7 +680,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -675,7 +715,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -708,7 +750,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -741,7 +785,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -774,7 +820,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -807,7 +855,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -840,7 +890,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -873,7 +925,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -906,7 +960,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -939,7 +995,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -972,7 +1030,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1005,7 +1065,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1038,7 +1100,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1071,7 +1135,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1104,7 +1170,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1137,7 +1205,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1170,7 +1240,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1203,7 +1275,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1236,7 +1310,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1269,7 +1345,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1302,7 +1380,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1335,7 +1415,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1368,7 +1450,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1401,7 +1485,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1434,7 +1520,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1467,7 +1555,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1500,7 +1590,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1533,7 +1625,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1566,7 +1660,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1599,7 +1695,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1632,7 +1730,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1665,7 +1765,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1698,7 +1800,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1731,7 +1835,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1764,7 +1870,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1797,7 +1905,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1830,7 +1940,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1863,7 +1975,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1896,7 +2010,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1929,7 +2045,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1962,7 +2080,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1995,7 +2115,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2028,7 +2150,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2061,7 +2185,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2094,7 +2220,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2127,7 +2255,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2160,7 +2290,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2193,7 +2325,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2226,7 +2360,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2259,7 +2395,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2292,7 +2430,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2325,7 +2465,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2358,7 +2500,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2391,7 +2535,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2424,7 +2570,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2457,7 +2605,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2490,7 +2640,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2523,7 +2675,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2556,7 +2710,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2589,7 +2745,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2622,7 +2780,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2655,7 +2815,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2688,7 +2850,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2721,7 +2885,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2754,7 +2920,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2787,7 +2955,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2820,7 +2990,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2853,7 +3025,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2886,7 +3060,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2919,7 +3095,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2952,7 +3130,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2985,7 +3165,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3018,7 +3200,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3051,7 +3235,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3084,7 +3270,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3117,7 +3305,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3150,7 +3340,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3183,7 +3375,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3216,7 +3410,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3249,7 +3445,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3282,7 +3480,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3315,7 +3515,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3348,7 +3550,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3381,7 +3585,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3414,7 +3620,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3447,7 +3655,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3480,7 +3690,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3513,7 +3725,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3546,7 +3760,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3579,7 +3795,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3612,7 +3830,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3645,7 +3865,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3678,7 +3900,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3711,7 +3935,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3744,7 +3970,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3777,7 +4005,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3810,7 +4040,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3843,7 +4075,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3876,7 +4110,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3909,7 +4145,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3942,7 +4180,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3975,7 +4215,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4008,7 +4250,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4041,7 +4285,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4074,7 +4320,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4107,7 +4355,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4140,7 +4390,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4173,7 +4425,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4206,7 +4460,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4239,7 +4495,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4272,7 +4530,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4305,7 +4565,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4338,7 +4600,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4371,7 +4635,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4404,7 +4670,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4437,7 +4705,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4470,7 +4740,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4503,7 +4775,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4536,7 +4810,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4569,7 +4845,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4602,7 +4880,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4635,7 +4915,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4668,7 +4950,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4701,7 +4985,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4734,7 +5020,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4767,7 +5055,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4800,7 +5090,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4833,7 +5125,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4866,7 +5160,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4899,7 +5195,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4932,7 +5230,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4965,7 +5265,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4998,7 +5300,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5031,7 +5335,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5064,7 +5370,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5097,7 +5405,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5130,7 +5440,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5163,7 +5475,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5196,7 +5510,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5229,7 +5545,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5262,7 +5580,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5295,7 +5615,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5328,7 +5650,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5361,7 +5685,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5394,7 +5720,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5427,7 +5755,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5460,7 +5790,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5493,7 +5825,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5526,7 +5860,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5559,7 +5895,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5592,7 +5930,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5625,7 +5965,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5658,7 +6000,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5691,7 +6035,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5724,7 +6070,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5757,7 +6105,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5790,7 +6140,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5823,7 +6175,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5856,7 +6210,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5889,7 +6245,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5922,7 +6280,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5955,7 +6315,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5988,7 +6350,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6021,7 +6385,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6054,7 +6420,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6087,7 +6455,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6120,7 +6490,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6153,7 +6525,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6186,7 +6560,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6219,7 +6595,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6252,7 +6630,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6285,7 +6665,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6318,7 +6700,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6351,7 +6735,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6384,7 +6770,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6417,7 +6805,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6450,7 +6840,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6483,7 +6875,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6516,7 +6910,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6549,7 +6945,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6582,7 +6980,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6615,7 +7015,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6648,7 +7050,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6681,7 +7085,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6714,7 +7120,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6747,7 +7155,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6780,7 +7190,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6813,7 +7225,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6846,7 +7260,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6879,7 +7295,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6912,7 +7330,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6945,7 +7365,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6978,7 +7400,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7011,7 +7435,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7044,7 +7470,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7077,7 +7505,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7110,7 +7540,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7143,7 +7575,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7176,7 +7610,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7209,7 +7645,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7242,7 +7680,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7275,7 +7715,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7308,7 +7750,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7341,7 +7785,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7374,7 +7820,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7407,7 +7855,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7440,7 +7890,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7473,7 +7925,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7506,7 +7960,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7539,7 +7995,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7572,7 +8030,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7605,7 +8065,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7638,7 +8100,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7671,7 +8135,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7704,7 +8170,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7737,7 +8205,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7770,7 +8240,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7803,7 +8275,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7836,7 +8310,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7869,7 +8345,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7902,7 +8380,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7935,7 +8415,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7968,7 +8450,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8001,7 +8485,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8034,7 +8520,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8067,7 +8555,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8100,7 +8590,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8133,7 +8625,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8166,7 +8660,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8199,7 +8695,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8232,7 +8730,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8265,7 +8765,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8298,7 +8800,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8331,7 +8835,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8364,7 +8870,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8397,7 +8905,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8430,7 +8940,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8463,7 +8975,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8496,7 +9010,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8529,7 +9045,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8562,7 +9080,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8595,7 +9115,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8628,7 +9150,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8661,7 +9185,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8694,7 +9220,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8727,7 +9255,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8760,7 +9290,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8793,7 +9325,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8826,7 +9360,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8859,7 +9395,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8892,7 +9430,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8925,7 +9465,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8958,7 +9500,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8991,7 +9535,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9024,7 +9570,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9057,7 +9605,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9090,7 +9640,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9123,7 +9675,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9156,7 +9710,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9189,7 +9745,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9222,7 +9780,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9255,7 +9815,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9288,7 +9850,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9321,7 +9885,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9354,7 +9920,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9387,7 +9955,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9420,7 +9990,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9453,7 +10025,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9486,7 +10060,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9519,7 +10095,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9552,7 +10130,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9585,7 +10165,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9618,7 +10200,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9651,7 +10235,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9684,7 +10270,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9717,7 +10305,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9750,7 +10340,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9783,7 +10375,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9816,7 +10410,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9849,7 +10445,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9882,7 +10480,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9915,7 +10515,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9948,7 +10550,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9981,7 +10585,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10014,7 +10620,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10047,7 +10655,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10080,7 +10690,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10113,7 +10725,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10146,7 +10760,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10179,7 +10795,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10212,7 +10830,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10245,7 +10865,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10278,7 +10900,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10311,7 +10935,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10344,7 +10970,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10377,7 +11005,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10410,7 +11040,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10443,7 +11075,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10476,7 +11110,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10509,7 +11145,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10542,7 +11180,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10575,7 +11215,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10608,7 +11250,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10641,7 +11285,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10674,7 +11320,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10707,7 +11355,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10740,7 +11390,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10773,7 +11425,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10806,7 +11460,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10839,7 +11495,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10872,7 +11530,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10905,7 +11565,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10938,7 +11600,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10971,7 +11635,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11004,7 +11670,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11037,7 +11705,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11070,7 +11740,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11103,7 +11775,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11136,7 +11810,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11169,7 +11845,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11202,7 +11880,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11235,7 +11915,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11268,7 +11950,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11301,7 +11985,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11334,7 +12020,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11367,7 +12055,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11400,7 +12090,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11433,7 +12125,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11466,7 +12160,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11499,7 +12195,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11532,7 +12230,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11565,7 +12265,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11598,7 +12300,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11631,7 +12335,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11664,7 +12370,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11697,7 +12405,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11730,7 +12440,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11763,7 +12475,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11796,7 +12510,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11829,7 +12545,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11862,7 +12580,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11895,7 +12615,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11928,7 +12650,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11961,7 +12685,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11994,7 +12720,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12027,7 +12755,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12060,7 +12790,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12093,7 +12825,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12126,7 +12860,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12159,7 +12895,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12192,7 +12930,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12225,7 +12965,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12258,7 +13000,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12291,7 +13035,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12324,7 +13070,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12357,7 +13105,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12390,7 +13140,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12423,7 +13175,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12456,7 +13210,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12489,7 +13245,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12522,7 +13280,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12555,7 +13315,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12588,7 +13350,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12621,7 +13385,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12654,7 +13420,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12687,7 +13455,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12720,7 +13490,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12753,7 +13525,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12786,7 +13560,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12819,7 +13595,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12852,7 +13630,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12885,7 +13665,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12918,7 +13700,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12951,7 +13735,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12984,7 +13770,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13017,7 +13805,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13050,7 +13840,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13083,7 +13875,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13116,7 +13910,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13149,7 +13945,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13182,7 +13980,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13215,7 +14015,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13248,7 +14050,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13281,7 +14085,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13314,7 +14120,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13347,7 +14155,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13380,7 +14190,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13413,7 +14225,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13446,7 +14260,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13479,7 +14295,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13512,7 +14330,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13545,7 +14365,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13578,7 +14400,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13611,7 +14435,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13644,7 +14470,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13677,7 +14505,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13710,7 +14540,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13743,7 +14575,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13776,7 +14610,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13809,7 +14645,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13842,7 +14680,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13875,7 +14715,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13908,7 +14750,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13941,7 +14785,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13974,7 +14820,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14007,7 +14855,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14040,7 +14890,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14073,7 +14925,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14106,7 +14960,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14139,7 +14995,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14172,7 +15030,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14205,7 +15065,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14238,7 +15100,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14271,7 +15135,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14304,7 +15170,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14337,7 +15205,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14370,7 +15240,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14403,7 +15275,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14436,7 +15310,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14469,7 +15345,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14502,7 +15380,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14535,7 +15415,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14568,7 +15450,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14601,7 +15485,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14634,7 +15520,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14667,7 +15555,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14700,7 +15590,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14733,7 +15625,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14766,7 +15660,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14799,7 +15695,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14832,7 +15730,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14865,7 +15765,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14898,7 +15800,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14931,7 +15835,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14964,7 +15870,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14997,7 +15905,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15030,7 +15940,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15063,7 +15975,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15096,7 +16010,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15129,7 +16045,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15162,7 +16080,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15195,7 +16115,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15228,7 +16150,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15261,7 +16185,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15294,7 +16220,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15327,7 +16255,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15360,7 +16290,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15393,7 +16325,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15426,7 +16360,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15459,7 +16395,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15492,7 +16430,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15525,7 +16465,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15558,7 +16500,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15591,7 +16535,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15624,7 +16570,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15657,7 +16605,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15690,7 +16640,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15723,7 +16675,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15756,7 +16710,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15789,7 +16745,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15822,7 +16780,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15855,7 +16815,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15888,7 +16850,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15921,7 +16885,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15954,7 +16920,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15987,7 +16955,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16020,7 +16990,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16053,7 +17025,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16086,7 +17060,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16119,7 +17095,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16152,7 +17130,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16185,7 +17165,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16218,7 +17200,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16251,7 +17235,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16284,7 +17270,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16317,7 +17305,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16350,7 +17340,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16383,7 +17375,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16416,7 +17410,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16449,7 +17445,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16482,7 +17480,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16515,7 +17515,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16548,7 +17550,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16581,7 +17585,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16614,7 +17620,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16647,7 +17655,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16680,7 +17690,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16713,7 +17725,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16746,7 +17760,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16779,7 +17795,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16812,7 +17830,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16845,7 +17865,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16878,7 +17900,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16911,7 +17935,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16944,7 +17970,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16977,7 +18005,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17010,7 +18040,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17043,7 +18075,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17076,7 +18110,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17109,7 +18145,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17142,7 +18180,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17175,7 +18215,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17208,7 +18250,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17241,7 +18285,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17274,7 +18320,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17307,7 +18355,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17340,7 +18390,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17373,7 +18425,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17406,7 +18460,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17439,7 +18495,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17472,7 +18530,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17505,7 +18565,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17538,7 +18600,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17571,7 +18635,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17604,7 +18670,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17637,7 +18705,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17670,7 +18740,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17703,7 +18775,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17736,7 +18810,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17769,7 +18845,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17802,7 +18880,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17835,7 +18915,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17868,7 +18950,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17901,7 +18985,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17934,7 +19020,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17967,7 +19055,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18000,7 +19090,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18033,7 +19125,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18066,7 +19160,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18099,7 +19195,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18132,7 +19230,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18165,7 +19265,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18198,7 +19300,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18231,7 +19335,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18264,7 +19370,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18297,7 +19405,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18330,7 +19440,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18363,7 +19475,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18396,7 +19510,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18429,7 +19545,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18462,7 +19580,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18495,7 +19615,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18528,7 +19650,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18561,7 +19685,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18594,7 +19720,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18627,7 +19755,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18660,7 +19790,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18693,7 +19825,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18726,7 +19860,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18759,7 +19895,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18792,7 +19930,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18825,7 +19965,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18858,7 +20000,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18891,7 +20035,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18924,7 +20070,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18957,7 +20105,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18990,7 +20140,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19023,7 +20175,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19056,7 +20210,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19089,7 +20245,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19122,7 +20280,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19155,7 +20315,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19188,7 +20350,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19221,7 +20385,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19254,7 +20420,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19287,7 +20455,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19320,7 +20490,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19353,7 +20525,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19386,7 +20560,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19419,7 +20595,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19452,7 +20630,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19485,7 +20665,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19518,7 +20700,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19551,7 +20735,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19584,7 +20770,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19617,7 +20805,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19650,7 +20840,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19683,7 +20875,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19716,7 +20910,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19749,7 +20945,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19782,7 +20980,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19815,7 +21015,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19848,7 +21050,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19881,7 +21085,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19914,7 +21120,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19947,7 +21155,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19980,7 +21190,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20013,7 +21225,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20046,7 +21260,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20079,7 +21295,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20112,7 +21330,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20145,7 +21365,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20178,7 +21400,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20211,7 +21435,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20244,7 +21470,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20277,7 +21505,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20310,7 +21540,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20343,7 +21575,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20376,7 +21610,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20409,7 +21645,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20442,7 +21680,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20475,7 +21715,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20508,7 +21750,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20541,7 +21785,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20574,7 +21820,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20607,7 +21855,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20640,7 +21890,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20673,7 +21925,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20706,7 +21960,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20739,7 +21995,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20772,7 +22030,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20805,7 +22065,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20838,7 +22100,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20871,7 +22135,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20904,7 +22170,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20937,7 +22205,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20970,7 +22240,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21003,7 +22275,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21036,7 +22310,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21069,7 +22345,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21102,7 +22380,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21135,7 +22415,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21168,7 +22450,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21201,7 +22485,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21234,7 +22520,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21267,7 +22555,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21300,7 +22590,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21333,7 +22625,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21366,7 +22660,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21399,7 +22695,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21432,7 +22730,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21465,7 +22765,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21498,7 +22800,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21531,7 +22835,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21564,7 +22870,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21597,7 +22905,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21630,7 +22940,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21663,7 +22975,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21696,7 +23010,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21729,7 +23045,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21762,7 +23080,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21795,7 +23115,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21828,7 +23150,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21861,7 +23185,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21894,7 +23220,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21927,7 +23255,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21960,7 +23290,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21993,7 +23325,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22026,7 +23360,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22059,7 +23395,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22092,7 +23430,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22125,7 +23465,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22158,7 +23500,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22191,7 +23535,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22224,7 +23570,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22257,7 +23605,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22290,7 +23640,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22323,7 +23675,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22356,7 +23710,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22389,7 +23745,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22422,7 +23780,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22455,7 +23815,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22488,7 +23850,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22521,7 +23885,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22554,7 +23920,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22587,7 +23955,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22620,7 +23990,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22653,7 +24025,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22686,7 +24060,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22719,7 +24095,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22752,7 +24130,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22785,7 +24165,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22818,7 +24200,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22851,7 +24235,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22884,7 +24270,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22917,7 +24305,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22950,7 +24340,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22983,7 +24375,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23016,7 +24410,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23049,7 +24445,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23082,7 +24480,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23115,7 +24515,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23148,7 +24550,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23181,7 +24585,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23214,7 +24620,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23247,7 +24655,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23280,7 +24690,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23313,7 +24725,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23346,7 +24760,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23379,7 +24795,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23412,7 +24830,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23445,7 +24865,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23478,7 +24900,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23511,7 +24935,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23544,7 +24970,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23577,7 +25005,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23610,7 +25040,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23643,7 +25075,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23676,7 +25110,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23709,7 +25145,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23742,7 +25180,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23775,7 +25215,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23808,7 +25250,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23841,7 +25285,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23874,7 +25320,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23907,7 +25355,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23940,7 +25390,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23973,7 +25425,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24006,7 +25460,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24039,7 +25495,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24072,7 +25530,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24105,7 +25565,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24138,7 +25600,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24171,7 +25635,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24204,7 +25670,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24237,7 +25705,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24270,7 +25740,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24303,7 +25775,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24336,7 +25810,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24369,7 +25845,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24402,7 +25880,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24435,7 +25915,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24468,7 +25950,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24501,7 +25985,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24534,7 +26020,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24567,7 +26055,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",

--- a/cernopendata/modules/fixtures/data/records/cms-l1-trigger-information-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-l1-trigger-information-Run2011A.json
@@ -14,7 +14,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -45,7 +47,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -88,7 +92,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -131,7 +137,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -174,7 +182,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -217,7 +227,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -260,7 +272,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -303,7 +317,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-luminosity-information-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-luminosity-information-Run2012B.json
@@ -11,7 +11,9 @@
     "collections": [
       "CMS-Luminosity-Information"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-luminosity-information.json
+++ b/cernopendata/modules/fixtures/data/records/cms-luminosity-information.json
@@ -11,7 +11,9 @@
     "collections": [
       "CMS-Luminosity-Information"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -63,7 +65,9 @@
     "collections": [
       "CMS-Luminosity-Information"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-open-data-instructions-2017.json
+++ b/cernopendata/modules/fixtures/data/records/cms-open-data-instructions-2017.json
@@ -11,7 +11,11 @@
     "collections": [
       "CMS-Open-Data-Instructions"
     ],
-    "date_created": "2010-2012",
+    "date_created": [
+      "2010",
+      "2011",
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -54,7 +58,11 @@
     "collections": [
       "CMS-Open-Data-Instructions"
     ],
-    "date_created": "2010-2012",
+    "date_created": [
+      "2010",
+      "2011",
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -98,7 +106,11 @@
     "collections": [
       "CMS-Open-Data-Instructions"
     ],
-    "date_created": "2010-2012",
+    "date_created": [
+      "2010",
+      "2011",
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -141,7 +153,11 @@
     "collections": [
       "CMS-Open-Data-Instructions"
     ],
-    "date_created": "2010-2012",
+    "date_created": [
+      "2010",
+      "2011",
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-open-data-instructions.json
+++ b/cernopendata/modules/fixtures/data/records/cms-open-data-instructions.json
@@ -165,7 +165,9 @@
     "collections": [
       "CMS-Open-Data-Instructions"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -198,7 +200,9 @@
     "collections": [
       "CMS-Open-Data-Instructions"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -226,7 +230,11 @@
     "collections": [
       "CMS-Open-Data-Instructions"
     ],
-    "date_created": "2010-2012",
+    "date_created": [
+      "2010",
+      "2011",
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-pileup-configuration-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-pileup-configuration-files.json
@@ -14,7 +14,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-pileup-datasets-2011.json
+++ b/cernopendata/modules/fixtures/data/records/cms-pileup-datasets-2011.json
@@ -15,7 +15,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-pileup-datasets-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-pileup-datasets-2012.json
@@ -15,7 +15,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2011A.json
@@ -15,7 +15,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -143,7 +145,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -271,7 +275,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -413,7 +419,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -555,7 +563,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -725,7 +735,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -867,7 +879,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -981,7 +995,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -1109,7 +1125,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -1293,7 +1311,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -1421,7 +1441,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -1563,7 +1585,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -1719,7 +1743,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -1875,7 +1901,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -2045,7 +2073,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -2173,7 +2203,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -2315,7 +2347,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -2471,7 +2505,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {
@@ -2582,7 +2618,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "date_reprocessed": "2011",
     "distribution": {

--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012B.json
@@ -15,7 +15,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -263,7 +265,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -385,7 +389,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -493,7 +499,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -629,7 +637,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -821,7 +831,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -985,7 +997,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1107,7 +1121,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1257,7 +1273,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1561,7 +1579,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1669,7 +1689,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1875,7 +1897,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1997,7 +2021,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2203,7 +2229,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2325,7 +2353,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2517,7 +2547,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2695,7 +2727,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2943,7 +2977,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3247,7 +3283,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3369,7 +3407,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3519,7 +3559,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3739,7 +3781,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4127,7 +4171,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4249,7 +4295,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4651,7 +4699,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4857,7 +4907,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {

--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012C.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012C.json
@@ -15,7 +15,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -305,7 +307,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -427,7 +431,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -605,7 +611,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -769,7 +777,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1045,7 +1055,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1293,7 +1305,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1415,7 +1429,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1593,7 +1609,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2065,7 +2083,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2173,7 +2193,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2435,7 +2457,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2557,7 +2581,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2735,7 +2761,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2857,7 +2885,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3035,7 +3065,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3255,7 +3287,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3601,7 +3635,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4409,7 +4445,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4531,7 +4569,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4667,7 +4707,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4971,7 +5013,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -5401,7 +5445,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -5579,7 +5625,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -5855,7 +5903,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -6145,7 +6195,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {

--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets.json
@@ -15,7 +15,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -199,7 +201,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -369,7 +373,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -525,7 +531,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -709,7 +717,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -893,7 +903,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -1077,7 +1089,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -1261,7 +1275,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -1417,7 +1433,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -1531,7 +1549,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -1729,7 +1749,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -1913,7 +1935,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -2097,7 +2121,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {
@@ -2309,7 +2335,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "date_reprocessed": "2011",
     "distribution": {

--- a/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2011A.json
@@ -15,7 +15,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-reco-configuration-files-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-reco-configuration-files-2012.json
@@ -15,7 +15,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -64,7 +66,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -113,7 +117,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -162,7 +168,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -211,7 +219,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -260,7 +270,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -309,7 +321,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -358,7 +372,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -407,7 +423,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -456,7 +474,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -505,7 +525,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -554,7 +576,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -603,7 +627,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -652,7 +678,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -701,7 +729,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -750,7 +780,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -799,7 +831,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -848,7 +882,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -897,7 +933,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -946,7 +984,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -995,7 +1035,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1044,7 +1086,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1093,7 +1137,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1142,7 +1188,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1191,7 +1239,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1240,7 +1290,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1289,7 +1341,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1338,7 +1392,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1387,7 +1443,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1436,7 +1494,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1485,7 +1545,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1534,7 +1596,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1583,7 +1647,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1632,7 +1698,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1681,7 +1749,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1730,7 +1800,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1779,7 +1851,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1828,7 +1902,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1877,7 +1953,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1926,7 +2004,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -1975,7 +2055,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2024,7 +2106,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2073,7 +2157,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2122,7 +2208,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2171,7 +2259,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2220,7 +2310,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2269,7 +2361,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2318,7 +2412,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2367,7 +2463,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2416,7 +2514,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2465,7 +2565,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -2514,7 +2616,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010.json
@@ -22,7 +22,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -100,7 +102,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -178,7 +182,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -256,7 +262,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -334,7 +342,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -412,7 +422,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -490,7 +502,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -568,7 +582,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -646,7 +662,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -724,7 +742,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -802,7 +822,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -880,7 +902,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -958,7 +982,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1036,7 +1062,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1114,7 +1142,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1192,7 +1222,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1270,7 +1302,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1348,7 +1382,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1426,7 +1462,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1504,7 +1542,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1582,7 +1622,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1660,7 +1702,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1738,7 +1782,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1816,7 +1862,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1894,7 +1942,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -1972,7 +2022,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2050,7 +2102,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2128,7 +2182,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2206,7 +2262,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2284,7 +2342,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2362,7 +2422,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2440,7 +2502,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2518,7 +2582,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2603,7 +2669,9 @@
       "match_efficiency:": 1,
       "value": 23095400400
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2681,7 +2749,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2759,7 +2829,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2837,7 +2909,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2915,7 +2989,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -2993,7 +3069,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -3071,7 +3149,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -3149,7 +3229,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -3227,7 +3309,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -3305,7 +3389,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -3383,7 +3469,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -3461,7 +3549,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -3539,7 +3629,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -3617,7 +3709,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -3695,7 +3789,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -3773,7 +3869,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -3851,7 +3949,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -3929,7 +4029,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4007,7 +4109,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4085,7 +4189,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4163,7 +4269,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4241,7 +4349,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4319,7 +4429,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4397,7 +4509,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4475,7 +4589,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4553,7 +4669,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4631,7 +4749,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4709,7 +4829,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4787,7 +4909,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4865,7 +4989,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -4943,7 +5069,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5021,7 +5149,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5099,7 +5229,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5177,7 +5309,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5255,7 +5389,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5333,7 +5469,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5411,7 +5549,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5489,7 +5629,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5567,7 +5709,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5645,7 +5789,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5723,7 +5869,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5801,7 +5949,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5879,7 +6029,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -5957,7 +6109,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6035,7 +6189,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6113,7 +6269,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6191,7 +6349,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6269,7 +6429,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6347,7 +6509,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6425,7 +6589,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6503,7 +6669,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6581,7 +6749,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6659,7 +6829,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6737,7 +6909,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6815,7 +6989,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6893,7 +7069,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -6971,7 +7149,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -7049,7 +7229,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -7127,7 +7309,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -7205,7 +7389,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -7283,7 +7469,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -7361,7 +7549,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -7439,7 +7629,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -7517,7 +7709,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -7595,7 +7789,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -7673,7 +7869,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {
@@ -7751,7 +7949,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2010",
     "distribution": {

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2012.json
@@ -22,7 +22,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -149,7 +151,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -276,7 +280,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -382,7 +388,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -488,7 +496,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -601,7 +611,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -714,7 +726,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -827,7 +841,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -940,7 +956,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1053,7 +1071,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1166,7 +1186,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1293,7 +1315,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1403,7 +1427,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1516,7 +1542,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1629,7 +1657,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1826,7 +1856,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -1939,7 +1971,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2052,7 +2086,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2179,7 +2215,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2292,7 +2330,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2545,7 +2585,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2672,7 +2714,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2799,7 +2843,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -2926,7 +2972,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3053,7 +3101,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3166,7 +3216,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3307,7 +3359,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3434,7 +3488,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3547,7 +3603,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3660,7 +3718,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3787,7 +3847,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -3914,7 +3976,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4083,7 +4147,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4196,7 +4262,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4309,7 +4377,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4422,7 +4492,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4535,7 +4607,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4662,7 +4736,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4817,7 +4893,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -4944,7 +5022,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -5071,7 +5151,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -5184,7 +5266,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -5294,7 +5378,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -5407,7 +5493,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -5520,7 +5608,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -5633,7 +5723,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -5746,7 +5838,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -5859,7 +5953,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -5986,7 +6082,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -6099,7 +6197,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -6212,7 +6312,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -6325,7 +6427,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -6452,7 +6556,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -6565,7 +6671,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -6692,7 +6800,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -6847,7 +6957,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -6974,7 +7086,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -7115,7 +7229,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -7242,7 +7358,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -7355,7 +7473,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -7475,7 +7595,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -7616,7 +7738,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -7743,7 +7867,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -7870,7 +7996,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -7997,7 +8125,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -8110,7 +8240,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -8223,7 +8355,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -8336,7 +8470,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -8449,7 +8585,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -8562,7 +8700,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -8675,7 +8815,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -8788,7 +8930,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -8901,7 +9045,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -9014,7 +9160,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -9141,7 +9289,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -9268,7 +9418,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -9388,7 +9540,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -9515,7 +9669,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -9656,7 +9812,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -9769,7 +9927,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -9896,7 +10056,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -10023,7 +10185,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -10150,7 +10314,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -10263,7 +10429,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -10390,7 +10558,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -10503,7 +10673,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -10616,7 +10788,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -10729,7 +10903,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -10842,7 +11018,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -10955,7 +11133,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -11068,7 +11248,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -11195,7 +11377,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -11322,7 +11506,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -11435,7 +11621,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -11562,7 +11750,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -11689,7 +11879,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -11802,7 +11994,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -11915,7 +12109,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -12028,7 +12224,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -12141,7 +12339,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -12254,7 +12454,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -12367,7 +12569,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -12480,7 +12684,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -12607,7 +12813,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -12720,7 +12928,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -12833,7 +13043,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -12960,7 +13172,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -13073,7 +13287,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -13200,7 +13416,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -13327,7 +13545,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -13454,7 +13674,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -13581,7 +13803,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -13708,7 +13932,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -13821,7 +14047,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -13934,7 +14162,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -14047,7 +14277,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -14160,7 +14392,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -14273,7 +14507,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -14386,7 +14622,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -14499,7 +14737,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -14612,7 +14852,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -14725,7 +14967,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -14838,7 +15082,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -14965,7 +15211,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -15092,7 +15340,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -15219,7 +15469,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -15346,7 +15598,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -15459,7 +15713,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -15586,7 +15842,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -15713,7 +15971,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -15840,7 +16100,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -15967,7 +16229,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -16094,7 +16358,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -16221,7 +16487,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -16334,7 +16602,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -16461,7 +16731,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -16574,7 +16846,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -16701,7 +16975,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -16825,7 +17101,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -16952,7 +17230,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -17065,7 +17345,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -17192,7 +17474,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -17305,7 +17589,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -17418,7 +17704,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -17531,7 +17819,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -17644,7 +17934,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -17757,7 +18049,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -17870,7 +18164,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -17983,7 +18279,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -18096,7 +18394,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -18209,7 +18509,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -18336,7 +18638,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -18463,7 +18767,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -18576,7 +18882,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -19067,7 +19375,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -19180,7 +19490,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -19307,7 +19619,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -19476,7 +19790,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -19589,7 +19905,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -19730,7 +20048,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -19843,7 +20163,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -19956,7 +20278,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -20069,7 +20393,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -20182,7 +20508,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -20295,7 +20623,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -20408,7 +20738,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -20521,7 +20853,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -20774,7 +21108,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -20887,7 +21223,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -21000,7 +21338,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -21113,7 +21453,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -21226,7 +21568,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -21339,7 +21683,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -21452,7 +21798,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -21565,7 +21913,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -21692,7 +22042,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -21819,7 +22171,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -21932,7 +22286,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -22059,7 +22415,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -22186,7 +22544,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -22299,7 +22659,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -22454,7 +22816,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -22567,7 +22931,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -22680,7 +23046,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -22807,7 +23175,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -22927,7 +23297,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -23082,7 +23454,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -23195,7 +23569,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -23308,7 +23684,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -23449,7 +23827,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -23576,7 +23956,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -23689,7 +24071,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -23802,7 +24186,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -23915,7 +24301,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -24028,7 +24416,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -24183,7 +24573,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -24310,7 +24702,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -24423,7 +24817,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -24550,7 +24946,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -24663,7 +25061,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -24888,7 +25288,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -25001,7 +25403,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -25142,7 +25546,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -25283,7 +25689,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -25410,7 +25818,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -25523,7 +25933,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -25650,7 +26062,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -25777,7 +26191,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -25904,7 +26320,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -26017,7 +26435,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -26130,7 +26550,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -26243,7 +26665,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -26356,7 +26780,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -26469,7 +26895,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -26624,7 +27052,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -26751,7 +27181,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -26864,7 +27296,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -26991,7 +27425,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -27118,7 +27554,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -27231,7 +27669,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -27344,7 +27784,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -27471,7 +27913,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -27584,7 +28028,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -27690,7 +28136,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -27831,7 +28279,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -27944,7 +28394,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -28057,7 +28509,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -28170,7 +28624,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -28283,7 +28739,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -28396,7 +28854,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -28537,7 +28997,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -28678,7 +29140,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -28805,7 +29269,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -28932,7 +29398,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -29052,7 +29520,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -29207,7 +29677,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -29320,7 +29792,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -29433,7 +29907,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -29560,7 +30036,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -29673,7 +30151,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -29814,7 +30294,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -29941,7 +30423,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -30054,7 +30538,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -30195,7 +30681,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -30308,7 +30796,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -30435,7 +30925,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -30548,7 +31040,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -30675,7 +31169,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -30802,7 +31298,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -30915,7 +31413,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -31028,7 +31528,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -31141,7 +31643,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -31254,7 +31758,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -31364,7 +31870,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -31477,7 +31985,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -31590,7 +32100,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -31717,7 +32229,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -31827,7 +32341,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -31940,7 +32456,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -32053,7 +32571,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -32194,7 +32714,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -32307,7 +32829,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -32420,7 +32944,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -32547,7 +33073,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -32674,7 +33202,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -32801,7 +33331,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -32928,7 +33460,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -33041,7 +33575,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -33154,7 +33690,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -33267,7 +33805,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -33394,7 +33934,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -33507,7 +34049,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -33634,7 +34178,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -33747,7 +34293,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -33874,7 +34422,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -33987,7 +34537,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -34100,7 +34652,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -34213,7 +34767,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -34326,7 +34882,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -34439,7 +34997,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -34566,7 +35126,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -34679,7 +35241,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -34806,7 +35370,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -34919,7 +35485,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -35032,7 +35600,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -35145,7 +35715,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -35272,7 +35844,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -35385,7 +35959,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -35512,7 +36088,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -35625,7 +36203,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -35752,7 +36332,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -35865,7 +36447,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -35978,7 +36562,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -36091,7 +36677,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -36218,7 +36806,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -36331,7 +36921,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -36444,7 +37036,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -36557,7 +37151,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -36684,7 +37280,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {
@@ -36794,7 +37392,9 @@
       "energy": "8TeV",
       "type": "pp"
     },
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "date_reprocessed": "2012",
     "distribution": {

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
@@ -22,7 +22,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -143,7 +145,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -252,7 +256,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -373,7 +379,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -494,7 +502,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -603,7 +613,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -724,7 +736,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -845,7 +859,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -966,7 +982,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1074,7 +1092,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1194,7 +1214,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1315,7 +1337,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1448,7 +1472,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1557,7 +1583,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1690,7 +1718,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1811,7 +1841,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -1932,7 +1964,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2053,7 +2087,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2162,7 +2198,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2295,7 +2333,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2428,7 +2468,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2537,7 +2579,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2646,7 +2690,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2767,7 +2813,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2876,7 +2924,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -2997,7 +3047,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3118,7 +3170,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3239,7 +3293,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3360,7 +3416,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3469,7 +3527,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3590,7 +3650,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3699,7 +3761,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3832,7 +3896,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -3941,7 +4007,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4050,7 +4118,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4180,7 +4250,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4321,7 +4393,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4439,7 +4513,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4545,7 +4621,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4651,7 +4729,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4760,7 +4840,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4868,7 +4950,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -4976,7 +5060,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5084,7 +5170,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5204,7 +5292,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5325,7 +5415,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5482,7 +5574,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5603,7 +5697,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5711,7 +5807,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5819,7 +5917,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -5928,7 +6028,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6037,7 +6139,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6158,7 +6262,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6267,7 +6373,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6376,7 +6484,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6484,7 +6594,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6592,7 +6704,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6701,7 +6815,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6810,7 +6926,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -6918,7 +7036,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7040,7 +7160,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7149,7 +7271,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7284,7 +7408,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7393,7 +7519,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7514,7 +7642,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7622,7 +7752,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7742,7 +7874,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -7934,7 +8068,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8042,7 +8178,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8150,7 +8288,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8258,7 +8398,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8366,7 +8508,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8474,7 +8618,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8582,7 +8728,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8690,7 +8838,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8798,7 +8948,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -8906,7 +9058,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9014,7 +9168,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9122,7 +9278,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9231,7 +9389,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9340,7 +9500,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9461,7 +9623,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9570,7 +9734,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9703,7 +9869,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9808,7 +9976,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -9926,7 +10096,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10032,7 +10204,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10150,7 +10324,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10256,7 +10432,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10377,7 +10555,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10521,7 +10701,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10725,7 +10907,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10869,7 +11053,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -10989,7 +11175,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11097,7 +11285,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11302,7 +11492,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11602,7 +11794,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11710,7 +11904,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11818,7 +12014,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -11938,7 +12136,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12046,7 +12246,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12191,7 +12393,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12300,7 +12504,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12445,7 +12651,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12590,7 +12798,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12723,7 +12933,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12832,7 +13044,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -12941,7 +13155,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13050,7 +13266,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13171,7 +13389,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13304,7 +13524,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13425,7 +13647,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13546,7 +13770,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13655,7 +13881,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13776,7 +14004,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -13885,7 +14115,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14006,7 +14238,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14127,7 +14361,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14248,7 +14484,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14369,7 +14607,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14478,7 +14718,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14599,7 +14841,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14720,7 +14964,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14841,7 +15087,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -14962,7 +15210,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15083,7 +15333,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15204,7 +15456,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15313,7 +15567,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15422,7 +15678,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15531,7 +15789,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15640,7 +15900,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15749,7 +16011,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15858,7 +16122,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -15967,7 +16233,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16076,7 +16344,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16185,7 +16455,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16294,7 +16566,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16403,7 +16677,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16512,7 +16788,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16621,7 +16899,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16730,7 +17010,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16839,7 +17121,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -16948,7 +17232,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17069,7 +17355,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17178,7 +17466,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17287,7 +17577,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17396,7 +17688,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17517,7 +17811,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17638,7 +17934,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17771,7 +18069,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -17892,7 +18192,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18001,7 +18303,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18110,7 +18414,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18231,7 +18537,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18340,7 +18648,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18461,7 +18771,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18570,7 +18882,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18679,7 +18993,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18788,7 +19104,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -18897,7 +19215,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19018,7 +19338,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19151,7 +19473,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19272,7 +19596,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19380,7 +19706,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19488,7 +19816,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19596,7 +19926,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19704,7 +20036,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19812,7 +20146,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -19921,7 +20257,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20030,7 +20368,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20138,7 +20478,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20247,7 +20589,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20356,7 +20700,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20465,7 +20811,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20570,7 +20918,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20676,7 +21026,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20782,7 +21134,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -20888,7 +21242,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -21009,7 +21365,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -21166,7 +21524,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -21323,7 +21683,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -21456,7 +21818,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -21565,7 +21929,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -21686,7 +22052,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -21819,7 +22187,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -21928,7 +22298,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -22049,7 +22421,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -22182,7 +22556,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -22291,7 +22667,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -22424,7 +22802,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -22545,7 +22925,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -22654,7 +23036,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -22763,7 +23147,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -22884,7 +23270,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -23017,7 +23405,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -23126,7 +23516,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -23235,7 +23627,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -23356,7 +23750,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -23489,7 +23885,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -23610,7 +24008,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -23731,7 +24131,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -23876,7 +24278,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -23985,7 +24389,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -24094,7 +24500,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -24212,7 +24620,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -24321,7 +24731,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -24442,7 +24854,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -24551,7 +24965,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -24660,7 +25076,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -24805,7 +25223,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -24950,7 +25370,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -25071,7 +25493,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -25194,7 +25618,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -25305,7 +25731,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -25416,7 +25844,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -25539,7 +25969,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -25650,7 +26082,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -25785,7 +26219,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -25896,7 +26332,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -26019,7 +26457,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -26166,7 +26606,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -26313,7 +26755,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -26457,7 +26901,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -26577,7 +27023,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -26686,7 +27134,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -26807,7 +27257,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -26916,7 +27368,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -27025,7 +27479,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -27134,7 +27590,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -27255,7 +27713,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -27412,7 +27872,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -27545,7 +28007,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -27678,7 +28142,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -27787,7 +28253,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -27908,7 +28376,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -28053,7 +28523,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -28186,7 +28658,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -28307,7 +28781,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -28440,7 +28916,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -28561,7 +29039,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -28669,7 +29149,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -28777,7 +29259,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -28897,7 +29381,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -29006,7 +29492,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -29115,7 +29603,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -29284,7 +29774,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -29393,7 +29885,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -29514,7 +30008,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -29623,7 +30119,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -29731,7 +30229,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -29840,7 +30340,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -29948,7 +30450,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -30069,7 +30573,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -30190,7 +30696,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -30298,7 +30806,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -30406,7 +30916,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -30514,7 +31026,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -30622,7 +31136,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -30730,7 +31246,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -30838,7 +31356,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -30946,7 +31466,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -31054,7 +31576,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -31162,7 +31686,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -31270,7 +31796,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -31378,7 +31906,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -31486,7 +32016,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -31595,7 +32127,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -31704,7 +32238,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -31813,7 +32349,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -31922,7 +32460,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -32043,7 +32583,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -32152,7 +32694,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -32285,7 +32829,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -32430,7 +32976,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -32539,7 +33087,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -32660,7 +33210,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -32769,7 +33321,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -32878,7 +33432,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -32999,7 +33555,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -33108,7 +33666,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -33217,7 +33777,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -33326,7 +33888,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -33435,7 +33999,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -33568,7 +34134,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -33677,7 +34245,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -33798,7 +34368,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -33907,7 +34479,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -34016,7 +34590,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -34125,7 +34701,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -34258,7 +34836,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -34378,7 +34958,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -34486,7 +35068,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -34619,7 +35203,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -34740,7 +35326,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -34849,7 +35437,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -34970,7 +35560,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -35091,7 +35683,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -35212,7 +35806,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -35321,7 +35917,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -35430,7 +36028,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -35551,7 +36151,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -35660,7 +36262,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -35769,7 +36373,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -35878,7 +36484,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -35987,7 +36595,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -36096,7 +36706,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -36205,7 +36817,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -36314,7 +36928,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -36423,7 +37039,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -36532,7 +37150,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -36641,7 +37261,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -36750,7 +37372,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -36870,7 +37494,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -36978,7 +37604,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -37098,7 +37726,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -37206,7 +37836,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -37314,7 +37946,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -37434,7 +38068,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -37554,7 +38190,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -37662,7 +38300,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -37770,7 +38410,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -37878,7 +38520,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -37986,7 +38630,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -38106,7 +38752,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -38226,7 +38874,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -38334,7 +38984,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -38442,7 +39094,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -38551,7 +39205,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -38672,7 +39328,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -38793,7 +39451,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -38902,7 +39562,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -39023,7 +39685,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -39132,7 +39796,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -39253,7 +39919,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -39397,7 +40065,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -39505,7 +40175,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -39614,7 +40286,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -39734,7 +40408,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -39843,7 +40519,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -39964,7 +40642,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -40111,7 +40791,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -40219,7 +40901,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -40328,7 +41012,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -40436,7 +41122,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -40544,7 +41232,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -40653,7 +41343,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -40773,7 +41465,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -40893,7 +41587,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -41002,7 +41698,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -41171,7 +41869,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -41280,7 +41980,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -41389,7 +42091,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -41510,7 +42214,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -41655,7 +42361,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -41776,7 +42484,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -41885,7 +42595,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -41993,7 +42705,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -42102,7 +42816,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -42211,7 +42927,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -42319,7 +43037,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -42440,7 +43160,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -42561,7 +43283,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -42669,7 +43393,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -42780,7 +43506,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -42927,7 +43655,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -43035,7 +43765,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -43143,7 +43875,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -43278,7 +44012,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -43386,7 +44122,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -43506,7 +44244,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -43614,7 +44354,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -43734,7 +44476,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -43843,7 +44587,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -43952,7 +44698,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -44061,7 +44809,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -44182,7 +44932,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -44329,7 +45081,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -44461,7 +45215,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -44620,7 +45376,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -44729,7 +45487,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -44839,7 +45599,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -44962,7 +45724,9 @@
       "energy": "7TeV",
       "type": "pp"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2018",
     "date_reprocessed": "2011",
     "distribution": {

--- a/cernopendata/modules/fixtures/data/records/cms-tools-ana-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-ana-Run2011A.json
@@ -16,7 +16,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "number_files": 1
@@ -107,7 +109,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "number_files": 1

--- a/cernopendata/modules/fixtures/data/records/cms-tools-ana.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-ana.json
@@ -12,7 +12,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -115,7 +117,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-tools-cmssw-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-cmssw-Run2011A.json
@@ -11,7 +11,10 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2011-2012",
+    "date_created": [
+      "2011",
+      "2012"
+    ],
     "date_published": "2016",
     "doi": "10.7483/OPENDATA.CMS.WYJG.FYK9",
     "experiment": "CMS",

--- a/cernopendata/modules/fixtures/data/records/cms-tools-cmssw.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-cmssw.json
@@ -11,7 +11,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "doi": "10.7483/OPENDATA.CMS.84K2.KUH7",
     "experiment": "CMS",

--- a/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-filter.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-filter.json
@@ -12,7 +12,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2015",
     "distribution": {
       "formats": [
@@ -93,7 +95,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-spectrum-2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-spectrum-2010.json
@@ -21,7 +21,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-tools-higgsexample20112012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-higgsexample20112012.json
@@ -18,7 +18,10 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2011-2012",
+    "date_created": [
+      "2011",
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -209,7 +212,10 @@
     "collections": [
       "CMS-Derived-Datasets"
     ],
-    "date_created": "2011-2012",
+    "date_created": [
+      "2011",
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-tools-ispy-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-ispy-2012.json
@@ -12,7 +12,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "license": {

--- a/cernopendata/modules/fixtures/data/records/cms-tools-ispy-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-ispy-Run2011A.json
@@ -12,7 +12,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "license": {

--- a/cernopendata/modules/fixtures/data/records/cms-tools-ispy.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-ispy.json
@@ -12,7 +12,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "experiment": "CMS",
     "license": {

--- a/cernopendata/modules/fixtures/data/records/cms-tools-reco.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-reco.json
@@ -13,7 +13,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -80,7 +82,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-2012.json
@@ -12,7 +12,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
@@ -11,7 +11,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -97,7 +99,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
@@ -11,7 +11,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -94,7 +96,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2015",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-trigger-examples.json
+++ b/cernopendata/modules/fixtures/data/records/cms-trigger-examples.json
@@ -12,7 +12,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [
@@ -73,7 +75,9 @@
     "collections": [
       "CMS-Tools"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-trigger-information-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-trigger-information-2012.json
@@ -11,7 +11,9 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",

--- a/cernopendata/modules/fixtures/data/records/cms-trigger-information-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-trigger-information-Run2011A.json
@@ -11,7 +11,9 @@
     "collections": [
       "CMS-Trigger-Information"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",

--- a/cernopendata/modules/fixtures/data/records/cms-trigger-path-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-trigger-path-Run2011A.json
@@ -14,7 +14,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -45,7 +47,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -76,7 +80,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -107,7 +113,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -138,7 +146,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -169,7 +179,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -200,7 +212,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -231,7 +245,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -262,7 +278,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -293,7 +311,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -324,7 +344,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -355,7 +377,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -386,7 +410,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -417,7 +443,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -448,7 +476,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -479,7 +509,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -510,7 +542,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -541,7 +575,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -572,7 +608,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -603,7 +641,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -634,7 +674,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -665,7 +707,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -696,7 +740,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -727,7 +773,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -758,7 +806,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -789,7 +839,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -820,7 +872,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -851,7 +905,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -882,7 +938,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -913,7 +971,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -944,7 +1004,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -975,7 +1037,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1006,7 +1070,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1037,7 +1103,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1068,7 +1136,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1099,7 +1169,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1130,7 +1202,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1161,7 +1235,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1192,7 +1268,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1223,7 +1301,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1254,7 +1334,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1285,7 +1367,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1316,7 +1400,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1347,7 +1433,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1378,7 +1466,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1409,7 +1499,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1440,7 +1532,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1471,7 +1565,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1502,7 +1598,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1533,7 +1631,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1564,7 +1664,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1595,7 +1697,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1626,7 +1730,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1657,7 +1763,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1688,7 +1796,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1719,7 +1829,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1750,7 +1862,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1781,7 +1895,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1812,7 +1928,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1843,7 +1961,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1874,7 +1994,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1905,7 +2027,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1936,7 +2060,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1967,7 +2093,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -1998,7 +2126,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2029,7 +2159,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2060,7 +2192,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2091,7 +2225,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2122,7 +2258,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2153,7 +2291,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2184,7 +2324,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2215,7 +2357,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2246,7 +2390,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2277,7 +2423,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2308,7 +2456,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2339,7 +2489,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2370,7 +2522,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2401,7 +2555,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2432,7 +2588,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2463,7 +2621,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2494,7 +2654,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2525,7 +2687,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2556,7 +2720,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2587,7 +2753,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2618,7 +2786,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2649,7 +2819,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2680,7 +2852,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2711,7 +2885,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2742,7 +2918,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2773,7 +2951,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2804,7 +2984,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2835,7 +3017,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2866,7 +3050,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2897,7 +3083,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2928,7 +3116,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2959,7 +3149,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -2990,7 +3182,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3021,7 +3215,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3052,7 +3248,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3083,7 +3281,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3114,7 +3314,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3145,7 +3347,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3176,7 +3380,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3207,7 +3413,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3238,7 +3446,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3269,7 +3479,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3300,7 +3512,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3331,7 +3545,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3362,7 +3578,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3393,7 +3611,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3424,7 +3644,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3455,7 +3677,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3486,7 +3710,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3517,7 +3743,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3548,7 +3776,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3579,7 +3809,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3610,7 +3842,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3641,7 +3875,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3672,7 +3908,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3703,7 +3941,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3734,7 +3974,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3765,7 +4007,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3796,7 +4040,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3827,7 +4073,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3858,7 +4106,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3889,7 +4139,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3920,7 +4172,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3951,7 +4205,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -3982,7 +4238,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4013,7 +4271,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4044,7 +4304,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4075,7 +4337,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4106,7 +4370,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4137,7 +4403,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4168,7 +4436,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4199,7 +4469,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4230,7 +4502,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4261,7 +4535,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4292,7 +4568,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4323,7 +4601,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4354,7 +4634,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4385,7 +4667,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4416,7 +4700,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4447,7 +4733,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4478,7 +4766,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4509,7 +4799,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4540,7 +4832,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4571,7 +4865,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4602,7 +4898,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4633,7 +4931,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4664,7 +4964,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4695,7 +4997,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4726,7 +5030,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4757,7 +5063,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4788,7 +5096,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4819,7 +5129,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4850,7 +5162,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4881,7 +5195,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4912,7 +5228,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4943,7 +5261,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -4974,7 +5294,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5005,7 +5327,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5036,7 +5360,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5067,7 +5393,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5098,7 +5426,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5129,7 +5459,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5160,7 +5492,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5191,7 +5525,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5222,7 +5558,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5253,7 +5591,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5284,7 +5624,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5315,7 +5657,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5346,7 +5690,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5377,7 +5723,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5408,7 +5756,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5439,7 +5789,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5470,7 +5822,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5501,7 +5855,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5532,7 +5888,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5563,7 +5921,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5594,7 +5954,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5625,7 +5987,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5656,7 +6020,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5687,7 +6053,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5718,7 +6086,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5749,7 +6119,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5780,7 +6152,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5811,7 +6185,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5842,7 +6218,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5873,7 +6251,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5904,7 +6284,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5935,7 +6317,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5966,7 +6350,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -5997,7 +6383,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6028,7 +6416,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6059,7 +6449,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6090,7 +6482,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6121,7 +6515,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6152,7 +6548,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6183,7 +6581,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6214,7 +6614,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6245,7 +6647,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6276,7 +6680,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6307,7 +6713,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6338,7 +6746,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6369,7 +6779,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6400,7 +6812,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6431,7 +6845,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6462,7 +6878,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6493,7 +6911,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6524,7 +6944,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6555,7 +6977,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6586,7 +7010,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6617,7 +7043,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6648,7 +7076,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6679,7 +7109,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6710,7 +7142,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6741,7 +7175,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6772,7 +7208,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6803,7 +7241,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6834,7 +7274,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6865,7 +7307,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6896,7 +7340,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6927,7 +7373,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6958,7 +7406,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -6989,7 +7439,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7020,7 +7472,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7051,7 +7505,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7082,7 +7538,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7113,7 +7571,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7144,7 +7604,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7175,7 +7637,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7206,7 +7670,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7237,7 +7703,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7268,7 +7736,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7299,7 +7769,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7330,7 +7802,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7361,7 +7835,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7392,7 +7868,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7423,7 +7901,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7454,7 +7934,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7485,7 +7967,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7516,7 +8000,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7547,7 +8033,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7578,7 +8066,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7609,7 +8099,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7640,7 +8132,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7671,7 +8165,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7702,7 +8198,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7733,7 +8231,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7764,7 +8264,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7795,7 +8297,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7826,7 +8330,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7857,7 +8363,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7888,7 +8396,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7919,7 +8429,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7950,7 +8462,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -7981,7 +8495,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8012,7 +8528,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8043,7 +8561,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8074,7 +8594,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8105,7 +8627,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8136,7 +8660,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8167,7 +8693,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8198,7 +8726,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8229,7 +8759,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8260,7 +8792,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8291,7 +8825,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8322,7 +8858,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8353,7 +8891,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8384,7 +8924,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8415,7 +8957,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8446,7 +8990,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8477,7 +9023,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8508,7 +9056,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8539,7 +9089,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8570,7 +9122,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8601,7 +9155,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8632,7 +9188,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8663,7 +9221,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8694,7 +9254,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8725,7 +9287,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8756,7 +9320,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8787,7 +9353,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8818,7 +9386,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8849,7 +9419,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8880,7 +9452,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8911,7 +9485,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8942,7 +9518,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -8973,7 +9551,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9004,7 +9584,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9035,7 +9617,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9066,7 +9650,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9097,7 +9683,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9128,7 +9716,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9159,7 +9749,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9190,7 +9782,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9221,7 +9815,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9252,7 +9848,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9283,7 +9881,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9314,7 +9914,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9345,7 +9947,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9376,7 +9980,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9407,7 +10013,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9438,7 +10046,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9469,7 +10079,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9500,7 +10112,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9531,7 +10145,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9562,7 +10178,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9593,7 +10211,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9624,7 +10244,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9655,7 +10277,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9686,7 +10310,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9717,7 +10343,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9748,7 +10376,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9779,7 +10409,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9810,7 +10442,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9841,7 +10475,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9872,7 +10508,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9903,7 +10541,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9934,7 +10574,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9965,7 +10607,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -9996,7 +10640,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10027,7 +10673,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10058,7 +10706,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10089,7 +10739,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10120,7 +10772,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10151,7 +10805,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10182,7 +10838,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10213,7 +10871,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10244,7 +10904,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10275,7 +10937,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10306,7 +10970,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10337,7 +11003,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10368,7 +11036,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10399,7 +11069,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10430,7 +11102,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10461,7 +11135,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10492,7 +11168,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10523,7 +11201,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10554,7 +11234,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10585,7 +11267,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10616,7 +11300,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10647,7 +11333,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10678,7 +11366,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10709,7 +11399,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10740,7 +11432,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10771,7 +11465,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10802,7 +11498,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10833,7 +11531,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10864,7 +11564,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10895,7 +11597,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10926,7 +11630,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10957,7 +11663,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -10988,7 +11696,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11019,7 +11729,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11050,7 +11762,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11081,7 +11795,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11112,7 +11828,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11143,7 +11861,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11174,7 +11894,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11205,7 +11927,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11236,7 +11960,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11267,7 +11993,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11298,7 +12026,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11329,7 +12059,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11360,7 +12092,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11391,7 +12125,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11422,7 +12158,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11453,7 +12191,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11484,7 +12224,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11515,7 +12257,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11546,7 +12290,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11577,7 +12323,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11608,7 +12356,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11639,7 +12389,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11670,7 +12422,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11701,7 +12455,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11732,7 +12488,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11763,7 +12521,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11794,7 +12554,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11825,7 +12587,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11856,7 +12620,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11887,7 +12653,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11918,7 +12686,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11949,7 +12719,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -11980,7 +12752,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12011,7 +12785,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12042,7 +12818,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12073,7 +12851,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12104,7 +12884,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12135,7 +12917,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12166,7 +12950,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12197,7 +12983,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12228,7 +13016,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12259,7 +13049,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12290,7 +13082,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12321,7 +13115,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12352,7 +13148,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12383,7 +13181,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12414,7 +13214,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12445,7 +13247,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12476,7 +13280,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12507,7 +13313,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12538,7 +13346,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12569,7 +13379,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12600,7 +13412,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12631,7 +13445,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12662,7 +13478,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12693,7 +13511,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12724,7 +13544,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12755,7 +13577,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12786,7 +13610,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12817,7 +13643,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12848,7 +13676,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12879,7 +13709,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12910,7 +13742,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12941,7 +13775,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -12972,7 +13808,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13003,7 +13841,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13034,7 +13874,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13065,7 +13907,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13096,7 +13940,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13127,7 +13973,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13158,7 +14006,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13189,7 +14039,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13220,7 +14072,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13251,7 +14105,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13282,7 +14138,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13313,7 +14171,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13344,7 +14204,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13375,7 +14237,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13406,7 +14270,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13437,7 +14303,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13468,7 +14336,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13499,7 +14369,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13530,7 +14402,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13561,7 +14435,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13592,7 +14468,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13623,7 +14501,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13654,7 +14534,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13685,7 +14567,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13716,7 +14600,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13747,7 +14633,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13778,7 +14666,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13809,7 +14699,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13840,7 +14732,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13871,7 +14765,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13902,7 +14798,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13933,7 +14831,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13964,7 +14864,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -13995,7 +14897,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14026,7 +14930,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14057,7 +14963,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14088,7 +14996,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14119,7 +15029,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14150,7 +15062,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14181,7 +15095,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14212,7 +15128,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14243,7 +15161,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14274,7 +15194,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14305,7 +15227,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14336,7 +15260,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14367,7 +15293,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14398,7 +15326,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14429,7 +15359,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14460,7 +15392,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14491,7 +15425,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14522,7 +15458,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14553,7 +15491,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14584,7 +15524,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14615,7 +15557,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14646,7 +15590,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14677,7 +15623,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14708,7 +15656,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14739,7 +15689,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14770,7 +15722,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14801,7 +15755,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14832,7 +15788,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14863,7 +15821,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14894,7 +15854,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14925,7 +15887,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14956,7 +15920,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -14987,7 +15953,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15018,7 +15986,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15049,7 +16019,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15080,7 +16052,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15111,7 +16085,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15142,7 +16118,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15173,7 +16151,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15204,7 +16184,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15235,7 +16217,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15266,7 +16250,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15297,7 +16283,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15328,7 +16316,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15359,7 +16349,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15390,7 +16382,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15421,7 +16415,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15452,7 +16448,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15483,7 +16481,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15514,7 +16514,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15545,7 +16547,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15576,7 +16580,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15607,7 +16613,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15638,7 +16646,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15669,7 +16679,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15700,7 +16712,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15731,7 +16745,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15762,7 +16778,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15793,7 +16811,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15824,7 +16844,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15855,7 +16877,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15886,7 +16910,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15917,7 +16943,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15948,7 +16976,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -15979,7 +17009,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16010,7 +17042,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16041,7 +17075,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16072,7 +17108,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16103,7 +17141,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16134,7 +17174,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16165,7 +17207,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16196,7 +17240,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16227,7 +17273,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16258,7 +17306,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16289,7 +17339,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16320,7 +17372,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16351,7 +17405,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16382,7 +17438,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16413,7 +17471,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16444,7 +17504,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16475,7 +17537,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16506,7 +17570,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16537,7 +17603,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16568,7 +17636,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16599,7 +17669,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16630,7 +17702,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16661,7 +17735,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16692,7 +17768,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16723,7 +17801,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16754,7 +17834,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16785,7 +17867,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16816,7 +17900,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16847,7 +17933,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16878,7 +17966,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16909,7 +17999,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16940,7 +18032,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -16971,7 +18065,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17002,7 +18098,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17033,7 +18131,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17064,7 +18164,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17095,7 +18197,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17126,7 +18230,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17157,7 +18263,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17188,7 +18296,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17219,7 +18329,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17250,7 +18362,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17281,7 +18395,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17312,7 +18428,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17343,7 +18461,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17374,7 +18494,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17405,7 +18527,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17436,7 +18560,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17467,7 +18593,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17498,7 +18626,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17529,7 +18659,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17560,7 +18692,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17591,7 +18725,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17622,7 +18758,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17653,7 +18791,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17684,7 +18824,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17715,7 +18857,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17746,7 +18890,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17777,7 +18923,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17808,7 +18956,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17839,7 +18989,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17870,7 +19022,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17901,7 +19055,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17932,7 +19088,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17963,7 +19121,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -17994,7 +19154,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18025,7 +19187,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18056,7 +19220,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18087,7 +19253,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18118,7 +19286,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18149,7 +19319,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18180,7 +19352,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18211,7 +19385,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18242,7 +19418,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18273,7 +19451,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18304,7 +19484,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18335,7 +19517,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18366,7 +19550,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18397,7 +19583,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18428,7 +19616,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18459,7 +19649,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18490,7 +19682,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18521,7 +19715,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18552,7 +19748,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18583,7 +19781,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18614,7 +19814,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18645,7 +19847,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18676,7 +19880,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18707,7 +19913,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18738,7 +19946,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18769,7 +19979,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18800,7 +20012,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18831,7 +20045,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18862,7 +20078,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18893,7 +20111,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18924,7 +20144,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18955,7 +20177,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -18986,7 +20210,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19017,7 +20243,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19048,7 +20276,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19079,7 +20309,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19110,7 +20342,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19141,7 +20375,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19172,7 +20408,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19203,7 +20441,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19234,7 +20474,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19265,7 +20507,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19296,7 +20540,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19327,7 +20573,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19358,7 +20606,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19389,7 +20639,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19420,7 +20672,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19451,7 +20705,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19482,7 +20738,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19513,7 +20771,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19544,7 +20804,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19575,7 +20837,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19606,7 +20870,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19637,7 +20903,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19668,7 +20936,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19699,7 +20969,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19730,7 +21002,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19761,7 +21035,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19792,7 +21068,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19823,7 +21101,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19854,7 +21134,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19885,7 +21167,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19916,7 +21200,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19947,7 +21233,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -19978,7 +21266,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20009,7 +21299,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20040,7 +21332,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20071,7 +21365,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20102,7 +21398,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20133,7 +21431,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20164,7 +21464,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20195,7 +21497,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20226,7 +21530,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20257,7 +21563,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20288,7 +21596,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20319,7 +21629,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20350,7 +21662,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20381,7 +21695,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20412,7 +21728,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20443,7 +21761,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20474,7 +21794,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20505,7 +21827,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20536,7 +21860,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20567,7 +21893,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20598,7 +21926,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20629,7 +21959,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20660,7 +21992,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20691,7 +22025,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20722,7 +22058,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20753,7 +22091,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20784,7 +22124,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20815,7 +22157,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20846,7 +22190,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20877,7 +22223,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20908,7 +22256,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20939,7 +22289,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -20970,7 +22322,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21001,7 +22355,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21032,7 +22388,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21063,7 +22421,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21094,7 +22454,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21125,7 +22487,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21156,7 +22520,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21187,7 +22553,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21218,7 +22586,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21249,7 +22619,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21280,7 +22652,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21311,7 +22685,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21342,7 +22718,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21373,7 +22751,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21404,7 +22784,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21435,7 +22817,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21466,7 +22850,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21497,7 +22883,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21528,7 +22916,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21559,7 +22949,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21590,7 +22982,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21621,7 +23015,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21652,7 +23048,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21683,7 +23081,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21714,7 +23114,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21745,7 +23147,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21776,7 +23180,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21807,7 +23213,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21838,7 +23246,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21869,7 +23279,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21900,7 +23312,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21931,7 +23345,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21962,7 +23378,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -21993,7 +23411,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22024,7 +23444,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22055,7 +23477,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22086,7 +23510,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22117,7 +23543,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22148,7 +23576,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22179,7 +23609,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22210,7 +23642,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22241,7 +23675,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22272,7 +23708,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22303,7 +23741,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22334,7 +23774,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22365,7 +23807,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22396,7 +23840,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22427,7 +23873,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22458,7 +23906,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22489,7 +23939,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22520,7 +23972,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22551,7 +24005,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22582,7 +24038,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22613,7 +24071,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22644,7 +24104,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22675,7 +24137,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22706,7 +24170,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22737,7 +24203,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22768,7 +24236,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22799,7 +24269,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22830,7 +24302,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22861,7 +24335,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22892,7 +24368,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22923,7 +24401,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22954,7 +24434,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -22985,7 +24467,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23016,7 +24500,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23047,7 +24533,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23078,7 +24566,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23109,7 +24599,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23140,7 +24632,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23171,7 +24665,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23202,7 +24698,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23233,7 +24731,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23264,7 +24764,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23295,7 +24797,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23326,7 +24830,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23357,7 +24863,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23388,7 +24896,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23419,7 +24929,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23450,7 +24962,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23481,7 +24995,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23512,7 +25028,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23543,7 +25061,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23574,7 +25094,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23605,7 +25127,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23636,7 +25160,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23667,7 +25193,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23698,7 +25226,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23729,7 +25259,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23760,7 +25292,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23791,7 +25325,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23822,7 +25358,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23853,7 +25391,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23884,7 +25424,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23915,7 +25457,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23946,7 +25490,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -23977,7 +25523,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24008,7 +25556,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24039,7 +25589,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24070,7 +25622,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24101,7 +25655,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24132,7 +25688,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24163,7 +25721,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24194,7 +25754,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24225,7 +25787,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24256,7 +25820,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24287,7 +25853,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24318,7 +25886,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24349,7 +25919,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24380,7 +25952,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24411,7 +25985,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24442,7 +26018,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24473,7 +26051,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24504,7 +26084,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24535,7 +26117,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24566,7 +26150,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24597,7 +26183,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24628,7 +26216,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24659,7 +26249,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24690,7 +26282,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24721,7 +26315,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24752,7 +26348,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24783,7 +26381,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24814,7 +26414,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24845,7 +26447,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24876,7 +26480,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24907,7 +26513,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24938,7 +26546,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -24969,7 +26579,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25000,7 +26612,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25031,7 +26645,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25062,7 +26678,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25093,7 +26711,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25124,7 +26744,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25155,7 +26777,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25186,7 +26810,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25217,7 +26843,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25248,7 +26876,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25279,7 +26909,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25310,7 +26942,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25341,7 +26975,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25372,7 +27008,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25403,7 +27041,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25434,7 +27074,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25465,7 +27107,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25496,7 +27140,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25527,7 +27173,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25558,7 +27206,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25589,7 +27239,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25620,7 +27272,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25651,7 +27305,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25682,7 +27338,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25713,7 +27371,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25744,7 +27404,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25775,7 +27437,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25806,7 +27470,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25837,7 +27503,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25868,7 +27536,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25899,7 +27569,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25930,7 +27602,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25961,7 +27635,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -25992,7 +27668,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26023,7 +27701,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26054,7 +27734,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26085,7 +27767,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26116,7 +27800,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26147,7 +27833,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26178,7 +27866,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26209,7 +27899,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26240,7 +27932,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26271,7 +27965,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26302,7 +27998,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26333,7 +28031,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26364,7 +28064,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26395,7 +28097,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26426,7 +28130,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26457,7 +28163,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26488,7 +28196,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26519,7 +28229,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26550,7 +28262,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26581,7 +28295,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26612,7 +28328,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26643,7 +28361,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26674,7 +28394,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26705,7 +28427,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26736,7 +28460,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26767,7 +28493,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26798,7 +28526,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26829,7 +28559,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26860,7 +28592,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26891,7 +28625,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26922,7 +28658,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26953,7 +28691,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -26984,7 +28724,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27015,7 +28757,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27046,7 +28790,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27077,7 +28823,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27108,7 +28856,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27139,7 +28889,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27170,7 +28922,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27201,7 +28955,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27232,7 +28988,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27263,7 +29021,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27294,7 +29054,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27325,7 +29087,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27356,7 +29120,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27387,7 +29153,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27418,7 +29186,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27449,7 +29219,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27480,7 +29252,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27511,7 +29285,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27542,7 +29318,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27573,7 +29351,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27604,7 +29384,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27635,7 +29417,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27666,7 +29450,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27697,7 +29483,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27728,7 +29516,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27759,7 +29549,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27790,7 +29582,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27821,7 +29615,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27852,7 +29648,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27883,7 +29681,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27914,7 +29714,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27945,7 +29747,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -27976,7 +29780,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28007,7 +29813,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28038,7 +29846,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28069,7 +29879,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28100,7 +29912,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28131,7 +29945,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28162,7 +29978,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28193,7 +30011,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28224,7 +30044,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28255,7 +30077,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28286,7 +30110,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28317,7 +30143,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28348,7 +30176,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28379,7 +30209,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28410,7 +30242,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28441,7 +30275,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28472,7 +30308,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28503,7 +30341,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28534,7 +30374,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28565,7 +30407,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28596,7 +30440,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28627,7 +30473,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28658,7 +30506,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28689,7 +30539,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28720,7 +30572,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28751,7 +30605,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28782,7 +30638,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28813,7 +30671,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28844,7 +30704,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28875,7 +30737,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28906,7 +30770,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28937,7 +30803,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28968,7 +30836,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -28999,7 +30869,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29030,7 +30902,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29061,7 +30935,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29092,7 +30968,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29123,7 +31001,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29154,7 +31034,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29185,7 +31067,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29216,7 +31100,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29247,7 +31133,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29278,7 +31166,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29309,7 +31199,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29340,7 +31232,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29371,7 +31265,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29402,7 +31298,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29433,7 +31331,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29464,7 +31364,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29495,7 +31397,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29526,7 +31430,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29557,7 +31463,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29588,7 +31496,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29619,7 +31529,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29650,7 +31562,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29681,7 +31595,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29712,7 +31628,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29743,7 +31661,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29774,7 +31694,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29805,7 +31727,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29836,7 +31760,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29867,7 +31793,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29898,7 +31826,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29929,7 +31859,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",
@@ -29960,7 +31892,9 @@
     "collision_information": {
       "energy": "7TeV"
     },
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "experiment": "CMS",
     "publisher": "CERN Open Data Portal",

--- a/cernopendata/modules/fixtures/data/records/cms-validated-runs-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validated-runs-Run2012B.json
@@ -12,7 +12,9 @@
       "CMS-Validated-Runs",
       "CMS-Validation-Utilities"
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-validated-runs.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validated-runs.json
@@ -12,7 +12,9 @@
       "CMS-Validated-Runs",
       "CMS-Validation-Utilities"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2014",
     "distribution": {
       "formats": [
@@ -78,7 +80,9 @@
       "CMS-Validated-Runs",
       "CMS-Validation-Utilities"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-validation-code-Run2010B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validation-code-Run2010B.json
@@ -21,7 +21,9 @@
     "collections": [
       "CMS-Validation-Utilities"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -170,7 +172,9 @@
     "collections": [
       "CMS-Validation-Utilities"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [
@@ -301,7 +305,9 @@
     "collections": [
       "CMS-Validation-Utilities"
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2016",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-validation-code-jet-tuple.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validation-code-jet-tuple.json
@@ -15,7 +15,9 @@
     "collections": [
       "CMS-Validation-Utilities"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/cms-validation-code-ttbar.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validation-code-ttbar.json
@@ -12,7 +12,9 @@
     "collections": [
       "CMS-Validation-Utilities"
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2017",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/opera-author-list-multiplicity.json
+++ b/cernopendata/modules/fixtures/data/records/opera-author-list-multiplicity.json
@@ -524,7 +524,11 @@
     "collections": [
       "Author-Lists"
     ],
-    "date_created": "2010-2012",
+    "date_created": [
+      "2010",
+      "2011",
+      "2012"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/opera-author-list-tau.json
+++ b/cernopendata/modules/fixtures/data/records/opera-author-list-tau.json
@@ -552,7 +552,11 @@
     "collections": [
       "Author-Lists"
     ],
-    "date_created": "2010-2012",
+    "date_created": [
+      "2010",
+      "2011",
+      "2012"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/opera-detector-events-tau.json
+++ b/cernopendata/modules/fixtures/data/records/opera-detector-events-tau.json
@@ -121,7 +121,9 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2009",
+    "date_created": [
+      "2009"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [
@@ -362,7 +364,9 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2009",
+    "date_created": [
+      "2009"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [
@@ -603,7 +607,9 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2010",
+    "date_created": [
+      "2010"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [
@@ -844,7 +850,9 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [
@@ -1085,7 +1093,9 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [
@@ -1326,7 +1336,9 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [
@@ -1567,7 +1579,9 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2011",
+    "date_created": [
+      "2011"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [
@@ -1808,7 +1822,9 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [
@@ -2049,7 +2065,9 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [
@@ -2290,7 +2308,9 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2012",
+    "date_created": [
+      "2012"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/opera-ecc-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/opera-ecc-datasets.json
@@ -61,7 +61,11 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2010-2012",
+    "date_created": [
+      "2010",
+      "2011",
+      "2012"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [
@@ -223,7 +227,12 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2009-2012",
+    "date_created": [
+      "2009",
+      "2010",
+      "2011",
+      "2012"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/fixtures/data/records/opera-ed-datasets.json
+++ b/cernopendata/modules/fixtures/data/records/opera-ed-datasets.json
@@ -69,7 +69,11 @@
         "variable": "timestamp"
       }
     ],
-    "date_created": "2010-2012",
+    "date_created": [
+      "2010",
+      "2011",
+      "2012"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [
@@ -231,7 +235,12 @@
         "variable": "trType"
       }
     ],
-    "date_created": "2009-2012",
+    "date_created": [
+      "2009",
+      "2010",
+      "2011",
+      "2012"
+    ],
     "date_published": "2018",
     "distribution": {
       "formats": [

--- a/cernopendata/modules/records/serializers/schemas/schemaorg_schemas.py
+++ b/cernopendata/modules/records/serializers/schemas/schemaorg_schemas.py
@@ -46,8 +46,7 @@ class RecordSchemaorgSchema(Schema):
     identifier = fields.Method('get_identifier', dump_to='identifier')
     url = fields.Method('get_url', dump_to='url')
     creator = fields.Method('get_creator', dump_to='creator')
-    date_created = fields.Str(attribute='date_created',
-                              dump_to='dateCreated')
+    date_created = fields.Method('get_date_created', dump_to='dateCreated')
     date_published = fields.Str(attribute='date_published',
                                 dump_to='datePublished')
     publisher = fields.Method('get_publisher', dump_to='publisher')
@@ -88,6 +87,10 @@ class RecordSchemaorgSchema(Schema):
         else:
             recid = obj.get('recid', None)
             return "{}/record/{}".format(SITE_URL, recid)
+
+    def get_date_created(self, obj):
+        """Get most recent date_created year."""
+        return max(obj.get('date_created', ['0', ]))
 
     def get_publisher(self, obj):
         """Get publisher based on publisher field."""


### PR DESCRIPTION
* Amends schema, serialisers, fixtures to make `date_created` a list. Useful for
  values such as `2010-2012`. (closes #2505)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>