### PR TITLE
records: CMS validation software file size fix

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-validation-code-Run2010B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validation-code-Run2010B.json
@@ -40,7 +40,7 @@
     "files": [
       {
         "checksum": "sha1:3db193e02aaf2353702962f3988afe8b8461ae7d",
-        "size": 2348,
+        "size": 3161,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/readme.txt"
       },
       {
@@ -50,12 +50,12 @@
       },
       {
         "checksum": "sha1:eabdd35487945176f65b3b3f69c8ebfdb1dbf215",
-        "size": 14689,
+        "size": 29227,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/DemoAnalyzer.cc"
       },
       {
         "checksum": "sha1:8e6b39334d50d06713cdd396df119024a7663997",
-        "size": 3525,
+        "size": 5088,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/demoanalyzer_cfg.py"
       },
       {
@@ -188,7 +188,7 @@
     "files": [
       {
         "checksum": "sha1:3db193e02aaf2353702962f3988afe8b8461ae7d",
-        "size": 2348,
+        "size": 2971,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/readme.txt"
       },
       {
@@ -198,12 +198,12 @@
       },
       {
         "checksum": "sha1:eabdd35487945176f65b3b3f69c8ebfdb1dbf215",
-        "size": 14689,
+        "size": 29410,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/DemoAnalyzer.cc"
       },
       {
         "checksum": "sha1:8e6b39334d50d06713cdd396df119024a7663997",
-        "size": 3525,
+        "size": 5228,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/demoanalyzer_cfg.py"
       },
       {
@@ -318,7 +318,7 @@
     "files": [
       {
         "checksum": "sha1:3db193e02aaf2353702962f3988afe8b8461ae7d",
-        "size": 2348,
+        "size": 2980,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/readme.txt"
       },
       {
@@ -328,12 +328,12 @@
       },
       {
         "checksum": "sha1:eabdd35487945176f65b3b3f69c8ebfdb1dbf215",
-        "size": 14689,
+        "size": 35250,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/DemoAnalyzer.cc"
       },
       {
         "checksum": "sha1:8e6b39334d50d06713cdd396df119024a7663997",
-        "size": 3525,
+        "size": 5093,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/demoanalyzer_cfg.py"
       },
       {


### PR DESCRIPTION
* Fixes sizes for several CMS validation software files, solving the truncated
  file display over HTTP protocol access. The XRootD protocol access was
  working fine. (closes #2509)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>