### PR TITLE
records: ATLAS file sizes and checksums

### DIFF
--- a/cernopendata/modules/fixtures/data/records/alice-analysis-modules.json
+++ b/cernopendata/modules/fixtures/data/records/alice-analysis-modules.json
@@ -18,7 +18,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:1c06f1e5",
         "size": 2086046,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/PtAnalysis.tgz"
       }
@@ -61,7 +61,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:49beca01",
         "size": 31139203,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/alice-mc.tgz"
       }
@@ -107,7 +107,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:154c512a",
         "size": 15469921,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/alice-raa.tgz"
       }
@@ -150,7 +150,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:695acd4e",
         "size": 42540,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/bootstrap.tgz"
       }

--- a/cernopendata/modules/fixtures/data/records/alice-learning-resources.json
+++ b/cernopendata/modules/fixtures/data/records/alice-learning-resources.json
@@ -19,7 +19,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:2a6d0a372b14f4bccf62b5a658d66c3a591915d4",
+        "checksum": "adler32:9c33e07f",
         "size": 403277,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/documentation/1103106_20-A4-at-144-dpi.jpg"
       }

--- a/cernopendata/modules/fixtures/data/records/atlas-higgs-challenge-2014.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-higgs-challenge-2014.json
@@ -165,7 +165,7 @@
     "experiment": "ATLAS",
     "files": [
       {
-        "checksum": "sha1:639b1dbd97a709a739122a9a5dcd99b49d55d86c",
+        "checksum": "adler32:e4717bbe",
         "size": 65630848,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/higgs-challenge-2014/atlas-higgs-challenge-2014-v2.csv.gz"
       }
@@ -248,7 +248,7 @@
     "experiment": "ATLAS",
     "files": [
       {
-        "checksum": "sha1:91d16d6e44f837083f93513d42221c71c39e81a9",
+        "checksum": "adler32:da03684c",
         "size": 381738,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/higgs-challenge-2014/atlas-higgs-challenge-2014.pdf"
       }
@@ -344,7 +344,7 @@
     "experiment": "ATLAS",
     "files": [
       {
-        "checksum": "sha1:29dbd473108a291e354b9913027714ca163e2686",
+        "checksum": "adler32:616d2faf",
         "size": 24467,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/higgs-challenge-2014/HiggsML2014-1.0.tar.gz"
       }


### PR DESCRIPTION
* Verifies all ATLAS file sizes and sets file checksums to Adler32.
  (addresses #2528)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>