### PR TITLE
records: CMS file sizes and checksums

### DIFF
--- a/cernopendata/modules/fixtures/data/records/alice-analysis-modules.json
+++ b/cernopendata/modules/fixtures/data/records/alice-analysis-modules.json
@@ -18,7 +18,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:1c06f1e5",
         "size": 2086046,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/PtAnalysis.tgz"
       }
@@ -61,7 +61,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:49beca01",
         "size": 31139203,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/alice-mc.tgz"
       }
@@ -107,7 +107,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:154c512a",
         "size": 15469921,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/alice-raa.tgz"
       }
@@ -150,7 +150,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:695acd4e",
         "size": 42540,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/bootstrap.tgz"
       }

--- a/cernopendata/modules/fixtures/data/records/alice-learning-resources.json
+++ b/cernopendata/modules/fixtures/data/records/alice-learning-resources.json
@@ -19,7 +19,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:2a6d0a372b14f4bccf62b5a658d66c3a591915d4",
+        "checksum": "adler32:9c33e07f",
         "size": 403277,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/documentation/1103106_20-A4-at-144-dpi.jpg"
       }

--- a/cernopendata/modules/fixtures/data/records/atlas-higgs-challenge-2014.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-higgs-challenge-2014.json
@@ -165,7 +165,7 @@
     "experiment": "ATLAS",
     "files": [
       {
-        "checksum": "sha1:639b1dbd97a709a739122a9a5dcd99b49d55d86c",
+        "checksum": "adler32:e4717bbe",
         "size": 65630848,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/higgs-challenge-2014/atlas-higgs-challenge-2014-v2.csv.gz"
       }
@@ -248,7 +248,7 @@
     "experiment": "ATLAS",
     "files": [
       {
-        "checksum": "sha1:91d16d6e44f837083f93513d42221c71c39e81a9",
+        "checksum": "adler32:da03684c",
         "size": 381738,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/higgs-challenge-2014/atlas-higgs-challenge-2014.pdf"
       }
@@ -344,7 +344,7 @@
     "experiment": "ATLAS",
     "files": [
       {
-        "checksum": "sha1:29dbd473108a291e354b9913027714ca163e2686",
+        "checksum": "adler32:616d2faf",
         "size": 24467,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/higgs-challenge-2014/HiggsML2014-1.0.tar.gz"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-author-list-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-author-list-2012.json
@@ -19859,7 +19859,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8d6b9e4fdd4e109d3b802f4b9ca7fc49739b7b45",
+        "checksum": "adler32:5c4ad3dc",
         "size": 221620,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/cms-author-list-2012.pdf"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-author-list-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-author-list-Run2011A.json
@@ -19859,7 +19859,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8d6b9e4fdd4e109d3b802f4b9ca7fc49739b7b45",
+        "checksum": "adler32:5c4ad3dc",
         "size": 221620,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/cms-author-list-2011.pdf"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-author-list.json
+++ b/cernopendata/modules/fixtures/data/records/cms-author-list.json
@@ -19034,7 +19034,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bd91887ec0d4a998d5b8619f94e7683402803e09",
+        "checksum": "adler32:c3b0b7c2",
         "size": 229896,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/cms-author-list-2010.pdf"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-2012.json
@@ -30,12 +30,12 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9f6b79104ed3562232849454dd6cb6b5039e9238",
+        "checksum": "adler32:eff33dde",
         "size": 119808,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/db/FT53_V21A_AN6.db"
       },
       {
-        "checksum": "sha1:4fa656cdfe9efd4bae55d776b16e144b40fb2706",
+        "checksum": "adler32:bc538ea1",
         "size": 120832,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/db/FT53_V21A_AN6_RUNC.db"
       }
@@ -85,7 +85,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6f0f12509c70baddb99380da8859d879e3f5b58f",
+        "checksum": "adler32:b5869cf3",
         "size": 130048,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/db/START53_V27.db"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-configuration-files-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-configuration-files-2012.json
@@ -30,7 +30,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:95a4acb310c47679ac9988b6fe2615e638ad8238",
+        "checksum": "adler32:89584861",
         "size": 3873,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4bf2a2af9e9349832e2e60bf33b1e64d.configFile.py"
       }
@@ -82,7 +82,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:77558fd0580cb6f896cfe804cc17f1bea5c1e982",
+        "checksum": "adler32:f61ca218",
         "size": 5015,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0d0714743f0204ed3c0144941eb3ca01.configFile.py"
       }
@@ -134,7 +134,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a9e77fa1531d68a5af659fa1e99b488937eb4429",
+        "checksum": "adler32:fe0ae0a4",
         "size": 4280,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/456bd364d581640f6aaf924e8caa10b6.configFile.py"
       }
@@ -186,7 +186,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:633948c8cbd1df4104c6eecd3c960e82165e331a",
+        "checksum": "adler32:4226360c",
         "size": 4115655,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/a1fa6affe6e78c84b0ab48d1be9b6b9d.configFile.py"
       }
@@ -238,7 +238,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:29420fc17652a7f39c37890855954c293b0d167b",
+        "checksum": "adler32:081b5c3d",
         "size": 3936,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/44d78e47491ea65e30d0fb31c0696265.configFile.py"
       }
@@ -290,7 +290,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:211ffc2225be8e8363edd1dbfeee059f870feac6",
+        "checksum": "adler32:168d300b",
         "size": 374119,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0bbcec91bd5bb892feebe5a3e37f8f24.configFile.py"
       }
@@ -342,7 +342,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:47300e6f254c27a79cfc99b1b9569baffd3108a1",
+        "checksum": "adler32:0873605a",
         "size": 3960,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4740397cabbd08f77e728185d3901e4d.configFile.py"
       }
@@ -394,7 +394,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ac71a4df5442f12af64fbb61056b237621ae938a",
+        "checksum": "adler32:eafc082e",
         "size": 7206,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4ab3250d23e554446ebc010f2394f820.configFile.py"
       }
@@ -446,7 +446,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ff55c74837179dc27c267e21e40c4f7b9be19cc1",
+        "checksum": "adler32:262d779a",
         "size": 829102,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8ff550697a152ca7e29535c8e2cdbc34.configFile.py"
       }
@@ -498,7 +498,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0de1b4f48512a48b459261fb3b72c9d6605f62ad",
+        "checksum": "adler32:d3813c42",
         "size": 579953,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/df06ea86f6f8e8b03d64449d07d23f57.configFile.py"
       }
@@ -550,7 +550,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7e42c74ff56b09fd28a40282d9da17a5d51ed6fe",
+        "checksum": "adler32:e588efd3",
         "size": 4340,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/e608c935a486dbc17d186f3f1eee13dd.configFile.py"
       }
@@ -602,7 +602,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:aed228472a95baaddb9164a498fe75368589a03f",
+        "checksum": "adler32:2cbad46c",
         "size": 13621,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d400d015.configFile.py"
       }
@@ -654,7 +654,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e37b2cba4f3ef9491402742ac28c123e7450617c",
+        "checksum": "adler32:d46ff5c1",
         "size": 1988861,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/670953a2632e648ac1ceada4ce34b5cf.configFile.py"
       }
@@ -706,7 +706,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2e5a6087fc93e64ebb8d855554d6c2dc7256938c",
+        "checksum": "adler32:87ccefa9",
         "size": 4340,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/89e1cc8f64e148a8fe87a31c72a43f56.configFile.py"
       }
@@ -758,7 +758,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:174ea46803ab9cfb8df8d2fa6ca201f5f997ce60",
+        "checksum": "adler32:e08bff87",
         "size": 4113236,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/aa57a0041839d6b495260c3c0702cfee.configFile.py"
       }
@@ -810,7 +810,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:081c3b6637f017f14330a275b77f45ccf4202c13",
+        "checksum": "adler32:e820d622",
         "size": 6947,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/04e1a92f4e9492326a3e70ac37f4211e.configFile.py"
       }
@@ -862,7 +862,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:670e01022e5b8dc136d9e18bf304cab7ad9863d6",
+        "checksum": "adler32:7f1711f0",
         "size": 376053,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/779f0c01780043cb5ed3e273593eb291.configFile.py"
       }
@@ -914,7 +914,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c1a85eced04610f09c05f8234e7e85cb349c452e",
+        "checksum": "adler32:13574831",
         "size": 3873,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/75afac677b36415e441fdebe47de2845.configFile.py"
       }
@@ -966,7 +966,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7be604c808813060035bceed4abb7798f90d47c6",
+        "checksum": "adler32:fa944d94",
         "size": 3893,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/47044d6dd3e2cfdf991bce885e4ac67e.configFile.py"
       }
@@ -1018,7 +1018,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a54363722ead51c28b0156c475f00e115deef2c0",
+        "checksum": "adler32:b282e1bc",
         "size": 2552437,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/af5c50965a75874b05b20990207a78dc.configFile.py"
       }
@@ -1070,7 +1070,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:332ef25066b9daaabbb9a6fa4e20441c6974d9c6",
+        "checksum": "adler32:6e79d2e8",
         "size": 13614,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/db0105697625bdea8cedb18cd3ffa279.configFile.py"
       }
@@ -1122,7 +1122,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7454d95d5abc61f392bceb25e3e3022ba6b386bc",
+        "checksum": "adler32:2a5a88a8",
         "size": 5973,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c9156ec47a1f8e42dcd7b5c0f9f9955a.configFile.py"
       }
@@ -1174,7 +1174,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:70db56108703673097c2c6596cce62c3da8e8a7d",
+        "checksum": "adler32:7e2e5c48",
         "size": 3936,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/16f37748c2526047dfeb738193a2c604.configFile.py"
       }
@@ -1226,7 +1226,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dc9967169f53fa90917d147202f094889b0f5762",
+        "checksum": "adler32:4a055f1b",
         "size": 3930,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/546f8a96e2dfb72d4858f8a763e070cf.configFile.py"
       }
@@ -1278,7 +1278,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b05dc81d8f1baea40e786fd5f72e41a2aa9abf65",
+        "checksum": "adler32:5a85e8d7",
         "size": 513913,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2fecc267b797a1ea84edb843fbf9f2c7.configFile.py"
       }
@@ -1330,7 +1330,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:795cb02b84df57a05d1e623e055dadf17b3c2892",
+        "checksum": "adler32:0892c353",
         "size": 4115311,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/aa57a0041839d6b495260c3c07028eef.configFile.py"
       }
@@ -1382,7 +1382,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c31ba7d4e974cd92183523c342c12e1eae19f8a3",
+        "checksum": "adler32:9086efea",
         "size": 4340,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0371e5696db9bf58a7162bb96e9f7e6e.configFile.py"
       }
@@ -1434,7 +1434,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:95c5174630a382709b89585ead1692953880c7c8",
+        "checksum": "adler32:f97fe10c",
         "size": 4280,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/9f556d1eb7432ad365825ca05cab4176.configFile.py"
       }
@@ -1486,7 +1486,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9a934317bd0119d34323c3ae216a98838d059422",
+        "checksum": "adler32:e8c0fc21",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/090b469d74662aafa8b50b15182c09b5.configFile.py"
       }
@@ -1538,7 +1538,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bfbadbf5ad5278047c25bd7d492034a47110fb6c",
+        "checksum": "adler32:984fcd48",
         "size": 6207,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/a8b87e4a93ad780670c2864baf18d8f4.configFile.py"
       }
@@ -1590,7 +1590,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a027e0a15c2e02674ced77f3eb6a46fcbbe612d9",
+        "checksum": "adler32:e54774de",
         "size": 5688,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/320df834ed2a0446c7a2485723eaebfa.configFile.py"
       }
@@ -1642,7 +1642,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f9c92c66d937f9b667f20118d56017e180a812d8",
+        "checksum": "adler32:bd02efba",
         "size": 4340,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0bbcec91bd5bb892feebe5a3e37fa917.configFile.py"
       }
@@ -1694,7 +1694,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9cea94d30c54911ac41bbe5c8b3c3bd304230c5f",
+        "checksum": "adler32:0bf3dfba",
         "size": 3575,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/1097e7d4bdde2109bec55eeb210903c3.configFile.py"
       }
@@ -1746,7 +1746,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:35d19fdc96c70b139240ca310ed19ae0b0347efb",
+        "checksum": "adler32:9aa0ef95",
         "size": 4340,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/331f67c8c835bc29be9f6bc7eaab9845.configFile.py"
       }
@@ -1798,7 +1798,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3016b84cbda7bbd1aff12ca2ce70ded8b7419a58",
+        "checksum": "adler32:dd7a172c",
         "size": 8539,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/bba69ae19e1fbc577b22ff737999dfc2.configFile.py"
       }
@@ -1850,7 +1850,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:396ef1350c0d3357dacfa0271319bd67ae1db291",
+        "checksum": "adler32:4886f726",
         "size": 6341,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/791a4c1208863ba7b363a500a0f5e296.configFile.py"
       }
@@ -1902,7 +1902,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e5e327ade43d1b8433bcdc668759553efeecb65f",
+        "checksum": "adler32:63d29f4b",
         "size": 519377,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7418839ecfc94eb105cf051859e786d5.configFile.py"
       }
@@ -1954,7 +1954,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:324d683f047af0ab32906e30997d5df4cac46f3c",
+        "checksum": "adler32:dd7dc7d8",
         "size": 7171,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c5be5f65754ad5ed58ab89beb1f6b672.configFile.py"
       }
@@ -2006,7 +2006,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d167f55fb1e92eec9347b223a705a3ebfedce3c5",
+        "checksum": "adler32:826bfd07",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d3783a5330cef148bf0c5d82f0a132df.configFile.py"
       }
@@ -2058,7 +2058,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8947eb103da5affa60d5b192d43e7adbf6bf61bf",
+        "checksum": "adler32:86b82a43",
         "size": 4515,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f7caa6060cdc830e4f4ebbbb668cc50b.configFile.py"
       }
@@ -2110,7 +2110,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:795cb02b84df57a05d1e623e055dadf17b3c2892",
+        "checksum": "adler32:0892c353",
         "size": 4115311,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/e9a45574e7745bd0b40883f583f64515.configFile.py"
       }
@@ -2162,7 +2162,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:795cb02b84df57a05d1e623e055dadf17b3c2892",
+        "checksum": "adler32:0892c353",
         "size": 4115311,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d3c47a7be87c7505f6e08aa447d7d116.configFile.py"
       }
@@ -2214,7 +2214,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:71fd9b93df93e30d2cadc9def78e91a12fdd1ff9",
+        "checksum": "adler32:1ad181ff",
         "size": 6723,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/426fb7c8dfa9efe58cac3521728d4943.configFile.py"
       }
@@ -2266,7 +2266,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:de0706caa8c3d99fb1e52cd5b0c452f13868c145",
+        "checksum": "adler32:e102e058",
         "size": 3578,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/63bd4a7936ef520bcba9b3ec12d915e0.configFile.py"
       }
@@ -2318,7 +2318,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fc3acb7c291d5abcea9e24ef0c57ea46a15cd7fe",
+        "checksum": "adler32:39cbefb8",
         "size": 4340,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8119c367dee83f4172eac646b0cae31b.configFile.py"
       }
@@ -2370,7 +2370,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:75097eb28d65d9d681951bd56b3a56fc8ac1fc23",
+        "checksum": "adler32:4111fb72",
         "size": 7163,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/5970a6fbd16ef9292bc7b024546d32d1.configFile.py"
       }
@@ -2422,7 +2422,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7fd23343d57da136f22532a27e59fe2777ec37dd",
+        "checksum": "adler32:04f1020c",
         "size": 2552533,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/e9a45574e7745bd0b40883f583f63ce7.configFile.py"
       }
@@ -2474,7 +2474,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f04acbf1bb61a5fa297ecba70518bdaf9ee26240",
+        "checksum": "adler32:b2f005d3",
         "size": 7110,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b46933860a057882bf17fc7c87f217e1.configFile.py"
       }
@@ -2526,7 +2526,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f6c9122d882db5983c51e99d2b3298ace0290e9a",
+        "checksum": "adler32:8cf94d9f",
         "size": 3893,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0a59ee88a578153c9e4180dc37beff6b.configFile.py"
       }
@@ -2578,7 +2578,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0b7338ba46359202d9f23ee61bffe24d1f4897c2",
+        "checksum": "adler32:4bb397d7",
         "size": 382893,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f28b11acba79d1afdee8e50fa99d5253.configFile.py"
       }
@@ -2630,7 +2630,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:570db487a7e37f79a16444a2d7052c023ce581ad",
+        "checksum": "adler32:78e81139",
         "size": 578697,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/68bc98ede8b255529ddfb5a59dfdd761.configFile.py"
       }
@@ -2682,7 +2682,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0636cdbd2a4a9c95c3d25ebb033bd8e42f9a4894",
+        "checksum": "adler32:96fb483b",
         "size": 3873,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/76b67a85cce50002d1f4cece160099d5.configFile.py"
       }
@@ -2734,7 +2734,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fbd1b5efb5e0d8660514708db3dd59d2cc7f1c67",
+        "checksum": "adler32:ccf02d31",
         "size": 5471,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/476ed66a3dbb1efee54679522acfbbb2.configFile.py"
       }
@@ -2786,7 +2786,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5227ecb0be5d3bb3c325501f85f807e4db12b1c5",
+        "checksum": "adler32:aef9a21e",
         "size": 6863,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/38a55ca555837edbc1cefe73e21f44e7.configFile.py"
       }
@@ -2838,7 +2838,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1fbef1c8cc58c69050db4c46f747a9cbf85e4d34",
+        "checksum": "adler32:0cd2eb03",
         "size": 4115095,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/536c958a6a6194302477cf2e8eb809d4.configFile.py"
       }
@@ -2890,7 +2890,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4e258c32382688ae2e7c829be8ee9abc21193200",
+        "checksum": "adler32:4b1e5c42",
         "size": 3936,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2b5a11c191137d26587bf465a25298df.configFile.py"
       }
@@ -2942,7 +2942,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:213d91d9d21c1d7108b45a8753cdf55eea7c8320",
+        "checksum": "adler32:b29dc1b9",
         "size": 6183,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/64b5791933f6728b5da9a18618023f81.configFile.py"
       }
@@ -2994,7 +2994,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9d1c7b51ad4185c0091d9d656db5d49e64309909",
+        "checksum": "adler32:31864d6e",
         "size": 7642,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2ee2be9aece8ed5991b918d37b75a7b5.configFile.py"
       }
@@ -3046,7 +3046,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7fd23343d57da136f22532a27e59fe2777ec37dd",
+        "checksum": "adler32:04f1020c",
         "size": 2552533,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d3c47a7be87c7505f6e08aa447d7aeec.configFile.py"
       }
@@ -3098,7 +3098,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:03a406994695fc0671c8075c012693d0c1415177",
+        "checksum": "adler32:97a1483b",
         "size": 3873,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/89e035f1ab28a0c4877a43855d2fba8b.configFile.py"
       }
@@ -3150,7 +3150,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b5223717523cd009e70549324f29352143b0a128",
+        "checksum": "adler32:6c19f144",
         "size": 386655,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/456bd364d581640f6aaf924e8cecacae.configFile.py"
       }
@@ -3202,7 +3202,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e3914f8d3f45467dd02055382a7848ca8b928443",
+        "checksum": "adler32:a17cbeda",
         "size": 13562,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/76b67a85cce50002d1f4cece162052f3.configFile.py"
       }
@@ -3254,7 +3254,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bb8e8935cd7fdde65c30b21cfc42d9dce3f3ebaf",
+        "checksum": "adler32:ba630523",
         "size": 576645,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b0a9b9b5c10ea2a462ecdb5666e72aba.configFile.py"
       }
@@ -3306,7 +3306,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4dcc7e35f9b332d314c8836cfc3a5fb51f22fb46",
+        "checksum": "adler32:7d4d4839",
         "size": 3873,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/89e035f1ab28a0c4877a43855d2fe99b.configFile.py"
       }
@@ -3358,7 +3358,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e9966c8bab3401414cbb03f59176b0bc779c47e7",
+        "checksum": "adler32:ed84aecf",
         "size": 4117170,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/af5c50965a75874b05b20990207a813f.configFile.py"
       }
@@ -3410,7 +3410,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:597dacae07d8b66e7fc03b434dbadbaacf72a58c",
+        "checksum": "adler32:cdb8bed2",
         "size": 13546,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/db0105697625bdea8cedb18cd3ffdaa1.configFile.py"
       }
@@ -3462,7 +3462,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6f25f7efcfb6124f959b634b3f768677ad2e00d8",
+        "checksum": "adler32:eb53094c",
         "size": 574951,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/26fdddf613007b2ae46390fe57c48985.configFile.py"
       }
@@ -3514,7 +3514,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:177a621afc6588403059b1d0d8377b4f905d73c5",
+        "checksum": "adler32:4a1c89c7",
         "size": 6752,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/320df834ed2a0446c7a2485723e840ff.configFile.py"
       }
@@ -3566,7 +3566,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7b4f0aad98d67769a3c5b6a4e6401e2ed58b593a",
+        "checksum": "adler32:dcf2d0d3",
         "size": 13612,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d4012f58.configFile.py"
       }
@@ -3618,7 +3618,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8f1ff42987aee352a7f98b50599752b334e3e0f2",
+        "checksum": "adler32:eeeb7255",
         "size": 578849,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/bbc8b4b8c9757ca67c6695d4cf5cc97f.configFile.py"
       }
@@ -3670,7 +3670,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5d829507508ff6cdcecb2402e523ccef62609ef5",
+        "checksum": "adler32:c300d99d",
         "size": 580565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cec87afc37373850854c6eeb5a05a6ec.configFile.py"
       }
@@ -3722,7 +3722,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7fd23343d57da136f22532a27e59fe2777ec37dd",
+        "checksum": "adler32:04f1020c",
         "size": 2552533,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/aa57a0041839d6b495260c3c07028780.configFile.py"
       }
@@ -3774,7 +3774,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5cb117b4ac49a7c092c9663565e75e584393a137",
+        "checksum": "adler32:5acd3629",
         "size": 1289242,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/5063daa4545fc6fb5581d1fbf47bd238.configFile.py"
       }
@@ -3826,7 +3826,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9361f061ecaebc7667330ffd176697f78a4aab01",
+        "checksum": "adler32:aabcdfb2",
         "size": 3575,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/44d78e47491ea65e30d0fb31c0663411.configFile.py"
       }
@@ -3878,7 +3878,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ab9ef2e51e3d28d575c33e5133fa2f950e880432",
+        "checksum": "adler32:537e9aaf",
         "size": 23285,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/5f4b0cd39df51764c7fdb4d539b792fc.configFile.py"
       }
@@ -3930,7 +3930,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6fc0fe37956331f6d7fde7c2dc15e1250988da31",
+        "checksum": "adler32:16065efc",
         "size": 7918,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/a97a2f6c22dfba999c0131657a81ecfd.configFile.py"
       }
@@ -3982,7 +3982,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:88c0e2672f9a1bb49da9f924ef7a41733d477b71",
+        "checksum": "adler32:2821c3a2",
         "size": 578252,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7a7fe226d63c57f01b9283607fae7215.configFile.py"
       }
@@ -4034,7 +4034,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fcd42fa7d9c835839577b26db2f8e9ed02f66599",
+        "checksum": "adler32:8f46095c",
         "size": 574951,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/26fdddf613007b2ae46390fe57c51d48.configFile.py"
       }
@@ -4086,7 +4086,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a656a38615542bf2d3687e6f5fc323829ea39c31",
+        "checksum": "adler32:c5d4812c",
         "size": 6723,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8119c367dee83f4172eac646b0cb249c.configFile.py"
       }
@@ -4138,7 +4138,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bb79cdb757ec740cbc6827f5cf2470656630ab07",
+        "checksum": "adler32:132efdb0",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/13781a5a5bbb4736e868a764676b0dd9.configFile.py"
       }
@@ -4190,7 +4190,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c063f5a1a336b8f161f88cea71d4ca7eec5a21c5",
+        "checksum": "adler32:93550577",
         "size": 7200,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/fd559aa178861e2e34ae2dc367593c00.configFile.py"
       }
@@ -4242,7 +4242,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:94299e8197f9216ea9207954c1fc86fcfa66e00b",
+        "checksum": "adler32:9cd28bce",
         "size": 6843,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7117df1fb73675a926c10ed36c4b5688.configFile.py"
       }
@@ -4294,7 +4294,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b799720e11a8d73d381e67128901fd9adff70156",
+        "checksum": "adler32:bc64e055",
         "size": 3578,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0fa8dfb75c35107952fe8ff6e5c44553.configFile.py"
       }
@@ -4346,7 +4346,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b61b3b97faf5ee5540549593c13789c84495dcf1",
+        "checksum": "adler32:11b55c53",
         "size": 3936,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/5063daa4545fc6fb5581d1fbf4c8b6e1.configFile.py"
       }
@@ -4398,7 +4398,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b05dc81d8f1baea40e786fd5f72e41a2aa9abf65",
+        "checksum": "adler32:5a85e8d7",
         "size": 513913,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f487f1bc88531560fb99dea29f9bdb83.configFile.py"
       }
@@ -4450,7 +4450,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a54363722ead51c28b0156c475f00e115deef2c0",
+        "checksum": "adler32:b282e1bc",
         "size": 2552437,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0ca987d3618599fa991a065351fb4b35.configFile.py"
       }
@@ -4502,7 +4502,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fe6a74d2ccecc0ee1eaf47ca8865c99e28e92072",
+        "checksum": "adler32:ae987788",
         "size": 6693,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/47e7c86552e77dd5909308babf5edb8f.configFile.py"
       }
@@ -4554,7 +4554,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:32de935ea720da4d62f7a685ee3b21cba36b4fe9",
+        "checksum": "adler32:4a1bb623",
         "size": 4170,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/13781a5a5bbb4736e868a76467505c48.configFile.py"
       }
@@ -4606,7 +4606,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f71ee8b0759a2ff4947a66bb2adb483aef3a0086",
+        "checksum": "adler32:42bc923c",
         "size": 477646,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f071ce0e7144a1a36d59c6a7cb2fdd38.configFile.py"
       }
@@ -4658,7 +4658,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:936f7e393b40ba4973fbe3c96b10ba727d5fc4b8",
+        "checksum": "adler32:36b3e04a",
         "size": 3578,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/5853800b1046f0849f5881db5d4ae31d.configFile.py"
       }
@@ -4710,7 +4710,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:363dd176d7807091cb1b6e2d16f583ccbf0fb523",
+        "checksum": "adler32:56155c45",
         "size": 3936,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2fcba5bfd9640a78b177615db5111c01.configFile.py"
       }
@@ -4762,7 +4762,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d80b3abd395ae6537414d638d1e882fc954c6b9a",
+        "checksum": "adler32:c69d4deb",
         "size": 7831,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ab011660516de04655483c9cdbc31d55.configFile.py"
       }
@@ -4814,7 +4814,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ce2cb03343ab9e1aa84bfd311a010fe12c5a870e",
+        "checksum": "adler32:4bff33ae",
         "size": 3840,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/47044d6dd3e2cfdf991bce885e295105.configFile.py"
       }
@@ -4866,7 +4866,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:25d7b6b1ca63ca2bc15a3a58bcb7dca71b7a1c80",
+        "checksum": "adler32:6031db8e",
         "size": 580570,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cec87afc37373850854c6eeb5a0588de.configFile.py"
       }
@@ -4918,7 +4918,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8236e27a2b97665d35ff7931db4dbab70fdf8eac",
+        "checksum": "adler32:f2c45882",
         "size": 7669,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d65fdd337ebdbb1418a6c9054f7de334.configFile.py"
       }
@@ -4970,7 +4970,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a5654b021f287665905abca5fb0c1a579ef347c0",
+        "checksum": "adler32:90c4dff1",
         "size": 7029,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0371e5696db9bf58a7162bb96e8ebb76.configFile.py"
       }
@@ -5022,7 +5022,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0274c26f22a70d736c989f806a327c3669a60db5",
+        "checksum": "adler32:dd0e5ed4",
         "size": 5800,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d7c7e40a2583db7d5ecc08b5c9c2e71e.configFile.py"
       }
@@ -5074,7 +5074,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c97c1f0a1420834b6dac8cd1ce58fedfb319bf54",
+        "checksum": "adler32:e0f4e058",
         "size": 3578,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d2caac9a171373ceb6d7fea03a0664f3.configFile.py"
       }
@@ -5126,7 +5126,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1297448f07f915356310d443848b4a3419df14d1",
+        "checksum": "adler32:c8e7f578",
         "size": 444830,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8496a2ee52184a4ac590c87773b15218.configFile.py"
       }
@@ -5178,7 +5178,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:98e63989b719d46e47a9a014533fe47a5eecca20",
+        "checksum": "adler32:56630663",
         "size": 510000,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4476f4abc138fcd5893171c122347692.configFile.py"
       }
@@ -5230,7 +5230,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a13fc628e643baada62889794f720c1183faa561",
+        "checksum": "adler32:659f4ff7",
         "size": 7441,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0e46467874ef0e605ca0243ed42c5ef0.configFile.py"
       }
@@ -5282,7 +5282,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:98e63989b719d46e47a9a014533fe47a5eecca20",
+        "checksum": "adler32:56630663",
         "size": 510000,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/392b7a9e9a323ab1a5f9f40cb88ea4c5.configFile.py"
       }
@@ -5334,7 +5334,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5cee4d9a2d8ac080544301796d073f0cea81a31d",
+        "checksum": "adler32:d4dfe057",
         "size": 3578,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ca1aba93f117fe6b377020ef8c516857.configFile.py"
       }
@@ -5386,7 +5386,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6e825c3ca67ed6214c7403fab1a1b440cb11e763",
+        "checksum": "adler32:1e160bec",
         "size": 300671,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/040c0f24ce975888e625ff737c6f8f04.configFile.py"
       }
@@ -5438,7 +5438,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2f8bf27060956f9dc3532bbf413e258c946d0d7a",
+        "checksum": "adler32:7de10671",
         "size": 510000,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2d531935ea5bdbbab8a136c6fb2ad19a.configFile.py"
       }
@@ -5490,7 +5490,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a4152f133b1f41d0f989691b603c834e2c87ae01",
+        "checksum": "adler32:4f90dd6e",
         "size": 474564,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/546f8a96e2dfb72d4858f8a763e78c23.configFile.py"
       }
@@ -5542,7 +5542,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a39a362943c80ce841073e1b1b235bc42f0197ab",
+        "checksum": "adler32:686f068c",
         "size": 510001,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8a4510df07202188f24d952fc640ba19.configFile.py"
       }
@@ -5594,7 +5594,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:530f360f49acc8ad4391bdc6712877d4460f9fd4",
+        "checksum": "adler32:a3bf5cd5",
         "size": 3939,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/5853800b1046f0849f5881db5d4e0370.configFile.py"
       }
@@ -5646,7 +5646,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a8e7a393b9af70cd82e52935350d1d9c05ad822f",
+        "checksum": "adler32:4251d107",
         "size": 13613,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d4008445.configFile.py"
       }
@@ -5698,7 +5698,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1e0ced7918dc10d0f62c7d4cbe1d9f1b4d7ec351",
+        "checksum": "adler32:c580c453",
         "size": 7981,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d8903f8e7b5a3e285332467c595a6a09.configFile.py"
       }
@@ -5750,7 +5750,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:98e63989b719d46e47a9a014533fe47a5eecca20",
+        "checksum": "adler32:56630663",
         "size": 510000,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4476f4abc138fcd5893171c1222bd91f.configFile.py"
       }
@@ -5802,7 +5802,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:71d0410ffd51aef4622fb37e14638d1bdf1396fa",
+        "checksum": "adler32:d440f8d7",
         "size": 574884,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/26fdddf613007b2ae46390fe57c44789.configFile.py"
       }
@@ -5854,7 +5854,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cd8dfff674920655d90a23973841e9b36f474e70",
+        "checksum": "adler32:08255c3d",
         "size": 3936,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ea6cef0f993c66b77ddec45c81e5249b.configFile.py"
       }
@@ -5906,7 +5906,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fa0f8cbc14a15a3a7dc7582aa7c5e4b427e8d250",
+        "checksum": "adler32:1dd80161",
         "size": 6351,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/946cfeb9b320e5e675f724fdadf15899.configFile.py"
       }
@@ -5958,7 +5958,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:41bade921bc1583ad1ec7fea3ee937ad193dec84",
+        "checksum": "adler32:f33b53fb",
         "size": 4811,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/309f3e26aeb5d8fe86e7f46a5e4c48cd.configFile.py"
       }
@@ -6010,7 +6010,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:29420fc17652a7f39c37890855954c293b0d167b",
+        "checksum": "adler32:081b5c3d",
         "size": 3936,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/44d78e47491ea65e30d0fb31c093a849.configFile.py"
       }
@@ -6062,7 +6062,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:74083faff2547323e983cbaffde1ebb2e8deba29",
+        "checksum": "adler32:cec95eab",
         "size": 31494,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/da3e9a2c05ada265549f8f2880ae6fd0.configFile.py"
       }
@@ -6114,7 +6114,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c254be09bbf72d71bcb00af83a8a11c61210aae3",
+        "checksum": "adler32:b7158822",
         "size": 5932,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f1aec7a9455c3b903a473b02eea8f9b2.configFile.py"
       }
@@ -6166,7 +6166,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1c4b89290c1a070a06d5bbcbb4a375ef1329ef64",
+        "checksum": "adler32:f6297f59",
         "size": 575635,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/28991b96748afc67ee2e050bc1d3f770.configFile.py"
       }
@@ -6218,7 +6218,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8fbf34860b0dfec26fe90e43b780dcfef5fa56ed",
+        "checksum": "adler32:63f347f7",
         "size": 3870,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8f91659c553a1dded963a264033efb92.configFile.py"
       }
@@ -6270,7 +6270,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5d819dca587841bea5bf189e071288cbbbc1f8f9",
+        "checksum": "adler32:baf5f6ef",
         "size": 7149,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/9d54194e5d356ff42199d258d5ecc73e.configFile.py"
       }
@@ -6322,7 +6322,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:796c8ebc4785c71353ec460dc7c7165bb95511a6",
+        "checksum": "adler32:d0b09dae",
         "size": 476040,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/546f8a96e2dfb72d4858f8a763e29c2d.configFile.py"
       }
@@ -6374,7 +6374,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:faecb742fcc3cf3dc7dbe8e6c95749801349faec",
+        "checksum": "adler32:55a8fce5",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d810ef070d56d47ec4814640bf8aba33.configFile.py"
       }
@@ -6426,7 +6426,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d4bdae012dd783959a02b7a164c95da57f1ffb10",
+        "checksum": "adler32:ce89001c",
         "size": 382608,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/a55b167926fb3c72d081ffe8b09b1570.configFile.py"
       }
@@ -6478,7 +6478,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:734e7dbaa13225e5fa06b109746ec70ddc700cd6",
+        "checksum": "adler32:0672097a",
         "size": 574952,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/26fdddf613007b2ae46390fe57c52c92.configFile.py"
       }
@@ -6530,7 +6530,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:768a3418fd00516c9a50c8ae645b9e9991d8354a",
+        "checksum": "adler32:8421e75f",
         "size": 6094,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/320df834ed2a0446c7a2485723ea3870.configFile.py"
       }
@@ -6582,7 +6582,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:735a858fb89aa09efb68b09dcf5be658aeacc39f",
+        "checksum": "adler32:94dad026",
         "size": 13609,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d4018ab1.configFile.py"
       }
@@ -6634,7 +6634,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2f47d14f8053dcb0ef2b8b73608c22058571c3e0",
+        "checksum": "adler32:5f8f5ce3",
         "size": 3939,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/63bd4a7936ef520bcba9b3ec12da0d06.configFile.py"
       }
@@ -6686,7 +6686,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:052f1cda0ddc3e54a9ece0665b4e368b6d606d0b",
+        "checksum": "adler32:fb76f000",
         "size": 4340,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8119c367dee83f4172eac646b0cd01ab.configFile.py"
       }
@@ -6738,7 +6738,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b05dc81d8f1baea40e786fd5f72e41a2aa9abf65",
+        "checksum": "adler32:5a85e8d7",
         "size": 513913,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b31348c308254b46589d683f53afcbdf.configFile.py"
       }
@@ -6790,7 +6790,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a5239ec54c947536d636626e8588fd2ff99de6a3",
+        "checksum": "adler32:99085c4a",
         "size": 3936,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b67f9d426c363da68eb1d680b3272adf.configFile.py"
       }
@@ -6842,7 +6842,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:efc7caeb2a79e3440d7a26806075b052239cddef",
+        "checksum": "adler32:a29d0afb",
         "size": 4443,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d3783a5330cef148bf0c5d82f09f699a.configFile.py"
       }
@@ -6894,7 +6894,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:881124701146a7df0e30754b7b7a7c5a6bebc9e2",
+        "checksum": "adler32:2f78115f",
         "size": 5388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/6917aa2e79caf45db3687b097ec69367.configFile.py"
       }
@@ -6946,7 +6946,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a39a362943c80ce841073e1b1b235bc42f0197ab",
+        "checksum": "adler32:686f068c",
         "size": 510001,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8a4510df07202188f24d952fc63eefae.configFile.py"
       }
@@ -6998,7 +6998,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:615a4ccd7db4ed16e31c5012f6842fe93998788a",
+        "checksum": "adler32:51e59cdf",
         "size": 388522,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c7174caf27a8905a303774dbf574bd94.configFile.py"
       }
@@ -7050,7 +7050,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:10608ec3848a1849253e5d9ecda3d8c365d0783a",
+        "checksum": "adler32:83661d97",
         "size": 35425,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/474c963e5502a2add5b69e5adcc04e53.configFile.py"
       }
@@ -7102,7 +7102,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c7507494c26916dd007874237031e25440527670",
+        "checksum": "adler32:6c4d4931",
         "size": 578577,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/240850ae487c32cc361680d59df1ad20.configFile.py"
       }
@@ -7154,7 +7154,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bbd0e4a95f7cc92f5c5f2a12c79337e511a2cd45",
+        "checksum": "adler32:8becd177",
         "size": 13615,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d40056d7.configFile.py"
       }
@@ -7206,7 +7206,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f6371bf7885b76cf5d2d3671141679eed37e1b4d",
+        "checksum": "adler32:82bb5f93",
         "size": 3930,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/546f8a96e2dfb72d4858f8a763e32436.configFile.py"
       }
@@ -7258,7 +7258,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eb4963d76f3ded7db78c12e5b9ac13c06d0182db",
+        "checksum": "adler32:db915f99",
         "size": 3930,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/a55b167926fb3c72d081ffe8b0a1ee7f.configFile.py"
       }
@@ -7310,7 +7310,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d6fc68028f158842a3402e34d7e8c71ceb8a53fa",
+        "checksum": "adler32:327b7bc7",
         "size": 579072,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b764adc8ec45bf8913ce4ec957217b5d.configFile.py"
       }
@@ -7362,7 +7362,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9c486bb56fa156bc8744bdacea730bfa96729da5",
+        "checksum": "adler32:856cdf60",
         "size": 7335,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/fca27096ac10e9418d7588ae4cd2470a.configFile.py"
       }
@@ -7414,7 +7414,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d949ca64e5ad1534083d816924c94f0eec47240f",
+        "checksum": "adler32:defcc499",
         "size": 10671,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/bd3f7129862b8627ae313cff5e003451.configFile.py"
       }
@@ -7466,7 +7466,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9751405c13f13cb3c37b4f10a45810ae04ef2238",
+        "checksum": "adler32:54765048",
         "size": 484896,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/546f8a96e2dfb72d4858f8a763e585c0.configFile.py"
       }
@@ -7518,7 +7518,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4f4fcb858f300865b0235e308cfd4968df2d96c5",
+        "checksum": "adler32:94a6da9c",
         "size": 580568,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cec87afc37373850854c6eeb5a057a99.configFile.py"
       }
@@ -7570,7 +7570,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fe7977a47f84057a6246ff35c263372452f127f1",
+        "checksum": "adler32:57ac881d",
         "size": 5932,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f1aec7a9455c3b903a473b02eeab0b16.configFile.py"
       }
@@ -7622,7 +7622,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e92d120426e37c2540fdc298a43369063ebcb1f3",
+        "checksum": "adler32:5f815ce3",
         "size": 3939,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d2caac9a171373ceb6d7fea03a069322.configFile.py"
       }
@@ -7674,7 +7674,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b4d11aa02761f64ed4c111573abe0c452e1468b8",
+        "checksum": "adler32:51529f60",
         "size": 8214,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0b96e1e102bfd138d3d0f657dc92afde.configFile.py"
       }
@@ -7726,7 +7726,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b852431f22ba315f2437998128b2b66587787211",
+        "checksum": "adler32:b6297ae6",
         "size": 8116,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/64b5791933f6728b5da9a186180154be.configFile.py"
       }
@@ -7778,7 +7778,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:73e13dd3ada63fe5c1025b4a67da80a801be89e1",
+        "checksum": "adler32:aac6aa34",
         "size": 19237,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/3096b1b45454d7d563e5c870da9c918e.configFile.py"
       }
@@ -7830,7 +7830,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4f6166f0cc32860e5854a66767a4b40575d3b570",
+        "checksum": "adler32:c2a4efb6",
         "size": 576064,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cf4f2d0d0f3bc97530e34764ca4b3883.configFile.py"
       }
@@ -7882,7 +7882,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4223f50686c287c13dea1f772150af58b2bd9f75",
+        "checksum": "adler32:ad49fd16",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f8abe7968868767ce2912717166ac226.configFile.py"
       }
@@ -7934,7 +7934,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c291a41b5ee373baab03bebe8f9aab10bc5b12f8",
+        "checksum": "adler32:48b27ad7",
         "size": 513507,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/55e014650bd2a7ae5deb891f3aaa1b63.configFile.py"
       }
@@ -7986,7 +7986,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:648d7d01ae69eea9d2b10787e3b19e4803da5207",
+        "checksum": "adler32:ab0d4877",
         "size": 3873,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f83bc23f20bdf9090c24e193b7f5b3c6.configFile.py"
       }
@@ -8038,7 +8038,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dccde2122991bc592d50f56bd0d459c61642c72e",
+        "checksum": "adler32:99a108b3",
         "size": 118273,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/16f37748c2526047dfeb738193a2bbbd.configFile.py"
       }
@@ -8090,7 +8090,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6ec72a1d1713927811a1027055c80a7b095843c3",
+        "checksum": "adler32:ffcebcab",
         "size": 8946,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4ab3250d23e554446ebc010f2394ef5f.configFile.py"
       }
@@ -8142,7 +8142,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:099cb183c49cf28442731ad7cbdb0f2940817632",
+        "checksum": "adler32:3a772fc1",
         "size": 377669,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/646d2083db45042b8cf395bbc896ae84.configFile.py"
       }
@@ -8194,7 +8194,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e352711c140e5d81be0f345000d2959d83d0bc8f",
+        "checksum": "adler32:ab4dd418",
         "size": 13620,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/db0105697625bdea8cedb18cd3ff3d0c.configFile.py"
       }
@@ -8246,7 +8246,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2f8bf27060956f9dc3532bbf413e258c946d0d7a",
+        "checksum": "adler32:7de10671",
         "size": 510000,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/1847f5756a92904b22ee1933f2ef0212.configFile.py"
       }
@@ -8298,7 +8298,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f71f86b2e484e5b90d472b2cf99177dbf5b03e95",
+        "checksum": "adler32:21a98bc9",
         "size": 6843,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/99c154f3323c3367abc654ed3ce106f1.configFile.py"
       }
@@ -8350,7 +8350,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c291a41b5ee373baab03bebe8f9aab10bc5b12f8",
+        "checksum": "adler32:48b27ad7",
         "size": 513507,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/48fd5522d9cefaff189bc7e5f45d50d9.configFile.py"
       }
@@ -8402,7 +8402,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:223753d879a10c77dc60f5b823fa3655529f58b8",
+        "checksum": "adler32:f711049e",
         "size": 7198,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b8bdbfb779cf32668c3c9b17e71067ff.configFile.py"
       }
@@ -8454,7 +8454,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:78bb3fe5f63a621540fd70d10fb95183e4a96efe",
+        "checksum": "adler32:cd95c401",
         "size": 6888,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/331f67c8c835bc29be9f6bc7eaa3bbcd.configFile.py"
       }
@@ -8506,7 +8506,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:91aa4260f066d6260932d8ae2a0347c6f6e9964d",
+        "checksum": "adler32:ff6abd63",
         "size": 6936,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f8abe7968868767ce2912717166a8ecf.configFile.py"
       }
@@ -8558,7 +8558,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cf888d010f50eb31da0c21029453a7906e612f69",
+        "checksum": "adler32:4249e249",
         "size": 7349,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/9d54194e5d356ff42199d258d5eac969.configFile.py"
       }
@@ -8610,7 +8610,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:94a8579f0c8fabd597e21790e96bdd2b25935d51",
+        "checksum": "adler32:4ee43e67",
         "size": 20621,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2fcba5bfd9640a78b177615db57e9c43.configFile.py"
       }
@@ -8662,7 +8662,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b2969dc08776af174c5b310c641b3fab0da2a249",
+        "checksum": "adler32:4df63eaa",
         "size": 5528,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/476ed66a3dbb1efee54679522acec49a.configFile.py"
       }
@@ -8714,7 +8714,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:126e6d93dce0c064890baff34a8a39714dbb6dd0",
+        "checksum": "adler32:8ccc62c9",
         "size": 692228,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/9f556d1eb7432ad365825ca05cab30e4.configFile.py"
       }
@@ -8766,7 +8766,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e4a8a0d13a1af79f97ed846c0336b52c5cfb2789",
+        "checksum": "adler32:0eed6518",
         "size": 577994,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ec289fabc2b840a4d120a0fc580145e7.configFile.py"
       }
@@ -8818,7 +8818,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:11c94543576860d6fdc82d200ae46fa7160612d0",
+        "checksum": "adler32:b8cc8f6f",
         "size": 6765,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7b09170ba4f82d70c8ecd2b2f6f05b0d.configFile.py"
       }
@@ -8870,7 +8870,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5d154d1e0d202c13f356eb346ae5038746f0934c",
+        "checksum": "adler32:4967f2d3",
         "size": 8345,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2c492950f4ccb7e3c32e3277b126f3b2.configFile.py"
       }
@@ -8922,7 +8922,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cda5b71ef10159dfd99521bc630cc07d8ba2d4a9",
+        "checksum": "adler32:ceb54f35",
         "size": 6531,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4e0bcaa0704451048659be67b18d33b6.configFile.py"
       }
@@ -8974,7 +8974,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7a70bbcc6547920c5e1c4ab8247fb67302b78743",
+        "checksum": "adler32:d215f311",
         "size": 5322,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c5be5f65754ad5ed58ab89beb1f54cc8.configFile.py"
       }
@@ -9026,7 +9026,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:493d1ca8fa789d672c6069c49b4ca9922686c17c",
+        "checksum": "adler32:e6d9d394",
         "size": 13617,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/db0105697625bdea8cedb18cd3ff7611.configFile.py"
       }
@@ -9078,7 +9078,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bca4a4db541f4e80e248d594e06296855accdf4d",
+        "checksum": "adler32:3ddf5b7e",
         "size": 7981,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ab011660516de04655483c9cdbd579db.configFile.py"
       }
@@ -9130,7 +9130,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e1e71cfa237051c117c999fc6f0f78a819023bd7",
+        "checksum": "adler32:44f4011c",
         "size": 6350,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/717fe61569cf80753ee9308cb1eb7383.configFile.py"
       }
@@ -9182,7 +9182,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2f3b20a16b4d91d861e2597f466a958b64992877",
+        "checksum": "adler32:f5a84d92",
         "size": 3893,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/50f44161c67d6d2fa349dea4f115a212.configFile.py"
       }
@@ -9234,7 +9234,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9600594420467b86126672b46a862d86de8d9400",
+        "checksum": "adler32:6648336b",
         "size": 4518,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/476ed66a3dbb1efee54679522acf9bad.configFile.py"
       }
@@ -9286,7 +9286,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cae1fff5faad1b7e1307fb8d1ede6cdf5779e259",
+        "checksum": "adler32:ba90968a",
         "size": 512744,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f4b3da317b12375f344f06bf28b77f72.configFile.py"
       }
@@ -9338,7 +9338,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f26e22e44ed4ccd75fc41d8d31e8b9d6fd581b8d",
+        "checksum": "adler32:e15507e4",
         "size": 100038,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/5063daa4545fc6fb5581d1fbf4c89f58.configFile.py"
       }
@@ -9390,7 +9390,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4c8e6b98b0596b1888355e9a085f5236aad79832",
+        "checksum": "adler32:5c6b7aba",
         "size": 5762,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ea307f92467620d7382d109fe78ed368.configFile.py"
       }
@@ -9442,7 +9442,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e9966c8bab3401414cbb03f59176b0bc779c47e7",
+        "checksum": "adler32:ed84aecf",
         "size": 4117170,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0ca987d3618599fa991a065351fe5192.configFile.py"
       }
@@ -9494,7 +9494,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:efc14fae57b5a4de70e1a65b465f4be326fc48d0",
+        "checksum": "adler32:4e6447d8",
         "size": 4749,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0d0714743f0204ed3c0144941edfcd23.configFile.py"
       }
@@ -9546,7 +9546,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:349def31d7cfbdeba164be09272043f48dd41e6d",
+        "checksum": "adler32:64ef85ac",
         "size": 8561,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2ee2be9aece8ed5991b918d37b78cda6.configFile.py"
       }
@@ -9598,7 +9598,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e4b6e6bdf188944edec9632f40c0d33e3539f497",
+        "checksum": "adler32:3b7a09da",
         "size": 574954,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/26fdddf613007b2ae46390fe57c4552b.configFile.py"
       }
@@ -9650,7 +9650,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:334669407b491a13ec73e1d1d8a3eb4ed92464f3",
+        "checksum": "adler32:6db59651",
         "size": 512744,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f4b3da317b12375f344f06bf28b79c50.configFile.py"
       }
@@ -9702,7 +9702,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e8b422f1e18e722c809bd490f75442332d2da508",
+        "checksum": "adler32:9a371ba2",
         "size": 17602,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/6c58336df652e548738f3a5f36576c50.configFile.py"
       }
@@ -9754,7 +9754,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5ad4db1f9e665360be0f36bce1a4a87578f59f3d",
+        "checksum": "adler32:611fd025",
         "size": 13609,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d401601b.configFile.py"
       }
@@ -9806,7 +9806,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:53debadba5b6f9a37f6e2104e2f77726ade9c802",
+        "checksum": "adler32:351f4c38",
         "size": 7636,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/3dee573dad60eed2500ca1e6db5138ec.configFile.py"
       }
@@ -9858,7 +9858,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c2f4407eeeed8779b49f05881345f4f721798aae",
+        "checksum": "adler32:90874c4d",
         "size": 7825,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ab011660516de04655483c9cdbc32939.configFile.py"
       }
@@ -9910,7 +9910,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1ddf66db712ee246cdbb29ca41080fbe5e381649",
+        "checksum": "adler32:e5ce951a",
         "size": 6783,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0d0714743f0204ed3c0144941eb56b4a.configFile.py"
       }
@@ -9962,7 +9962,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c7400e547c33f99e57153f0d59cb17cc22b4e74e",
+        "checksum": "adler32:40f394d0",
         "size": 512739,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f4b3da317b12375f344f06bf28b7ab9d.configFile.py"
       }
@@ -10014,7 +10014,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8ce2ecbdad9d7021fab4faae0df10c8839b0fde7",
+        "checksum": "adler32:b157483d",
         "size": 3873,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f071ce0e7144a1a36d59c6a7cb3053fb.configFile.py"
       }
@@ -10066,7 +10066,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:01b2c750ac2e584b95ef3a1f378006e831249c17",
+        "checksum": "adler32:1e3b5f62",
         "size": 385793,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/546f8a96e2dfb72d4858f8a763da939c.configFile.py"
       }
@@ -10118,7 +10118,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:141c1f244ff190d49834c681a43238ad22676c35",
+        "checksum": "adler32:2ba05f53",
         "size": 438758,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2c19fb19cabea903b695d2f8964e91f2.configFile.py"
       }
@@ -10170,7 +10170,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0cbe6a222451b55a9dbe1214f2ecb67fc80449ac",
+        "checksum": "adler32:2f6c523b",
         "size": 6668,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/1ac6d193605fc02b9ef72f9a139e9ac0.configFile.py"
       }
@@ -10222,7 +10222,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4002f50d6a3cd79937da20e478b58c6a137e80c6",
+        "checksum": "adler32:bca334fd",
         "size": 1130776,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/240850ae487c32cc361680d59d477704.configFile.py"
       }
@@ -10274,7 +10274,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:49a44e327fed4147c78ef760c5fae43cda54a362",
+        "checksum": "adler32:955bf3af",
         "size": 378335,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ca17536e80c4ae2f0b036c9c62e77faa.configFile.py"
       }
@@ -10326,7 +10326,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eac0d5565c6cb8366dce0742711a125bea00ae68",
+        "checksum": "adler32:c2cad481",
         "size": 579584,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b8194440c3a1867cea3313a723ffdce5.configFile.py"
       }
@@ -10378,7 +10378,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a09679c2ff72f000ddb2e5dd7f2b52c072648123",
+        "checksum": "adler32:83135035",
         "size": 46390,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/131b82ef254ea71d1ea95c78e744ac00.configFile.py"
       }
@@ -10430,7 +10430,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:83bf51b8cbda88044fac3e316056683b5e95dd80",
+        "checksum": "adler32:cb717f58",
         "size": 443211,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8496a2ee52184a4ac590c87773b0f346.configFile.py"
       }
@@ -10482,7 +10482,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c31ba7d4e974cd92183523c342c12e1eae19f8a3",
+        "checksum": "adler32:9086efea",
         "size": 4340,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/af306a06723a063501eb27601bb5401f.configFile.py"
       }
@@ -10534,7 +10534,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:40669bd1851da9b524f332a3f97eac8a2785d66b",
+        "checksum": "adler32:d8584867",
         "size": 3873,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/670953a2632e648ac1ceada4ce34cf28.configFile.py"
       }
@@ -10586,7 +10586,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cdff7a371fd82b6b175f7fcb0a80d77013f9f17f",
+        "checksum": "adler32:168d8827",
         "size": 5932,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/adda25dea992e96fb7e8f4be89889c0b.configFile.py"
       }
@@ -10638,7 +10638,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e5371f5164fadad20c84b64df20d6d030d636a7d",
+        "checksum": "adler32:b329b816",
         "size": 6153,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/a8b87e4a93ad780670c2864baf162c61.configFile.py"
       }
@@ -10690,7 +10690,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:79089c540e9e4dea07fcb3bbf68cce6ac1259f6a",
+        "checksum": "adler32:99d35e44",
         "size": 31943,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ef642a99908dbdb47abb111c45cb1c17.configFile.py"
       }
@@ -10742,7 +10742,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f4ce9bbb77b1f1796ee5f44b574c82e4bb92146c",
+        "checksum": "adler32:4869d944",
         "size": 7020,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/604b1f2cb97826580dcee0388647af71.configFile.py"
       }
@@ -10794,7 +10794,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7db6a7ece6e9bbaf471dc0636af550ac01e81eae",
+        "checksum": "adler32:bcb4d5f4",
         "size": 7319,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b37f1b3570d9d1afb6ab490d0b558bf0.configFile.py"
       }
@@ -10846,7 +10846,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b4b7f8057e4e409197ef32e1d4dcd1cd0b881030",
+        "checksum": "adler32:8ce09509",
         "size": 512739,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f4b3da317b12375f344f06bf28b78dbd.configFile.py"
       }
@@ -10898,7 +10898,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9361f061ecaebc7667330ffd176697f78a4aab01",
+        "checksum": "adler32:aabcdfb2",
         "size": 3575,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/44d78e47491ea65e30d0fb31c092d018.configFile.py"
       }
@@ -10950,7 +10950,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:413250b0d5588ffcb37393765d020cc0180cd366",
+        "checksum": "adler32:1a527bae",
         "size": 579073,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/df06ea86f6f8e8b03d64449d07d2bbf8.configFile.py"
       }
@@ -11002,7 +11002,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2b23ec94117f5f08eeda9bbe9fc5ec4f87e8e3dc",
+        "checksum": "adler32:edc4008d",
         "size": 440909,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/afce20d0a4ebee0ab7bd45ac218cd3b0.configFile.py"
       }
@@ -11054,7 +11054,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c47248c5f8fc67ad0e34880c651d18db40fc9379",
+        "checksum": "adler32:037dc1eb",
         "size": 575448,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cec87afc37373850854c6eeb5a05e3f8.configFile.py"
       }
@@ -11106,7 +11106,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:188ac86a640f1dcdf172c9c67341ebad3f4c1472",
+        "checksum": "adler32:b667adf8",
         "size": 519203,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/901f56a4732e8ea5a60cd45e0fcc141a.configFile.py"
       }
@@ -11158,7 +11158,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5edb13d3d6d836a1805d16c9c5a61d41a810d487",
+        "checksum": "adler32:1f6b9e54",
         "size": 6867,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4c16eb9ba250e1d23d813c1db6a4175d.configFile.py"
       }
@@ -11210,7 +11210,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0dc1504ab098a690c2b16091670af7036a644f3b",
+        "checksum": "adler32:c216c99c",
         "size": 8766,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/59687d1d79393aecf64d6439b6bfa710.configFile.py"
       }
@@ -11262,7 +11262,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:da1a802e12c081976b5d2e0d780ad95eb1a6f359",
+        "checksum": "adler32:ffababb3",
         "size": 4130,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/e608c935a486dbc17d186f3f1ed657a0.configFile.py"
       }
@@ -11314,7 +11314,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:902f1542631840e88bf8f59e76bbe8baceb6e4d4",
+        "checksum": "adler32:32b22996",
         "size": 7378,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b354983335f663c9ca1bf9c81856e190.configFile.py"
       }
@@ -11366,7 +11366,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6ed395508934f46c5447362e252a167a1961b6db",
+        "checksum": "adler32:cf0452a5",
         "size": 6670,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/1ac6d193605fc02b9ef72f9a139a7fe2.configFile.py"
       }
@@ -11418,7 +11418,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ce5019d0ace1304c24419e4e8d74ca55825efcc7",
+        "checksum": "adler32:8ab97c60",
         "size": 6720,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8e6085cdbce6bc0ce24311750537fcba.configFile.py"
       }
@@ -11470,7 +11470,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bc7a174932c2a2c17a5709abaab949069bf4bb80",
+        "checksum": "adler32:515ed158",
         "size": 13615,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d4001c1a.configFile.py"
       }
@@ -11522,7 +11522,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b9bb5df0986c33ce3e5c00fda20e292d0e22bd1d",
+        "checksum": "adler32:8ed6cfe4",
         "size": 7277,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/deea5caa7ac69677bb7713109c42a1dc.configFile.py"
       }
@@ -11574,7 +11574,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a1edb42390480308a06d5b662463b09097ee5a8f",
+        "checksum": "adler32:8d90097b",
         "size": 7139,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/331f67c8c835bc29be9f6bc7eaab4a30.configFile.py"
       }
@@ -11626,7 +11626,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1297448f07f915356310d443848b4a3419df14d1",
+        "checksum": "adler32:c8e7f578",
         "size": 444830,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cd342343bfcfe5f9b2bae586f25f6eea.configFile.py"
       }
@@ -11678,7 +11678,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a5cf97a26bd1b6045bfaaf6850ef8051605d91f7",
+        "checksum": "adler32:fa32477b",
         "size": 3870,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/779f0c01780043cb5ed3e273593ecf30.configFile.py"
       }
@@ -11730,7 +11730,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:65b37436c4fffb93965502e3dc5378db5b77e262",
+        "checksum": "adler32:607d6578",
         "size": 5573,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/36e728b9528949ad9a643e314bfca1c6.configFile.py"
       }
@@ -11782,7 +11782,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d93dcdca5e80c39ec346b3e5a7b4c85c283857a1",
+        "checksum": "adler32:9b67769c",
         "size": 6594,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d8903f8e7b5a3e285332467c595a7889.configFile.py"
       }
@@ -11834,7 +11834,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:002cccf233417f9ae98110431413f7a4e26c04f6",
+        "checksum": "adler32:ef5fe379",
         "size": 388814,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/75afac677b36415e441fdebe47ddf6fb.configFile.py"
       }
@@ -11886,7 +11886,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:322f547da4bdafe0f6fb56a8741e513d6aa0cdac",
+        "checksum": "adler32:7ad74286",
         "size": 6001,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f8745e0ea7dfc03fdc35ca88c453ac07.configFile.py"
       }
@@ -11938,7 +11938,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:961e9e49e8213fd3a06f0ccb6638b900630f6c1c",
+        "checksum": "adler32:68315f91",
         "size": 3930,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/546f8a96e2dfb72d4858f8a763e85406.configFile.py"
       }
@@ -11990,7 +11990,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cafa11554f7d03ac544abf0fee6105ca03183176",
+        "checksum": "adler32:de3570b3",
         "size": 5742,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d810ef070d56d47ec4814640bf8a9652.configFile.py"
       }
@@ -12042,7 +12042,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2ee626a42018277693a6eb1e02c270105bc3fadc",
+        "checksum": "adler32:44009ef3",
         "size": 13653,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/df27c7e3d4d321a821d24b3505228625.configFile.py"
       }
@@ -12094,7 +12094,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ec810a84746c60b3b95ba6a305f6bd1993f50f6b",
+        "checksum": "adler32:11cf87b1",
         "size": 6741,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/d8903f8e7b5a3e285332467c595a3067.configFile.py"
       }
@@ -12146,7 +12146,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ab3af8f506359ce71789549cb9c3ec9c58ccde87",
+        "checksum": "adler32:37e1f943",
         "size": 411091,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f83bc23f20bdf9090c24e193b7f17112.configFile.py"
       }
@@ -12198,7 +12198,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:98e63989b719d46e47a9a014533fe47a5eecca20",
+        "checksum": "adler32:56630663",
         "size": 510000,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/461fa132265397451d419bb8fc7def3e.configFile.py"
       }
@@ -12250,7 +12250,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1c21fdcbc9ed5758f37b26bc5bf72a758c6c0290",
+        "checksum": "adler32:aac6dfb2",
         "size": 3575,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ea6cef0f993c66b77ddec45c81e1ae40.configFile.py"
       }
@@ -12302,7 +12302,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e6642ef02f08d34a51fed445f35b58d3fa3761e1",
+        "checksum": "adler32:9b6772a2",
         "size": 3979,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/13781a5a5bbb4736e868a76467a8a9f6.configFile.py"
       }
@@ -12354,7 +12354,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b4438d4f833b31b580693f7de1b37cc3ebbf9a73",
+        "checksum": "adler32:aa0782d1",
         "size": 6728,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7b09170ba4f82d70c8ecd2b2f6f06525.configFile.py"
       }
@@ -12406,7 +12406,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1880f4f87b06a4bb6e8690e43a7c2e2990624f2a",
+        "checksum": "adler32:faf9dec2",
         "size": 441834,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7afc415b5e06c9d7224775a35bfe9029.configFile.py"
       }
@@ -12458,7 +12458,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6f227e73c30aafdd03d69d6fdc426a4ff7043d5e",
+        "checksum": "adler32:f40b00d7",
         "size": 4462,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/05e7f803b55fe910471147e8498f3f2d.configFile.py"
       }
@@ -12510,7 +12510,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f1766610969a1fcccf98915b0f55533e919ea527",
+        "checksum": "adler32:bc412a2f",
         "size": 9206,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2fcba5bfd9640a78b177615db510fee7.configFile.py"
       }
@@ -12562,7 +12562,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a098a290cfd7527a076ca06b7806351a551fd226",
+        "checksum": "adler32:2c5d5c55",
         "size": 3936,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/6c58336df652e548738f3a5f36578315.configFile.py"
       }
@@ -12614,7 +12614,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f59b9b46e3da6bd963d3d4cdfd8d91cb49f3a7c7",
+        "checksum": "adler32:a9aa8573",
         "size": 6729,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2a5c442b819a23729e85645ec23f0799.configFile.py"
       }
@@ -12666,7 +12666,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7ae918cd538703a900a476bb9cbfe753517da87f",
+        "checksum": "adler32:36201877",
         "size": 59577,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2b5a11c191137d26587bf465a2526b6b.configFile.py"
       }
@@ -12718,7 +12718,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f4cce065525da81439726f2a45373c44ac9252cb",
+        "checksum": "adler32:522d5ce2",
         "size": 3939,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/ca1aba93f117fe6b377020ef8c53095d.configFile.py"
       }
@@ -12770,7 +12770,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c47615e4feaeacb8d013cf20f672df497b753e51",
+        "checksum": "adler32:026c631f",
         "size": 44751,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/9a1d64aafe0b81067d9ac04402ca825f.configFile.py"
       }
@@ -12822,7 +12822,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:799d5fba74826937bff04d5a54f7f32ec790389a",
+        "checksum": "adler32:e5663495",
         "size": 2566593,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/a1fa6affe6e78c84b0ab48d1be9b6849.configFile.py"
       }
@@ -12874,7 +12874,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:47083c7adbea4756f45e69e6ee52813ad7a9d612",
+        "checksum": "adler32:a960d771",
         "size": 580846,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/240850ae487c32cc361680d59def9cb1.configFile.py"
       }
@@ -12926,7 +12926,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6f6293b0d50043178b412d490a6d806c44e12b06",
+        "checksum": "adler32:3ee5e49d",
         "size": 512958,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/91fe8a2d7cd44a1fadbc1d407a80f092.configFile.py"
       }
@@ -12978,7 +12978,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:05704642022f1ce8e689e699ba142a84612fa160",
+        "checksum": "adler32:ec3b47db",
         "size": 3870,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c7174caf27a8905a303774dbf5757ef3.configFile.py"
       }
@@ -13030,7 +13030,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eda2667e372999d9deaf7b399d367d2711a541dc",
+        "checksum": "adler32:dd487ed6",
         "size": 4851,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/1ac6d193605fc02b9ef72f9a139d52e1.configFile.py"
       }
@@ -13082,7 +13082,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c9e0a347d6cd661fc4da24fb6a4d7d54a79436f4",
+        "checksum": "adler32:055233a4",
         "size": 3840,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/eaa1ca506797a63862c42776c7eef3ab.configFile.py"
       }
@@ -13134,7 +13134,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:65e6a34c47c73503c0494f8129925abce7ec0763",
+        "checksum": "adler32:1ab64845",
         "size": 3873,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/646d2083db45042b8cf395bbc898361c.configFile.py"
       }
@@ -13186,7 +13186,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:00d59178afe60e4950dcb71c6e416eacb3e82151",
+        "checksum": "adler32:a00e1934",
         "size": 7151,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/f7caa6060cdc830e4f4ebbbb66890f96.configFile.py"
       }
@@ -13238,7 +13238,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c291a41b5ee373baab03bebe8f9aab10bc5b12f8",
+        "checksum": "adler32:48b27ad7",
         "size": 513507,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/29289acf35def22f963de630c850a8cd.configFile.py"
       }
@@ -13290,7 +13290,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2b6bcdee5bb617423081ed581a22015bb12cbc1e",
+        "checksum": "adler32:6d313d68",
         "size": 575907,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8d24bab03a9447be589727bad8f8a2a5.configFile.py"
       }
@@ -13342,7 +13342,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5281d44a4fa8e7a27bf2aab00840b9c5514ef5fd",
+        "checksum": "adler32:b19af65b",
         "size": 6339,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/791a4c1208863ba7b363a500a0f3f219.configFile.py"
       }
@@ -13394,7 +13394,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cae9349473abd07d205d1e04041d2a30bc8bdf02",
+        "checksum": "adler32:f37dbcb6",
         "size": 13557,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/76b67a85cce50002d1f4cece1622b1db.configFile.py"
       }
@@ -13446,7 +13446,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:60fa95a4ba0084abc72e525220b1199249c2bdee",
+        "checksum": "adler32:0ea04b5f",
         "size": 7430,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/47e7c86552e77dd5909308babf660ce5.configFile.py"
       }
@@ -13498,7 +13498,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:11b778049b97a297ae497ade63ca503f4f992075",
+        "checksum": "adler32:bc9ac4ee",
         "size": 536943,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/89e035f1ab28a0c4877a43855d2fb3a3.configFile.py"
       }
@@ -13550,7 +13550,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ca19352d803a29cd0cafe70cf8cd821c62131b3b",
+        "checksum": "adler32:733b5c45",
         "size": 3936,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/1097e7d4bdde2109bec55eeb210916b2.configFile.py"
       }
@@ -13602,7 +13602,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e78f594a556fd65b1efefc2f9458686b22adb47b",
+        "checksum": "adler32:bfcb961e",
         "size": 512742,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/77a3ead6ad2fd8a3ee6652b760be2fd9.configFile.py"
       }
@@ -13654,7 +13654,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:614b2d058167ca92dd1ac3711860cf9746c0246a",
+        "checksum": "adler32:ea354da6",
         "size": 3893,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/5063daa4545fc6fb5581d1fbf47be57b.configFile.py"
       }
@@ -13706,7 +13706,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ed1508168fa82a6b3d8efcb4beacfb76d19d23cc",
+        "checksum": "adler32:121d3340",
         "size": 378923,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/89e1cc8f64e148a8fe87a31c72a40c6c.configFile.py"
       }
@@ -13758,7 +13758,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ea0623dea8b6790f4f4bf92bff616bf2d1fe5590",
+        "checksum": "adler32:ff3dbf21",
         "size": 7853,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/47e7c86552e77dd5909308babf59f357.configFile.py"
       }
@@ -13810,7 +13810,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b2ab52fb58c152cc97557801fe4e8f58e75e2078",
+        "checksum": "adler32:ecd31df1",
         "size": 583177,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8630bdb103dad448ac350c124678dcc5.configFile.py"
       }
@@ -13862,7 +13862,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:340b5d3b3fb65faa5136bfe765e5771b1c8d0561",
+        "checksum": "adler32:8d866b57",
         "size": 8082,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2df75b5f3a22f36fe622ef135ce000be.configFile.py"
       }
@@ -13914,7 +13914,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6e32bff6b85e4c5227be4d86e31f070b5fc12f8d",
+        "checksum": "adler32:4efaa07e",
         "size": 6863,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/bba69ae19e1fbc577b22ff73799f156e.configFile.py"
       }
@@ -13966,7 +13966,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:db2228882a881137618512722622178c2134e48f",
+        "checksum": "adler32:3656c560",
         "size": 373789,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/76b67a85cce50002d1f4cece16003481.configFile.py"
       }
@@ -14018,7 +14018,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0b4eb5a50c5909d24c10543cc670a230be47261c",
+        "checksum": "adler32:3e900127",
         "size": 6350,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/7d57c3abb9981f8e962ad0921ebfc0fb.configFile.py"
       }
@@ -14070,7 +14070,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f96f99cb4c3c38412b1c78a5359c76d8febd76a6",
+        "checksum": "adler32:139a1dff",
         "size": 2550362,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/536c958a6a6194302477cf2e8eb3c11b.configFile.py"
       }
@@ -14122,7 +14122,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f23f766b9b0f203069cc89f9b41e90fa89bf1048",
+        "checksum": "adler32:0bf78e83",
         "size": 62664,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/03d0c452db253224763ab1bf4655c3e6.configFile.py"
       }
@@ -14174,7 +14174,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f98075b82b710526879ef4431167be47187e41f9",
+        "checksum": "adler32:6b2f18e5",
         "size": 382560,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4bf2a2af9e9349832e2e60bf33b1c63c.configFile.py"
       }
@@ -14226,7 +14226,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d77439c3e7848ddd4e6517469de3db1ec8c6aa90",
+        "checksum": "adler32:377cc1b3",
         "size": 13552,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/db0105697625bdea8cedb18cd3ff0597.configFile.py"
       }
@@ -14278,7 +14278,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:32a4f7f54a0f2980d44e6f01cfe5c470ddcdb20e",
+        "checksum": "adler32:5f17d44e",
         "size": 13621,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/c8516b9454a656fd0efc1742d400fd95.configFile.py"
       }
@@ -14330,7 +14330,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ed9887830dbd1957ab9542d2e5eb45c145031522",
+        "checksum": "adler32:dbcc33b9",
         "size": 3840,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0a59ee88a578153c9e4180dc37bedcfb.configFile.py"
       }
@@ -14382,7 +14382,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6af844ae0597301d7656239e30f737c73a1c4d9f",
+        "checksum": "adler32:2e48011b",
         "size": 6350,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/32e6e06e42ce14eaad2990144133985b.configFile.py"
       }
@@ -14434,7 +14434,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f4990c821f19dc4449e3d3a9e8ad342492f118f0",
+        "checksum": "adler32:5d71d2d6",
         "size": 13614,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/db0105697625bdea8cedb18cd3fecfa0.configFile.py"
       }
@@ -14486,7 +14486,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0e4505bc6c94b052dd84967ecfc2c33df3bb9b11",
+        "checksum": "adler32:3e74fda8",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/b46933860a057882bf17fc7c87f323c1.configFile.py"
       }
@@ -14538,7 +14538,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4ffa746a44182c2c99113b6ba8b037846363393f",
+        "checksum": "adler32:9d455f95",
         "size": 3930,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/546f8a96e2dfb72d4858f8a763e6bbc9.configFile.py"
       }
@@ -14590,7 +14590,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cd573bc57a26319ad71d168b9a4b8a4bfd6031ae",
+        "checksum": "adler32:84e0eff6",
         "size": 4340,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/331f67c8c835bc29be9f6bc7eaa3c42b.configFile.py"
       }
@@ -14642,7 +14642,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a93785bfa1510610f0eb051d88e745c94b387f98",
+        "checksum": "adler32:65224d9c",
         "size": 3893,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/2fcba5bfd9640a78b177615db5850b30.configFile.py"
       }
@@ -14694,7 +14694,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:98e63989b719d46e47a9a014533fe47a5eecca20",
+        "checksum": "adler32:56630663",
         "size": 510000,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/4476f4abc138fcd5893171c122428f8e.configFile.py"
       }
@@ -14746,7 +14746,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:499abe24d7f22a70c46741b218060acbdd8129c9",
+        "checksum": "adler32:ffe3e8aa",
         "size": 7062,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/8119c367dee83f4172eac646b0c7560e.configFile.py"
       }
@@ -14798,7 +14798,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:17a9788871316c33beff157511882a84857b6f92",
+        "checksum": "adler32:6675260e",
         "size": 7311,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/1f2ff1a5230d60b6d26f0a41bdd280c6.configFile.py"
       }
@@ -14850,7 +14850,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dde86a16b4eb680695a2f0702d2b39557d478b0e",
+        "checksum": "adler32:3492e110",
         "size": 4280,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/456bd364d581640f6aaf924e8cecf9c3.configFile.py"
       }
@@ -14902,7 +14902,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f08c83b400981f665d13e3015b6f698ab4cfc290",
+        "checksum": "adler32:e8dc7f62",
         "size": 361076,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/bd3f7129862b8627ae313cff5e016121.configFile.py"
       }
@@ -14954,7 +14954,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f30e76cae971cd445efa7c22996a126775e2c1c5",
+        "checksum": "adler32:73c33d13",
         "size": 576826,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/34d68021bbbfb64692432c553bba6859.configFile.py"
       }
@@ -15006,7 +15006,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:00b6ac38219471f5e8ac1278f934d93b075ac771",
+        "checksum": "adler32:37345ce0",
         "size": 3939,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0fa8dfb75c35107952fe8ff6e5c46b07.configFile.py"
       }
@@ -15058,7 +15058,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fd148740fff8b0eba083fffa12328992a97de946",
+        "checksum": "adler32:e3e3814b",
         "size": 8029,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/a30b01ec31a6214af3ada4153c7765b0.configFile.py"
       }
@@ -15110,7 +15110,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8cb63a6c39255e94ffa80a5391b58404dcbb0701",
+        "checksum": "adler32:6a82daf7",
         "size": 580569,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cec87afc37373850854c6eeb5a058c9e.configFile.py"
       }
@@ -15162,7 +15162,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:84ec173c261ec901b124b6dcaa29f28838649fc1",
+        "checksum": "adler32:deedfcc5",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/6917aa2e79caf45db3687b097ec6a636.configFile.py"
       }
@@ -15214,7 +15214,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:19291aac99bdeb32a1b384cdf10234271a584ec2",
+        "checksum": "adler32:c290340c",
         "size": 531449,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/89e035f1ab28a0c4877a43855d2f8a3f.configFile.py"
       }
@@ -15266,7 +15266,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:584937a682ef9b1bc8d90467e99aaf55fd9cddb3",
+        "checksum": "adler32:50cb98b6",
         "size": 4971,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/0d0714743f0204ed3c0144941eb1468c.configFile.py"
       }
@@ -15318,7 +15318,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:75640ffdeb53cbf8160484cf8277b40012915608",
+        "checksum": "adler32:0fe81d0b",
         "size": 375037,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/456bd364d581640f6aaf924e8caa06e9.configFile.py"
       }
@@ -15370,7 +15370,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fbfced8232acb826a3c97d55b682e985a7ae30e7",
+        "checksum": "adler32:e57329b9",
         "size": 690032,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/9d146c40331d0b1ca09582720ad3d275.configFile.py"
       }
@@ -15422,7 +15422,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:146fb09e590158bd20f9da9f53e0026877a3587f",
+        "checksum": "adler32:67a3f9f3",
         "size": 4382,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/af306a06723a063501eb27601b9df047.configFile.py"
       }
@@ -15474,7 +15474,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b7104249848a31150729b34c425b22005d8c52cf",
+        "checksum": "adler32:f4a7c348",
         "size": 578250,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/e4da65342a00bdb04dc8fdc3e635261c.configFile.py"
       }
@@ -15526,7 +15526,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7bdf987eeb7205b8f457e6a9f4756e82f0ee2f08",
+        "checksum": "adler32:fac43e40",
         "size": 2550458,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/aa57a0041839d6b495260c3c0702c38b.configFile.py"
       }
@@ -15578,7 +15578,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3e9278185f37fd6b6a8d9eddb4c1b915e4d674af",
+        "checksum": "adler32:7d9f9677",
         "size": 7077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/dc93d4968faf1343ed9a38b33b80758c.configFile.py"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-configuration-files-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-configuration-files-Run2011A.json
@@ -27,7 +27,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b888f714576906c13aa5b472c53b48459b70925e",
+        "checksum": "adler32:c17e074d",
         "size": 9188,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91430774.configFile.py"
       }
@@ -73,7 +73,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:94288f8163dd4cebda83158cc16756a272af937e",
+        "checksum": "adler32:5b33bc33",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf05a71f.configFile.py"
       }
@@ -119,7 +119,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7ef9ad4e4dfbd5de5d05fa1117d82000ce11b548",
+        "checksum": "adler32:d79b9e63",
         "size": 7516,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4515630011652d2fbae85c3707cb6ffb.configFile.py"
       }
@@ -165,7 +165,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7dbb7c6618f5332e0d4a7002f1d3819daad6c489",
+        "checksum": "adler32:745e9c53",
         "size": 3626,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db28e87bf.configFile.py"
       }
@@ -211,7 +211,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ad2a9e0fab1cb89a0129587a0b67db6ed416dbf1",
+        "checksum": "adler32:44d507a7",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a69a2.configFile.py"
       }
@@ -257,7 +257,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:240634a0bdcd36280af25c803d7b3d955ffbe0a4",
+        "checksum": "adler32:be83a186",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6ce248.configFile.py"
       }
@@ -303,7 +303,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9a89b18c841f2330beedb7d7a609689683530ded",
+        "checksum": "adler32:8b8aeb13",
         "size": 3612,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f51aba8.configFile.py"
       }
@@ -349,7 +349,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:261d14c1154c208df2939f07cdb7d13beed397aa",
+        "checksum": "adler32:de109c84",
         "size": 3628,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db28f4f49.configFile.py"
       }
@@ -395,7 +395,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:47dfad1061ec5865c175c3de2fc53f9e52ea821f",
+        "checksum": "adler32:e08b6d2d",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f910174222c.configFile.py"
       }
@@ -441,7 +441,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:08aa578d126eec68b473aefbcfada1668eb320ae",
+        "checksum": "adler32:951507a0",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91638ee9.configFile.py"
       }
@@ -487,7 +487,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c9246676ddbb5c467862e0ae8ef4b9e36420f4bc",
+        "checksum": "adler32:fb4ba1a2",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e703c2e.configFile.py"
       }
@@ -533,7 +533,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0fa97cdc60747a739c064483b037e49ddb9179c1",
+        "checksum": "adler32:d2f3a19f",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6c7389.configFile.py"
       }
@@ -579,7 +579,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ee3e7d4a5b0568571230389741bdb12ac8123e84",
+        "checksum": "adler32:ec82014c",
         "size": 3078,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc95bbd6e.configFile.py"
       }
@@ -625,7 +625,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3a070e01ebab1e58d725eb5f6f6fa77986eb94e6",
+        "checksum": "adler32:e0d370f0",
         "size": 2576,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc942efba.configFile.py"
       }
@@ -671,7 +671,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d7d7e1909ca9bc8915b083140723f0a9ff851775",
+        "checksum": "adler32:16d84572",
         "size": 9053,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7c7c0e8e128b3d1a9f287090342346e0.configFile.py"
       }
@@ -717,7 +717,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ab202bf01b7a27e8e67d660395a127464a587fe8",
+        "checksum": "adler32:aecfaa2e",
         "size": 6019,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd8d1a0.configFile.py"
       }
@@ -763,7 +763,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:12d6dd7faf721012814a8913c9dd16213ad47cfe",
+        "checksum": "adler32:23d79bb5",
         "size": 7505,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4a1f22052abb5b3c51ee42f4dcdee483.configFile.py"
       }
@@ -809,7 +809,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2cf8e3d7abaf0664b10c3fe214b7e5ffd96a547e",
+        "checksum": "adler32:ca2c3403",
         "size": 6463,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf082009.configFile.py"
       }
@@ -855,7 +855,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8fc7e41cf49c99d06a247590891cfeb6a4f83db8",
+        "checksum": "adler32:86a7078d",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a2a58.configFile.py"
       }
@@ -901,7 +901,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f8cbfd1b70b7bca4c6e85cb8da32c6920f2b190e",
+        "checksum": "adler32:8d07aac4",
         "size": 6022,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695ce3da3f.configFile.py"
       }
@@ -947,7 +947,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a2bfae01067e557c67be20179f16941ef2706215",
+        "checksum": "adler32:ebf10ca7",
         "size": 7241,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf0e401e.configFile.py"
       }
@@ -993,7 +993,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7d39b9d6fff8f6768502755885c3294dd51edfcb",
+        "checksum": "adler32:4f44a17b",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6c4391.configFile.py"
       }
@@ -1039,7 +1039,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:44abaa260453fe2b9f02389de4864a6ec87c483a",
+        "checksum": "adler32:a1e2cc1a",
         "size": 7006,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de55910b1.configFile.py"
       }
@@ -1085,7 +1085,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:beaeeaf02816e004f8c541093bbdad17518d7bb7",
+        "checksum": "adler32:8cc7bc64",
         "size": 2075,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf0d425d.configFile.py"
       }
@@ -1131,7 +1131,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6c35a2af9bd0685422518ac199d4dfa246a33e5f",
+        "checksum": "adler32:52e3a4e7",
         "size": 3655,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6c3430.configFile.py"
       }
@@ -1177,7 +1177,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5064e7bb19fd542b53325f38fa33ce5f22f4106f",
+        "checksum": "adler32:8731a198",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6c544b.configFile.py"
       }
@@ -1223,7 +1223,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dd0c6760fa82d6345d4cdcf79e82bd4a77ba1e89",
+        "checksum": "adler32:4b20e987",
         "size": 3608,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f4f38c2.configFile.py"
       }
@@ -1269,7 +1269,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eac4c9ee8c15f93f75ab2e16394b015dc512214f",
+        "checksum": "adler32:941d9184",
         "size": 3588,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a3e9a49adb11d7079eda533cfa26a199.configFile.py"
       }
@@ -1315,7 +1315,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e0de75f083b3393e40063740b6b5757adc45222e",
+        "checksum": "adler32:704b3c39",
         "size": 9028,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/532578856e4aba9f49cb063f9baed097.configFile.py"
       }
@@ -1361,7 +1361,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ddd868b26eff3f6b70a50aa15adf283c31c9581c",
+        "checksum": "adler32:db259c09",
         "size": 7506,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/82684178352d5f0db3b347b48c60ffe7.configFile.py"
       }
@@ -1407,7 +1407,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9242072d824b6687186b6264916067c820376ba7",
+        "checksum": "adler32:87f5f047",
         "size": 8063,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c8c18849c66ed34bafa1f8cb42279272.configFile.py"
       }
@@ -1453,7 +1453,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ba56fe56f5c5c5c726a5d5c630dab62a5369d009",
+        "checksum": "adler32:c0b38a85",
         "size": 8883,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b25309c97c5b8870f77c36c91bb9bb48.configFile.py"
       }
@@ -1499,7 +1499,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:41b6f8564c73b88e213dd3808fe016e5c6d99708",
+        "checksum": "adler32:f4ac9d96",
         "size": 3631,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f39b8d56dd05ca1999a63e01752419fa.configFile.py"
       }
@@ -1545,7 +1545,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6090de2a28dfcac89f7bf0a001c744c56f5cb0b5",
+        "checksum": "adler32:9f1c0886",
         "size": 9193,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b914912ac.configFile.py"
       }
@@ -1591,7 +1591,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:83a6de8867661efee14c1cea713da28b359dc8ae",
+        "checksum": "adler32:5fc5c7f7",
         "size": 2105,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cc9663d.configFile.py"
       }
@@ -1637,7 +1637,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5996a7119398bbf146d07c5ea6a09fa852a165bc",
+        "checksum": "adler32:5cfb07a5",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b914557cf.configFile.py"
       }
@@ -1683,7 +1683,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9495a0f2c4e76a4b7f1651131306b7fa41d459aa",
+        "checksum": "adler32:f9247038",
         "size": 2574,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc9384974.configFile.py"
       }
@@ -1729,7 +1729,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:11f814844d34267841ead56fb7c4a07fefff3c12",
+        "checksum": "adler32:6c566d1c",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b78f836a8fc0457f3d1cf47679205dce.configFile.py"
       }
@@ -1775,7 +1775,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e55155c031b33679317c953c4638f17a6b13ddfe",
+        "checksum": "adler32:b36c3204",
         "size": 13553,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cbb3e0ee51f19be8f8a04cf25963e402.configFile.py"
       }
@@ -1821,7 +1821,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6f6992baf376cb13bc4b0f9be645b25997f1d1d0",
+        "checksum": "adler32:d62a47ce",
         "size": 109920,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7b0f1f8e4df3d63108f095f9fa57f554.configFile.py"
       }
@@ -1867,7 +1867,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:026d376a80037e9c008d58f45edf1d2dcafac704",
+        "checksum": "adler32:93f66e57",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f91017475f2.configFile.py"
       }
@@ -1913,7 +1913,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8e259660eddd9a5b19aa38348ccc016aa1b9e20b",
+        "checksum": "adler32:753986ca",
         "size": 8878,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9143d801.configFile.py"
       }
@@ -1959,7 +1959,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9922ca38f56c1f85a5ee3faad8e19ea7617d7a10",
+        "checksum": "adler32:1a32e143",
         "size": 7015,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0cac1a565bda09ad57a6810efe437c3a.configFile.py"
       }
@@ -2005,7 +2005,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eb6259b81a0ab6b779efd910fb9ab3c69a3786e2",
+        "checksum": "adler32:4d3aa193",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6d0236.configFile.py"
       }
@@ -2051,7 +2051,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:090eda0a849326b5ef7bff290fa918804dd9f952",
+        "checksum": "adler32:0326790a",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53eec1a6e.configFile.py"
       }
@@ -2097,7 +2097,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d5f0a255145f181f08fbaefb6d6bafa9be5fb1a9",
+        "checksum": "adler32:1209a6d9",
         "size": 3661,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f39b8d56dd05ca1999a63e017523ff89.configFile.py"
       }
@@ -2143,7 +2143,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c686dd33a8338de7f6f6b46e849d214ade51bda1",
+        "checksum": "adler32:1c678743",
         "size": 5104,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6c6ff3f35efb680aebe72ced3d0211de.configFile.py"
       }
@@ -2189,7 +2189,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c112fb70975528a61354a9888df2f9aa538a1295",
+        "checksum": "adler32:9e5dbc40",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf2c69c1.configFile.py"
       }
@@ -2235,7 +2235,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2c361197d98a497694fa3d6ec8aa7124df2dccd0",
+        "checksum": "adler32:1579725a",
         "size": 2582,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6c4978.configFile.py"
       }
@@ -2281,7 +2281,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d6f4c2fda14775befa2d93794af91bc1f1665ca5",
+        "checksum": "adler32:6c2a1dcb",
         "size": 6412,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8d6b90fd328fcdf734c4595f7086f4aa.configFile.py"
       }
@@ -2327,7 +2327,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b8620b8b9e1cc5fa0cf2912aa5c3088d55c0a6bd",
+        "checksum": "adler32:3d3272a4",
         "size": 2583,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6cc7f4.configFile.py"
       }
@@ -2373,7 +2373,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7800a87d6ebc39bd59fc2ad86039c8f5be380c5d",
+        "checksum": "adler32:cf7492bb",
         "size": 8906,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101748d9e.configFile.py"
       }
@@ -2419,7 +2419,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6e35a92ac0659c609b84c2eb4122d34f0577a01c",
+        "checksum": "adler32:e3fc079c",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91457b5a.configFile.py"
       }
@@ -2465,7 +2465,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1112a30de70e7e9ee6d42ef77e11235f02687888",
+        "checksum": "adler32:711d72ca",
         "size": 2584,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6ce5eb.configFile.py"
       }
@@ -2511,7 +2511,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2cb1c8e30b2d002dca212564ec53b584ee92ba64",
+        "checksum": "adler32:496beba5",
         "size": 7785,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9e0fb63675bdd7dc5283db9af45df5c2.configFile.py"
       }
@@ -2557,7 +2557,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:579a635c725bc084c55e5aa8763ab739114d52ad",
+        "checksum": "adler32:175125f2",
         "size": 7199,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de556aa6a.configFile.py"
       }
@@ -2603,7 +2603,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6558387744dc5fff9a6d89b8934b00fbe0584f3e",
+        "checksum": "adler32:4d45a193",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e7205ac.configFile.py"
       }
@@ -2649,7 +2649,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:67920ad25e4547d48dd153aa5145153c04a85f2c",
+        "checksum": "adler32:48e5eb07",
         "size": 7781,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4a1f22052abb5b3c51ee42f4dcdf63a5.configFile.py"
       }
@@ -2695,7 +2695,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d7f5a524970a2b0496405d45c1e3c1f638f8af33",
+        "checksum": "adler32:313c6d39",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f91017460b2.configFile.py"
       }
@@ -2741,7 +2741,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3a89c524e92195c57343561eef2306efbf678bc9",
+        "checksum": "adler32:9d74e21b",
         "size": 3590,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/2e0a80c07f23808d4b75c974eaf58837.configFile.py"
       }
@@ -2787,7 +2787,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:05fdb8a10b1e3e458ffffddd41a03184f9e13180",
+        "checksum": "adler32:f4f107ae",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a3d21.configFile.py"
       }
@@ -2833,7 +2833,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ec264e08ab409cc539680bfb4beb6e0fda2d973e",
+        "checksum": "adler32:bea6a4bf",
         "size": 3653,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6b5c4e.configFile.py"
       }
@@ -2879,7 +2879,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:29a30e30b569021e52490074647ac6f562044dc3",
+        "checksum": "adler32:77fbecd1",
         "size": 3618,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f520eec.configFile.py"
       }
@@ -2925,7 +2925,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:92aeaa1f0d59dbcd015339f0ccb16fec82133b8d",
+        "checksum": "adler32:b8471de2",
         "size": 7238,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f5cf4.configFile.py"
       }
@@ -2971,7 +2971,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2569ab442a9977e620517c58f1608f776da7300a",
+        "checksum": "adler32:3221a6a9",
         "size": 3662,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f39b8d56dd05ca1999a63e017523fa17.configFile.py"
       }
@@ -3017,7 +3017,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f8a181ee7b0552003e8a30e74551f5ef442e7dda",
+        "checksum": "adler32:40b4dc66",
         "size": 6945,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/caf0a1e27e00a4ac2cf66edbe3650da8.configFile.py"
       }
@@ -3063,7 +3063,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:19e27a23f026f4ac62ad281c4342914d12d81fc3",
+        "checksum": "adler32:a6a41d0a",
         "size": 6408,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8d6b90fd328fcdf734c4595f708e40a7.configFile.py"
       }
@@ -3109,7 +3109,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6bcb3f1f7cdfebaeb4b96fe48c7ea94d3efa763b",
+        "checksum": "adler32:dd576d2c",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101741485.configFile.py"
       }
@@ -3155,7 +3155,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a11406b1b6bbc9e795b1032fb0f371a78f46c7c8",
+        "checksum": "adler32:a8180888",
         "size": 9193,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b915008a0.configFile.py"
       }
@@ -3201,7 +3201,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:32d21fbc2557cdee5a782a47e1835c8f3eac20ca",
+        "checksum": "adler32:7df3a284",
         "size": 7525,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4515630011652d2fbae85c3707cb762c.configFile.py"
       }
@@ -3247,7 +3247,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6523837b2f2aa6fded16be5569532f76e335f508",
+        "checksum": "adler32:7d38bc3a",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01b27e.configFile.py"
       }
@@ -3293,7 +3293,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:992fcc577694d2ad875cfcae9f25e57ddc677d82",
+        "checksum": "adler32:63dd793a",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba690346afb7.configFile.py"
       }
@@ -3339,7 +3339,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c94f57636a2a5bdd75e1e4f8263dc5487af316f4",
+        "checksum": "adler32:bc84a19e",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e91b14d.configFile.py"
       }
@@ -3385,7 +3385,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5066fac8b9297fc64b22e9b0e6f8eddfaba03c4a",
+        "checksum": "adler32:c21ce777",
         "size": 3686,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c9e000c71f90818cafc2ea88b2e7e184.configFile.py"
       }
@@ -3431,7 +3431,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5a904ff782a7cf8306de9e3e1fc7f7aaf0babce7",
+        "checksum": "adler32:bccba16f",
         "size": 3646,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6602d94fea27826ae6e8e0fcd3cb1667.configFile.py"
       }
@@ -3477,7 +3477,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:986f5ee69da8ec661f0cacf6ecb1ec45335c9a7a",
+        "checksum": "adler32:df03be3d",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf3961dd.configFile.py"
       }
@@ -3523,7 +3523,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eb8b80bf80684de6869680591ea17eed3888b3ab",
+        "checksum": "adler32:71a4f83f",
         "size": 8876,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8c6e215a3026002258a2dbea0b28203e.configFile.py"
       }
@@ -3569,7 +3569,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ed107bc1b2f996d581fc61462bcfa16a7e2c612b",
+        "checksum": "adler32:897f7269",
         "size": 2582,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6cd449.configFile.py"
       }
@@ -3615,7 +3615,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3eac79969359b12217fddb1b884dd246268909c0",
+        "checksum": "adler32:c08da16e",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6c4942.configFile.py"
       }
@@ -3661,7 +3661,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:280390ca0dd4407801b3ca1d26bfa85911f44306",
+        "checksum": "adler32:d743ffd2",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9181dcfde0729882b44992132015be09.configFile.py"
       }
@@ -3707,7 +3707,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cee4d84c6ef5455de1d67373f9e585a96a359a4b",
+        "checksum": "adler32:b4bf6d27",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101743bed.configFile.py"
       }
@@ -3753,7 +3753,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c487dc52db5b96c3e864372b0886e64ca9f3ae72",
+        "checksum": "adler32:4ecb1e6c",
         "size": 7241,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191ef9d6.configFile.py"
       }
@@ -3799,7 +3799,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3eb254a2812df3cca007058c737e4ea621e7900c",
+        "checksum": "adler32:9c8c5db5",
         "size": 6643,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/1156e999350f625b865f0777d7f9b7df.configFile.py"
       }
@@ -3845,7 +3845,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:881dba5e6f2fe17b125e79eff595468cc1d63a3c",
+        "checksum": "adler32:7d3e7f55",
         "size": 6660,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de55404a1.configFile.py"
       }
@@ -3891,7 +3891,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7168d7938791aa1827badd26876a4e91cad15bfb",
+        "checksum": "adler32:14fe6d8f",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb886a3.configFile.py"
       }
@@ -3937,7 +3937,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bd54c25ac1f580dcfb345bd34b374d62a97d2843",
+        "checksum": "adler32:c43bff3f",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0cac1a565bda09ad57a6810efe44961c.configFile.py"
       }
@@ -3983,7 +3983,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f8c049baec392caf7d1851a0ccdc2d1c8bf6c7f5",
+        "checksum": "adler32:ed41a30b",
         "size": 6828,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/2f1e2ccb71a5dc3b16aeb4bc3e72fdb1.configFile.py"
       }
@@ -4029,7 +4029,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:82d4ea264712a6cb50d42d70613b6d02fcd44d15",
+        "checksum": "adler32:f89d73cd",
         "size": 2586,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ec457e6.configFile.py"
       }
@@ -4075,7 +4075,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:998c4c66c648981e3275fb366b7e00b75f284712",
+        "checksum": "adler32:bdd4a66d",
         "size": 7573,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9ebe5de2113c461586671dca1e09299d.configFile.py"
       }
@@ -4121,7 +4121,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:545e6c5e75db771bea50d892fc8e9cf1b492328c",
+        "checksum": "adler32:3d126463",
         "size": 30740,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd5176f.configFile.py"
       }
@@ -4167,7 +4167,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:797a732e146832d1ca674d9fe552189d404635fc",
+        "checksum": "adler32:d5f207b5",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a093c.configFile.py"
       }
@@ -4213,7 +4213,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:76ed142bfe4337ffd6dbb7e72ba69c4c2294f45a",
+        "checksum": "adler32:0699fb47",
         "size": 3058,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc95bd0a9.configFile.py"
       }
@@ -4259,7 +4259,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:476d65a34087808b57b2a29c5e25ca5db16df160",
+        "checksum": "adler32:86c82c1d",
         "size": 7213,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de555c9b3.configFile.py"
       }
@@ -4305,7 +4305,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d92813bf39d353977a38884ea4d420010c76f478",
+        "checksum": "adler32:330aa933",
         "size": 6015,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cdafbdd.configFile.py"
       }
@@ -4351,7 +4351,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:89ac2c8cc82bb31eb8a8c27238b6f927fbb3ebd2",
+        "checksum": "adler32:19df1ee7",
         "size": 7244,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f0786.configFile.py"
       }
@@ -4397,7 +4397,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:08e5551c036ecfcccf12517ffbc224a27f6f8c52",
+        "checksum": "adler32:9f279d2f",
         "size": 3629,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db2908f57.configFile.py"
       }
@@ -4443,7 +4443,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d012255f5b26779ebce72a4d09f1c625e9eacf12",
+        "checksum": "adler32:82e60796",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91639ba5.configFile.py"
       }
@@ -4489,7 +4489,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8c942e6da7a1129a350d9f46c0bf64104b8dd0da",
+        "checksum": "adler32:f19d6d8b",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8a7af.configFile.py"
       }
@@ -4535,7 +4535,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:023e2fe97e15f39afa9588094a2ac277ba45b4d0",
+        "checksum": "adler32:75a73b6b",
         "size": 3218,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4f1f909dc818ac109c868566853a100b.configFile.py"
       }
@@ -4581,7 +4581,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6b1358532bdd39305b59295e8b4211fac561286a",
+        "checksum": "adler32:9f54709f",
         "size": 2575,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc9456bf3.configFile.py"
       }
@@ -4627,7 +4627,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b1690c757ad3bee2e1b9e7ca4a3e19e832ec5012",
+        "checksum": "adler32:ac0310dd",
         "size": 2301,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b365e646c.configFile.py"
       }
@@ -4673,7 +4673,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:48c7bf5a19eb0051323839d319498087418c52d4",
+        "checksum": "adler32:7cd3f6f6",
         "size": 7053,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/eee98ac39b28e880d1fcff7934dc2071.configFile.py"
       }
@@ -4719,7 +4719,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0f3553b2a45c5817ce2d9bd056a5a87dfbfdd333",
+        "checksum": "adler32:29e8c910",
         "size": 2108,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd575d6.configFile.py"
       }
@@ -4765,7 +4765,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8a318ccfb51f763d9011803aca0596cae3535869",
+        "checksum": "adler32:bc8b940b",
         "size": 5937,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cdb4a55.configFile.py"
       }
@@ -4811,7 +4811,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6818aa3d8b54fb32200e1592248ab4b8a4a0efb0",
+        "checksum": "adler32:7c50eb1d",
         "size": 7781,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9e0fb63675bdd7dc5283db9af45da3f9.configFile.py"
       }
@@ -4857,7 +4857,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f4f84870f3e498f971edd66bd2d2862a0a045f4d",
+        "checksum": "adler32:812da180",
         "size": 3646,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6b5026.configFile.py"
       }
@@ -4903,7 +4903,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:429068c0e39efdb1ae28b8e609ec81fb6b09b870",
+        "checksum": "adler32:cb7decb3",
         "size": 3028,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc95bc89c.configFile.py"
       }
@@ -4949,7 +4949,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ee1388e5f7770828ac20e89d58b17b0a7857698e",
+        "checksum": "adler32:daac6039",
         "size": 6649,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/1156e999350f625b865f0777d7f89e82.configFile.py"
       }
@@ -4995,7 +4995,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:56a6fb6e166fe198d5ee754569d2648f4876db07",
+        "checksum": "adler32:1ec0088e",
         "size": 7048,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/787d59798ba1957342f08d4d11fd40d1.configFile.py"
       }
@@ -5041,7 +5041,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:242e4c55af9d68dc72b1ec3061b6e8af8729344c",
+        "checksum": "adler32:ad46aa2c",
         "size": 6019,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/5a969e363f8f7c70403095bd1ed4059a.configFile.py"
       }
@@ -5087,7 +5087,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:24ce88e4e3dbcd8a03b4ee06c822bf655bb2ab75",
+        "checksum": "adler32:bf0f0ef6",
         "size": 2295,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b36620512.configFile.py"
       }
@@ -5133,7 +5133,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:466997049a1988aa2d5f61bdb2085c844598525d",
+        "checksum": "adler32:9ccde1da",
         "size": 3680,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c9e000c71f90818cafc2ea88b2e7e2b7.configFile.py"
       }
@@ -5179,7 +5179,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b75cfb962d1c834988deb036ff400f10545e11c6",
+        "checksum": "adler32:4c987915",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53eea9c7b.configFile.py"
       }
@@ -5225,7 +5225,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:95251d193fe6df9320be273e2415a7e6f076aaf7",
+        "checksum": "adler32:9f3107a8",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b914fc3e6.configFile.py"
       }
@@ -5271,7 +5271,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fed0d98dd58df647685a79a4dbef0494baff0561",
+        "checksum": "adler32:53480882",
         "size": 9193,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b914fe535.configFile.py"
       }
@@ -5317,7 +5317,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5f2fc5911c1eb597a529e4a881e5e578630bc036",
+        "checksum": "adler32:c7a3724e",
         "size": 2582,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6ccb70.configFile.py"
       }
@@ -5363,7 +5363,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3d48ac14fc37e7a2efad1b45027fb80275700b76",
+        "checksum": "adler32:cbac97f9",
         "size": 6784,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c729fce63ed969fa8b51acab368c394e.configFile.py"
       }
@@ -5409,7 +5409,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:95d5b4542a9560e49ca759f4b7bccb98935cc0bc",
+        "checksum": "adler32:a0e5bd34",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf0149b4.configFile.py"
       }
@@ -5455,7 +5455,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b023f87cee2049bf0762dd3fa8cffa72388b690a",
+        "checksum": "adler32:4dbf9689",
         "size": 8919,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/40f18a4101a71b9631b737ae01700e35.configFile.py"
       }
@@ -5501,7 +5501,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5188f62d13898aa5c02a3282ce14cc928ea39aa0",
+        "checksum": "adler32:05a2d30c",
         "size": 6993,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b17ed01fdcb093aaf395ab27ff34e3bd.configFile.py"
       }
@@ -5547,7 +5547,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3c009bce88bd0e7174d39e64fc2d07beaa038899",
+        "checksum": "adler32:675d5cdf",
         "size": 3328,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6c6ff3f35efb680aebe72ced3d024dc2.configFile.py"
       }
@@ -5593,7 +5593,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8eef78c8edb77d6153ce7755a639aa522aea051a",
+        "checksum": "adler32:315d6d94",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8bd98.configFile.py"
       }
@@ -5639,7 +5639,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b3de37f0f8322f905e024d3b27a0c893dd748b5f",
+        "checksum": "adler32:8cda6d60",
         "size": 2566,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101742e06.configFile.py"
       }
@@ -5685,7 +5685,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a2a7cd22d0a4fca075a345e7cb95440df8f75ec0",
+        "checksum": "adler32:1bcaa970",
         "size": 6016,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8d6b90fd328fcdf734c4595f7091cd60.configFile.py"
       }
@@ -5731,7 +5731,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4c16f6416636ff47172e7e43fe2cd598dd5895af",
+        "checksum": "adler32:9f25a184",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e7089e4.configFile.py"
       }
@@ -5777,7 +5777,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bb202a99d65cb611fa35ab9dfc9aa7258c1584d0",
+        "checksum": "adler32:c69fff69",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/51bf5a6e98020fb8fa6dece923ed59d1.configFile.py"
       }
@@ -5823,7 +5823,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:37771a1ee467c12e25515b2057e24cff0a5d8698",
+        "checksum": "adler32:2ddca191",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e708382.configFile.py"
       }
@@ -5869,7 +5869,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6c984b471b424026634664c7abe7c419a76cb551",
+        "checksum": "adler32:6d490035",
         "size": 7860,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/983b066ccca9897c4131e0559ae28aa4.configFile.py"
       }
@@ -5915,7 +5915,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b6ec8ceb28632ca0ff0c97f8b99e663e0743ef46",
+        "checksum": "adler32:009e2689",
         "size": 9000,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/532578856e4aba9f49cb063f9baec169.configFile.py"
       }
@@ -5961,7 +5961,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cc69a5ffbc0dd7b51e8dc646b264faa0bf1cafe1",
+        "checksum": "adler32:1a9d6db5",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb89677.configFile.py"
       }
@@ -6007,7 +6007,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5fd8c98292cd39373c25c3d941b71dd33bf23f68",
+        "checksum": "adler32:ad95ea4b",
         "size": 2997,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0de33f0c9cb94c9f73cd4e86d85bc166.configFile.py"
       }
@@ -6053,7 +6053,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3638241d38e36c2bb924435aa2ff4b3ccf53ac35",
+        "checksum": "adler32:6296edbd",
         "size": 3618,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/fa79ed2f93428d49ddb4d27246d78312.configFile.py"
       }
@@ -6099,7 +6099,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a24fe1fd7aa8e44c73f6f3f3e98adb23f11b765d",
+        "checksum": "adler32:6c06f352",
         "size": 7045,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/29be6bf0a7154bef099908f61c134f32.configFile.py"
       }
@@ -6145,7 +6145,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fcc1dd233f47b2d53484257606ace57fb678050a",
+        "checksum": "adler32:8731791e",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ebc76de.configFile.py"
       }
@@ -6191,7 +6191,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fbb4f80b59b82269c6701ce2591161a05c279452",
+        "checksum": "adler32:f0da07b3",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b78f836a8fc0457f3d1cf4767948a508.configFile.py"
       }
@@ -6237,7 +6237,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:48362197d8bf479d3be3dc4ea7141a731dea38f1",
+        "checksum": "adler32:047974a2",
         "size": 2590,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6dfc47.configFile.py"
       }
@@ -6283,7 +6283,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:deeeeec7e38780e81cd1e5d757bba1233918e2c5",
+        "checksum": "adler32:b876a6dd",
         "size": 4378,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6c6ff3f35efb680aebe72ced3d010e42.configFile.py"
       }
@@ -6329,7 +6329,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bed1919d53f7c5533c417db3b804975d792c3432",
+        "checksum": "adler32:356d1df7",
         "size": 7239,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f8a11.configFile.py"
       }
@@ -6375,7 +6375,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4f0dcf6432949d3a20d5fb01dee3f0fc41ae1b25",
+        "checksum": "adler32:ab00ec06",
         "size": 3699,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4866695a076ae48d093c752532bd8bff.configFile.py"
       }
@@ -6421,7 +6421,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:17971c6346f0cc5d31c922201e66dfd1e0612362",
+        "checksum": "adler32:b9569c82",
         "size": 3627,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db28f6a0b.configFile.py"
       }
@@ -6467,7 +6467,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c0c527a9d28e4676ed2c9538f51ec2006138a99d",
+        "checksum": "adler32:d9568c67",
         "size": 6780,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/664dd7856adaa0b955b09f1433e374c4.configFile.py"
       }
@@ -6513,7 +6513,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:70c47dabdc82a66208d164f6b912a63b7d455406",
+        "checksum": "adler32:f920aa3f",
         "size": 6019,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd75400.configFile.py"
       }
@@ -6559,7 +6559,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5e43cdfe7e1b82070705d4959a2dbeef3c3ec24c",
+        "checksum": "adler32:1b5ea1ce",
         "size": 3647,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6b61a1.configFile.py"
       }
@@ -6605,7 +6605,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5064f7963e161b3a9f6057b87a9aee7bedf782b1",
+        "checksum": "adler32:4f53083e",
         "size": 9191,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9142fcdd.configFile.py"
       }
@@ -6651,7 +6651,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:43fcf5f189b1104f0c80e49bea1f55a6c6a7cdd4",
+        "checksum": "adler32:a06678fe",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba69033f98ec.configFile.py"
       }
@@ -6697,7 +6697,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c4a3fda9cdc22984d1203eb82b3ec3d80dc1e4ae",
+        "checksum": "adler32:89fc70e1",
         "size": 2576,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc93d44ba.configFile.py"
       }
@@ -6743,7 +6743,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:69463be8fbf2b33c15ad1cb55967709f7cf09db3",
+        "checksum": "adler32:79c3601d",
         "size": 6651,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/796833acecbdb5e17bde7cd309059294.configFile.py"
       }
@@ -6789,7 +6789,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:60dde75280999dfd27c972305ae6d1a9cc9ee64e",
+        "checksum": "adler32:861d6da0",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8ae2b.configFile.py"
       }
@@ -6835,7 +6835,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c75b361195c97bca6101c5fbf4b438777a47541d",
+        "checksum": "adler32:4fc0e7ef",
         "size": 3608,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f521a2e.configFile.py"
       }
@@ -6881,7 +6881,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b9c56d3a8ffb2fd63e9ba63fb6a4c79a2495c3ca",
+        "checksum": "adler32:1115c90e",
         "size": 2108,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd570f4.configFile.py"
       }
@@ -6927,7 +6927,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ec1ce5ed53f5967780c0cad984a71e87485ec50c",
+        "checksum": "adler32:7d9e7f88",
         "size": 6662,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de558d69d.configFile.py"
       }
@@ -6973,7 +6973,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3f996deb7e5df654c6d1450bde4e5caa95d90338",
+        "checksum": "adler32:23276d92",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8a909.configFile.py"
       }
@@ -7019,7 +7019,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d86381bb8bd8b660f8e768fb7ac656045d654ba7",
+        "checksum": "adler32:baace4b5",
         "size": 3596,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/2e0a80c07f23808d4b75c974eaf56214.configFile.py"
       }
@@ -7065,7 +7065,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ff90ab67897c89b901fd966c01b0d5623a8fca32",
+        "checksum": "adler32:1e1b6d34",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f91017424d9.configFile.py"
       }
@@ -7111,7 +7111,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eaab3d46448d32f3c624072c6436fa0d8de10ed6",
+        "checksum": "adler32:5902078c",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a0ec2.configFile.py"
       }
@@ -7157,7 +7157,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:89b779daab56faf04f2db06a6547a826b691733c",
+        "checksum": "adler32:9306a924",
         "size": 6014,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cda3a44.configFile.py"
       }
@@ -7203,7 +7203,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c8daf4535029bd1f7e399e7f24eed58aae3f01c3",
+        "checksum": "adler32:a3d77467",
         "size": 2586,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc942b5c9.configFile.py"
       }
@@ -7249,7 +7249,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:14dcd68f0b65ece975fed0b3f28efa2aa70ca0f6",
+        "checksum": "adler32:e604973b",
         "size": 7498,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4515630011652d2fbae85c3707cb6303.configFile.py"
       }
@@ -7295,7 +7295,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9ecb81837e60e8e848dd153cb85918d6391f918b",
+        "checksum": "adler32:bd3903de",
         "size": 3088,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc95e0251.configFile.py"
       }
@@ -7341,7 +7341,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f07ca9241e89fbde90a4d1cde71b71410ee67a15",
+        "checksum": "adler32:167c7930",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53e0089cb.configFile.py"
       }
@@ -7387,7 +7387,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6e416461ccd3fbbc20831c86e0cb1233149372c7",
+        "checksum": "adler32:45c83ffc",
         "size": 9061,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/532578856e4aba9f49cb063f9baec55b.configFile.py"
       }
@@ -7433,7 +7433,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:61a909bc6d442806dbbed09917dbfa0b4b113262",
+        "checksum": "adler32:a73c88b1",
         "size": 191427,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8d6b90fd328fcdf734c4595f70e2c87c.configFile.py"
       }
@@ -7479,7 +7479,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ac3ac86dd5a2fd2fb8a04d08abf95a804c8e36df",
+        "checksum": "adler32:753ca2f5",
         "size": 3651,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/88d21e388acd9191c9e326ff6dc48d10.configFile.py"
       }
@@ -7525,7 +7525,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4ec27a63592ce2563374fa7d54895fdf5f6fa817",
+        "checksum": "adler32:201205ff",
         "size": 9186,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9163813d.configFile.py"
       }
@@ -7571,7 +7571,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4ca0d62cae4cbc87041a0dfb188b146e8181008b",
+        "checksum": "adler32:46dd0d2e",
         "size": 7241,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf097785.configFile.py"
       }
@@ -7617,7 +7617,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:146eac0915ffeb0f5194e5e18f111e3362f303fa",
+        "checksum": "adler32:99630848",
         "size": 9191,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a7718.configFile.py"
       }
@@ -7663,7 +7663,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:318fad05b4fdaffd65f20d793d338dc6698e6ce8",
+        "checksum": "adler32:83f0bd2f",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01bf87.configFile.py"
       }
@@ -7709,7 +7709,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:440cb6440428816b1a7c7082e17d64de04c99e29",
+        "checksum": "adler32:97bce972",
         "size": 6987,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/584825b69f5a095993efd0af12bb5e42.configFile.py"
       }
@@ -7755,7 +7755,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d283e6b467b1a76181f0763578333863229216ab",
+        "checksum": "adler32:d282b1b0",
         "size": 4153,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/51bf5a6e98020fb8fa6dece923ed48d8.configFile.py"
       }
@@ -7801,7 +7801,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cff0bd10ff6eb22ed7bc1e1dc7a13577c250c83d",
+        "checksum": "adler32:1548feab",
         "size": 141650,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7b0f1f8e4df3d63108f095f9fa57f7ab.configFile.py"
       }
@@ -7847,7 +7847,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2efe43ffa30b784a28e63faf9131d57ec091075c",
+        "checksum": "adler32:63fe8482",
         "size": 7444,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9e0fb63675bdd7dc5283db9af45dee2f.configFile.py"
       }
@@ -7893,7 +7893,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d7affeb844dd13d5f3cef573edddbc125708b496",
+        "checksum": "adler32:6ca3a195",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6ce0aa.configFile.py"
       }
@@ -7939,7 +7939,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0306007ce8d749af6d5f1213906c7b638ff47262",
+        "checksum": "adler32:c5b1a3a7",
         "size": 3653,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e8df5e4.configFile.py"
       }
@@ -7985,7 +7985,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5fa45aa840d6b5d22d26a25e2730917d104874d6",
+        "checksum": "adler32:697d718d",
         "size": 2578,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ebd51c7.configFile.py"
       }
@@ -8031,7 +8031,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c71611e75f56ab56ef04d37e4e2d3c795c2481a6",
+        "checksum": "adler32:bf6e7209",
         "size": 2579,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc91b8a2d.configFile.py"
       }
@@ -8077,7 +8077,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e4dee16d3a9b49385a756ce3a6276eaed73925b8",
+        "checksum": "adler32:171ff300",
         "size": 3048,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f23324c0cc10d31c5a86d5e5ecc18194.configFile.py"
       }
@@ -8123,7 +8123,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e550001fce90a0697a806c10befa2466c9d86360",
+        "checksum": "adler32:90f3af4b",
         "size": 7699,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/5889fd7a33a3028626be5391385a468f.configFile.py"
       }
@@ -8169,7 +8169,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e66659dcd52028397cb2d874f11a4493e26e5f03",
+        "checksum": "adler32:3dc72230",
         "size": 7205,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/fc458394c2843a2ab77397966d51b3c0.configFile.py"
       }
@@ -8215,7 +8215,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1692cfac175d0ddd6cb9ddf2b647f0414d443cc3",
+        "checksum": "adler32:d993a18b",
         "size": 3646,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/222fee3fd4cf6edf83c4f37ad062d132.configFile.py"
       }
@@ -8261,7 +8261,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:17fc5427d6a232d1e3690a756764b7efab816f0e",
+        "checksum": "adler32:7812bc38",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf081293.configFile.py"
       }
@@ -8307,7 +8307,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:42969e538d0738a6636b9fd2ac3882779b436bbc",
+        "checksum": "adler32:688ebd2a",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf370842.configFile.py"
       }
@@ -8353,7 +8353,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ca48d3aac49139f9156db8021b0e84dc3fa41953",
+        "checksum": "adler32:da95000b",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/2f1e2ccb71a5dc3b16aeb4bc3e7300cc.configFile.py"
       }
@@ -8399,7 +8399,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:51cd4ad6b7eda182a758436d289d61cf04d32bd5",
+        "checksum": "adler32:1c10c6d5",
         "size": 2101,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695ccc7bf7.configFile.py"
       }
@@ -8445,7 +8445,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dd8b0f8d708ec0a55215825affbee487de200f3d",
+        "checksum": "adler32:1b7dff5b",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/1f48c8f34162458caedc7b1af94a232c.configFile.py"
       }
@@ -8491,7 +8491,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:60e16bcd4ac3b738d5106d9ef904c2d04ef99ac3",
+        "checksum": "adler32:cec8a11c",
         "size": 3645,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/88d21e388acd9191c9e326ff6dc478a3.configFile.py"
       }
@@ -8537,7 +8537,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3450ea755a8943f6458c6268d165f33d8205e79a",
+        "checksum": "adler32:ddeca188",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e703972.configFile.py"
       }
@@ -8583,7 +8583,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ca82da6daea52920d67cae28e48ec82881042c11",
+        "checksum": "adler32:9f6ca49d",
         "size": 3654,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6ce548.configFile.py"
       }
@@ -8629,7 +8629,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f4d7935482f5b41df0f631d2c5d86bf78d60faa7",
+        "checksum": "adler32:f91aab74",
         "size": 6026,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cdca324.configFile.py"
       }
@@ -8675,7 +8675,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3e918c28a8a3f92e54376ee1b6174cf26694c733",
+        "checksum": "adler32:ec2775fd",
         "size": 242502,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/88d21e388acd9191c9e326ff6dcafcff.configFile.py"
       }
@@ -8721,7 +8721,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0a504cf4cc17e47375c4852f67a145bee68eaa30",
+        "checksum": "adler32:85cd0019",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e057b5071cdc2df588be80e24a131404.configFile.py"
       }
@@ -8767,7 +8767,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:83be02df6d7829caf20400d67b8c22fb036e451a",
+        "checksum": "adler32:7a74bd2c",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf3cf54d.configFile.py"
       }
@@ -8813,7 +8813,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:026f766a8eeb3f5e4cdedb8911cef559e7bd223c",
+        "checksum": "adler32:7128ff77",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b17ed01fdcb093aaf395ab27ff353404.configFile.py"
       }
@@ -8859,7 +8859,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:316fd73fb6f4f22360fa9818aa066280a5105822",
+        "checksum": "adler32:53abeb59",
         "size": 7783,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4a1f22052abb5b3c51ee42f4dcdf5de7.configFile.py"
       }
@@ -8905,7 +8905,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1f5443979b4de6300d8daaa39e16a86495fe8728",
+        "checksum": "adler32:86648b62",
         "size": 4291,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d7c7e40a2583db7d5ecc08b5c9b12d26.configFile.py"
       }
@@ -8951,7 +8951,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c58e2bf867b27120390c4c14ea98faaf9b7d05e0",
+        "checksum": "adler32:e3a0aa2b",
         "size": 6019,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd7a448.configFile.py"
       }
@@ -8997,7 +8997,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fa76f0185015c924783bca03b96be637f8b341b8",
+        "checksum": "adler32:188ea225",
         "size": 3648,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6b407b.configFile.py"
       }
@@ -9043,7 +9043,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e1925424feaf57fc6bca667745aa5b03196a766f",
+        "checksum": "adler32:078e9507",
         "size": 8904,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/584825b69f5a095993efd0af12bb32cd.configFile.py"
       }
@@ -9089,7 +9089,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:58beb2d4dfd5a0bad53cd2d51b8fd3dd2ac3200b",
+        "checksum": "adler32:2fdbc8f3",
         "size": 6960,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9181dcfde0729882b449921320147b6e.configFile.py"
       }
@@ -9135,7 +9135,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:aec5c055435fd14d0bf3d1d31de94235a0d14218",
+        "checksum": "adler32:cb9f454a",
         "size": 216191,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/04afaf020d06de306b97edf3a0461d24.configFile.py"
       }
@@ -9181,7 +9181,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d1c814d007f3d056e81a9895cb57f17269315e4c",
+        "checksum": "adler32:c57bbd39",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf024c8a.configFile.py"
       }
@@ -9227,7 +9227,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1657eb999a281e3af8425b137c7ada1139e16953",
+        "checksum": "adler32:8c0a8498",
         "size": 84927,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/339cd62364712af8a4d594691b415ac1.configFile.py"
       }
@@ -9273,7 +9273,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eccecbbb7af0c87dd8a42e8f4d4995f1b26c8272",
+        "checksum": "adler32:8d62a182",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e8ea2cd.configFile.py"
       }
@@ -9319,7 +9319,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4514048dab811bf094aba76fc5774c4b22e31032",
+        "checksum": "adler32:0104a68a",
         "size": 3662,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db2931b0d.configFile.py"
       }
@@ -9365,7 +9365,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8b7d5d4958c4d690297ca0ec8b821a8dd41d7391",
+        "checksum": "adler32:087ef78e",
         "size": 8876,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/5d08a4b52573d04c228c9be58e7ba7ed.configFile.py"
       }
@@ -9411,7 +9411,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a816a0c3c5d270972a7e767a118318bc57730e45",
+        "checksum": "adler32:93c8ec30",
         "size": 7004,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/1f48c8f34162458caedc7b1af94a180a.configFile.py"
       }
@@ -9457,7 +9457,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e0159de048d160c96dc480fe9e07a0f87463fd73",
+        "checksum": "adler32:92e40657",
         "size": 8135,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf09dde3.configFile.py"
       }
@@ -9503,7 +9503,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8d4498f32fdc504f55dbf8401a9b4b79fde43a3f",
+        "checksum": "adler32:0d8e9ce9",
         "size": 3629,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db28f7d3f.configFile.py"
       }
@@ -9549,7 +9549,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:972110569119d35fcaf2b70290ff4f461dda2bcb",
+        "checksum": "adler32:3229076f",
         "size": 9188,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9163680d.configFile.py"
       }
@@ -9595,7 +9595,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d88f29472951fc0042992783bd10bd58cfaa95ff",
+        "checksum": "adler32:f93db577",
         "size": 16761,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/76dd68e16f83f9e75ac62a241e2ff844.configFile.py"
       }
@@ -9641,7 +9641,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e243c9be023f56acdf46887cee5d58eeff02537b",
+        "checksum": "adler32:8e78bd58",
         "size": 2078,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01ca14.configFile.py"
       }
@@ -9687,7 +9687,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:135c4e18f63c067eede0fbb118a622ed07914786",
+        "checksum": "adler32:470ac7f5",
         "size": 2105,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/3aca8f1bdff067de8609ce4479b9fffc.configFile.py"
       }
@@ -9733,7 +9733,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:78a4c0e30a16c8b87b9d6f3e036fe244fe7afcf4",
+        "checksum": "adler32:6133a98e",
         "size": 6016,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cdb60c7.configFile.py"
       }
@@ -9779,7 +9779,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6020b9ea3922281f1734c45d669c9685ba00f1a6",
+        "checksum": "adler32:11171e60",
         "size": 7240,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f6796.configFile.py"
       }
@@ -9825,7 +9825,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:83488c36608fa7c23223acae657215188ebacba1",
+        "checksum": "adler32:94dc78fc",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ebefdcb.configFile.py"
       }
@@ -9871,7 +9871,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:350072253ec2b0a6defb5ec2d2cfaf5ed43e706f",
+        "checksum": "adler32:7aa6f808",
         "size": 8879,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/5d08a4b52573d04c228c9be58e7c9ab8.configFile.py"
       }
@@ -9917,7 +9917,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9a74b4f774b4bc83c21435c7e8eaed243b7bb445",
+        "checksum": "adler32:539c74f2",
         "size": 2587,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc94e8056.configFile.py"
       }
@@ -9963,7 +9963,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f4b498d0e41ac6d60456b4f612db1becb24a8ab6",
+        "checksum": "adler32:46726d96",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8c7ef.configFile.py"
       }
@@ -10009,7 +10009,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f9fefd8338c60c0e61e6d61bbb6a480ea07576b4",
+        "checksum": "adler32:797f337e",
         "size": 6460,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf09a4d8.configFile.py"
       }
@@ -10055,7 +10055,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6928b3f4807f5e69a6d64e4902936792760ae40d",
+        "checksum": "adler32:8690fc0a",
         "size": 4639,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6c6ff3f35efb680aebe72ced3d012006.configFile.py"
       }
@@ -10101,7 +10101,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b282d9b50d9e8e99fcc86ecbe5977c1bdc8ebc8f",
+        "checksum": "adler32:a98224c4",
         "size": 8997,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7c7c0e8e128b3d1a9f287090342312e2.configFile.py"
       }
@@ -10147,7 +10147,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5dfe18c814013080e16e28ae6562f208c538bd0c",
+        "checksum": "adler32:942f791e",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ec793ac.configFile.py"
       }
@@ -10193,7 +10193,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:93fda8d108ba47ef0f5d9464f52a4e1fee8c5cb0",
+        "checksum": "adler32:9df6e1ba",
         "size": 3680,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c9e000c71f90818cafc2ea88b2e7f02c.configFile.py"
       }
@@ -10239,7 +10239,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5c4a6ba8c5ed6670298cb8327a056f4ab0514ac6",
+        "checksum": "adler32:cbeb724f",
         "size": 2582,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6cfb7b.configFile.py"
       }
@@ -10285,7 +10285,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9cb2691360651fddf25287a7dfb26999be228fe7",
+        "checksum": "adler32:efce07ad",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91455828.configFile.py"
       }
@@ -10331,7 +10331,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d61f638afcea3ef067553bd9cd1ebcdc77a3df0e",
+        "checksum": "adler32:0bae729a",
         "size": 2583,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6d0393.configFile.py"
       }
@@ -10377,7 +10377,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:74062da093f1a5d505c9d40fcb4e05f05c4e88a5",
+        "checksum": "adler32:fe92a421",
         "size": 3653,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db2951c61.configFile.py"
       }
@@ -10423,7 +10423,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4919bb00ef282b5bf2621202c5bbbc453dd76aa3",
+        "checksum": "adler32:7e920f4c",
         "size": 9045,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cbb3e0ee51f19be8f8a04cf25963e11a.configFile.py"
       }
@@ -10469,7 +10469,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8f9c4cd6d56418f81e0853c38435b4d39c5481e0",
+        "checksum": "adler32:4703bc2f",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf371d91.configFile.py"
       }
@@ -10515,7 +10515,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:90a9e707ff67776256312f2de43f5d2b30913f23",
+        "checksum": "adler32:d74b07a0",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9143d1cf.configFile.py"
       }
@@ -10561,7 +10561,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e3d7d68729ab51674b910cca93794016bd1d6423",
+        "checksum": "adler32:29db9264",
         "size": 8906,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c08df1fda127154276e899c872a73726.configFile.py"
       }
@@ -10607,7 +10607,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5dd8feacf7327028ac4d48de522934f1c1fae730",
+        "checksum": "adler32:ba6ab9c4",
         "size": 3556,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/bba69ae19e1fbc577b22ff7379801965.configFile.py"
       }
@@ -10653,7 +10653,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:55a172fde945971ffe02f5063479a475a30a2ff1",
+        "checksum": "adler32:a76c1e4a",
         "size": 7240,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f4e0a.configFile.py"
       }
@@ -10699,7 +10699,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a50a22ae390db084b9a65728f0a7c0959145d337",
+        "checksum": "adler32:01bae856",
         "size": 4579,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6c6ff3f35efb680aebe72ced3d0114b3.configFile.py"
       }
@@ -10745,7 +10745,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:120a0a87ca44e89b9603fb3ff4994db59fee8eb0",
+        "checksum": "adler32:01efe99f",
         "size": 3608,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f4f344f.configFile.py"
       }
@@ -10791,7 +10791,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:265bf2acacb86ba571ed4ef9aa432970f5c33bdf",
+        "checksum": "adler32:6b40bd2b",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf3692b1.configFile.py"
       }
@@ -10837,7 +10837,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:62d9dc0be600ac72e9e94e6657a2d259f00f946e",
+        "checksum": "adler32:6893c70a",
         "size": 2102,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd7ae8d.configFile.py"
       }
@@ -10883,7 +10883,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1d85de67874827ba6a4db43667b23a0e3d052901",
+        "checksum": "adler32:35d8716c",
         "size": 2577,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc94e7575.configFile.py"
       }
@@ -10929,7 +10929,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3da3b85cc67071033c46c8e743dd4662c6ad79e5",
+        "checksum": "adler32:71bce5df",
         "size": 3684,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c9e000c71f90818cafc2ea88b2e92143.configFile.py"
       }
@@ -10975,7 +10975,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0b08d3d853e3df2c63b08570b0dba9a2b039a352",
+        "checksum": "adler32:38a49d5f",
         "size": 3629,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db28f5b74.configFile.py"
       }
@@ -11021,7 +11021,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f6ee5221fa8cc0d93a2008b145b8432a7e6c4dc0",
+        "checksum": "adler32:1f3a2ce4",
         "size": 7217,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de559091e.configFile.py"
       }
@@ -11067,7 +11067,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:536e34c84fa2ce8020bb65ffc284daee423a519b",
+        "checksum": "adler32:0b54ea7e",
         "size": 2997,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0de33f0c9cb94c9f73cd4e86d85bb408.configFile.py"
       }
@@ -11113,7 +11113,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b91becd2daeeb02a9c971f58e3dda275d43050e9",
+        "checksum": "adler32:67d7fdb5",
         "size": 3068,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc95ea473.configFile.py"
       }
@@ -11159,7 +11159,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e4e985c6430c6b827d945450097469799100aa78",
+        "checksum": "adler32:dd11a134",
         "size": 3645,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/222fee3fd4cf6edf83c4f37ad06aee2e.configFile.py"
       }
@@ -11205,7 +11205,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:87b9ee78ba6fca1194fa06e010e93fbcb72178ef",
+        "checksum": "adler32:dad29c23",
         "size": 3626,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f39b8d56dd05ca1999a63e017522b2bd.configFile.py"
       }
@@ -11251,7 +11251,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3ecc9e026f49922862a6f4f3c302957986b76513",
+        "checksum": "adler32:dbe2a1a0",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e701da7.configFile.py"
       }
@@ -11297,7 +11297,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:580481f40e88422d55a64eb5ee8f6342b83f12a5",
+        "checksum": "adler32:516c916f",
         "size": 8912,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b78f836a8fc0457f3d1cf476794b8075.configFile.py"
       }
@@ -11343,7 +11343,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:07edfb7cc6131a4d0f92d89390cd6bca4e8485eb",
+        "checksum": "adler32:a45578fd",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba69033fa308.configFile.py"
       }
@@ -11389,7 +11389,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c0836dfbdcb98f5808f2a95946256b33301a8690",
+        "checksum": "adler32:1ebb7442",
         "size": 2588,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6c4761.configFile.py"
       }
@@ -11435,7 +11435,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7319437f96d04c6c454f82490174743b1ccac6e3",
+        "checksum": "adler32:3adda13d",
         "size": 3645,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/222fee3fd4cf6edf83c4f37ad06ace96.configFile.py"
       }
@@ -11481,7 +11481,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:964125ff9ea69421a3f2ddb3e21e03c5a3b624e0",
+        "checksum": "adler32:abd13b36",
         "size": 8038,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9ebe5de2113c461586671dca1e0933a5.configFile.py"
       }
@@ -11527,7 +11527,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3f345a2683e77249f1581f5710546532c5b58f02",
+        "checksum": "adler32:d9daffe7",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/787d59798ba1957342f08d4d11fd908b.configFile.py"
       }
@@ -11573,7 +11573,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e97b0c1d246dffdf5c35a21892b3d8f39d933b20",
+        "checksum": "adler32:9cb2abcd",
         "size": 6027,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cda44c5.configFile.py"
       }
@@ -11619,7 +11619,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:472d950294deaa857b6ca610bdff8e4a16c15359",
+        "checksum": "adler32:61e87917",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ec02a75.configFile.py"
       }
@@ -11665,7 +11665,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:364dbbc3a2892f87cdf88235ec71aa36431f87c8",
+        "checksum": "adler32:8a65f79d",
         "size": 8876,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f0d6b2bf7129ab2b0e2d083668b685d9.configFile.py"
       }
@@ -11711,7 +11711,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:67bd0e77ad4112a3bfceeb48d38e3b0db9a1c884",
+        "checksum": "adler32:78bbbd2c",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf010f0e.configFile.py"
       }
@@ -11757,7 +11757,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:49214a29bdb73629630ca5099183377ff4202297",
+        "checksum": "adler32:f30e9f68",
         "size": 7514,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/510c7148bdece85b1d05dd872b265ad9.configFile.py"
       }
@@ -11803,7 +11803,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c21c4c58c250d34f1f70aa357f8ecf1294d41ed1",
+        "checksum": "adler32:a4e60ed1",
         "size": 2294,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b365fdf38.configFile.py"
       }
@@ -11849,7 +11849,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8db031bffac5d6855e5781b34fb74885495b073f",
+        "checksum": "adler32:e26c9cd6",
         "size": 3627,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db28f6d80.configFile.py"
       }
@@ -11895,7 +11895,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1701acda1b674a8719ad26a1a035ac945fa2dae3",
+        "checksum": "adler32:7d4bab7e",
         "size": 4140,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d4a9628510529dee2af9af0bc92340b8.configFile.py"
       }
@@ -11941,7 +11941,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:054bb7d0a1b39b6a11411509e77b208eac26984a",
+        "checksum": "adler32:c24307ac",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b914fc5e9.configFile.py"
       }
@@ -11987,7 +11987,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cd2de3b4c99749723bbb74bd38c19e91ffe3367f",
+        "checksum": "adler32:4608bc2e",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf378daa.configFile.py"
       }
@@ -12033,7 +12033,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b3f3bafb00341816287e1ce0a3fe1655c890a5bd",
+        "checksum": "adler32:133ea1c7",
         "size": 3645,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e71ebbc.configFile.py"
       }
@@ -12079,7 +12079,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5f2b6634ef6f72caf0040e3fa7d35efada22a43b",
+        "checksum": "adler32:7b8bbc37",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf02765b.configFile.py"
       }
@@ -12125,7 +12125,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:76ec2090389e3566e9df3b13582de186f76d1a9e",
+        "checksum": "adler32:edc77908",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba69033e3a47.configFile.py"
       }
@@ -12171,7 +12171,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a50c9ccfdaa989fcf215b1356d913e897f0e6848",
+        "checksum": "adler32:641d2076",
         "size": 82932,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8d6b90fd328fcdf734c4595f70e92ced.configFile.py"
       }
@@ -12217,7 +12217,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1544adfa55c1765abaa885ed95ffb86f53e8a86a",
+        "checksum": "adler32:77ec3570",
         "size": 9033,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7c7c0e8e128b3d1a9f28709034230d8c.configFile.py"
       }
@@ -12263,7 +12263,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:77768e30d9fa0afbfc0eda2015d1390cd57792f0",
+        "checksum": "adler32:ebfe65fc",
         "size": 9192,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/bae16f62ba4e90393266e2b342d1d10a.configFile.py"
       }
@@ -12309,7 +12309,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:593234af2ddf7834d6f1ea49fac67362c8e14af0",
+        "checksum": "adler32:121f1e93",
         "size": 7241,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f5c81.configFile.py"
       }
@@ -12355,7 +12355,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d3af536645e797e0603147e36a5a659318734834",
+        "checksum": "adler32:588f6d3d",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101741df0.configFile.py"
       }
@@ -12401,7 +12401,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6dad7675b99e0dc9178f25a8b5c21683df7ec5d6",
+        "checksum": "adler32:d4de0830",
         "size": 9191,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9144bb8e.configFile.py"
       }
@@ -12447,7 +12447,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:986158cb7af0e08d97d4e776d2b646039a3f94fb",
+        "checksum": "adler32:26e7c821",
         "size": 2105,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd7ae5f.configFile.py"
       }
@@ -12493,7 +12493,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:77763d5b299a72955b32762c2ecb071c208cf74e",
+        "checksum": "adler32:7b9e9c73",
         "size": 138112,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cceb077.configFile.py"
       }
@@ -12539,7 +12539,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8cd10c8db8274257f319822f2fd76e59bc1065dd",
+        "checksum": "adler32:3d3cbd22",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf017225.configFile.py"
       }
@@ -12585,7 +12585,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b1a7d7bfd658520c25476dbaa9316e3896861f4d",
+        "checksum": "adler32:abb95dc4",
         "size": 6643,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d1e71d39919455bc55d126c5a80192dd.configFile.py"
       }
@@ -12631,7 +12631,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fae89b0789b1a0199ea66795f248e17a30524be0",
+        "checksum": "adler32:e5e38e0a",
         "size": 3577,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a3e9a49adb11d7079eda533cfa1f8b39.configFile.py"
       }
@@ -12677,7 +12677,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e9b06475be487afa46ca87da5fe6511d329c5d00",
+        "checksum": "adler32:2bcc7932",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53e006ee3.configFile.py"
       }
@@ -12723,7 +12723,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f2db3021eac8cc6c5c8f8d2834132c08f50c2a8b",
+        "checksum": "adler32:93f1a185",
         "size": 3646,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/88d21e388acd9191c9e326ff6dc48a67.configFile.py"
       }
@@ -12769,7 +12769,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:96c9509b02677b2a80a75bb1c1c9a05c156cd17e",
+        "checksum": "adler32:a2a71e37",
         "size": 7239,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f57e2.configFile.py"
       }
@@ -12815,7 +12815,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f15b549aa2b66e559349ca23eee5c73c9bc0f3ae",
+        "checksum": "adler32:6c380749",
         "size": 9188,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a55aa.configFile.py"
       }
@@ -12861,7 +12861,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bc270346c1fe282524b6ca360249df5bdd044f63",
+        "checksum": "adler32:d0ddc3cf",
         "size": 2098,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf00f661.configFile.py"
       }
@@ -12907,7 +12907,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fff88ebb8256662898eaf93075e67fe38037d87f",
+        "checksum": "adler32:6e89f7d4",
         "size": 3948,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/62bbbeb9072f4819cb9a6a0673240e80.configFile.py"
       }
@@ -12953,7 +12953,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8abd573c3932d1d2105d00c5384b4d75d3fe60dd",
+        "checksum": "adler32:54a26d99",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8b900.configFile.py"
       }
@@ -12999,7 +12999,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f068aaba4356498fb8cf706072972df6839b82a1",
+        "checksum": "adler32:f370e07f",
         "size": 3586,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/2e0a80c07f23808d4b75c974eaf57bbc.configFile.py"
       }
@@ -13045,7 +13045,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4f3b16011ae23362cf78da184a4badd14484ed6d",
+        "checksum": "adler32:104657d2",
         "size": 7377,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a18d736b69d54ffbc617374d326dd3fd.configFile.py"
       }
@@ -13091,7 +13091,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:31818fc4048ee7aebec97fbe97af66001541b144",
+        "checksum": "adler32:83f1a30d",
         "size": 3651,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/222fee3fd4cf6edf83c4f37ad06b200b.configFile.py"
       }
@@ -13137,7 +13137,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:692d1de962b9ae4398fa43c7c9a7f584a5dad53c",
+        "checksum": "adler32:d59f1e96",
         "size": 7242,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f1560.configFile.py"
       }
@@ -13183,7 +13183,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:66fbce279cfe11e8d06819a296fd2d87a8286713",
+        "checksum": "adler32:a4b6f373",
         "size": 7254,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/45f0d743eb37f734b1c0870479dd06d4.configFile.py"
       }
@@ -13229,7 +13229,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:831655207b437a5c2cca64c48711238942ef04f8",
+        "checksum": "adler32:25a7bc2a",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf023d61.configFile.py"
       }
@@ -13275,7 +13275,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:87ca44956fd8c88747bfc8087a05f43f82818937",
+        "checksum": "adler32:5c557427",
         "size": 2588,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6c3c6d.configFile.py"
       }
@@ -13321,7 +13321,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6b618ce2033452739a088bd95fdc2fb3cebf22b0",
+        "checksum": "adler32:990cbd30",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf369d8a.configFile.py"
       }
@@ -13367,7 +13367,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:af8b11f69474ff197c843ae49f8ecf3338d2e1e5",
+        "checksum": "adler32:e14cf326",
         "size": 16107,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/76dd68e16f83f9e75ac62a241e303b48.configFile.py"
       }
@@ -13413,7 +13413,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:64af224ac79381c457742adadd2ff0434e321c70",
+        "checksum": "adler32:73cebc37",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf023e33.configFile.py"
       }
@@ -13459,7 +13459,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9c521d9ecb3e9843dd5cbba098d15673811631ff",
+        "checksum": "adler32:f45172db",
         "size": 2584,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6d091f.configFile.py"
       }
@@ -13505,7 +13505,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6e486e73fe14a5fa7a2b78ee3e4c17a2fb729bcf",
+        "checksum": "adler32:e05703d5",
         "size": 4653,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d7c7e40a2583db7d5ecc08b5c9b12a62.configFile.py"
       }
@@ -13551,7 +13551,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:00b4352d0c4c1eb24bc6f1edd0d2532426b937d1",
+        "checksum": "adler32:a392262c",
         "size": 7200,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de559dfbe.configFile.py"
       }
@@ -13597,7 +13597,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ea2bf5aede9bcb5af7d252f443c61c65e525b436",
+        "checksum": "adler32:71f28f46",
         "size": 8898,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/41e90e49470d54645977450d28d23740.configFile.py"
       }
@@ -13643,7 +13643,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:008f0bba811c158201897d8be08aecf8b8c88f99",
+        "checksum": "adler32:f39d7299",
         "size": 2583,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6d0bcd.configFile.py"
       }
@@ -13689,7 +13689,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9aba4461b8b731577fbb583be610ab2edeaceec0",
+        "checksum": "adler32:bcf86d28",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101745520.configFile.py"
       }
@@ -13735,7 +13735,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e11ad03151316330e0d560d07bac41436df8945d",
+        "checksum": "adler32:2597edd5",
         "size": 3618,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f51f811.configFile.py"
       }
@@ -13781,7 +13781,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:179e80985976b64469ceca4f8d9674a15857d930",
+        "checksum": "adler32:359bbd22",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01ef7b.configFile.py"
       }
@@ -13827,7 +13827,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:28c3f9398a7a83a3545b684672e3efa0aeee63ba",
+        "checksum": "adler32:ded4bc49",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf026adc.configFile.py"
       }
@@ -13873,7 +13873,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:26cdead8271f7525aed587f00e7c0dd26292ddfc",
+        "checksum": "adler32:20523935",
         "size": 8046,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9ebe5de2113c461586671dca1e091d6b.configFile.py"
       }
@@ -13919,7 +13919,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:80689e56293b5abb58b54d27921ad1985d6bc8d5",
+        "checksum": "adler32:5bdcbc35",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf013da9.configFile.py"
       }
@@ -13965,7 +13965,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5baca0af1d25bb4fda2b6988123726ee320ca469",
+        "checksum": "adler32:d39bffbd",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d4a9628510529dee2af9af0bc92626b6.configFile.py"
       }
@@ -14011,7 +14011,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b1a8d1ab0c33848771e53961173cfd4af27948cf",
+        "checksum": "adler32:7d5a0ecb",
         "size": 2294,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b365e5591.configFile.py"
       }
@@ -14057,7 +14057,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d18370ed00d509900ba2e03f43a8fd08126032da",
+        "checksum": "adler32:457d7937",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba690346aaf5.configFile.py"
       }
@@ -14103,7 +14103,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c176900ca1c91d5beec45c8b3654357036d36385",
+        "checksum": "adler32:9db096d0",
         "size": 8919,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/40f18a4101a71b9631b737ae01701b7a.configFile.py"
       }
@@ -14149,7 +14149,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e9851f5597f2bd46f349d7b87578a1153f45605a",
+        "checksum": "adler32:b58173bf",
         "size": 2586,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ec04500.configFile.py"
       }
@@ -14195,7 +14195,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b9a5320e0ad0e6c879b6abecab05989690c5b983",
+        "checksum": "adler32:5b616d3e",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101744b84.configFile.py"
       }
@@ -14241,7 +14241,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:240b7fdfd1c6b62d04ed937e0363d566ed85ed72",
+        "checksum": "adler32:c476089a",
         "size": 9193,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9144e254.configFile.py"
       }
@@ -14287,7 +14287,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a521580a55923295062580f6a484e8c816c7140c",
+        "checksum": "adler32:c16203b6",
         "size": 7158,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a97027acd9102d625e32a3b4f78e7a14.configFile.py"
       }
@@ -14333,7 +14333,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:185330356f929c10b6689537a4916e74bd917d03",
+        "checksum": "adler32:669b9c78",
         "size": 3628,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f39b8d56dd05ca1999a63e017522bc72.configFile.py"
       }
@@ -14379,7 +14379,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:07989e8fae7cbf382a13b6765fc978054d0680e7",
+        "checksum": "adler32:66846d3f",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f910173f2f5.configFile.py"
       }
@@ -14425,7 +14425,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eb6d23a8469d236d427f91cc7456d9d2da09cebb",
+        "checksum": "adler32:34d08cbb",
         "size": 3573,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a3e9a49adb11d7079eda533cfa1f9ee3.configFile.py"
       }
@@ -14471,7 +14471,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3c7ca92e6e3ecdf988de7efbb60e8bb1b64c2af5",
+        "checksum": "adler32:4409f110",
         "size": 4340,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/caf0a1e27e00a4ac2cf66edbe3651f28.configFile.py"
       }
@@ -14517,7 +14517,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a4aa55e50daf04945766f62b4208b2a25fd58c1b",
+        "checksum": "adler32:760d36c0",
         "size": 7398,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cbb3e0ee51f19be8f8a04cf2596463d2.configFile.py"
       }
@@ -14563,7 +14563,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b0c9adb0ede099ebc34191076643d0e0534063c9",
+        "checksum": "adler32:a15c25b6",
         "size": 7185,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/35f991cb1c1e772c0acaa98f4c796a89.configFile.py"
       }
@@ -14609,7 +14609,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:309941d0955addec5835d0a70460c73b62ef599e",
+        "checksum": "adler32:5d400e69",
         "size": 17052,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/796833acecbdb5e17bde7cd309059dc6.configFile.py"
       }
@@ -14655,7 +14655,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c053dc11a0ecb43da8abacbb70d1a8e4b1b31d23",
+        "checksum": "adler32:a886bd34",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf3cf4ac.configFile.py"
       }
@@ -14701,7 +14701,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d6ee57f7d0655880bb0df00e8a1b105f9cd5af58",
+        "checksum": "adler32:976e33c0",
         "size": 6461,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf2cf92b.configFile.py"
       }
@@ -14747,7 +14747,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:91bc17e7d66ea714efc44332cd41b24a3a80a88f",
+        "checksum": "adler32:60440794",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916a5f6b.configFile.py"
       }
@@ -14793,7 +14793,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:59702644a06f2a386daef4b1968397fe6525d9d4",
+        "checksum": "adler32:35f5079b",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91500162.configFile.py"
       }
@@ -14839,7 +14839,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f9e436e6372f1796ab038fdf12240cac39fae860",
+        "checksum": "adler32:a0fc2e16",
         "size": 24190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd507b4.configFile.py"
       }
@@ -14885,7 +14885,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:aca3a3ec9f2effe93e3529dc05334be06472913c",
+        "checksum": "adler32:27096d36",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101746b88.configFile.py"
       }
@@ -14931,7 +14931,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a1f4146ff83eb1946ba9ff3adce67e484154331e",
+        "checksum": "adler32:a4260cf3",
         "size": 2288,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b365ee6ab.configFile.py"
       }
@@ -14977,7 +14977,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7196f40804374641f7396c382a280f2ee4e647b8",
+        "checksum": "adler32:614ba46b",
         "size": 3654,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db2932a7d.configFile.py"
       }
@@ -15023,7 +15023,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a1d227edf8faac72d3bfb7c9ab5ef2f4536ed224",
+        "checksum": "adler32:e482758f",
         "size": 2589,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc9289a21.configFile.py"
       }
@@ -15069,7 +15069,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0ac7bb5ff2d8116ebfae7601918c17239a4705d1",
+        "checksum": "adler32:12b1a483",
         "size": 3653,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6b7105.configFile.py"
       }
@@ -15115,7 +15115,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b5b4161562b210c56beece3701b04360b5db208a",
+        "checksum": "adler32:fd101655",
         "size": 7129,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de567d3b6.configFile.py"
       }
@@ -15161,7 +15161,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7fbcfd2e4b8284cb085e3465fe1f90a327231967",
+        "checksum": "adler32:6b9c7473",
         "size": 10290,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/76dd68e16f83f9e75ac62a241e301035.configFile.py"
       }
@@ -15207,7 +15207,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8585fe4023b84c9710eff63efd033f480cfd3e62",
+        "checksum": "adler32:b10ebc40",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf39cbbe.configFile.py"
       }
@@ -15253,7 +15253,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8eb78834c08bc8116b1aeae78b9d2f2dce8a9488",
+        "checksum": "adler32:59d6e967",
         "size": 3693,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4866695a076ae48d093c752532bd8133.configFile.py"
       }
@@ -15299,7 +15299,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ae0d0d01e6c9d39eba88b15a5650f7b15a985d7e",
+        "checksum": "adler32:d2d1d7f2",
         "size": 8046,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/bd00ebc013d37b71001c73501add57a1.configFile.py"
       }
@@ -15345,7 +15345,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b86a7148d363f6fa1e73b8f4006faa32f450982d",
+        "checksum": "adler32:d4e4c7eb",
         "size": 2104,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd7295f.configFile.py"
       }
@@ -15391,7 +15391,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e65690981a1ea0bb31be15e9d02fdd59376d0f27",
+        "checksum": "adler32:6a973bc3",
         "size": 8238,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a18d736b69d54ffbc617374d326decc3.configFile.py"
       }
@@ -15437,7 +15437,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b01abffcc5630ca7ee62ef1fc999c07878583f0a",
+        "checksum": "adler32:be8ea186",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e70bbef.configFile.py"
       }
@@ -15483,7 +15483,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bc5a4fde2e96fd47c58f686937485b49bcfd4df5",
+        "checksum": "adler32:f2b9ea0f",
         "size": 2997,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0de33f0c9cb94c9f73cd4e86d8560a62.configFile.py"
       }
@@ -15529,7 +15529,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ddc8ea9a392eb75670e8671c454348ede55ba0b8",
+        "checksum": "adler32:f66d1e82",
         "size": 7241,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f1c3a.configFile.py"
       }
@@ -15575,7 +15575,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8bab8d4e2ed49865f381678e7273672f3dc3823e",
+        "checksum": "adler32:1c98eaa6",
         "size": 2997,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0de33f0c9cb94c9f73cd4e86d85b9364.configFile.py"
       }
@@ -15621,7 +15621,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:767008751ed5690de2850364155e89dd4f846c05",
+        "checksum": "adler32:6d46a1bf",
         "size": 3647,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6602d94fea27826ae6e8e0fcd3ca7156.configFile.py"
       }
@@ -15667,7 +15667,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b995419d7b25b7d00b28d0d1dea74c8100a6806c",
+        "checksum": "adler32:a951bc40",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01d739.configFile.py"
       }
@@ -15713,7 +15713,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:df457e52c24496199bd2355a369e3b73008c7fe3",
+        "checksum": "adler32:ff8b129e",
         "size": 4008,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/62bbbeb9072f4819cb9a6a067323e45d.configFile.py"
       }
@@ -15759,7 +15759,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f33e64ed184165c39d5d5dbb573139f061eaa944",
+        "checksum": "adler32:f9d5bb98",
         "size": 33375,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e9503a7214b07c7c615203890ad7407d.configFile.py"
       }
@@ -15805,7 +15805,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a330df215d89a3efae81980a1ae0f19646a1d9c2",
+        "checksum": "adler32:2fdba179",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6c984f.configFile.py"
       }
@@ -15851,7 +15851,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a54d3623cc09e40d185ea6d26bdecf2d29586f16",
+        "checksum": "adler32:01808a97",
         "size": 2667,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101744922.configFile.py"
       }
@@ -15897,7 +15897,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0c9c1c4f7d01c9e11684fbf9609f21c38ca310e6",
+        "checksum": "adler32:ba12b804",
         "size": 3495,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/01a9d2b5582107b1dbc8e080145c42b4.configFile.py"
       }
@@ -15943,7 +15943,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f906fad07b7f27bca9188f59bf2aa48c468370c6",
+        "checksum": "adler32:12206d34",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101746efa.configFile.py"
       }
@@ -15989,7 +15989,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9ae2bf4267c6d22e4e72027dd966f593c416780a",
+        "checksum": "adler32:994d7314",
         "size": 2585,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6cf399.configFile.py"
       }
@@ -16035,7 +16035,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:634161bd2fbe58b82f9127c33e37d9f7d4df1795",
+        "checksum": "adler32:9b200a94",
         "size": 7167,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f7f84.configFile.py"
       }
@@ -16081,7 +16081,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c36ed3caff04b06cb0c33859ce913501321cce25",
+        "checksum": "adler32:f535a137",
         "size": 3645,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/88d21e388acd9191c9e326ff6dc45c17.configFile.py"
       }
@@ -16127,7 +16127,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:887cf51ce1f3af2997d6e02664d3bd4a5f08dda3",
+        "checksum": "adler32:68a638b0",
         "size": 7259,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d7c7e40a2583db7d5ecc08b5c9b04488.configFile.py"
       }
@@ -16173,7 +16173,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c8175acdaae5a6ce5e9679f02da3fec91a50557b",
+        "checksum": "adler32:6c3f9da2",
         "size": 3631,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db2952010.configFile.py"
       }
@@ -16219,7 +16219,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:55ff5d8cb7a6a857a8f62eff638dacad09ca0972",
+        "checksum": "adler32:5bb1ee22",
         "size": 9868,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/3b550de389a8797af7b60cb845542d62.configFile.py"
       }
@@ -16265,7 +16265,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:672ec453fe15f7524aad9d55b1d594ed268e0905",
+        "checksum": "adler32:03d46d32",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f9101740763.configFile.py"
       }
@@ -16311,7 +16311,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:26cc0f6197537859786c8971810883bf14d55dff",
+        "checksum": "adler32:3fff1259",
         "size": 8933,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f0d6b2bf7129ab2b0e2d083668b67ca0.configFile.py"
       }
@@ -16357,7 +16357,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5c355c5d571fc80b5309a4ceb8e8039491f1e62e",
+        "checksum": "adler32:484ba3f6",
         "size": 3653,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7e87e26a3ecea5744a10820db293246a.configFile.py"
       }
@@ -16403,7 +16403,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d7ef85843b4d1d42d555c161a347da4f9316cbf2",
+        "checksum": "adler32:85089cf5",
         "size": 3629,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/f39b8d56dd05ca1999a63e0175229881.configFile.py"
       }
@@ -16449,7 +16449,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cf854e2034f1dbce9e01bd2714bd5e2b0df1fd5b",
+        "checksum": "adler32:14e04244",
         "size": 62931,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e9503a7214b07c7c615203890adecf09.configFile.py"
       }
@@ -16495,7 +16495,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b873a368c5ce8119097a508b175a948d79c70508",
+        "checksum": "adler32:7097bc37",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf024355.configFile.py"
       }
@@ -16541,7 +16541,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ee3d772543c75a8f203409456a21e083d9665741",
+        "checksum": "adler32:8c5d1722",
         "size": 4038,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/62bbbeb9072f4819cb9a6a067323f1ba.configFile.py"
       }
@@ -16587,7 +16587,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:006611ae47d1104c7f673f601a980df02d2256f5",
+        "checksum": "adler32:32254c71",
         "size": 11114,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cbb3e0ee51f19be8f8a04cf25964189c.configFile.py"
       }
@@ -16633,7 +16633,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:277c0a32aa90ecd9e37e5f422b16232764253910",
+        "checksum": "adler32:ca413bc7",
         "size": 111304,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/8d6b90fd328fcdf734c4595f70da3faf.configFile.py"
       }
@@ -16679,7 +16679,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f1bca1884265215d9b17fc57efeec5923d36f6b7",
+        "checksum": "adler32:64cc7ff5",
         "size": 6663,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de555da99.configFile.py"
       }
@@ -16725,7 +16725,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c9a846b601e9eae24cf8940ae766c525537abe8c",
+        "checksum": "adler32:2753713c",
         "size": 2577,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ebcc0db.configFile.py"
       }
@@ -16771,7 +16771,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:332176224ba5567f557e502b0e1ee4537d1d302a",
+        "checksum": "adler32:af42bd37",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01534f.configFile.py"
       }
@@ -16817,7 +16817,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7dfac0fc48fca6fa2bf3bcd40f6ac767402fb992",
+        "checksum": "adler32:b7986da7",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb89c0b.configFile.py"
       }
@@ -16863,7 +16863,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dd14d943c7c5782de0684a56b98d63961694cc62",
+        "checksum": "adler32:13377930",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba6903468f82.configFile.py"
       }
@@ -16909,7 +16909,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ffcf60fa24578938cff854624aa3b221e0c26941",
+        "checksum": "adler32:7033cbfc",
         "size": 23945,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695ccc51b5.configFile.py"
       }
@@ -16955,7 +16955,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2425cc0b3350a258ca91e59e4ddf95c2d39bc7d4",
+        "checksum": "adler32:eea1084c",
         "size": 9191,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9150006a.configFile.py"
       }
@@ -17001,7 +17001,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:28baca7e23f10c5367e58b534dcfb746820d782d",
+        "checksum": "adler32:3e4c91fe",
         "size": 3590,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a3e9a49adb11d7079eda533cfa1f8236.configFile.py"
       }
@@ -17047,7 +17047,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:82cca52739cf5bef4ba3b8968769d8946430ed50",
+        "checksum": "adler32:e8a8ea9c",
         "size": 2997,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0de33f0c9cb94c9f73cd4e86d85bc34e.configFile.py"
       }
@@ -17093,7 +17093,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d32b90494f471984e8f7aed0acf19f6abc61c99c",
+        "checksum": "adler32:48a7da2b",
         "size": 6960,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e057b5071cdc2df588be80e24a11fb92.configFile.py"
       }
@@ -17139,7 +17139,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:07c7c06cdcd05bff6897762d7fe7fc86243a7e2c",
+        "checksum": "adler32:086a7299",
         "size": 2583,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/947fc12e45a0789d78f4cf2e4a6cf6f4.configFile.py"
       }
@@ -17185,7 +17185,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6c12e70e50bc03fc3eacbaf89e0eac9953275e5a",
+        "checksum": "adler32:94602d72",
         "size": 9185,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf0a2a9b.configFile.py"
       }
@@ -17231,7 +17231,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ba91a4f6ae47d2ae480dcde165df79e92e0f23ce",
+        "checksum": "adler32:4388e941",
         "size": 3693,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4866695a076ae48d093c752532bd83d4.configFile.py"
       }
@@ -17277,7 +17277,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c8821effea5b54cf6497cdbd8cd553f7e8cee5ca",
+        "checksum": "adler32:7537e1f5",
         "size": 3680,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c9e000c71f90818cafc2ea88b2e7dc6e.configFile.py"
       }
@@ -17323,7 +17323,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ed103d9b78a022eae7ca9ec8a2fc38d94a9c7da9",
+        "checksum": "adler32:4def2617",
         "size": 7201,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de553ce09.configFile.py"
       }
@@ -17369,7 +17369,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:354ee2b867a613870cd05b29d979e2991a2ede60",
+        "checksum": "adler32:00c90866",
         "size": 9193,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b916352f3.configFile.py"
       }
@@ -17415,7 +17415,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5de1a6dee7a5504c0dd6704d16a6fb276689507a",
+        "checksum": "adler32:6b8507b8",
         "size": 9190,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b9142efe4.configFile.py"
       }
@@ -17461,7 +17461,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f1195289e79936cba7100993ad8c91a4bf5b1bdd",
+        "checksum": "adler32:e9136dae",
         "size": 2565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/23c01d3a9a0824b0bc16413a3cb8c957.configFile.py"
       }
@@ -17507,7 +17507,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cdf36cbd1f4801ecb56865c6c14f36f9d5deec60",
+        "checksum": "adler32:2fe6a179",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e702e3f.configFile.py"
       }
@@ -17553,7 +17553,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1634345e7deb08f57af305b828e45a2bd347a2c5",
+        "checksum": "adler32:eb75a4a4",
         "size": 3654,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e6bdbeb.configFile.py"
       }
@@ -17599,7 +17599,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3df75c25ce4d5028a09541be6e1ab97d19d8993f",
+        "checksum": "adler32:6ddaff23",
         "size": 4388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c729fce63ed969fa8b51acab368c66c5.configFile.py"
       }
@@ -17645,7 +17645,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c71aa7d57625f797da8f6c196aefbb8d6f69eb17",
+        "checksum": "adler32:3a717089",
         "size": 2575,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c637c5fe20bd26655249c48bc92f24fc.configFile.py"
       }
@@ -17691,7 +17691,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6af36aada8d28ed89f1d0f55ec2fc53f7c513ccc",
+        "checksum": "adler32:f0862e3f",
         "size": 8997,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7c7c0e8e128b3d1a9f28709034231c06.configFile.py"
       }
@@ -17737,7 +17737,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:919f780d21aea866d85a344512f2eba3818b47bc",
+        "checksum": "adler32:74a3f67f",
         "size": 4609,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d7c7e40a2583db7d5ecc08b5c9b12c79.configFile.py"
       }
@@ -17783,7 +17783,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b9255e80e37992e45774ca86263d32a136ef5b35",
+        "checksum": "adler32:c985e8af",
         "size": 3612,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/30e13855854aafbbf5042c9d7f520829.configFile.py"
       }
@@ -17829,7 +17829,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3579c523b05b0c12de3da22895813d8fdfe8cd88",
+        "checksum": "adler32:dada0e8a",
         "size": 2293,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b36619685.configFile.py"
       }
@@ -17875,7 +17875,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:05fdd326937498367cdd533f15356f78827e1c58",
+        "checksum": "adler32:97f773e7",
         "size": 11629,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/d7c7e40a2583db7d5ecc08b5c9b03da0.configFile.py"
       }
@@ -17921,7 +17921,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c19f912496dbc93fabb163e29db3483e958cc18d",
+        "checksum": "adler32:685578f6",
         "size": 2600,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/47de7af4e28799c29752ba69033fb1f0.configFile.py"
       }
@@ -17967,7 +17967,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:21da2da6fc4a375f7ece9508dd7839b095a2f48c",
+        "checksum": "adler32:0be209dd",
         "size": 9873,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/9ee7ac18c8fac8c1a71e3a640bffcea0.configFile.py"
       }
@@ -18013,7 +18013,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:57fad0049269093a3c1cc2f5c363df9917a9d7a5",
+        "checksum": "adler32:ed038a94",
         "size": 2667,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/98e64546356a58b305c61f910174234f.configFile.py"
       }
@@ -18059,7 +18059,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3e709bf33dedb20d6390d468132b4b879e89a961",
+        "checksum": "adler32:09e3244b",
         "size": 4068,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/62bbbeb9072f4819cb9a6a067323c437.configFile.py"
       }
@@ -18105,7 +18105,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c3740a8da8e4e50e8f3a97e1c3e98595479f5571",
+        "checksum": "adler32:23a778b9",
         "size": 2597,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e22b2bb5b0981d6ba66a06f53ec3b2e7.configFile.py"
       }
@@ -18151,7 +18151,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3323ee57c3aad731f97ed92fc137ed541969a6e1",
+        "checksum": "adler32:aa8d3214",
         "size": 4098,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/62bbbeb9072f4819cb9a6a0673241858.configFile.py"
       }
@@ -18197,7 +18197,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a87abb193e8cb6474c29408ff8e623dff9e5243e",
+        "checksum": "adler32:8c279c28",
         "size": 7505,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/4a1f22052abb5b3c51ee42f4dcde9c69.configFile.py"
       }
@@ -18243,7 +18243,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4d683f0c1083f26a7c6c611d3a7d4b4212900cdc",
+        "checksum": "adler32:c710bd39",
         "size": 2077,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf01a589.configFile.py"
       }
@@ -18289,7 +18289,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9ac9ae029cfe088296b27e937b1fac5d3db5efb7",
+        "checksum": "adler32:d930a189",
         "size": 3644,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/0d0714743f0204ed3c0144941e91811a.configFile.py"
       }
@@ -18335,7 +18335,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:33fb52e7db643b28a0f342ccc8121b9dc9cdabdf",
+        "checksum": "adler32:11d9114f",
         "size": 2303,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/6d737d082061a17da3b72f6b3660cc77.configFile.py"
       }
@@ -18381,7 +18381,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d96ccc03a2cf3d0f71406cb2710257efeece539a",
+        "checksum": "adler32:2acdcbf3",
         "size": 7006,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/e75da0ef8a4c51a102040e9de5556901.configFile.py"
       }
@@ -18427,7 +18427,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:286ece8dced265d1db509145fbfc135e64779e43",
+        "checksum": "adler32:1fff0765",
         "size": 9188,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b91695301.configFile.py"
       }
@@ -18473,7 +18473,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:863d43ec17d59b2d9cb80fa60c9fbffcd0f07dfc",
+        "checksum": "adler32:8949f776",
         "size": 3929,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/62bbbeb9072f4819cb9a6a067324280c.configFile.py"
       }
@@ -18519,7 +18519,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f6cc4c10eab1f5b2fc960391850563552b729f64",
+        "checksum": "adler32:5f97aa21",
         "size": 6019,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c5215c4f10370f5925caa5695cd9eb0e.configFile.py"
       }
@@ -18565,7 +18565,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:575029c211662f8cf9b9b69575b80e9f8f56deed",
+        "checksum": "adler32:9f789184",
         "size": 3588,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a3e9a49adb11d7079eda533cfa1ee549.configFile.py"
       }
@@ -18611,7 +18611,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0fe02b9b42ff513309a296d98a4a1a32dee05307",
+        "checksum": "adler32:13545fd0",
         "size": 6651,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/1156e999350f625b865f0777d7f9562d.configFile.py"
       }
@@ -18657,7 +18657,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5c676d499048be3df7dc59d2efc0ba0ad8e900e0",
+        "checksum": "adler32:3e54bc2e",
         "size": 2074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf018ce5.configFile.py"
       }
@@ -18703,7 +18703,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cb343785ab838977a2cb4cf4b3143f968eb8f2a8",
+        "checksum": "adler32:d9c01eef",
         "size": 7244,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7bb91b34c2fcdd08f00eb3d3191f06e4.configFile.py"
       }
@@ -18749,7 +18749,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0108aed065c109efdbe82d33975c8e5bb44dc3c9",
+        "checksum": "adler32:5939f13d",
         "size": 4340,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/664dd7856adaa0b955b09f1433e38123.configFile.py"
       }
@@ -18795,7 +18795,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c584f4c2d1446f0012ae39d3c738f9522c610207",
+        "checksum": "adler32:6b57e1d2",
         "size": 3680,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/c9e000c71f90818cafc2ea88b2e7da63.configFile.py"
       }
@@ -18841,7 +18841,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:39136eb6cf80977d6d7e6d73a3be9ad6ec662b68",
+        "checksum": "adler32:62fb0834",
         "size": 9191,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/7daa6d84dd09f0024e982d7b914461c7.configFile.py"
       }
@@ -18887,7 +18887,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:31f273c10a920412785444fa54df009a81e3d557",
+        "checksum": "adler32:142bea81",
         "size": 2997,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a97027acd9102d625e32a3b4f78c79ac.configFile.py"
       }
@@ -18933,7 +18933,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2928ee56c5dfc6c46165fbf139904eb5a4f04ea8",
+        "checksum": "adler32:ebdec232",
         "size": 2093,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/a8b87e4a93ad780670c2864baf00ffcf.configFile.py"
       }
@@ -18979,7 +18979,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:71334c348823d47b5220a166f1f71e65d3d0bacb",
+        "checksum": "adler32:d34d4380",
         "size": 4595,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e958aa8.configFile.py"
       }
@@ -19025,7 +19025,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:874873bfab129bf792cb6e2abf3eff49912ec8c3",
+        "checksum": "adler32:83474140",
         "size": 4590,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e97b7c2.configFile.py"
       }
@@ -19071,7 +19071,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1c76982e4631b4f6fd58bd71005c0168ff9fc3f8",
+        "checksum": "adler32:abd741b8",
         "size": 4591,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e972c4b.configFile.py"
       }
@@ -19117,7 +19117,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b29184313a41e4e14bdfbe060c8aae8635f10f0a",
+        "checksum": "adler32:8b1acb93",
         "size": 6697,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e9527d4.configFile.py"
       }
@@ -19163,7 +19163,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f4bb3aac04c80c74a3678064591ac959715282c8",
+        "checksum": "adler32:65334229",
         "size": 4592,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e936581.configFile.py"
       }
@@ -19209,7 +19209,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:efbf56cf3aa01cbf14be96540509382464e5a75e",
+        "checksum": "adler32:16b581a7",
         "size": 8819,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e995804.configFile.py"
       }
@@ -19255,7 +19255,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e058b214b6ccdb7d241cdca3035e069586e1c138",
+        "checksum": "adler32:04cd44a3",
         "size": 4598,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e9675f4.configFile.py"
       }
@@ -19301,7 +19301,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7195cd810d3f75854c099d01385a4ec1d3b601a5",
+        "checksum": "adler32:5360417d",
         "size": 4590,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e963393.configFile.py"
       }
@@ -19347,7 +19347,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4d7f787feeaf74f881225e1d94ea99ffc79e5cc6",
+        "checksum": "adler32:0747429e",
         "size": 4594,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e9c2b96.configFile.py"
       }
@@ -19393,7 +19393,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8dc80bf12b23c5c3e4d59d9f340be4bb60b63097",
+        "checksum": "adler32:7bf9e747",
         "size": 7384,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e983f2e.configFile.py"
       }
@@ -19439,7 +19439,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:600801b794353db544d839de5865888a059cff94",
+        "checksum": "adler32:9f1f42d2",
         "size": 4593,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e927f5e.configFile.py"
       }
@@ -19485,7 +19485,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f5de088b2661b4f90c16faed795480c29a5a3096",
+        "checksum": "adler32:6e6843df",
         "size": 4596,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e9a2f16.configFile.py"
       }
@@ -19531,7 +19531,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:db5449f68580b3b3c1cac34daf7f0cb5298da9e4",
+        "checksum": "adler32:3b0f40f6",
         "size": 4589,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e992c09.configFile.py"
       }
@@ -19577,7 +19577,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:53684fd5872c549832c01380bb8a0803acd3b408",
+        "checksum": "adler32:d652d959",
         "size": 6638,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e92401d.configFile.py"
       }
@@ -19623,7 +19623,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:34dc861c42a4d0d5169420f7758de1a3226fe775",
+        "checksum": "adler32:c3694184",
         "size": 4590,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e95b846.configFile.py"
       }
@@ -19669,7 +19669,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:732578bd3e439f0ba341c2791d157b507aadd735",
+        "checksum": "adler32:53914388",
         "size": 4595,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e3db18c.configFile.py"
       }
@@ -19715,7 +19715,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:093756b71baab4992a859361fed18108a8bdf36d",
+        "checksum": "adler32:3114cb85",
         "size": 6697,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e463912.configFile.py"
       }
@@ -19761,7 +19761,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8051630d516bb6555f8ee74469b48eda73b6b850",
+        "checksum": "adler32:41aa66f3",
         "size": 8756,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e9b3301.configFile.py"
       }
@@ -19807,7 +19807,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c9f2c680d94e3f21802149fee16692264c7ca84c",
+        "checksum": "adler32:e7f14676",
         "size": 4602,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e40a16f.configFile.py"
       }
@@ -19853,7 +19853,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:aefd0dd405f9b452042a03409d290b2e51228100",
+        "checksum": "adler32:ac1f41a8",
         "size": 4591,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/b6ad4db04bcd6551c0d7907e7e91fbd4.configFile.py"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-csv-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-csv-files.json
@@ -66,7 +66,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5ed734291260108476cc73ad6e6948e067af579a",
+        "checksum": "adler32:9412cf10",
         "size": 1130837,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MultiJet/CSV/Apr21ReReco-v1/MultiJetRun2010B.csv.gz"
       }
@@ -135,57 +135,57 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c02038bcd10e2f99ec20ae48364138126c513707",
+        "checksum": "adler32:fcc5312a",
         "size": 1515458,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_0.csv"
       },
       {
-        "checksum": "sha1:28dadc13a7ad73129eb5b86d41e322da12e586bc",
+        "checksum": "adler32:19050705",
         "size": 15164517,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B.csv"
       },
       {
-        "checksum": "sha1:0da2e87ae55446646d967043dd0287d2dfad6ef8",
+        "checksum": "adler32:fb01b157",
         "size": 1519070,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_1.csv"
       },
       {
-        "checksum": "sha1:e37699128a5df23c72c3f82bee9100df1bc70ff9",
+        "checksum": "adler32:7e84a8e9",
         "size": 1517788,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_2.csv"
       },
       {
-        "checksum": "sha1:7100d14b68117c814a31cceeb36e6da43a0072ac",
+        "checksum": "adler32:7f0bd04c",
         "size": 1514795,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_3.csv"
       },
       {
-        "checksum": "sha1:737e01252db27aee177c3cd2872bcc3ff93001ac",
+        "checksum": "adler32:35ebb241",
         "size": 1512480,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_4.csv"
       },
       {
-        "checksum": "sha1:a0e3101e59c5356c953f86011ac98c0e16a02d44",
+        "checksum": "adler32:7c5b1042",
         "size": 1513438,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_5.csv"
       },
       {
-        "checksum": "sha1:34fe3f34eb1706313b8d227f9749910200e7d196",
+        "checksum": "adler32:1e7bca3b",
         "size": 1517489,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_6.csv"
       },
       {
-        "checksum": "sha1:cec72c075656abd838863a7701f3edf21248b8f6",
+        "checksum": "adler32:30a1bccf",
         "size": 1519419,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_7.csv"
       },
       {
-        "checksum": "sha1:28c1f2c6c0b1c9ba12674b557ae812f38941d968",
+        "checksum": "adler32:4c596409",
         "size": 1517741,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_8.csv"
       },
       {
-        "checksum": "sha1:a165e76d0909fc194cee33feea09033b9c203649",
+        "checksum": "adler32:9839f29c",
         "size": 1517640,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/CSV/Apr21ReReco-v1/MuRun2010B_9.csv"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-derived-csv-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-csv-Run2011A.json
@@ -111,42 +111,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8a4c77c6b029232002d48fea7046b44dc0329a21",
+        "checksum": "adler32:0607d5ee",
         "size": 7969331,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/CSV/12Oct2013-v1/Wmunu.csv"
       },
       {
-        "checksum": "sha1:09e44f937604ebfcf376df1cde989f1fb8541036",
+        "checksum": "adler32:1b06bb5d",
         "size": 9992209,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleElectron/CSV/12Oct2013-v1/Wenu.csv"
       },
       {
-        "checksum": "sha1:6c4240d2053407e6eacf42ea741381e3771727ca",
+        "checksum": "adler32:0d4cfe9f",
         "size": 970550,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/CSV/12Oct2013-v1/Zmumu.csv"
       },
       {
-        "checksum": "sha1:afb09475fefeba76b47c4b174d9f6f332a4481f0",
+        "checksum": "adler32:3ad4c332",
         "size": 1445651,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/CSV/12Oct2013-v1/Zee.csv"
       },
       {
-        "checksum": "sha1:a340510faad27eb26e7c5507bda17be245e51b58",
+        "checksum": "adler32:3f2809bc",
         "size": 11806904,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/CSV/12Oct2013-v1/Dimuon_SingleMu.csv"
       },
       {
-        "checksum": "sha1:0a5808fab9b380dce5d55f2aa5864f2931d49404",
+        "checksum": "adler32:5b87a72a",
         "size": 13935840,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/CSV/12Oct2013-v1/Dimuon_DoubleMu.csv"
       },
       {
-        "checksum": "sha1:8cc5dae7b28a24ed17e7b1cf05cbb21092e8d85a",
+        "checksum": "adler32:214e4077",
         "size": 2639302,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/CSV/12Oct2013-v1/Jpsimumu.csv"
       },
       {
-        "checksum": "sha1:690bcbb7a3c9ae4f8bb9e74f284d1ce3c50dcf3e",
+        "checksum": "adler32:5eef7b87",
         "size": 2599212,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/CSV/12Oct2013-v1/Ymumu.csv"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2011A.json
@@ -30,7 +30,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a100d93d3b27def7954fa5827e9717ab4ec407cc",
+        "checksum": "adler32:f0d6a520",
         "size": 2411180,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/BTag/IG/12Oct2013-v1/BTag.ig"
       }
@@ -108,7 +108,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2ebaaa08266c6369e929c5da38a56b2a40340ced",
+        "checksum": "adler32:15bcaf52",
         "size": 1798012,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/IG/12Oct2013-v1/DoubleElectron.ig"
       }
@@ -186,7 +186,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bab7be34c417b7ea9619ddca59cd4ba8cd7a5c6c",
+        "checksum": "adler32:bb7acec7",
         "size": 977790,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/IG/12Oct2013-v1/DoubleMu.ig"
       }
@@ -264,7 +264,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:304ad1e09d6f36882f54f54bd4375aa4271c7239",
+        "checksum": "adler32:56cb972e",
         "size": 2303208,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/ElectronHad/IG/12Oct2013-v1/ElectronHad.ig"
       }
@@ -342,7 +342,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d3c365fdd8221d3a987e77bc03118d459ce694b7",
+        "checksum": "adler32:905d4f8d",
         "size": 2211067,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/HT/IG/12Oct2013-v1/HT.ig"
       }
@@ -420,7 +420,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:65b943c86e7be81747d2518f4f8a8c801879da5f",
+        "checksum": "adler32:440a02de",
         "size": 1614085,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Jet/IG/12Oct2013-v1/Jet.ig"
       }
@@ -498,7 +498,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d5c24fc8a9ec9707cc71270292302f68dec2176c",
+        "checksum": "adler32:beaeecc3",
         "size": 2150169,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MET/IG/12Oct2013-v1/MET.ig"
       }
@@ -576,7 +576,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ed6721726c3b72c9565516907415e0af0e9ea932",
+        "checksum": "adler32:e5842aaf",
         "size": 1819169,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/METBTag/IG/12Oct2013-v1/METBTag.ig"
       }
@@ -654,7 +654,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9e19755b7d8867e901a4a207eaf133c66b6b29d3",
+        "checksum": "adler32:f7ca651b",
         "size": 887210,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MinimumBias/IG/12Oct2013-v1/MinimumBias.ig"
       }
@@ -732,7 +732,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ec269bb6d933b977a09a0d10c93ca393234feee6",
+        "checksum": "adler32:673d1c1e",
         "size": 2163729,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuEG/IG/12Oct2013-v1/MuEG.ig"
       }
@@ -810,7 +810,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cfb3cb6d98eecd798a3a2a6a7f0f52729d59076e",
+        "checksum": "adler32:bcef8544",
         "size": 2453022,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuHad/IG/12Oct2013-v1/MuHad.ig"
       }
@@ -888,7 +888,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:32b7aa78f6152ecc75061a04a0b65b344e197c30",
+        "checksum": "adler32:31d55ed2",
         "size": 2366586,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MultiJet/IG/12Oct2013-v1/MultiJet.ig"
       }
@@ -966,7 +966,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dce7399dc7441b72fe340076d2498c3abdd4a7bc",
+        "checksum": "adler32:cc9e4730",
         "size": 952330,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/MuOnia/IG/12Oct2013-v1/MuOnia.ig"
       }
@@ -1044,7 +1044,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:10df9baf26e81e00c8232b64c4df9f1697b4093e",
+        "checksum": "adler32:7bc72d44",
         "size": 1753916,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Photon/IG/12Oct2013-v1/Photon.ig"
       }
@@ -1122,7 +1122,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a19081ad26c63407d7eea74080e6ed046ac3f708",
+        "checksum": "adler32:5b9da950",
         "size": 2651040,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/PhotonHad/IG/12Oct2013-v1/PhotonHad.ig"
       }
@@ -1200,7 +1200,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a4acd4ea330c2438a1119438d7dfd8555cef2539",
+        "checksum": "adler32:ab0343a4",
         "size": 1813973,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleElectron/IG/12Oct2013-v1/SingleElectron.ig"
       }
@@ -1278,7 +1278,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d6580ac7560be6c87b1240560e788041fcb17ac0",
+        "checksum": "adler32:2e04cf30",
         "size": 1485070,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/IG/12Oct2013-v1/SingleMu.ig"
       }
@@ -1356,7 +1356,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:967e6c356b93c0d0fe5de1897572330658957238",
+        "checksum": "adler32:4aa38fa4",
         "size": 1392792,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Tau/IG/12Oct2013-v1/Tau.ig"
       }
@@ -1434,7 +1434,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:aef840b7d02da911cf1d802d9685084436006102",
+        "checksum": "adler32:4ad5e0fd",
         "size": 1603865,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/TauPlusX/IG/12Oct2013-v1/TauPlusX.ig"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012B.json
@@ -32,7 +32,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:25f583efc84fba23953501bbba90197e8f745fdb",
+        "checksum": "adler32:2ad5fc57",
         "size": 4657122,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/IG/22Jan2013-v1/BJetPlusX_Run2012B_0.ig"
       }
@@ -109,7 +109,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:981c3b0022b6ca9ce8c91d2d6d2e4811b3088370",
+        "checksum": "adler32:c96a40f4",
         "size": 2855989,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BTag/IG/22Jan2013-v1/BTag_Run2012B_0.ig"
       }
@@ -186,7 +186,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e6e3380fe96daa5d747077e41b0f83cf70aaf253",
+        "checksum": "adler32:6447e7b9",
         "size": 1213583,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/Commissioning/IG/22Jan2013-v1/Commissioning_Run2012B_0.ig"
       }
@@ -263,7 +263,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f0e937f78dbc432daf64b083d626b1bd853e58d8",
+        "checksum": "adler32:2a34a607",
         "size": 2735536,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/IG/22Jan2013-v1/DoubleElectron_Run2012B_0.ig"
       }
@@ -340,7 +340,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6315b113775e83c4cf9a4f1f7693feda1e661a21",
+        "checksum": "adler32:ba97d86a",
         "size": 2421331,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/IG/22Jan2013-v1/DoubleMuParked_Run2012B_0.ig"
       }
@@ -417,7 +417,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6c647816fdb33d58e5f37339c1ff9b56f9292edf",
+        "checksum": "adler32:102c3ef5",
         "size": 2290289,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/IG/22Jan2013-v1/DoublePhoton_Run2012B_0.ig"
       }
@@ -494,7 +494,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6af732ef22c007cb5222113c9eddf29e6216aae0",
+        "checksum": "adler32:5e32bc57",
         "size": 3483546,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhotonHighPt/IG/22Jan2013-v1/DoublePhotonHighPt_Run2012B_0.ig"
       }
@@ -571,7 +571,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0009d197aa5bb3f42842e241a401ab9f78d9e89f",
+        "checksum": "adler32:167d0cad",
         "size": 3496785,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/IG/22Jan2013-v1/ElectronHad_Run2012B_0.ig"
       }
@@ -648,7 +648,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7bd2fa50c5ad8a145d1770d4dee7d3e75952c645",
+        "checksum": "adler32:d68314c2",
         "size": 4297007,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/IG/22Jan2013-v1/HTMHTParked_Run2012B_0.ig"
       }
@@ -725,7 +725,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:af2ee47f08e04cb8c94949dc1663f4db47ca83de",
+        "checksum": "adler32:bbcf4f73",
         "size": 1635763,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HcalNZS/IG/22Jan2013-v1/HcalNZS_Run2012B_0.ig"
       }
@@ -802,7 +802,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dbb29dde6081ff5ea1fbe4297c88035ea6cd9487",
+        "checksum": "adler32:46253200",
         "size": 5070266,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/IG/22Jan2013-v1/JetHT_Run2012B_0.ig"
       }
@@ -879,7 +879,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fdb2c0c345438ee1728c982c360705257beac9d3",
+        "checksum": "adler32:32cf5980",
         "size": 3320518,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetMon/IG/22Jan2013-v1/JetMon_Run2012B_0.ig"
       }
@@ -956,7 +956,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2d8dec189915d8ceeeacb523921568d98f8d9887",
+        "checksum": "adler32:e614ba7d",
         "size": 2525841,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/IG/22Jan2013-v1/MET_Run2012B_0.ig"
       }
@@ -1033,7 +1033,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:434957cc490332f746859edf1823b70753afb9fe",
+        "checksum": "adler32:f5d06ff4",
         "size": 1674785,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MinimumBias/IG/22Jan2013-v1/MinimumBias_Run2012B_0.ig"
       }
@@ -1110,7 +1110,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:676e4b265a379632be8ae57a036c9012afa9b296",
+        "checksum": "adler32:f14cc19d",
         "size": 2767985,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/IG/22Jan2013-v1/MuEG_Run2012B_0.ig"
       }
@@ -1187,7 +1187,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:50405bc0086fa9c26b64a7a744b1b3b192d77023",
+        "checksum": "adler32:6a470fd1",
         "size": 4175894,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/IG/22Jan2013-v1/MuHad_Run2012B_0.ig"
       }
@@ -1264,7 +1264,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b3745d6c9b7882867778511d48ade58d11dc30c5",
+        "checksum": "adler32:9e1cf7ce",
         "size": 1903571,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/IG/22Jan2013-v1/MuOnia_Run2012B_0.ig"
       }
@@ -1341,7 +1341,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c0451b2c875e16e7d6fb169b4ac3047dd1b32330",
+        "checksum": "adler32:c7ac78e2",
         "size": 420370,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/NoBPTX/IG/22Jan2013-v1/NoBPTX_Run2012B_0.ig"
       }
@@ -1418,7 +1418,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ab2923deb1046de8236d46a45d3de2a802e49cba",
+        "checksum": "adler32:9df7d6c5",
         "size": 3293511,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/IG/22Jan2013-v1/PhotonHad_Run2012B_0.ig"
       }
@@ -1495,7 +1495,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6d09616b94253604f24cfe007fe9a4b33ab98e8e",
+        "checksum": "adler32:368c42ef",
         "size": 3115787,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/IG/22Jan2013-v1/SingleElectron_Run2012B_0.ig"
       }
@@ -1572,7 +1572,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:201c0cdf5946d2a2be30a6008050796c2bf915b8",
+        "checksum": "adler32:b538b35a",
         "size": 1748615,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/IG/22Jan2013-v1/SingleMu_Run2012B_0.ig"
       }
@@ -1649,7 +1649,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8b8188cfd4cdd33fa380090cf310b0b3187ca736",
+        "checksum": "adler32:56fb7383",
         "size": 2903012,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SinglePhoton/IG/22Jan2013-v1/SinglePhoton_Run2012B_0.ig"
       }
@@ -1726,7 +1726,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f38b9ab08589a7e3ec847802279796bb33e5b1d6",
+        "checksum": "adler32:047e8de9",
         "size": 2884098,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/IG/22Jan2013-v1/TauParked_Run2012B_0.ig"
       }
@@ -1803,7 +1803,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8ea52acbe86fa998447d1d4c5ad557ecb85c6a9b",
+        "checksum": "adler32:f3503913",
         "size": 2289465,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/IG/22Jan2013-v1/TauPlusX_Run2012B_0.ig"
       }
@@ -1880,7 +1880,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:48e50855f560aebfc0698133e73e4822aa9ef750",
+        "checksum": "adler32:f00ce9a6",
         "size": 3176610,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/IG/22Jan2013-v1/VBF1Parked_Run2012B_0.ig"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012C.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files-Run2012C.json
@@ -32,7 +32,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2b62f5b231ebcc5a097caa2df6e02622119837ee",
+        "checksum": "adler32:0b7738e7",
         "size": 3529192,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/IG/22Jan2013-v1/BJetPlusX_Run2012C_0.ig"
       }
@@ -109,7 +109,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cf2f64ab67ebbb07f1209475b9b73b482197279a",
+        "checksum": "adler32:d3623468",
         "size": 3065876,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BTag/IG/22Jan2013-v1/BTag_Run2012C_0.ig"
       }
@@ -186,7 +186,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:88867ab7d42aaea3f40d6dd05344b36e140eb7a1",
+        "checksum": "adler32:f70b4ee8",
         "size": 1543681,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/IG/22Jan2013-v1/Commissioning_Run2012C_0.ig"
       }
@@ -263,7 +263,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e32873dfd23ac1b404170f0a9a729f91c95deeb1",
+        "checksum": "adler32:25d42570",
         "size": 2257530,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/IG/22Jan2013-v1/DoubleElectron_Run2012C_0.ig"
       }
@@ -340,7 +340,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4477ed2ea68f9b101c03fc1378aa8c72b5d8dc4c",
+        "checksum": "adler32:c7743b4d",
         "size": 3012530,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/IG/22Jan2013-v1/DoubleMuParked_Run2012C_0.ig"
       }
@@ -417,7 +417,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e7263d2e7b8d7148dbd6ba643ec0654a5c21dd8c",
+        "checksum": "adler32:afee33dc",
         "size": 2581960,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/IG/22Jan2013-v2/DoublePhoton_Run2012C_0.ig"
       }
@@ -494,7 +494,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:13c79fb786ff0fc0f1cf0113879e69d8b1cfe3a1",
+        "checksum": "adler32:a5313ebc",
         "size": 3441201,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhotonHighPt/IG/22Jan2013-v1/DoublePhotonHighPt_Run2012C_0.ig"
       }
@@ -571,7 +571,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4222c37e3aa79df758eedcfbd15d6bac55127e4f",
+        "checksum": "adler32:a35e7447",
         "size": 3698072,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/IG/22Jan2013-v1/ElectronHad_Run2012C_0.ig"
       }
@@ -648,7 +648,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9ff633788501a8aa3613500ba5b3091262379abf",
+        "checksum": "adler32:807a3c5c",
         "size": 4539126,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/IG/22Jan2013-v1/HTMHTParked_Run2012C_0.ig"
       }
@@ -725,7 +725,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:614e01589c497c3aabd577971138d226c92cb492",
+        "checksum": "adler32:cd8d712f",
         "size": 2014385,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HcalNZS/IG/22Jan2013-v1/HcalNZS_Run2012C_0.ig"
       }
@@ -802,7 +802,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0e26be3cf1a712908c636fb27ce84b4d556af368",
+        "checksum": "adler32:9db33bd7",
         "size": 4834920,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/IG/22Jan2013-v1/JetHT_Run2012C_0.ig"
       }
@@ -879,7 +879,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7b1184bae0ac1ed3467790241deb093dd3db7f09",
+        "checksum": "adler32:e7eb1be8",
         "size": 3782469,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetMon/IG/22Jan2013-v1/JetMon_Run2012C_0.ig"
       }
@@ -956,7 +956,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fa6c680c2b829cbd60ead541dd9a3946876f37a3",
+        "checksum": "adler32:67324c4a",
         "size": 3032299,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/IG/22Jan2013-v1/MET_Run2012C_0.ig"
       }
@@ -1033,7 +1033,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:781360c427490e96fb9049afb9ea114e216916e0",
+        "checksum": "adler32:78c0b9e5",
         "size": 1129918,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MinimumBias/IG/22Jan2013-v1/MinimumBias_Run2012C_0.ig"
       }
@@ -1110,7 +1110,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eb4d6aa4286e612d32a955d43d9e4486f2719aae",
+        "checksum": "adler32:ba326216",
         "size": 2713188,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/IG/22Jan2013-v1/MuEG_Run2012C_0.ig"
       }
@@ -1187,7 +1187,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8cb0f25da4575c3c441d7d3db6e04693982a9b6f",
+        "checksum": "adler32:bb9b379a",
         "size": 4368131,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/IG/22Jan2013-v1/MuHad_Run2012C_0.ig"
       }
@@ -1264,7 +1264,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:01dc54f1e07fee641e7bf86d63bcf982599fd6f2",
+        "checksum": "adler32:bdee3189",
         "size": 2099934,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/IG/22Jan2013-v1/MuOnia_Run2012C_0.ig"
       }
@@ -1341,7 +1341,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:791b4b18cb79a6ea1e58e7e60cc860fe60eaeb0b",
+        "checksum": "adler32:39172f2d",
         "size": 481762,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/NoBPTX/IG/22Jan2013-v1/NoBPTX_Run2012C_0.ig"
       }
@@ -1418,7 +1418,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b528387c215eda69cfa09cee10cf644aba4abbc7",
+        "checksum": "adler32:86682bb8",
         "size": 4210535,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/IG/22Jan2013-v1/PhotonHad_Run2012C_0.ig"
       }
@@ -1495,7 +1495,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d812a70a0a9ce1115ba2660a822836fb1efa628f",
+        "checksum": "adler32:e6473603",
         "size": 3081204,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/IG/22Jan2013-v1/SingleElectron_Run2012C_0.ig"
       }
@@ -1572,7 +1572,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5d9501f3d8f8a920ec3f62de9ab6a3c6b9309ceb",
+        "checksum": "adler32:ed3ab7cb",
         "size": 2212692,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/IG/22Jan2013-v1/SingleMu_Run2012C_0.ig"
       }
@@ -1649,7 +1649,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b9550d0653802ec1b285a5e1777efbbde21013c8",
+        "checksum": "adler32:2b755677",
         "size": 3435007,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/IG/22Jan2013-v1/SinglePhoton_Run2012C_0.ig"
       }
@@ -1726,7 +1726,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ca249e14e06df5addc6895b3df800d9a845d9d11",
+        "checksum": "adler32:8f11fe59",
         "size": 2760392,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/IG/22Jan2013-v1/TauParked_Run2012C_0.ig"
       }
@@ -1803,7 +1803,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f868643fe9e4b5123d5225bf2df9a4183a5219fd",
+        "checksum": "adler32:5da0f3a1",
         "size": 2785003,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/IG/22Jan2013-v1/TauPlusX_Run2012C_0.ig"
       }
@@ -1880,7 +1880,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e16296f7d65edf7523f7ff94a12cbd45856f2af7",
+        "checksum": "adler32:830936a1",
         "size": 3077135,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/IG/22Jan2013-v1/VBF1Parked_Run2012C_0.ig"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-eventdisplay-files.json
@@ -30,7 +30,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:48499564c2525bc63725e2af58f2fa3d0f64121e",
+        "checksum": "adler32:94accac5",
         "size": 2678577,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/BTau/IG/Apr21ReReco-v1/BTau.ig"
       }
@@ -108,7 +108,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:379b271729979ce90eeade4d042e87aa7a965a90",
+        "checksum": "adler32:f19be8e4",
         "size": 2073957,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/EGMonitor/IG/Apr21ReReco-v1/EGMonitor.ig"
       }
@@ -186,7 +186,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e4807eec7bbcddd1695b27865aa0e87cb333c1b7",
+        "checksum": "adler32:19e263ae",
         "size": 2624275,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/IG/Apr21ReReco-v1/Electron.ig"
       }
@@ -264,7 +264,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f832d2484a7ab9728670af5c057386bd1707feb1",
+        "checksum": "adler32:14180e82",
         "size": 2790679,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/IG/Apr21ReReco-v1/Jet.ig"
       }
@@ -342,7 +342,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d8f557c22874369c6784eec4ff970b7d7761f854",
+        "checksum": "adler32:0ff08688",
         "size": 2362008,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/JetMETTauMonitor/IG/Apr21ReReco-v1/JetMETTauMonitor.ig"
       }
@@ -420,7 +420,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e386298f835c6bb78fdd37c5f37eadfc0d24404c",
+        "checksum": "adler32:a6203e56",
         "size": 1422441,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/METFwd/IG/Apr21ReReco-v1/METFwd.ig"
       }
@@ -498,7 +498,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:927cd0b0650e6aa544ac11dcf3972bb25b5b4d52",
+        "checksum": "adler32:c0af2d92",
         "size": 1850051,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/IG/Apr21ReReco-v1/Mu.ig"
       }
@@ -576,7 +576,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1e6356f236ecaa92d42347c3a6fc0073561d5371",
+        "checksum": "adler32:9374c291",
         "size": 1647687,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuMonitor/IG/Apr21ReReco-v1/MuMonitor.ig"
       }
@@ -654,7 +654,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f1ca77749350eaff219edb4493971f90144325be",
+        "checksum": "adler32:d5066a99",
         "size": 1713609,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MuOnia/IG/Apr21ReReco-v1/MuOnia.ig"
       }
@@ -732,7 +732,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7af68d773bf17dbd1e5ded609267095374644056",
+        "checksum": "adler32:92f4d277",
         "size": 3191630,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MultiJet/IG/Apr21ReReco-v1/MultiJet.ig"
       }
@@ -810,7 +810,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:56bad74163cb1775e2e2d75e538230a45feb62c3",
+        "checksum": "adler32:b362420f",
         "size": 2789061,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Photon/IG/Apr21ReReco-v1/Photon.ig"
       }
@@ -888,7 +888,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:32434e15cb103281459249e86dd313121f75f50b",
+        "checksum": "adler32:67b61df4",
         "size": 1452517,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Commissioning/IG/Apr21ReReco-v1/Commissioning.ig"
       }
@@ -966,7 +966,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a54ec4cdcee29379572555d0cf5b64cdd783d95d",
+        "checksum": "adler32:aeefae57",
         "size": 1145257,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/IG/Apr21ReReco-v1/MinimumBias.ig"
       }
@@ -1044,7 +1044,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:976f037abde65797cc2be2eef4ee1f116c8ced3d",
+        "checksum": "adler32:034385c2",
         "size": 618628,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/ZeroBias/IG/Apr21ReReco-v1/ZeroBias.ig"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-hamburg-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-hamburg-files.json
@@ -30,7 +30,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9befc2dcd08cace159db2357b91c73d08eff8e35",
+        "checksum": "adler32:54119ef5",
         "size": 17033333,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/data.root"
       }
@@ -88,7 +88,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9713d3bc9e1b48b50a8d56820e70f448d7bd165f",
+        "checksum": "adler32:7adb596e",
         "size": 5492946,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/ttbar.root"
       }
@@ -146,7 +146,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e30dc4216ec4e5f9890aa7fdef4db775f3e6e634",
+        "checksum": "adler32:ccf731d1",
         "size": 5019104,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/wjets.root"
       }
@@ -204,7 +204,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9004e67beea2dd7be0c703bc01afde6a295c990b",
+        "checksum": "adler32:3e96fc27",
         "size": 4776709,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/dy.root"
       }
@@ -262,7 +262,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:488d2d15c5f2e1c3446523f7da8b9a1c83340a64",
+        "checksum": "adler32:d25cc09f",
         "size": 338200,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/ww.root"
       }
@@ -320,7 +320,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:110f3ff2c10f947f78832d4ca25c88984450dbbe",
+        "checksum": "adler32:c1195001",
         "size": 264045,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/wz.root"
       }
@@ -378,7 +378,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ad1b1b7a7dda1cea99cbb302bb63267aabf41380",
+        "checksum": "adler32:8f4a25d2",
         "size": 217945,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/zz.root"
       }
@@ -436,7 +436,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:db7ab560518387e9a5d01c9b3a65e3d48076b594",
+        "checksum": "adler32:8ba0c6ac",
         "size": 501641,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/single_top.root"
       }
@@ -494,7 +494,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8f81d597c42222210ea881695666e3dbd6db49c2",
+        "checksum": "adler32:104aa944",
         "size": 24651,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/qcd.root"
       }
@@ -551,7 +551,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b703c0494e85b6914ef2aa960f01830e19ce97a2",
+        "checksum": "adler32:37dd921e",
         "size": 33730560,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/HEPTutorial_0.tar"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-hlt-2011-configuration-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-hlt-2011-configuration-files.json
@@ -26,7 +26,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:684787321494b0ff15481a3b069eed3c5bbb7b88",
+        "checksum": "adler32:15e63cbd",
         "size": 1463387,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.4_HLT_V4.py"
       }
@@ -71,7 +71,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c9cf102ed538ee15d3e6a9b6cf67830b41c8c7b8",
+        "checksum": "adler32:4f374585",
         "size": 1538053,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1.4e33_v1.1_HLT_V1.py"
       }
@@ -116,7 +116,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6ae48d518ef8ce75390ddac049417559127885b7",
+        "checksum": "adler32:fcbd7c79",
         "size": 1655327,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_2e33_v1.2_HLT_V1.py"
       }
@@ -161,7 +161,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3cbbd0f05f1094a77250ac92635660abec01bbaf",
+        "checksum": "adler32:44f4f138",
         "size": 1959685,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e33_v2.2_HLT_V4.py"
       }
@@ -206,7 +206,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bdc40f32ffd2f69904c669fd0bb8d3a6d3f0ada7",
+        "checksum": "adler32:072bd6db",
         "size": 952467,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.3_HLT_V4.py"
       }
@@ -251,7 +251,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4eaac0f6ca18ef0f7fd672b63b44beac4070b11a",
+        "checksum": "adler32:60514940",
         "size": 1093353,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.1_HLT_V6.py"
       }
@@ -296,7 +296,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:46415dac64446e03cffc114f192519fe64a1f1fa",
+        "checksum": "adler32:10400b8f",
         "size": 355630,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.1_HIHLT_V1.py"
       }
@@ -341,7 +341,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b7703d351bea098eeab9307f53b64449995dbc17",
+        "checksum": "adler32:ab41dd63",
         "size": 1655583,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_2e33_v1.2_HLT_V7.py"
       }
@@ -386,7 +386,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3806fbb369c19d64e8df3c91c6ef1ef561562dd5",
+        "checksum": "adler32:f325919e",
         "size": 1079939,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.2_HLT_V2.py"
       }
@@ -431,7 +431,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:89803a6b07a1811ff4e3084ca2febf1d7fd91e87",
+        "checksum": "adler32:d9d6d2ca",
         "size": 1080191,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.2_HLT_V3.py"
       }
@@ -476,7 +476,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:afd9287dc83b4f0177bf0bc482114fdf6e8d829a",
+        "checksum": "adler32:83b1b0b0",
         "size": 1720507,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v1.2_HLT_V1.py"
       }
@@ -521,7 +521,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:80bed2e30b257b794b3f56afd17c0d44b14701f6",
+        "checksum": "adler32:4a959553",
         "size": 1755310,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.2_HLT_V2.py"
       }
@@ -566,7 +566,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:19e986d975ccd5cc395acd87ef799b7db442ef7e",
+        "checksum": "adler32:8a18b087",
         "size": 1761005,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v4.0_HLT_V6.py"
       }
@@ -611,7 +611,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f487680640461da96a64243d4e66de1295e9e377",
+        "checksum": "adler32:c54ca3ba",
         "size": 1069189,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.1_HLT_V6.py"
       }
@@ -656,7 +656,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7f14be7413d6a43a583a0c3a7ef7de46968b87ca",
+        "checksum": "adler32:e36d0b80",
         "size": 1086697,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.3_HLT_V3.py"
       }
@@ -701,7 +701,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0d0594a2e557389306e979436c1317ffb6eb4122",
+        "checksum": "adler32:72b14837",
         "size": 1095518,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.2_HLT_V3.py"
       }
@@ -746,7 +746,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1bf95c8fa1ed4f8194307c96ec3f98bc691dbf31",
+        "checksum": "adler32:b0c948fa",
         "size": 355854,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.0_HIHLT_V3.py"
       }
@@ -791,7 +791,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:599e549a2456a97d15ed27fa64f762418249f0b6",
+        "checksum": "adler32:844ecaac",
         "size": 952435,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.2_HLT_V5.py"
       }
@@ -836,7 +836,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:55d12e7b08d19f5f04a6d2fedbbbd03a80a741c5",
+        "checksum": "adler32:94bf9abc",
         "size": 957304,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.3_HLT_V2.py"
       }
@@ -881,7 +881,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dc96ab0ae2478a4afdd6eca11e36161fb61ce068",
+        "checksum": "adler32:6487e179",
         "size": 1655605,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_2e33_v1.2_HLT_V4.py"
       }
@@ -926,7 +926,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:27048cb24c8f3628abb5f1ee07bc62f4d05969d4",
+        "checksum": "adler32:4a665a65",
         "size": 365129,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.7_HIHLT_V1.py"
       }
@@ -971,7 +971,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ea1e0682432490569fc8064eba5eae7cf4d178c7",
+        "checksum": "adler32:1e7a81a4",
         "size": 952166,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.2_HLT_V2.py"
       }
@@ -1016,7 +1016,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b8fe17febc060f255b9ac0e726f5ad69c178b755",
+        "checksum": "adler32:2061b76a",
         "size": 1957879,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e33_v2.2_HLT_V2.py"
       }
@@ -1061,7 +1061,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f35a4d5d047340b02e481cbd828fc3f395325c39",
+        "checksum": "adler32:9c4fed00",
         "size": 1291047,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v1.3_HLT_V2.py"
       }
@@ -1106,7 +1106,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2b0ac3f16474ad53e5e54e9f1a19e6bf39e6335f",
+        "checksum": "adler32:afc69b58",
         "size": 957307,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.3_HLT_V1.py"
       }
@@ -1151,7 +1151,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ed9bb9eba76eaa2f8702bef97ed7340a0dbb0fbe",
+        "checksum": "adler32:d8ee5cb6",
         "size": 1538081,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1.4e33_v1.2_HLT_V1.py"
       }
@@ -1196,7 +1196,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e07d18bd08bf877d21dd35c65ad6ddb5b3993aa2",
+        "checksum": "adler32:6d26f1ce",
         "size": 1464179,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.4_HLT_V8.py"
       }
@@ -1241,7 +1241,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8ca10eb17a7814b11800dc0158d2a981719e0725",
+        "checksum": "adler32:408ee311",
         "size": 1463128,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.4_HLT_V5.py"
       }
@@ -1286,7 +1286,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:072f428c0645bf8e0a7743ac945c6c54db2e7ff2",
+        "checksum": "adler32:decea33b",
         "size": 1720465,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v1.1_HLT_V3.py"
       }
@@ -1331,7 +1331,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e4ef4cef8e730ad6b58cd4fb392d3f63e1b853cf",
+        "checksum": "adler32:d2fa9683",
         "size": 365379,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.4_HIHLT_V1.py"
       }
@@ -1376,7 +1376,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:090959f22f76339cc05735f7ba68bec539e09603",
+        "checksum": "adler32:16c43f3c",
         "size": 1292225,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v1.3_HLT_V12.py"
       }
@@ -1421,7 +1421,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:640abaa547cee8c9e0a671e97899ac7aaa358830",
+        "checksum": "adler32:d129f11b",
         "size": 1756534,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v3.0_HLT_V2.py"
       }
@@ -1466,7 +1466,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bb8b8e079c2ed0a9f8eb60d9943dff8f4a3eafbe",
+        "checksum": "adler32:a3f0599d",
         "size": 365123,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.6_HIHLT_V2.py"
       }
@@ -1511,7 +1511,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:195a8182f9539c39959327f4ced8c5d720650e15",
+        "checksum": "adler32:0956e308",
         "size": 1463128,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.4_HLT_V6.py"
       }
@@ -1556,7 +1556,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e4bee4bd32474e861a78bcb35478fd4a9d9b6cec",
+        "checksum": "adler32:6f908a5f",
         "size": 1093621,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.1_HLT_V8.py"
       }
@@ -1601,7 +1601,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:84c1dedaee8bac400610739867a3cf456b8549ae",
+        "checksum": "adler32:0c68af6c",
         "size": 1291841,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v1.3_HLT_V6.py"
       }
@@ -1646,7 +1646,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:565cbdd10b0ffab52c3d5247be4e6558cd8bb85b",
+        "checksum": "adler32:5974917e",
         "size": 1754542,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.0_HLT_V7.py"
       }
@@ -1691,7 +1691,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e33f5e2eda27e827f68c9beb471ff217d8d15356",
+        "checksum": "adler32:7787978c",
         "size": 1759388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v3.1_HLT_V1.py"
       }
@@ -1736,7 +1736,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bf1f6e55af90306fe75e38058e856f0d2448cb37",
+        "checksum": "adler32:3979b0ec",
         "size": 952322,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.2_HLT_V7.py"
       }
@@ -1781,7 +1781,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d1ddcf853e69103608c0884e38be182dd21a3be1",
+        "checksum": "adler32:28526f7c",
         "size": 330986,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_2760GeV_v1.1_HLT_V4.py"
       }
@@ -1826,7 +1826,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:68d9fa0394240d6b7655d20ffb6fe6345ef0786c",
+        "checksum": "adler32:32a06fdd",
         "size": 330985,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_2760GeV_v1.1_HLT_V1.py"
       }
@@ -1871,7 +1871,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3634d27a332c73ccf073774971204349bf9f727d",
+        "checksum": "adler32:9428af2b",
         "size": 1760998,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v4.0_HLT_V5.py"
       }
@@ -1916,7 +1916,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9cb205e00208e001b0e960f5e16f7942050aca44",
+        "checksum": "adler32:7a5605ea",
         "size": 1757243,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.1_HLT_V2.py"
       }
@@ -1961,7 +1961,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ae90495c781c41e0d3851a76fde8fe8d9d852efe",
+        "checksum": "adler32:a70b15dd",
         "size": 957785,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.2_HLT_V7.py"
       }
@@ -2006,7 +2006,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7b4369ac26f897018217848149ffeb4c379a4c92",
+        "checksum": "adler32:c3feca38",
         "size": 1462994,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.5_HLT_V1.py"
       }
@@ -2051,7 +2051,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c593aadbf03385e65cbf949c48dd5b1260aee275",
+        "checksum": "adler32:0bf7e116",
         "size": 1655603,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_2e33_v1.2_HLT_V5.py"
       }
@@ -2096,7 +2096,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:237b42d9d7a2f9d61cf8ef9570ecdcce473b9bd4",
+        "checksum": "adler32:732ea753",
         "size": 363139,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.3_HIHLT_V5.py"
       }
@@ -2141,7 +2141,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e24bcd2d8bf2b188d9963633fd04c12d5d3dc755",
+        "checksum": "adler32:6af0cf70",
         "size": 362205,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.2_HIHLT_V2.py"
       }
@@ -2186,7 +2186,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3ce978992a4b32c10b50750c1af35e8dab39d4e1",
+        "checksum": "adler32:1557de81",
         "size": 1463878,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.4_HLT_V2.py"
       }
@@ -2231,7 +2231,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a5e29a83cb10545a3da0e88616af744e3340134c",
+        "checksum": "adler32:b84301bc",
         "size": 957517,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.1_HLT_V3.py"
       }
@@ -2276,7 +2276,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a58a1256ca0a621f5497e95ffe6338e79bc08eef",
+        "checksum": "adler32:c2841894",
         "size": 1068666,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.1_HLT_V3.py"
       }
@@ -2321,7 +2321,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:720836630a8971e18eee942e15c5e9fc3f1f339e",
+        "checksum": "adler32:3f54957d",
         "size": 1638691,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_2e33_v1.1_HLT_V1.py"
       }
@@ -2366,7 +2366,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6b4d66f1d4407d0daca0ed3a0264ce19bb6e9692",
+        "checksum": "adler32:b32118e3",
         "size": 957793,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.2_HLT_V5.py"
       }
@@ -2411,7 +2411,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:47fc06a4bd39ef516ef132b957cbbff16bc4f969",
+        "checksum": "adler32:73be83d1",
         "size": 1292502,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v1.3_HLT_V13.py"
       }
@@ -2456,7 +2456,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:197b61dd21ffd10bc0320784323f523c6962c520",
+        "checksum": "adler32:e948a9ef",
         "size": 952306,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.2_HLT_V6.py"
       }
@@ -2501,7 +2501,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3ce68ddd40b74cfc5ecdaf71260d5745c4c94e0a",
+        "checksum": "adler32:b62fce84",
         "size": 1068383,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.1_HLT_V1.py"
       }
@@ -2546,7 +2546,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0fd5e5d618d42fe9c8edaf54aebead5f5ccf8668",
+        "checksum": "adler32:0605a14c",
         "size": 1720455,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v1.1_HLT_V1.py"
       }
@@ -2591,7 +2591,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b533efd324806c790d9efbf6a1ce0090d11b6417",
+        "checksum": "adler32:49f69584",
         "size": 1638691,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_2e33_v1.1_HLT_V2.py"
       }
@@ -2636,7 +2636,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9ba1ad246cee6279071ee3ee27d212bfd9089bdc",
+        "checksum": "adler32:2e3ad2bd",
         "size": 1080191,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.2_HLT_V4.py"
       }
@@ -2681,7 +2681,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:92a86b2262d501e9b541561c6b448d331963ab31",
+        "checksum": "adler32:a383b030",
         "size": 952318,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.2_HLT_V8.py"
       }
@@ -2726,7 +2726,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:40997d3b7050a806d470f41eaf1125d5ecb26f11",
+        "checksum": "adler32:f602a753",
         "size": 363139,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.3_HIHLT_V1.py"
       }
@@ -2771,7 +2771,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:53c85ba3ad2b0e5c1287909eccc418d10b143946",
+        "checksum": "adler32:ed8828b0",
         "size": 1763875,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v5.0_HLT_V1.py"
       }
@@ -2816,7 +2816,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8793ef5c6921daff7e93985fd3c8db902d3b3d1e",
+        "checksum": "adler32:10915bfc",
         "size": 1538078,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1.4e33_v1.2_HLT_V3.py"
       }
@@ -2861,7 +2861,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4f20c561f9f8e92aeaabe0f5aeff436af9ab1c1d",
+        "checksum": "adler32:b7cb0b7f",
         "size": 1086697,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.3_HLT_V2.py"
       }
@@ -2906,7 +2906,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d518f4c31b63026d8691267880aea9dab382e8b8",
+        "checksum": "adler32:d51948f8",
         "size": 355854,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.0_HIHLT_V2.py"
       }
@@ -2951,7 +2951,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:771b75eea7fc55eb3f2077f1f8ebcf193a5b5f12",
+        "checksum": "adler32:6ca46f79",
         "size": 330986,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_2760GeV_v1.1_HLT_V3.py"
       }
@@ -2996,7 +2996,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c7b44b364be8c8ac3bc082dc4672c1ca43be3982",
+        "checksum": "adler32:01a4493e",
         "size": 1093353,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.1_HLT_V5.py"
       }
@@ -3041,7 +3041,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:448793811f09368d2571284a24113df37595d1bf",
+        "checksum": "adler32:09b6bb65",
         "size": 1761035,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v4.0_HLT_V2.py"
       }
@@ -3086,7 +3086,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:323b323e1ef8344a24417174052b812064d459a2",
+        "checksum": "adler32:8de7bb65",
         "size": 1761035,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v4.0_HLT_V3.py"
       }
@@ -3131,7 +3131,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:005df47fabe8712d30b2a85a93cec20a00688d67",
+        "checksum": "adler32:23bf1830",
         "size": 1068664,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v6.1_HLT_V5.py"
       }
@@ -3176,7 +3176,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b963125f7a7ef94e352ca3e487be5a99e129c9a9",
+        "checksum": "adler32:5ea91886",
         "size": 957791,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.2_HLT_V6.py"
       }
@@ -3221,7 +3221,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7ea0447b5043c977ba97bff6b9b675637b4a7991",
+        "checksum": "adler32:71db04f1",
         "size": 1802511,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e33_v1.4_HLT_V3.py"
       }
@@ -3266,7 +3266,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:45c7604cdc60433147bc7d868e4e8be6a86f5894",
+        "checksum": "adler32:89396818",
         "size": 1291550,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v1.3_HLT_V7.py"
       }
@@ -3311,7 +3311,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9cabb4ca4587d42ac5a574382eeb2edf4b81eab9",
+        "checksum": "adler32:e479d6db",
         "size": 952467,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v4.3_HLT_V3.py"
       }
@@ -3356,7 +3356,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6cc1f2b88fe4ba2337ef228f8d6aa75790daeda4",
+        "checksum": "adler32:f1259817",
         "size": 1802115,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e33_v1.4_HLT_V5.py"
       }
@@ -3401,7 +3401,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fc4659a5970b25d80d5f7f188efda12c429dcaf6",
+        "checksum": "adler32:17e42d5f",
         "size": 1465184,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.3_HLT_V3.py"
       }
@@ -3446,7 +3446,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2dcdb90e655bc6d763520415576fb79a51f6db9b",
+        "checksum": "adler32:46d1feb8",
         "size": 1755681,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.3_HLT_V2.py"
       }
@@ -3491,7 +3491,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ab2a82110c628da35349d56783d6d678c468afa4",
+        "checksum": "adler32:724118ec",
         "size": 1753085,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.0_HLT_V4.py"
       }
@@ -3536,7 +3536,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0731e73efed5d61b9d7a5c178ea4182b8132cc99",
+        "checksum": "adler32:92d69485",
         "size": 1755306,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.2_HLT_V3.py"
       }
@@ -3581,7 +3581,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:08542eb90a66f4e7127f87e6c30d57dbbd70786f",
+        "checksum": "adler32:77da0685",
         "size": 1757246,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v2.1_HLT_V1.py"
       }
@@ -3626,7 +3626,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6e94e9bb7710088aad6bca583feeb9d0ddfa760f",
+        "checksum": "adler32:0d340b83",
         "size": 1086697,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v8.3_HLT_V4.py"
       }
@@ -3671,7 +3671,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:de92e8d199fe95c79d918246031071c0c66895f0",
+        "checksum": "adler32:f705a308",
         "size": 1720464,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_3e33_v1.1_HLT_V4.py"
       }
@@ -3716,7 +3716,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:88f57667e9b50bce7327186f92f16ded7e862573",
+        "checksum": "adler32:b9ae8190",
         "size": 365274,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011HI_v1.6_HIHLT_V1.py"
       }
@@ -3761,7 +3761,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9e79fff0801341d77a2f1d437704c4dfd7f36114",
+        "checksum": "adler32:3d47268a",
         "size": 1465150,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_1e33_v2.3_HLT_V1.py"
       }
@@ -3806,7 +3806,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:52b4142b2f7e2b87c81c063f98d9e0088c951eb7",
+        "checksum": "adler32:47c0ea7c",
         "size": 957601,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/cdaq_physics_Run2011_5e32_v5.2_HLT_V2.py"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-hlt-configuration-files-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-hlt-configuration-files-2012.json
@@ -29,7 +29,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cdb4eddb00282f5d01f6fcfce70b53a8410ef71e",
+        "checksum": "adler32:e50150bd",
         "size": 2084149,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v4.2_HLT_V1.py"
       }
@@ -77,7 +77,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dd0fb4642fbf6fa9ed681d299b19f37f86a8ca5e",
+        "checksum": "adler32:90279805",
         "size": 2308868,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.0_HLT_V2.py"
       }
@@ -125,7 +125,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:514c0d3a5e223741a477456e838f35d31a3281dc",
+        "checksum": "adler32:9bcc6c73",
         "size": 2192031,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v1.1_HLT_V1.py"
       }
@@ -173,7 +173,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:55f328f1ab4706e49897cdcfb0533f2710821250",
+        "checksum": "adler32:72a79bab",
         "size": 2071786,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.3_HLT_V1.py"
       }
@@ -221,7 +221,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:deea4854dd80a1a721c9a2ff10e4a342963f26e0",
+        "checksum": "adler32:6f889f87",
         "size": 2067575,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.2_HLT_V3.py"
       }
@@ -269,7 +269,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2925ecd5e85deba962c64adab1eaa7e5c5357123",
+        "checksum": "adler32:a0d44ff8",
         "size": 2321436,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.1_HLT_V6.py"
       }
@@ -317,7 +317,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2d3aca75a9d79dbb26988e5a0ffde45551eb1126",
+        "checksum": "adler32:066bafb0",
         "size": 2064310,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.0_HLT_V4.py"
       }
@@ -365,7 +365,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:895cd479f1f1d4ecb8b27bd0cef692eda36b1b5e",
+        "checksum": "adler32:7112b02f",
         "size": 2064311,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.1_HLT_V1.py"
       }
@@ -413,7 +413,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:861be4b8249ce4bc51d593e05a8492501132e18c",
+        "checksum": "adler32:7b6ef66c",
         "size": 2059043,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.1_HLT_V11.py"
       }
@@ -461,7 +461,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:206a2afca55edd95fa5e826f81af3234c6b08b8d",
+        "checksum": "adler32:3ebf27de",
         "size": 2079227,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V21.py"
       }
@@ -509,7 +509,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7bfe201c4f3dd0514ecc5597361e682e2cdae97a",
+        "checksum": "adler32:84b1affd",
         "size": 2064311,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.0_HLT_V5.py"
       }
@@ -557,7 +557,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:91dd867b4f4555216dc0fe675c085188dc593b9f",
+        "checksum": "adler32:80fdafc6",
         "size": 2064310,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.0_HLT_V3.py"
       }
@@ -605,7 +605,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5510f163b0133a9f21eeecb13e1166824b22c894",
+        "checksum": "adler32:40a672d2",
         "size": 2042796,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.6_HLT_V5.py"
       }
@@ -653,7 +653,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c6d162c46f4cab1d06e5a377bae6b27813fb2242",
+        "checksum": "adler32:ac909220",
         "size": 2042914,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.8_HLT_V1.py"
       }
@@ -701,7 +701,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4c59efa2d18ee42bba58db60814d180e55a1edde",
+        "checksum": "adler32:52fcafcc",
         "size": 2064310,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.0_HLT_V2.py"
       }
@@ -749,7 +749,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6b18acb5027d7d812cdf338db4cd2eaa717cd8a5",
+        "checksum": "adler32:55b6cec4",
         "size": 2078704,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V3.py"
       }
@@ -797,7 +797,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f501d6c28d6443c018d48a8db76b81853430739a",
+        "checksum": "adler32:d593d070",
         "size": 2079765,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V15.py"
       }
@@ -845,7 +845,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ca7f1beb7cdbccf8b25343b81173395adac93c09",
+        "checksum": "adler32:a3eb4b64",
         "size": 2071454,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.3_HLT_V3.py"
       }
@@ -893,7 +893,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:60b0cd36a9d6c7962eec6778c2c8d1a7b1213fa6",
+        "checksum": "adler32:3039150a",
         "size": 2193391,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v1.2_HLT_V1.py"
       }
@@ -941,7 +941,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:07b400eb709484019aa7c70a9c5f88249f672197",
+        "checksum": "adler32:db00df7c",
         "size": 2045673,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.10_HLT_V1.py"
       }
@@ -989,7 +989,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:634d28aa49d3751f8a518189fa6c6d84b0ee80ac",
+        "checksum": "adler32:9b2a4b8f",
         "size": 2071455,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.3_HLT_V2.py"
       }
@@ -1037,7 +1037,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:036c97a41aeef6f7086c595765a3d879664f1d8d",
+        "checksum": "adler32:256d8bab",
         "size": 2051896,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v4.0_HLT_V1.py"
       }
@@ -1085,7 +1085,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9f00e57cbae6d8fa90ba8bfa493b2db152862e33",
+        "checksum": "adler32:18f5a0db",
         "size": 2059590,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.1_HLT_V13.py"
       }
@@ -1133,7 +1133,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1a10f3dda40a9490d60f37fe5e688dc8ce2d88ff",
+        "checksum": "adler32:224b9309",
         "size": 2052178,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.4_HLT_V5.py"
       }
@@ -1181,7 +1181,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:74a30e1a465ea306e69e40a7140f8d8712f1c769",
+        "checksum": "adler32:66d7975b",
         "size": 2078889,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.14_HLT_V1.py"
       }
@@ -1229,7 +1229,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:049c43cdf66071b66c1d438f06369c65991c1d07",
+        "checksum": "adler32:8bafcebd",
         "size": 2078704,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V2.py"
       }
@@ -1277,7 +1277,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:10ef3796de5a0651a1ae7ae822ced602ac469a0f",
+        "checksum": "adler32:8c805003",
         "size": 2321436,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.1_HLT_V7.py"
       }
@@ -1325,7 +1325,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fba62722ab75f483056e038e952d7f2446779120",
+        "checksum": "adler32:e60a0a5b",
         "size": 2078401,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.13_HLT_V1.py"
       }
@@ -1373,7 +1373,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:87333f29f12c409a973f2489bf57b0e3cfb1b97d",
+        "checksum": "adler32:6895f268",
         "size": 2189925,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v1.0_HLT_V2.py"
       }
@@ -1421,7 +1421,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a0a852fd1f96981c3e0ec7138cfdfc7c1decf348",
+        "checksum": "adler32:4a1addbb",
         "size": 383104,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012PI_PilotRun_PIHLT_V2.py"
       }
@@ -1469,7 +1469,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:30510f4d5aac1fe0ae20e8e8e74da2d13d2bd93f",
+        "checksum": "adler32:1dd7ca49",
         "size": 2047845,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.5_HLT_V1.py"
       }
@@ -1517,7 +1517,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e7474a2801fbcfbc8e05559aaf0104be5da26635",
+        "checksum": "adler32:b0564c50",
         "size": 2078617,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.12_HLT_V1.py"
       }
@@ -1565,7 +1565,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5274b68a3192610d713b3734217dc55337069388",
+        "checksum": "adler32:90fff32a",
         "size": 383184,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012PI_PilotRun_PIHLT_V4.py"
       }
@@ -1613,7 +1613,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:400ea11eaad2749d4e601f38efd1145ae16a47a4",
+        "checksum": "adler32:2dd1fca9",
         "size": 2046545,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.11_HLT_V2.py"
       }
@@ -1661,7 +1661,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7adcd41559a1ee991a62c7f0ea819561d6fbb0d3",
+        "checksum": "adler32:2cf592ea",
         "size": 2049751,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.4_HLT_V7.py"
       }
@@ -1709,7 +1709,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:385353e55b0cb023f2ab2ea8b933e07e31e7db6e",
+        "checksum": "adler32:287903fe",
         "size": 2043235,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.7_HLT_V1.py"
       }
@@ -1757,7 +1757,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:76d2687d324f9da8b0b849ba9b08719b41546061",
+        "checksum": "adler32:0514a739",
         "size": 2067597,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.2_HLT_V2.py"
       }
@@ -1805,7 +1805,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0d11aed4691f881ddfa7a93482527ab450288f58",
+        "checksum": "adler32:1eab4f0d",
         "size": 2103381,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.4_HLT_V1.py"
       }
@@ -1853,7 +1853,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bb0f380abeedaa5a422b90a359b96503f3c1e7b5",
+        "checksum": "adler32:1893d072",
         "size": 2079765,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V18.py"
       }
@@ -1901,7 +1901,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2a911e70e005b2516526993e8b6c86036da9e82d",
+        "checksum": "adler32:dd13f710",
         "size": 2059046,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v2.1_HLT_V12.py"
       }
@@ -1949,7 +1949,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9780b020f07adbc26b0d420393b068e75f7c1fb3",
+        "checksum": "adler32:bbfbcc3f",
         "size": 2048137,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.5_HLT_V3.py"
       }
@@ -1997,7 +1997,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cb76fe27a5bbe43b379f12be6640db474fa13234",
+        "checksum": "adler32:67339890",
         "size": 2308871,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.0_HLT_V3.py"
       }
@@ -2045,7 +2045,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:aff3583172e19e875e1ff001bce83fe6094524ee",
+        "checksum": "adler32:ff04780c",
         "size": 2051070,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v4.0_HLT_V4.py"
       }
@@ -2093,7 +2093,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:57493dd5ac2764e20fc1f93cc4618507d8671562",
+        "checksum": "adler32:000c4e94",
         "size": 2321428,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_8e33_v2.1_HLT_V5.py"
       }
@@ -2141,7 +2141,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0b18658b7ab191fc217c4e1a5aaf96f090bf4024",
+        "checksum": "adler32:9e99c0c9",
         "size": 2079718,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_5e33_v4.16_HLT_V14.py"
       }
@@ -2189,7 +2189,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:efb5a412cb51fd86db461b4292a43e0b74f0762e",
+        "checksum": "adler32:be29b01c",
         "size": 2064311,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v3.1_HLT_V2.py"
       }
@@ -2237,7 +2237,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1091157c7d15d2699f0ad4802b563adb58b08ef3",
+        "checksum": "adler32:66d77b2d",
         "size": 2051652,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/cdaq_physics_Run2012_7e33_v4.1_HLT_V1.py"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-l1-trigger-information-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-l1-trigger-information-Run2011A.json
@@ -59,7 +59,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:358ff14572147a14c96dc995539c2088606a493c",
+        "checksum": "adler32:d62fd59d",
         "size": 1320569,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v0_L1T_Scales_20101224_Imp0_0x101e.html"
       }
@@ -104,7 +104,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8c02402d42ce269feaa94f600ddcdfff3ca00377",
+        "checksum": "adler32:c4afdf34",
         "size": 2143499,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v1_L1T_Scales_20101224_Imp0_0x101f.html"
       }
@@ -149,7 +149,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:488c6ebc619727271d5e1b877498c3e56c3f32e4",
+        "checksum": "adler32:f22db7f2",
         "size": 2132671,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v2_L1T_Scales_20101224_Imp0_0x1020.html"
       }
@@ -194,7 +194,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5ea0b594b96bb5c4902856455310413e976f901a",
+        "checksum": "adler32:994f7012",
         "size": 2144756,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v3_L1T_Scales_20101224_Imp0_0x1021.html"
       }
@@ -239,7 +239,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5400c3fe94796cb98c6bf40c8d7758c70d387b3c",
+        "checksum": "adler32:3a1efb3c",
         "size": 2266449,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v4_L1T_Scales_20101224_Imp0_0x1022.html"
       }
@@ -284,7 +284,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6b0df268e06b43ac7f7dd9431ad3106b77623b25",
+        "checksum": "adler32:1850da23",
         "size": 2346311,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v5_L1T_Scales_20101224_Imp0_0x1023.html"
       }
@@ -329,7 +329,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a2913c6b9c22af214712cd880964310347544107",
+        "checksum": "adler32:43f5c435",
         "size": 2408843,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/trigger-information/2011/L1Menu_Collisions2011_v6_L1T_Scales_20101224_Imp0_0x1024.html"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-learning-resources.json
+++ b/cernopendata/modules/fixtures/data/records/cms-learning-resources.json
@@ -24,27 +24,27 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d867d94b052d96842fe9d7315cc08ee3086c9e91",
+        "checksum": "adler32:95053ba1",
         "size": 176942,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/TutorialDocu_3.pdf"
       },
       {
-        "checksum": "sha1:f7675608139f2f6fe149b091f6c49127f5c550c3",
+        "checksum": "adler32:2ec048fe",
         "size": 50493,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/TutorialExercisesPart1_2.pdf"
       },
       {
-        "checksum": "sha1:894c700036c048be44441c0ab375f0705746b115",
+        "checksum": "adler32:e55c9759",
         "size": 58664,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/TutorialExercisesPart2_2.pdf"
       },
       {
-        "checksum": "sha1:a419d01f7e714413e4646065b5d3b1eefff9e8fb",
+        "checksum": "adler32:db5e65ec",
         "size": 72563,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/TutorialExercisesPart3_2.pdf"
       },
       {
-        "checksum": "sha1:a7b769d106be94a229730b1e5ed4f5cd628b07cd",
+        "checksum": "adler32:1d170b1e",
         "size": 60883,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/hep-tutorial-2012/TutorialExercisesPart4_1.pdf"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-luminosity-information-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-luminosity-information-Run2012B.json
@@ -25,27 +25,27 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fda50848945c709b3fba2dda30c9712c86beabc2",
+        "checksum": "adler32:bb85f815",
         "size": 48284,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2012/2012lumi.txt"
       },
       {
-        "checksum": "sha1:0c63092d2b815e7c6510679b176c007bc1a1f30b",
+        "checksum": "adler32:c3f97792",
         "size": 12916,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2012/2012RunBlumi.txt"
       },
       {
-        "checksum": "sha1:47dcef3072b17f76734bc053f3c4c7bda1078cc9",
+        "checksum": "adler32:5b5b081b",
         "size": 16070,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2012/2012RunClumi.txt"
       },
       {
-        "checksum": "sha1:ea8837412e962faaf1ca452c9f7f4da678d648f2",
+        "checksum": "adler32:01a092b8",
         "size": 19463607,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2012/2012lumibyls.csv"
       },
       {
-        "checksum": "sha1:14ca08d74f697e106944c1e173ba909915a0f567",
+        "checksum": "adler32:cfd13a8f",
         "size": 49680,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2012/prescale2012.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-luminosity-information.json
+++ b/cernopendata/modules/fixtures/data/records/cms-luminosity-information.json
@@ -25,17 +25,17 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c101dbd1bea6c4a0f4e0b02344693ff3c5d0272f",
+        "checksum": "adler32:2d83056d",
         "size": 63840,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2010/2010lumi.txt"
       },
       {
-        "checksum": "sha1:47372391f417cec0e886fd912fccd37131530b1a",
+        "checksum": "adler32:33e2cf16",
         "size": 21429,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2010/2010RunBlumi.txt"
       },
       {
-        "checksum": "sha1:231d34287a8eb60320404a065a82a4caf8aa35f8",
+        "checksum": "adler32:cbeb9ad4",
         "size": 5840441,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2010/2010lumibyls.csv"
       }
@@ -79,22 +79,22 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:57e6f5c4d46ac496ac1536f39e9a2b8e07d2d527",
+        "checksum": "adler32:44a4c336",
         "size": 49349,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2011/2011lumi.txt"
       },
       {
-        "checksum": "sha1:64a5b4e899a1d25166d62d58c17444144e18fea7",
+        "checksum": "adler32:a27a8f6c",
         "size": 33867,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2011/2011RunAlumi.txt"
       },
       {
-        "checksum": "sha1:eff396954645741f78e8cfa6e2d2b875aac8e3c5",
+        "checksum": "adler32:773bc398",
         "size": 13708129,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2011/2011lumibyls.csv"
       },
       {
-        "checksum": "sha1:7e144b4b568a336d22f2915b9fac22fc4c3cc1e2",
+        "checksum": "adler32:7b811cc7",
         "size": 41460,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/luminosity/2011/prescale2011.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-masterclass-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-masterclass-files.json
@@ -24,32 +24,32 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f21c34f039ed4652a235a3d3ddbcf79bfedd4e52",
+        "checksum": "adler32:554607ac",
         "size": 1256,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/4lepton.csv"
       },
       {
-        "checksum": "sha1:58e98e08de2695724d9985ff121cbe442507c78a",
+        "checksum": "adler32:33171393",
         "size": 4086175,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/4lepton.ig"
       },
       {
-        "checksum": "sha1:927a8be894f8003e5fc0015f65f91bd850303d90",
+        "checksum": "adler32:7d7f9e7c",
         "size": 1966,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/4lepton.json"
       },
       {
-        "checksum": "sha1:c4b26032ab946c3b68f63d44dbf2c2005f5c062c",
+        "checksum": "adler32:dca4af81",
         "size": 869,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/diphoton.csv"
       },
       {
-        "checksum": "sha1:86a4a2ed86ead248ae871ffb8a18d4772df0d93d",
+        "checksum": "adler32:a1f52007",
         "size": 1909562,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/diphoton.ig"
       },
       {
-        "checksum": "sha1:f8c3d1a86c286d814f5b9b609196ac9ffde03c2a",
+        "checksum": "adler32:f2446507",
         "size": 1619,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/diphoton.json"
       }
@@ -115,112 +115,112 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8f3f4e054665eadd221181460bc7af39f9938535",
+        "checksum": "adler32:a5149946",
         "size": 374798,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi.csv"
       },
       {
-        "checksum": "sha1:689d44ca1becf0ba9c9f9c55779baa6f856487d6",
+        "checksum": "adler32:8d58d797",
         "size": 44825530,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_7.ig"
       },
       {
-        "checksum": "sha1:ce79e708634d36aa6219c7cc978d543ee566230b",
+        "checksum": "adler32:1d19467d",
         "size": 44952775,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_8.ig"
       },
       {
-        "checksum": "sha1:ac783c1a233e73817e8d33ab668853f2920c3f1b",
+        "checksum": "adler32:81db1266",
         "size": 45306364,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_9.ig"
       },
       {
-        "checksum": "sha1:57327c0d27c1e847195b15166138969185068ecb",
+        "checksum": "adler32:5f4a7f43",
         "size": 45547341,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_10.ig"
       },
       {
-        "checksum": "sha1:f60004a7a8806670a52f181303a01f801dec1ca5",
+        "checksum": "adler32:0550a56e",
         "size": 46411950,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_11.ig"
       },
       {
-        "checksum": "sha1:46e792a69624026ee1fe780134f4a809f2f2d581",
+        "checksum": "adler32:493579fa",
         "size": 44119119,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_12.ig"
       },
       {
-        "checksum": "sha1:598078e9db8745a15d636465c8feb8afd845b1dc",
+        "checksum": "adler32:c4be9794",
         "size": 47770858,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_13.ig"
       },
       {
-        "checksum": "sha1:50093fd6eb08ead5cf0c7e01b81b31ef39816a73",
+        "checksum": "adler32:35048038",
         "size": 44945861,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_14.ig"
       },
       {
-        "checksum": "sha1:019783e1e306855a3d7010a2ae466d1286c9c635",
+        "checksum": "adler32:c4ce3155",
         "size": 44963967,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_15.ig"
       },
       {
-        "checksum": "sha1:b7e98c79463a97a0b153bc5cb8d84c222d18d2ab",
+        "checksum": "adler32:3004b08f",
         "size": 47308677,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_16.ig"
       },
       {
-        "checksum": "sha1:2fe01aabc46670d02755cbae35d510c71136228b",
+        "checksum": "adler32:ad1dc654",
         "size": 702717,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi.json"
       },
       {
-        "checksum": "sha1:18476822171c34c74b8b9fc4bd73c647fbcef3c9",
+        "checksum": "adler32:6ce4d181",
         "size": 47491270,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_17.ig"
       },
       {
-        "checksum": "sha1:9a1642fdd7b3fc6bf461934874681924313dd7ee",
+        "checksum": "adler32:29321d28",
         "size": 47915241,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_18.ig"
       },
       {
-        "checksum": "sha1:31fd21887e07b595f8e6c42d13b0392ad50cf635",
+        "checksum": "adler32:358dbcad",
         "size": 46602078,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_19.ig"
       },
       {
-        "checksum": "sha1:076ed23f16608868fbfa76ffa1d8fd4ecb44d520",
+        "checksum": "adler32:dc7a90bd",
         "size": 45516907,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_0.ig"
       },
       {
-        "checksum": "sha1:2b99fdc665f4ac3eba7b932523bfff74798f6aeb",
+        "checksum": "adler32:db505304",
         "size": 45657377,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_1.ig"
       },
       {
-        "checksum": "sha1:17b7a088b32ff356d74a31b73ccb5066234ddae7",
+        "checksum": "adler32:87256fb3",
         "size": 46542194,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_2.ig"
       },
       {
-        "checksum": "sha1:afb35a3569277ae40433a8ef32b98b732206ebe8",
+        "checksum": "adler32:3ef51053",
         "size": 45653180,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_3.ig"
       },
       {
-        "checksum": "sha1:bf49e1d40871bae71617bf554785f3d6f368f927",
+        "checksum": "adler32:b199cf71",
         "size": 46370345,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_4.ig"
       },
       {
-        "checksum": "sha1:944fee9f9ccc8ef1bce0e9725b61e3b8065c63c4",
+        "checksum": "adler32:4d328cd2",
         "size": 46211699,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_5.ig"
       },
       {
-        "checksum": "sha1:fba720fd0122f11c8ecdc79375f2d28efd01818d",
+        "checksum": "adler32:b405219e",
         "size": 45927075,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon-Jpsi_6.ig"
       }
@@ -283,112 +283,112 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cf8c5a799d04198bce1703b75632ceab336e69ec",
+        "checksum": "adler32:6874cffe",
         "size": 69927400,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_0.ig"
       },
       {
-        "checksum": "sha1:db6e2eca98ae3177b5b4466beec841b3a5e5b94e",
+        "checksum": "adler32:9e157f96",
         "size": 68038227,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_17.ig"
       },
       {
-        "checksum": "sha1:b0afc9ec54d0c7a777ea50467b3414eeeb73a7c3",
+        "checksum": "adler32:2b0ce9f1",
         "size": 75784837,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_18.ig"
       },
       {
-        "checksum": "sha1:2109a5e8459739b9c6f4ba41b571ff29f414c593",
+        "checksum": "adler32:1ab43eeb",
         "size": 47582226,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_19.ig"
       },
       {
-        "checksum": "sha1:e5bf691fe186009e8428b7f2f036dea841eaeae7",
+        "checksum": "adler32:c785440d",
         "size": 73302582,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_2.ig"
       },
       {
-        "checksum": "sha1:835a30bca606b313d283487a3dcbc8e3433a3bc8",
+        "checksum": "adler32:0732b3b5",
         "size": 78761389,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_3.ig"
       },
       {
-        "checksum": "sha1:e3c98f28e2b457b6235b49ee4f73839948dd19ec",
+        "checksum": "adler32:6685d6bb",
         "size": 73108221,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_4.ig"
       },
       {
-        "checksum": "sha1:4b7bc394d9295e092122a49c3c573df3f7622edf",
+        "checksum": "adler32:cf4cd09f",
         "size": 68270656,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_5.ig"
       },
       {
-        "checksum": "sha1:26f7d8c7bf80bcda76124964db70b0d07e475161",
+        "checksum": "adler32:7030f850",
         "size": 69185658,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_6.ig"
       },
       {
-        "checksum": "sha1:d7517dae798803f4e61e8c6b5402f654b0124cf2",
+        "checksum": "adler32:8c732ad3",
         "size": 72485687,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_7.ig"
       },
       {
-        "checksum": "sha1:0cc8285a4dd45a2a88eb1183045ac3675137ad86",
+        "checksum": "adler32:68324b4e",
         "size": 73899071,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_8.ig"
       },
       {
-        "checksum": "sha1:7f32561472349a3efad4054399e4aa35f0023555",
+        "checksum": "adler32:8b72850e",
         "size": 65154346,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_1.ig"
       },
       {
-        "checksum": "sha1:e7851e3989324edb7355796ec330987cc30d00f3",
+        "checksum": "adler32:e940e112",
         "size": 75402324,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_9.ig"
       },
       {
-        "checksum": "sha1:028a21b67beee2391ee6d974d351087533ff97e8",
+        "checksum": "adler32:a4819bf7",
         "size": 68566933,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_10.ig"
       },
       {
-        "checksum": "sha1:ecc1c92188f339b5a4b580d2a92732881edbc466",
+        "checksum": "adler32:1fd819c5",
         "size": 78080960,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_11.ig"
       },
       {
-        "checksum": "sha1:d7e24b7550ca7e2f8e8baae54a957c26c18f76ca",
+        "checksum": "adler32:bad59a9f",
         "size": 77894471,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_12.ig"
       },
       {
-        "checksum": "sha1:b232eacb7070f6756bf8a838a659e908c5aa6361",
+        "checksum": "adler32:36bbbfbb",
         "size": 73451939,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_13.ig"
       },
       {
-        "checksum": "sha1:bf999e86abd0bc3d980d06324900c0b7c34d4d94",
+        "checksum": "adler32:e7e56452",
         "size": 68881869,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_14.ig"
       },
       {
-        "checksum": "sha1:1b520486d11329d735d7c55ea590937cf9f19c41",
+        "checksum": "adler32:6ca12c5c",
         "size": 68781154,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_15.ig"
       },
       {
-        "checksum": "sha1:6e2c402905a9692cd9a58fc9b513233243ea0203",
+        "checksum": "adler32:de0a3d79",
         "size": 68839305,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi_16.ig"
       },
       {
-        "checksum": "sha1:e8d627d09338de61404a01f4782fbbbdb7528efb",
+        "checksum": "adler32:f59504b3",
         "size": 295217,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi.csv"
       },
       {
-        "checksum": "sha1:d0fa31bfebd09c4ebefbd21a7b4892e99f7873d4",
+        "checksum": "adler32:cade8512",
         "size": 605140,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Jpsi.json"
       }
@@ -451,62 +451,62 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:13af9d3b335203b9f37479116b988840d4a06316",
+        "checksum": "adler32:b97ceddf",
         "size": 31475756,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon.json"
       },
       {
-        "checksum": "sha1:6ef5cb831608826543cdfb75ff95687d417266c6",
+        "checksum": "adler32:6ff04f0f",
         "size": 69359567,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_7.ig"
       },
       {
-        "checksum": "sha1:99a48d08ee4cd98550c6f8825584c9ae1bdb6984",
+        "checksum": "adler32:bd7caec8",
         "size": 68814448,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_8.ig"
       },
       {
-        "checksum": "sha1:b6cb4780c1899fead9e35006245a98e4c1d4ae0a",
+        "checksum": "adler32:8a32e225",
         "size": 72381700,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_9.ig"
       },
       {
-        "checksum": "sha1:e0a804f51c188323b5c349737a6d3c433214a5a3",
+        "checksum": "adler32:b47f7436",
         "size": 15075838,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon.csv"
       },
       {
-        "checksum": "sha1:69f3d7600aa83629876ae33f104192156d6ce4dc",
+        "checksum": "adler32:33d04cc9",
         "size": 66572060,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_0.ig"
       },
       {
-        "checksum": "sha1:35814129e7eff98d2ab64e2cbad27291c0308235",
+        "checksum": "adler32:bab1a742",
         "size": 69169047,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_1.ig"
       },
       {
-        "checksum": "sha1:53986f4931b5ea329a50148771becdc42089ec04",
+        "checksum": "adler32:066ff14c",
         "size": 67228960,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_2.ig"
       },
       {
-        "checksum": "sha1:54052f7072e4892a31f1cc6f4f9e314b0d7bebe1",
+        "checksum": "adler32:a627694d",
         "size": 67368771,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_3.ig"
       },
       {
-        "checksum": "sha1:53a44b80ff7284fff6fc2b1f5890d7d2e53badc0",
+        "checksum": "adler32:42e9fe46",
         "size": 67270859,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_4.ig"
       },
       {
-        "checksum": "sha1:a20ed0363c8f3a378ed098f50e915e624f799552",
+        "checksum": "adler32:d659d01b",
         "size": 65705946,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_5.ig"
       },
       {
-        "checksum": "sha1:6496145160b1506255855348a273a7737ef22825",
+        "checksum": "adler32:43c71aa6",
         "size": 69157089,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dimuon_6.ig"
       }
@@ -569,62 +569,62 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a1353f14b41454d4f30b6f9e1cca3146a194d727",
+        "checksum": "adler32:622cedce",
         "size": 73189908,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_0.ig"
       },
       {
-        "checksum": "sha1:7ea9f9f0720c4d2b7261608317c0c0e01f75bd2c",
+        "checksum": "adler32:3abf9720",
         "size": 14744033,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron.csv"
       },
       {
-        "checksum": "sha1:f6be560ec34f88b4ae3383bd87cf89e29f72e378",
+        "checksum": "adler32:881a0576",
         "size": 30243957,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron.json"
       },
       {
-        "checksum": "sha1:6228f89581167a0f4d4fd19ea2134d836ac13713",
+        "checksum": "adler32:de643407",
         "size": 74858467,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_1.ig"
       },
       {
-        "checksum": "sha1:569897777d557ecc9652d56b8ab10509bed425d2",
+        "checksum": "adler32:3a283589",
         "size": 73117459,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_2.ig"
       },
       {
-        "checksum": "sha1:3c492d7ffba66981181a24143b70588828a3997a",
+        "checksum": "adler32:2755f4c4",
         "size": 74063911,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_3.ig"
       },
       {
-        "checksum": "sha1:ded514e061023b73551ea606c265a709c59c4394",
+        "checksum": "adler32:b7bdf86b",
         "size": 72334392,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_4.ig"
       },
       {
-        "checksum": "sha1:4763808c4306240dc90c734a1aa8a11dfa0e252b",
+        "checksum": "adler32:9b2ffef5",
         "size": 74669334,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_5.ig"
       },
       {
-        "checksum": "sha1:408505b86a6692b080ac7a4bcabffdf27f4d4ce5",
+        "checksum": "adler32:964946c7",
         "size": 75602074,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_6.ig"
       },
       {
-        "checksum": "sha1:0af2f867c3767847c0ca0f0412383df1e33f717d",
+        "checksum": "adler32:55ef37d6",
         "size": 73475769,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_7.ig"
       },
       {
-        "checksum": "sha1:44df68cf3c2a7c0e0c50532cbaa37573180ba99c",
+        "checksum": "adler32:e7e491cf",
         "size": 78400529,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_8.ig"
       },
       {
-        "checksum": "sha1:c0cb37eebae23021301ede1f4e2146fd3ef9a6b0",
+        "checksum": "adler32:3d8ce124",
         "size": 75413930,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron_9.ig"
       }
@@ -687,112 +687,112 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5dd936e5fe4ad06c0d0ce4db6173c48f4a3702db",
+        "checksum": "adler32:a33f1812",
         "size": 72589491,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_0.ig"
       },
       {
-        "checksum": "sha1:b0d4e96d05d1637f1f08ef3a0441978060370a99",
+        "checksum": "adler32:a795b631",
         "size": 69319492,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_17.ig"
       },
       {
-        "checksum": "sha1:f693f7015e177e742adfb73b8001de9e52046e1c",
+        "checksum": "adler32:70d40dcd",
         "size": 73371933,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_18.ig"
       },
       {
-        "checksum": "sha1:906a61fa7b7c650a275749a445b28ebf720beb72",
+        "checksum": "adler32:1e417064",
         "size": 43562000,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_19.ig"
       },
       {
-        "checksum": "sha1:a928e317875e948abe8c4709ce67ce3196f8fe81",
+        "checksum": "adler32:8679c1f5",
         "size": 77272565,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_2.ig"
       },
       {
-        "checksum": "sha1:161beb76a10c52c18683a7d3329a33a758b822e5",
+        "checksum": "adler32:0ef0cb01",
         "size": 83965754,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_3.ig"
       },
       {
-        "checksum": "sha1:acb1deb58e042f638cdaf209d7bb22ce874da6f2",
+        "checksum": "adler32:8ce51951",
         "size": 84779897,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_4.ig"
       },
       {
-        "checksum": "sha1:c554a8832593915c245a4df109b5942986472fd6",
+        "checksum": "adler32:e9e32e18",
         "size": 75488170,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_5.ig"
       },
       {
-        "checksum": "sha1:b5dd313ee41077f23b7752ac4d6783cdbb65ddca",
+        "checksum": "adler32:dc5c995f",
         "size": 70368016,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_6.ig"
       },
       {
-        "checksum": "sha1:7028f7d5cc5e80318a7d7d62e2fb3aa3bb4a86b1",
+        "checksum": "adler32:0dcc11aa",
         "size": 74599753,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_7.ig"
       },
       {
-        "checksum": "sha1:fdcbfc9bacfdee662c7e008798d2becb3f75ef3c",
+        "checksum": "adler32:94a8ffc2",
         "size": 72520073,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_8.ig"
       },
       {
-        "checksum": "sha1:7b3023532762a9ac2689d293e47210a49466dcac",
+        "checksum": "adler32:2ef42ece",
         "size": 69478786,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_1.ig"
       },
       {
-        "checksum": "sha1:db58ff3d3d151883f405301b81bf7b4d1bc821a3",
+        "checksum": "adler32:0601efc9",
         "size": 71570303,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_9.ig"
       },
       {
-        "checksum": "sha1:f250c07bc43c391856699e9c0790a831cf2869a1",
+        "checksum": "adler32:add4f388",
         "size": 76250474,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_10.ig"
       },
       {
-        "checksum": "sha1:ba82d4f9403f41afd60f86123cd2925daf3aacbe",
+        "checksum": "adler32:a2cb8997",
         "size": 66170855,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_11.ig"
       },
       {
-        "checksum": "sha1:38bd6216e4f43624bea8a368940d159fb585843d",
+        "checksum": "adler32:75420a35",
         "size": 77124049,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_12.ig"
       },
       {
-        "checksum": "sha1:9b26cafd563e9feb1ecaaeeb5ef7e5bdcac630ae",
+        "checksum": "adler32:19168288",
         "size": 80943646,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_13.ig"
       },
       {
-        "checksum": "sha1:02deecddf23eb52406b6e3af31fd2bd52437610f",
+        "checksum": "adler32:9b91d371",
         "size": 78726695,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_14.ig"
       },
       {
-        "checksum": "sha1:3b4422ceffaa2fdfe72dff9786af134207855592",
+        "checksum": "adler32:eae84b2d",
         "size": 71798975,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_15.ig"
       },
       {
-        "checksum": "sha1:2ab6a5a5ed65478d516d2627bffabef43dfc8b5b",
+        "checksum": "adler32:ca97996b",
         "size": 67679915,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon_16.ig"
       },
       {
-        "checksum": "sha1:c54b742b26cd3ded48684716a35e6edaadf92757",
+        "checksum": "adler32:4705fac3",
         "size": 295203,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon.csv"
       },
       {
-        "checksum": "sha1:ffc73f0d954db941da877d459a69c34f8b791613",
+        "checksum": "adler32:bd627b31",
         "size": 605126,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/dielectron-Upsilon.json"
       }
@@ -855,37 +855,37 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8c60f830e48f5494ac701aaed823e8748718ebb1",
+        "checksum": "adler32:51f77643",
         "size": 138564,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee.csv"
       },
       {
-        "checksum": "sha1:fb07542706fd96161e2c6468b66c4aa7d005bbfe",
+        "checksum": "adler32:4cfa94a7",
         "size": 247216,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee.json"
       },
       {
-        "checksum": "sha1:55ca8dc768c1ddfd17d4a2bc4d9b1f28655a3162",
+        "checksum": "adler32:4674f52e",
         "size": 49249411,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee_0.ig"
       },
       {
-        "checksum": "sha1:6b86c50bdb35bade97c6f1e688b645eff894584a",
+        "checksum": "adler32:c1f00c07",
         "size": 47756345,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee_1.ig"
       },
       {
-        "checksum": "sha1:33b5291e3aa27c103c81c22affe087e38cd4b9cd",
+        "checksum": "adler32:1267ca13",
         "size": 49727895,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee_2.ig"
       },
       {
-        "checksum": "sha1:412b511e1e2fcc2b0c6d3e673a3fabc702e365e5",
+        "checksum": "adler32:b90632e4",
         "size": 47413375,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee_3.ig"
       },
       {
-        "checksum": "sha1:e9a1f04a124fc11a6eb6d3422811eb71e5be8ce9",
+        "checksum": "adler32:979a64d7",
         "size": 50992971,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zee_4.ig"
       }
@@ -948,37 +948,37 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:93d1784cdddbc6816e15294ef2fbfead3646168e",
+        "checksum": "adler32:b7d1c926",
         "size": 43191302,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu_0.ig"
       },
       {
-        "checksum": "sha1:1130b33123f7bedc2027423cb2909f5cdb53db28",
+        "checksum": "adler32:a7bfc822",
         "size": 42453798,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu_1.ig"
       },
       {
-        "checksum": "sha1:e9a95473eb5b9033090f87913acf16b249bd69ef",
+        "checksum": "adler32:965dae3d",
         "size": 44167394,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu_2.ig"
       },
       {
-        "checksum": "sha1:a6033444d6a3e13627301c3553ed5ec365bc8900",
+        "checksum": "adler32:92efe6eb",
         "size": 44768415,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu_3.ig"
       },
       {
-        "checksum": "sha1:a6608cd860a035fda03669d780d55ce7816c4145",
+        "checksum": "adler32:52b8112b",
         "size": 45457088,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu_4.ig"
       },
       {
-        "checksum": "sha1:dcc32850bae148c745031c342f618145b3ebdf93",
+        "checksum": "adler32:dbec436d",
         "size": 470360,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu.csv"
       },
       {
-        "checksum": "sha1:06414d8c8c829791cb398f3babbd5ffa617d315d",
+        "checksum": "adler32:e4edb7de",
         "size": 848381,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Zmumu.json"
       }
@@ -1041,62 +1041,62 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:850ceebe0ccc2e82d6ecee6296077f1af52a987e",
+        "checksum": "adler32:bd89683f",
         "size": 118664,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu.csv"
       },
       {
-        "checksum": "sha1:627a52d0a244259de7f7a963fd9441736a1b2ecd",
+        "checksum": "adler32:83cc6b86",
         "size": 62907595,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_7.ig"
       },
       {
-        "checksum": "sha1:680e86adbbdfea1032f3df3815caaefa123faaa6",
+        "checksum": "adler32:d9a37d9e",
         "size": 62674146,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_8.ig"
       },
       {
-        "checksum": "sha1:4f4879f60e22879f40dd09a46e8f932ad92d7a7b",
+        "checksum": "adler32:c272aef3",
         "size": 61176750,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_9.ig"
       },
       {
-        "checksum": "sha1:3c1922bc3d13ebd998414d026c0e02e34ffa9d2c",
+        "checksum": "adler32:7a64f2af",
         "size": 214620,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu.json"
       },
       {
-        "checksum": "sha1:a0237e67f657df3be714f4b704570ac8a1db9600",
+        "checksum": "adler32:5792a395",
         "size": 64952388,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_0.ig"
       },
       {
-        "checksum": "sha1:c7ebca32f1ac93049544304a6551a0bb1e9e5ee5",
+        "checksum": "adler32:ddb8fac6",
         "size": 60210853,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_1.ig"
       },
       {
-        "checksum": "sha1:8f0902d17ffa972aed348af33931eea8676bf7fd",
+        "checksum": "adler32:a54ddc21",
         "size": 61418718,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_2.ig"
       },
       {
-        "checksum": "sha1:178fef6536c09c781e006211a79c255c3f948743",
+        "checksum": "adler32:71ad04bb",
         "size": 63468946,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_3.ig"
       },
       {
-        "checksum": "sha1:6ff6900cdb1e7e1225be326cac32a14686efcc7b",
+        "checksum": "adler32:94058e82",
         "size": 62875572,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_4.ig"
       },
       {
-        "checksum": "sha1:556bed5ce721b88336a10204745bf7242d195fdd",
+        "checksum": "adler32:9b2c180b",
         "size": 61386136,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_5.ig"
       },
       {
-        "checksum": "sha1:b2a118efa7a9fa6bff3e53f0cc981ac08dd24f2e",
+        "checksum": "adler32:a3391aee",
         "size": 62332632,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wenu_6.ig"
       }
@@ -1159,62 +1159,62 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b94fccfa4d57f2715f89fdd3fbda2278bf82722d",
+        "checksum": "adler32:4cfc8e85",
         "size": 118774,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu.csv"
       },
       {
-        "checksum": "sha1:14b06991e21b2d3d250cc4ca25b5decd3b6d7c1e",
+        "checksum": "adler32:67ee070b",
         "size": 59026045,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_7.ig"
       },
       {
-        "checksum": "sha1:efe0842e6f8e5a5437ed8a968c199ad02a6fb37a",
+        "checksum": "adler32:c9ae7363",
         "size": 59259117,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_8.ig"
       },
       {
-        "checksum": "sha1:c28800ad6aa999d03b19596fa0bca56070ee0803",
+        "checksum": "adler32:634f1b69",
         "size": 58035272,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_9.ig"
       },
       {
-        "checksum": "sha1:3732c3f5dae22572db43378272899d2b813d4d80",
+        "checksum": "adler32:51c71904",
         "size": 214730,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu.json"
       },
       {
-        "checksum": "sha1:3109f5c16305a17017f61c6059b4358cb477423a",
+        "checksum": "adler32:f7d95d75",
         "size": 61590952,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_0.ig"
       },
       {
-        "checksum": "sha1:3ad816062eaafa768e04ab7adf9020b27c0ac101",
+        "checksum": "adler32:90657853",
         "size": 55434949,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_1.ig"
       },
       {
-        "checksum": "sha1:a2e53c9b8ed2797fe69f872eb2d3240028045785",
+        "checksum": "adler32:115bc685",
         "size": 58404898,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_2.ig"
       },
       {
-        "checksum": "sha1:c8274459786e9c5a5859cc013d0ef3e27e1a9b9c",
+        "checksum": "adler32:1fd122d7",
         "size": 56704404,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_3.ig"
       },
       {
-        "checksum": "sha1:55ddf00ee278dc10ac49306ce6b0e5581a69ef0b",
+        "checksum": "adler32:cd8f9d68",
         "size": 59413356,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_4.ig"
       },
       {
-        "checksum": "sha1:11bf18417e638d0c574690742750fa41ecd1873e",
+        "checksum": "adler32:45666666",
         "size": 60189101,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_5.ig"
       },
       {
-        "checksum": "sha1:4264d13bd949178997edc1b171adecc5ff5959d9",
+        "checksum": "adler32:37965d4f",
         "size": 60361441,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/Wmunu_6.ig"
       }
@@ -1277,387 +1277,387 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d77240bde483c8b0e061aa882485ae99240ccf63",
+        "checksum": "adler32:90e5d0d4",
         "size": 8747,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_1-leptons.csv"
       },
       {
-        "checksum": "sha1:2e02ecffccc37b6bd44d8efc1b09e79a3ccd0642",
+        "checksum": "adler32:0b77b77e",
         "size": 10588,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_11-lnu.csv"
       },
       {
-        "checksum": "sha1:3362162a7465f1de489c892489dbe1b9b3640741",
+        "checksum": "adler32:69e71bb4",
         "size": 123,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_11-photon.csv"
       },
       {
-        "checksum": "sha1:20fe6d102d3eed62808bf70959b8009fdea47af9",
+        "checksum": "adler32:0ddf0358",
         "size": 63150455,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_11.ig"
       },
       {
-        "checksum": "sha1:e2b01ee0801651c6e1cb2d20944c7c53eca43759",
+        "checksum": "adler32:a25c98ec",
         "size": 11650,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_12-leptons.csv"
       },
       {
-        "checksum": "sha1:7f6a2e9e3953fcd5110a56f623a5393201f03b93",
+        "checksum": "adler32:a384d009",
         "size": 10716,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_12-lnu.csv"
       },
       {
-        "checksum": "sha1:b0db7401b6ae827b4454d39dc64bc24da1252cc5",
+        "checksum": "adler32:d28a1c64",
         "size": 127,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_12-photon.csv"
       },
       {
-        "checksum": "sha1:5df7427aa9b95fa0c9fda077cb0f8de50951dac0",
+        "checksum": "adler32:f8bbca3e",
         "size": 59339377,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_12.ig"
       },
       {
-        "checksum": "sha1:14f2739184eeda5b50df808fb31dd0b632919f3b",
+        "checksum": "adler32:136b3da6",
         "size": 13903,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_13-leptons.csv"
       },
       {
-        "checksum": "sha1:db1f6f251ade5e2c0a0224cbcbdbaeb82369a045",
+        "checksum": "adler32:5a33032b",
         "size": 10996,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_13-lnu.csv"
       },
       {
-        "checksum": "sha1:2ead0e9864e2e583d78f0a0f6fb762c02044bc59",
+        "checksum": "adler32:dc1b1c79",
         "size": 127,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_13-photon.csv"
       },
       {
-        "checksum": "sha1:82ad8c8eabdd9bfc2fc2c6245e5608e7126f350c",
+        "checksum": "adler32:25c7e6bf",
         "size": 10846,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_1-lnu.csv"
       },
       {
-        "checksum": "sha1:5a0c98e9c38b407a8f84bcd3e2c942496589bb5e",
+        "checksum": "adler32:ae60746a",
         "size": 59788242,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_13.ig"
       },
       {
-        "checksum": "sha1:aad082eb92bf65f447249e3c17c3742fd16776c5",
+        "checksum": "adler32:7ef534c0",
         "size": 8379,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_14-leptons.csv"
       },
       {
-        "checksum": "sha1:278f6044be21d999fb934d1a650ee67587eeef89",
+        "checksum": "adler32:f9df7670",
         "size": 11611,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_14-lnu.csv"
       },
       {
-        "checksum": "sha1:381b0e9d1dd19b207b673a71f233ca85674a8802",
+        "checksum": "adler32:b7971c29",
         "size": 126,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_14-photon.csv"
       },
       {
-        "checksum": "sha1:fb47eac65724eaa1c78f5b5eb25bed4ade997f11",
+        "checksum": "adler32:c8ef88b6",
         "size": 64351304,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_14.ig"
       },
       {
-        "checksum": "sha1:dda63d9dfa0077446eed6e1cf11ecb5335e47a36",
+        "checksum": "adler32:db498e38",
         "size": 11599,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_15-leptons.csv"
       },
       {
-        "checksum": "sha1:dadcd9a2125e6cbca07a4206150dd1b84408e2fc",
+        "checksum": "adler32:96335e55",
         "size": 11490,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_15-lnu.csv"
       },
       {
-        "checksum": "sha1:ecf072fb20aea7f2f8e9cf7c9c2e2e87caf46abe",
+        "checksum": "adler32:bbfd1c4b",
         "size": 126,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_15-photon.csv"
       },
       {
-        "checksum": "sha1:f733dc07b11d1fbe39c0ddd5cf73ed9b82ff8583",
+        "checksum": "adler32:ebde83c3",
         "size": 60762184,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_15.ig"
       },
       {
-        "checksum": "sha1:02af7c0c56d3351f3044369a3a13c6b1e2d113ac",
+        "checksum": "adler32:637db39f",
         "size": 15899,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_16-leptons.csv"
       },
       {
-        "checksum": "sha1:3362162a7465f1de489c892489dbe1b9b3640741",
+        "checksum": "adler32:69e71bb4",
         "size": 123,
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_1-photons.csv"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_1-photon.csv"
       },
       {
-        "checksum": "sha1:dca8550db29425b4f450668e6e006c14b6a23a28",
+        "checksum": "adler32:a2383a85",
         "size": 9926,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_16-lnu.csv"
       },
       {
-        "checksum": "sha1:6c9759369d4725c2e13385f4d61cab5084bf0568",
+        "checksum": "adler32:63661b92",
         "size": 123,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_16-photon.csv"
       },
       {
-        "checksum": "sha1:0266109ce4cb76358cc3bdce794568b0d45a389d",
+        "checksum": "adler32:fc174749",
         "size": 59539570,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_16.ig"
       },
       {
-        "checksum": "sha1:219c0d72f79d713aa4be2a52f5428d5ad7145714",
+        "checksum": "adler32:b3edbcf5",
         "size": 9093,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_17-leptons.csv"
       },
       {
-        "checksum": "sha1:97eb4aeafa8baee81743980eda0d042a8cd54309",
+        "checksum": "adler32:49390252",
         "size": 10982,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_17-lnu.csv"
       },
       {
-        "checksum": "sha1:c5bf6fa4cc6a6654ef43be3f1a3bce4df1c6b2ac",
+        "checksum": "adler32:67891bac",
         "size": 123,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_17-photon.csv"
       },
       {
-        "checksum": "sha1:8a0cbc766aea0b37b9204344e663f445e97f350b",
+        "checksum": "adler32:53a475e8",
         "size": 62130580,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_17.ig"
       },
       {
-        "checksum": "sha1:e36ecbe54e1cbe78611b108aa2d762b20b354f07",
+        "checksum": "adler32:1f410ce3",
         "size": 13632,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_18-leptons.csv"
       },
       {
-        "checksum": "sha1:b914c33608c39fa087953def0624dc88f0caf148",
+        "checksum": "adler32:1ecbe943",
         "size": 10858,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_18-lnu.csv"
       },
       {
-        "checksum": "sha1:5edcd37a6c227bb3d48648896d9da27dc4163ec3",
+        "checksum": "adler32:a39c1c25",
         "size": 125,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_18-photon.csv"
       },
       {
-        "checksum": "sha1:bb5daf4b6dad2fe1185a3f90083b760b5050de27",
+        "checksum": "adler32:603b97f9",
         "size": 63466325,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_1.ig"
       },
       {
-        "checksum": "sha1:e23c6806c6199e4c1d47f8021fdaf9fb73f14c08",
+        "checksum": "adler32:2e9444d4",
         "size": 60314289,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_18.ig"
       },
       {
-        "checksum": "sha1:2559936f4b2dbde3592fcf1175ebc1a3ffb8de25",
+        "checksum": "adler32:012f0a6a",
         "size": 5403,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_19-leptons.csv"
       },
       {
-        "checksum": "sha1:bbbf6b7bfc2cb048ec9ee7cd526dade486de587a",
+        "checksum": "adler32:fb48d7f9",
         "size": 12141,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_19-lnu.csv"
       },
       {
-        "checksum": "sha1:e27bea1440f7e35dc573c6e3eb3701374bc885b2",
+        "checksum": "adler32:d57a1c5d",
         "size": 127,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_19-photon.csv"
       },
       {
-        "checksum": "sha1:8d9465d32e8b5346c74f5ccafcef42c983aaf327",
+        "checksum": "adler32:807db499",
         "size": 63208795,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_19.ig"
       },
       {
-        "checksum": "sha1:f046d5621f89534cc996b88a61cae0d7c3c3167e",
+        "checksum": "adler32:96da17fd",
         "size": 10950,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_2-leptons.csv"
       },
       {
-        "checksum": "sha1:d0c63276928139fabfb4e94bf634e8b93d2c10a8",
+        "checksum": "adler32:a14c2de8",
         "size": 11224,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_2-lnu.csv"
       },
       {
-        "checksum": "sha1:b0db7401b6ae827b4454d39dc64bc24da1252cc5",
+        "checksum": "adler32:d28a1c64",
         "size": 127,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_2-photon.csv"
       },
       {
-        "checksum": "sha1:9b4ab46c5067ef1f9af0d94439d566007401a3a9",
+        "checksum": "adler32:8d7f1c0a",
         "size": 62500899,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_2.ig"
       },
       {
-        "checksum": "sha1:243fa1f5be053c3cd6645078555b93d53af640b5",
+        "checksum": "adler32:d1f16dcd",
         "size": 12781,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_3-leptons.csv"
       },
       {
-        "checksum": "sha1:97469fdc84ffcdb8dc6465852f296fdce812f788",
+        "checksum": "adler32:71691377",
         "size": 6832,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_10-leptons.csv"
       },
       {
-        "checksum": "sha1:c54092f59c6d21cb8c9d007df05790ce5a83a977",
+        "checksum": "adler32:33641a80",
         "size": 11123,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_3-lnu.csv"
       },
       {
-        "checksum": "sha1:2ead0e9864e2e583d78f0a0f6fb762c02044bc59",
+        "checksum": "adler32:dc1b1c79",
         "size": 127,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_3-photon.csv"
       },
       {
-        "checksum": "sha1:7256a437f2c41bd757a73c42729dddea0cf8ab4b",
+        "checksum": "adler32:2c22d585",
         "size": 61956913,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_3.ig"
       },
       {
-        "checksum": "sha1:b7d5520ac9fd413f0ce5aec2a1af52e89a7794d6",
+        "checksum": "adler32:06ecd4e4",
         "size": 14707,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_4-leptons.csv"
       },
       {
-        "checksum": "sha1:e04c0494696c955c048588dfb147399a4cd2da83",
+        "checksum": "adler32:bb02b5ab",
         "size": 10576,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_4-lnu.csv"
       },
       {
-        "checksum": "sha1:381b0e9d1dd19b207b673a71f233ca85674a8802",
+        "checksum": "adler32:b7971c29",
         "size": 126,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_4-photon.csv"
       },
       {
-        "checksum": "sha1:2460e09e47b0c7a71f08cab02d5efc1d4343fd78",
+        "checksum": "adler32:be792bc3",
         "size": 62720130,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_4.ig"
       },
       {
-        "checksum": "sha1:da58cbb5990019fac8fb1596177b22a693e65157",
+        "checksum": "adler32:9df038e8",
         "size": 9780,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_5-leptons.csv"
       },
       {
-        "checksum": "sha1:33c9b111a95daa910031966a93fcd2e395d8f406",
+        "checksum": "adler32:73c27c11",
         "size": 11648,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_5-lnu.csv"
       },
       {
-        "checksum": "sha1:ecf072fb20aea7f2f8e9cf7c9c2e2e87caf46abe",
+        "checksum": "adler32:bbfd1c4b",
         "size": 126,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_5-photon.csv"
       },
       {
-        "checksum": "sha1:69f38f19d0ce1a3d0b57fa3408f65d41eafd3ee3",
+        "checksum": "adler32:3abead15",
         "size": 11914,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_10-lnu.csv"
       },
       {
-        "checksum": "sha1:3d42c620f1b8d25ec708dfc53dfe5a55ced04a96",
+        "checksum": "adler32:ebfa6b85",
         "size": 62710389,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_5.ig"
       },
       {
-        "checksum": "sha1:2df4a3c512fc9402cc175c1782219b25b48bc0c2",
+        "checksum": "adler32:6495dd6d",
         "size": 13387,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_6-leptons.csv"
       },
       {
-        "checksum": "sha1:82ca78a7f1ff2edf008323d59d1b5f3834a4c311",
+        "checksum": "adler32:6bbad5bb",
         "size": 10751,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_6-lnu.csv"
       },
       {
-        "checksum": "sha1:6c9759369d4725c2e13385f4d61cab5084bf0568",
+        "checksum": "adler32:63661b92",
         "size": 123,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_6-photon.csv"
       },
       {
-        "checksum": "sha1:d63398cb971e6af913073b6daa1ca860a1ee6173",
+        "checksum": "adler32:63fd3e3a",
         "size": 61086654,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_6.ig"
       },
       {
-        "checksum": "sha1:d29a43d866765321407b48b6e520c635e771702e",
+        "checksum": "adler32:7724c356",
         "size": 15972,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_7-leptons.csv"
       },
       {
-        "checksum": "sha1:a5c826f9f0c48b6ee09b0192092d178af31b0835",
+        "checksum": "adler32:57c997fd",
         "size": 10427,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_7-lnu.csv"
       },
       {
-        "checksum": "sha1:c5bf6fa4cc6a6654ef43be3f1a3bce4df1c6b2ac",
+        "checksum": "adler32:67891bac",
         "size": 123,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_7-photon.csv"
       },
       {
-        "checksum": "sha1:5c9f8abf63cf07d143cd50cc4e0aeba3e7348396",
+        "checksum": "adler32:cef8d1aa",
         "size": 65644163,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_7.ig"
       },
       {
-        "checksum": "sha1:5d1fb57c9f82c9dab5be0b5baa5979ef858b6e1a",
+        "checksum": "adler32:e10e2bae",
         "size": 9705,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_8-leptons.csv"
       },
       {
-        "checksum": "sha1:029dfd7f5bb4c0b65bda8207a8c14090140d7ca9",
+        "checksum": "adler32:52401b94",
         "size": 122,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_10-photon.csv"
       },
       {
-        "checksum": "sha1:5b684724db9a5976230b682db1134b147b773b27",
+        "checksum": "adler32:d1379778",
         "size": 11796,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_8-lnu.csv"
       },
       {
-        "checksum": "sha1:5edcd37a6c227bb3d48648896d9da27dc4163ec3",
+        "checksum": "adler32:a39c1c25",
         "size": 125,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_8-photon.csv"
       },
       {
-        "checksum": "sha1:1f0cbc195983a9972c08fea013c8370234a3711f",
+        "checksum": "adler32:a8744d50",
         "size": 65166464,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_8.ig"
       },
       {
-        "checksum": "sha1:d65edeb4e766f0ce7480b31a7283aad67c26960e",
+        "checksum": "adler32:3df5e2a8",
         "size": 6558,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_9-leptons.csv"
       },
       {
-        "checksum": "sha1:d08d55d4612ff8f8f5ce40dc33969553c3e8d4ba",
+        "checksum": "adler32:f6f0c3ab",
         "size": 12025,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_9-lnu.csv"
       },
       {
-        "checksum": "sha1:e27bea1440f7e35dc573c6e3eb3701374bc885b2",
+        "checksum": "adler32:d57a1c5d",
         "size": 127,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_9-photon.csv"
       },
       {
-        "checksum": "sha1:3fda5f251d3d905047221d5c3a396fc58d05586d",
+        "checksum": "adler32:9490ba00",
         "size": 57749966,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_9.ig"
       },
       {
-        "checksum": "sha1:0b731c14c94c1c3dcd1ba4b79631b8d388fbc0d5",
+        "checksum": "adler32:f3f466c8",
         "size": 59177597,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_10.ig"
       },
       {
-        "checksum": "sha1:ce3e341c86ef1b0d8d4b4754b4755859701c77b3",
+        "checksum": "adler32:cbbb3b62",
         "size": 13871,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass_11-leptons.csv"
       },
       {
-        "checksum": "sha1:63a458ac9397583bdda31147192b7cdca814b0da",
+        "checksum": "adler32:4df04e85",
         "size": 728576,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/masterclass-2014/masterclass-2014.xls"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-open-data-instructions-2017.json
+++ b/cernopendata/modules/fixtures/data/records/cms-open-data-instructions-2017.json
@@ -27,7 +27,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:673b32ebcfaa3369215de99fe382ae97f0f51292",
+        "checksum": "adler32:94c30ee1",
         "size": 6328249,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/cms-spreadsheet-materials-multiple-languages/cms-spreadsheet-materials-multiple-languages-1.0.tar.gz"
       }
@@ -74,7 +74,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:62c66b9e9880a4dc3bd974627ceb21869e41c8d4",
+        "checksum": "adler32:a043e9a3",
         "size": 85664941,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/cms-jupyter-materials-english/cms-jupyter-materials-english-1.0.tar.gz"
       }
@@ -122,7 +122,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:34971230f14fd19b8af8f787d46f8fd4bef02c17",
+        "checksum": "adler32:707f5bfb",
         "size": 614307,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/cms-rmaterial-multiple-languages/cms-rmaterial-multiple-languages-1.0.tar.gz"
       }
@@ -169,7 +169,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0be37c4464d591e2024863624030a71199888765",
+        "checksum": "adler32:49e4c241",
         "size": 11361597,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/cms-event-display-materials-multiple-languages/cms-event-display-materials-multiple-languages-1.0.tar.gz"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-open-data-instructions.json
+++ b/cernopendata/modules/fixtures/data/records/cms-open-data-instructions.json
@@ -21,7 +21,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4cb6abb14d8c1a5524e8035ccfeeea740a1174ea",
+        "checksum": "adler32:44c42208",
         "size": 24607321,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/outreach-exercise-2010/OutreachExercise2010.m4v"
       }
@@ -245,77 +245,77 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d136b1913319f79aea6bb7db6b904845c2a74818",
+        "checksum": "adler32:3e55d251",
         "size": 2408298,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/WorkGroup5_OpenData.pdf"
       },
       {
-        "checksum": "sha1:61e6768011c457a700908e4dbc8f2a9221b81665",
+        "checksum": "adler32:b61baf76",
         "size": 222926,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/1_ClassroomActivitiesVisualisation.pdf"
       },
       {
-        "checksum": "sha1:19628d1958945a3a94dfafe1e3f77426805d98f1",
+        "checksum": "adler32:942bb09a",
         "size": 335854,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/1_VisualisationOfEventsTutorial.pdf"
       },
       {
-        "checksum": "sha1:0a72dd8bae4e64dcfc62d880fa1eaf418af2f96d",
+        "checksum": "adler32:8c4f3ecb",
         "size": 1210860,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/2_ExcelExerciseForStudents.pdf"
       },
       {
-        "checksum": "sha1:bdde3ebbd3845b7f1bb66ddbab3aa2d18254d3aa",
+        "checksum": "adler32:cac4c624",
         "size": 782744,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/3_DiMuonHistogramExcelInstructions.pdf"
       },
       {
-        "checksum": "sha1:06803250e7d3aaa177ee2962529b18c221cd830c",
+        "checksum": "adler32:bce6b9f2",
         "size": 1570300,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/4_DiMuonHistogramSciLABInstructions.pdf"
       },
       {
-        "checksum": "sha1:fea8c4be798063229cb097b6d4e48896ef4f89f2",
+        "checksum": "adler32:41ce1bea",
         "size": 45035,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/4_DiMuonTeacherHandout.pdf"
       },
       {
-        "checksum": "sha1:f534d22ed0740f85a82b3f2f9c351899967535b7",
+        "checksum": "adler32:41ef1e55",
         "size": 578131,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/5_SharingJupyterNotebookInstructions.pdf"
       },
       {
-        "checksum": "sha1:8bd7cc1eee573d421ffd0de208e3b54988d81dd9",
+        "checksum": "adler32:3b78841e",
         "size": 288293,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/1_ClassroomActivitiesVisualisation.docx"
       },
       {
-        "checksum": "sha1:733b858a39169fb67cbb084630c511a17e0aa66b",
+        "checksum": "adler32:7370be92",
         "size": 460846,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/1_VisualisationOfEventsTutorial.docx"
       },
       {
-        "checksum": "sha1:20ee1263545668a20d165f8ec592f70a9ef6f1bb",
+        "checksum": "adler32:53afb352",
         "size": 1836092,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/2_ExcelExerciseForStudents.docx"
       },
       {
-        "checksum": "sha1:27f3f91cc39cae7e224babaa3c496afc8d1f4590",
+        "checksum": "adler32:f9ddfce0",
         "size": 931189,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/3_DiMuonHistogramExcelInstructions.docx"
       },
       {
-        "checksum": "sha1:53ef32733e8560002b57933684dbec2577ef8c21",
+        "checksum": "adler32:a008bf7b",
         "size": 1837202,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/4_DiMuonHistogramSciLABInstructions.docx"
       },
       {
-        "checksum": "sha1:7b1220171d300d605b2d4eda96efcc90c6bc6cbf",
+        "checksum": "adler32:a2f34928",
         "size": 61443,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/4_DiMuonTeacherHandout.docx"
       },
       {
-        "checksum": "sha1:0c0ad5f73fd6dfa1f813cc1ab6ca46465fababa2",
+        "checksum": "adler32:8bf027a7",
         "size": 699329,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/hst-programme-2016/5_SharingJupyterNotebookInstructions.docx"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-pileup-configuration-files.json
+++ b/cernopendata/modules/fixtures/data/records/cms-pileup-configuration-files.json
@@ -26,7 +26,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:adc9110968b5c5aca80c5914ef7bb46423b7c05c",
+        "checksum": "adler32:11ce0f5e",
         "size": 3418,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2011/mix_2011_FinalDist_OOTPU_cfi.py"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012B.json
@@ -38,154 +38,154 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6afa99f1cf3c632534c765b4e55ec76ec7372a82",
+        "checksum": "adler32:fb89064f",
         "description": "BJetPlusX AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
         "size": 276741,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:c137911dbe005bd648e9b1242c77801a5b8e2957",
+        "checksum": "adler32:2a4a8b47",
         "description": "BJetPlusX AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
         "size": 57816,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:be27d96b1ad759e2431f1a22e7be36a1058d2937",
+        "checksum": "adler32:67eb4788",
         "description": "BJetPlusX AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:e97aa5d647e4fbc9ea55476a6aa95b36f477afe0",
+        "checksum": "adler32:43d4473f",
         "description": "BJetPlusX AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:4cade2b5af0a1ea87a8060ee821c54e64dacad02",
+        "checksum": "adler32:27244730",
         "description": "BJetPlusX AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20004_file_index.json"
       },
       {
-        "checksum": "sha1:5195fb12cddf63b6d1b2c764f4a09b0d6c1e7e8e",
+        "checksum": "adler32:a6f947b6",
         "description": "BJetPlusX AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20009_file_index.json"
       },
       {
-        "checksum": "sha1:51221d04493e019285283b6aa4ae4917653adae4",
+        "checksum": "adler32:5bbbdb76",
         "description": "BJetPlusX AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
         "size": 278386,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:8ac8d824d6887dcda154081cfdb01cd3d167078f",
+        "checksum": "adler32:abba3c58",
         "description": "BJetPlusX AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
         "size": 12058,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:5cfda283e650bf6c1b4159a1bd5fc2c941d159d0",
+        "checksum": "adler32:a4a58e54",
         "description": "BJetPlusX AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
         "size": 550,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30003_file_index.json"
       },
       {
-        "checksum": "sha1:dc1d278d2f548ec16644dc27ddedbe48a4258451",
+        "checksum": "adler32:145146e7",
         "description": "BJetPlusX AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30005_file_index.json"
       },
       {
-        "checksum": "sha1:a6776fd2137d683e414cf3cc610beb129dd0bc68",
+        "checksum": "adler32:63194784",
         "description": "BJetPlusX AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30008_file_index.json"
       },
       {
-        "checksum": "sha1:2cf98231686b93f599b8c6f27d028139d4c135c5",
+        "checksum": "adler32:c7cef6ae",
         "description": "BJetPlusX AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
         "size": 128270,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:15c15a07339d26dc453a2e4182d139a738eb1c78",
+        "checksum": "adler32:ed564fcd",
         "description": "BJetPlusX AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
         "size": 26797,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:9c74a19d6d5efe5a85fca50cb693393c9204ce69",
+        "checksum": "adler32:330124dc",
         "description": "BJetPlusX AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:9c7d7adff55f41f97bdfdb0ac40a9316a51089f2",
+        "checksum": "adler32:31bc24bd",
         "description": "BJetPlusX AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:b6acf2ab8c8a431d7af505a98274b95ed82b4f09",
+        "checksum": "adler32:2f5724c8",
         "description": "BJetPlusX AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20004_file_index.txt"
       },
       {
-        "checksum": "sha1:e7c58ff9c1cbf4da6042b1869521ce07832d3ac3",
+        "checksum": "adler32:2ec924bf",
         "description": "BJetPlusX AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_20009_file_index.txt"
       },
       {
-        "checksum": "sha1:8497e0551ba67539df20c1feb9abae68d163c96d",
+        "checksum": "adler32:c1d2e4da",
         "description": "BJetPlusX AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
         "size": 129032,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:e858bb122351217c28be5baa52098ba7fd2abcfb",
+        "checksum": "adler32:d77c53cd",
         "description": "BJetPlusX AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
         "size": 5588,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:8411a735341fea1075018ba4c37aeda18fdf69c0",
+        "checksum": "adler32:a2874985",
         "description": "BJetPlusX AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
         "size": 254,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30003_file_index.txt"
       },
       {
-        "checksum": "sha1:f31cbd7ce065ca6d3ff5b308d9f3ef4382b8903d",
+        "checksum": "adler32:2b632495",
         "description": "BJetPlusX AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BJetPlusX_AOD_22Jan2013-v1_30005_file_index.txt"
       },
       {
-        "checksum": "sha1:219c10eb8b1ce665ae6e205ef0f001b34f7d0fd1",
+        "checksum": "adler32:301924d3",
         "description": "BJetPlusX AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
@@ -285,28 +285,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3f2cd1af4938bc61f85b9783ba5efe3a59547c87",
+        "checksum": "adler32:2e6b0337",
         "description": "BTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 95497,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BTag_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:3824e7ccdfa2c40e6da4497e306cdb8da8be0885",
+        "checksum": "adler32:66708952",
         "description": "BTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 62141,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BTag_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:56262403ea272ca03d01a5ad3d39f88b4fae3024",
+        "checksum": "adler32:f666589e",
         "description": "BTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 43310,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_BTag_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:1fe77fe302d88289d91dd49b8f59aabf3f370db6",
+        "checksum": "adler32:1c267c48",
         "description": "BTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 28182,
         "type": "index.txt",
@@ -406,14 +406,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4e1b57dd71dbfcbbc5fff8430e9930e3f515ae97",
+        "checksum": "adler32:2cc2f720",
         "description": "Commissioning AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 141504,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_Commissioning_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:f99b078c8a2ac74fb56e93e92a6f6a439541e960",
+        "checksum": "adler32:92a6784f",
         "description": "Commissioning AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 66679,
         "type": "index.txt",
@@ -513,42 +513,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f09ede99ea5354397a155cce8ed2e0adfc959d23",
+        "checksum": "adler32:724fdd15",
         "description": "DoubleElectron AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 278723,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleElectron_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:7433f5ee98bb31c27a09bfd6bd4cd5c767e9004b",
+        "checksum": "adler32:3ca2ea10",
         "description": "DoubleElectron AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 173261,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleElectron_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:34d860a1c1181627bce0541d3c1c1c704cd9d0d0",
+        "checksum": "adler32:e4c290f3",
         "description": "DoubleElectron AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 6418,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleElectron_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:a06400477058b6b2ec20cc808c3fc4a652afb747",
+        "checksum": "adler32:d9331b55",
         "description": "DoubleElectron AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 131868,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleElectron_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:130f9c2d413f58837bed7c6b1e2ad34b2d878f73",
+        "checksum": "adler32:06c4ad8a",
         "description": "DoubleElectron AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 81972,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleElectron_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:f75c3a3cc6dcb3f8c2517f631f8aec3f6b636492",
+        "checksum": "adler32:05957f4e",
         "description": "DoubleElectron AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 3036,
         "type": "index.txt",
@@ -648,98 +648,98 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b960f884d4086aad32ff349ffcd4137c95e61d4c",
+        "checksum": "adler32:ff88dddc",
         "description": "DoubleMuParked AOD dataset file index (1 of 7) for access to data via CMS virtual machine",
         "size": 839,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:d5350460a4cfa2f034d1ee719f936f5c03e21413",
+        "checksum": "adler32:d51f3a9d",
         "description": "DoubleMuParked AOD dataset file index (2 of 7) for access to data via CMS virtual machine",
         "size": 238826,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:1093b23663b2473a4c0d282ed2fe26e6bef69845",
+        "checksum": "adler32:49016215",
         "description": "DoubleMuParked AOD dataset file index (3 of 7) for access to data via CMS virtual machine",
         "size": 278723,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:f60bf7690af51a8995dd9d24c914a7a97a81f43d",
+        "checksum": "adler32:a17d718f",
         "description": "DoubleMuParked AOD dataset file index (4 of 7) for access to data via CMS virtual machine",
         "size": 69473,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:ce80ead2ba9006989d326fa06e4d1552df22aa29",
+        "checksum": "adler32:afc89309",
         "description": "DoubleMuParked AOD dataset file index (5 of 7) for access to data via CMS virtual machine",
         "size": 19042,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_210000_file_index.json"
       },
       {
-        "checksum": "sha1:3c983721ff7f3bf909c2dc7a7cef4ad0f3fad555",
+        "checksum": "adler32:0e8f9bd3",
         "description": "DoubleMuParked AOD dataset file index (6 of 7) for access to data via CMS virtual machine",
         "size": 12277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:52e797085084a1992c9e98bfe0559c45cbe9a0a9",
+        "checksum": "adler32:c9414e6b",
         "description": "DoubleMuParked AOD dataset file index (7 of 7) for access to data via CMS virtual machine",
         "size": 16802,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_310000_file_index.json"
       },
       {
-        "checksum": "sha1:5798f08d8a598fafe8902e7be3babe2edc2ddbca",
+        "checksum": "adler32:26967565",
         "description": "DoubleMuParked AOD dataset file index (1 of 7) for access to data via CMS virtual machine",
         "size": 396,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:a6fd67522a8653ec66286dc67a8253225be11b7d",
+        "checksum": "adler32:758b4772",
         "description": "DoubleMuParked AOD dataset file index (2 of 7) for access to data via CMS virtual machine",
         "size": 112992,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:39934bc27705f78ba9bd956afd0ae8324632d3ca",
+        "checksum": "adler32:7aa72503",
         "description": "DoubleMuParked AOD dataset file index (3 of 7) for access to data via CMS virtual machine",
         "size": 131868,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:3d7af9b643d25e5faa87ea3e0db33bbde6fd84de",
+        "checksum": "adler32:7b81f67b",
         "description": "DoubleMuParked AOD dataset file index (4 of 7) for access to data via CMS virtual machine",
         "size": 32868,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:808134c8008c31d39586c0ad342e8f5fb0411a63",
+        "checksum": "adler32:6f906c6f",
         "description": "DoubleMuParked AOD dataset file index (5 of 7) for access to data via CMS virtual machine",
         "size": 9044,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_210000_file_index.txt"
       },
       {
-        "checksum": "sha1:b9bba796ad6ec32e3020bc705ffb9fcf55fa75ad",
+        "checksum": "adler32:f64ab332",
         "description": "DoubleMuParked AOD dataset file index (6 of 7) for access to data via CMS virtual machine",
         "size": 5808,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoubleMuParked_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:075ce6b5f82114b86f3a257b3641b0de2e763902",
+        "checksum": "adler32:ee663699",
         "description": "DoubleMuParked AOD dataset file index (7 of 7) for access to data via CMS virtual machine",
         "size": 7980,
         "type": "index.txt",
@@ -839,70 +839,70 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f79f8d74f75e54427f69e70c4b4079bb32ba5ddd",
+        "checksum": "adler32:948e6ea5",
         "description": "DoublePhoton AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
         "size": 276725,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:729271c32ceb91a1a22580513e1c8bd39d878665",
+        "checksum": "adler32:3646eb63",
         "description": "DoublePhoton AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
         "size": 168972,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:26409984dfc39f769f5d743ec93d55c56680720e",
+        "checksum": "adler32:8f6a48f7",
         "description": "DoublePhoton AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20006_file_index.json"
       },
       {
-        "checksum": "sha1:4bd770832dc920256db3bec6c20100654bca62c0",
+        "checksum": "adler32:58514890",
         "description": "DoublePhoton AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20010_file_index.json"
       },
       {
-        "checksum": "sha1:d533ea92cad6ec93316fabc48cf579cefef7db30",
+        "checksum": "adler32:e1634951",
         "description": "DoublePhoton AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20015_file_index.json"
       },
       {
-        "checksum": "sha1:4b51174ee43611e0762bea0252ed1a4b811eb70c",
+        "checksum": "adler32:e6b26b7c",
         "description": "DoublePhoton AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
         "size": 129870,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:29e468ea786226f78dc88675ca9ca36a7f11b065",
+        "checksum": "adler32:13492ab7",
         "description": "DoublePhoton AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
         "size": 79300,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:093532a72d9f0f71f2bf6932c117b5b3c2699f8b",
+        "checksum": "adler32:d5162638",
         "description": "DoublePhoton AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20006_file_index.txt"
       },
       {
-        "checksum": "sha1:90ffe721c7b1dce0137ba3ae3e58f7abb44fabd7",
+        "checksum": "adler32:d16d260d",
         "description": "DoublePhoton AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhoton_AOD_22Jan2013-v1_20010_file_index.txt"
       },
       {
-        "checksum": "sha1:783eb36c29c1ad86eb4d60e07a24b87e6a64b005",
+        "checksum": "adler32:d33e2637",
         "description": "DoublePhoton AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
@@ -1002,28 +1002,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bf179507a8dec7378c963c837a5121cbb50e07d0",
+        "checksum": "adler32:7ec3bd89",
         "description": "DoublePhotonHighPt AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 149143,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhotonHighPt_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:4e18998d768b43c862cb5159ec32ec0566749dd8",
+        "checksum": "adler32:20a72974",
         "description": "DoublePhotonHighPt AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 136125,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhotonHighPt_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:12fc9fa802af51e8cc9dd5a3b8a58bf91ebf2f87",
+        "checksum": "adler32:c164c2a7",
         "description": "DoublePhotonHighPt AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 71672,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_DoublePhotonHighPt_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:588cfc17ea7bde79872b0d474052df21ff902ea5",
+        "checksum": "adler32:d0bc6dc3",
         "description": "DoublePhotonHighPt AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 65416,
         "type": "index.txt",
@@ -1123,56 +1123,56 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:638e36394a8e3b2bf3c6ad30ee5bc6ed2816e49d",
+        "checksum": "adler32:db771f2d",
         "description": "ElectronHad AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 81698,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:5fbbca5f7df9e8662aaea864687ec5c8adfb0fe4",
+        "checksum": "adler32:82c44799",
         "description": "ElectronHad AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:fd44b1ef8637c4c5dbeed9d2a2e10129e1a6eff2",
+        "checksum": "adler32:df580723",
         "description": "ElectronHad AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 243432,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:44fea1d7c53df1baf83705a131992d7127a4aa6d",
+        "checksum": "adler32:13f34865",
         "description": "ElectronHad AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:3e12a333f5a2e59157a6bc7dfebe8105c5954674",
+        "checksum": "adler32:6d408696",
         "description": "ElectronHad AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 38184,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:683313c9cb22a3ecb0cc0d07e10d404297d3c1e6",
+        "checksum": "adler32:9608258f",
         "description": "ElectronHad AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:4a73a691dc22e0d3a132b96a1a90d1d842e332a5",
+        "checksum": "adler32:fa08e3f1",
         "description": "ElectronHad AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 113778,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_ElectronHad_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:77f16dd76fe60be5b4ed7bc4f1ccd0df3f727d42",
+        "checksum": "adler32:9aee25bc",
         "description": "ElectronHad AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
@@ -1272,210 +1272,210 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8a641359e9eeae772610b77aa2496c255192464d",
+        "checksum": "adler32:7a22eb05",
         "description": "HTMHTParked AOD dataset file index (1 of 15) for access to data via CMS virtual machine",
         "size": 280692,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:61330fc56d5dbe9d7aaa1780f332bef1bfacf586",
+        "checksum": "adler32:41e0fb88",
         "description": "HTMHTParked AOD dataset file index (2 of 15) for access to data via CMS virtual machine",
         "size": 35605,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:67f418f61c67d059c2d5caac48d41887a762607d",
+        "checksum": "adler32:366a8fac",
         "description": "HTMHTParked AOD dataset file index (3 of 15) for access to data via CMS virtual machine",
         "size": 554,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:7accd93b1944cefcd044ca9cfe48b7db6c1a5361",
+        "checksum": "adler32:ec6947eb",
         "description": "HTMHTParked AOD dataset file index (4 of 15) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20004_file_index.json"
       },
       {
-        "checksum": "sha1:2e7b014360b54bc3237d1fab8ffcd1b85e0bb353",
+        "checksum": "adler32:08384800",
         "description": "HTMHTParked AOD dataset file index (5 of 15) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20005_file_index.json"
       },
       {
-        "checksum": "sha1:e72c9f878f15977d3d9aea461f7fb64838993a1d",
+        "checksum": "adler32:77d2809f",
         "description": "HTMHTParked AOD dataset file index (6 of 15) for access to data via CMS virtual machine",
         "size": 276002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:89843cadb32f0d493112c5196338ef8e901aacb3",
+        "checksum": "adler32:74216077",
         "description": "HTMHTParked AOD dataset file index (7 of 15) for access to data via CMS virtual machine",
         "size": 276002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:e1a21601a2b58d306503cc98b2cd703532eca7a6",
+        "checksum": "adler32:e232c7c1",
         "description": "HTMHTParked AOD dataset file index (8 of 15) for access to data via CMS virtual machine",
         "size": 40297,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:48c89a6641116c34ae930aea764084bfedb08922",
+        "checksum": "adler32:f40247d5",
         "description": "HTMHTParked AOD dataset file index (9 of 15) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30005_file_index.json"
       },
       {
-        "checksum": "sha1:d1f96f99f87f7f7a5e0ce12c8e232847d85264cb",
+        "checksum": "adler32:5d778fe0",
         "description": "HTMHTParked AOD dataset file index (10 of 15) for access to data via CMS virtual machine",
         "size": 554,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30006_file_index.json"
       },
       {
-        "checksum": "sha1:427caefb305814c18e9c1252905619ae211646fc",
+        "checksum": "adler32:f70547e2",
         "description": "HTMHTParked AOD dataset file index (11 of 15) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30009_file_index.json"
       },
       {
-        "checksum": "sha1:782b617731c01c655b096f4a52fc9ceb56aaced6",
+        "checksum": "adler32:10338f38",
         "description": "HTMHTParked AOD dataset file index (12 of 15) for access to data via CMS virtual machine",
         "size": 554,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30010_file_index.json"
       },
       {
-        "checksum": "sha1:62e58e5dd2e9b3ed6dc0702e1e3e13e804b6cd61",
+        "checksum": "adler32:50ef4884",
         "description": "HTMHTParked AOD dataset file index (13 of 15) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30012_file_index.json"
       },
       {
-        "checksum": "sha1:3726d57bd3cd71447b09b216c54f49ea0becda0a",
+        "checksum": "adler32:2bea4849",
         "description": "HTMHTParked AOD dataset file index (14 of 15) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30015_file_index.json"
       },
       {
-        "checksum": "sha1:247f311461dc01b1e1268de039b97a6b592508b2",
+        "checksum": "adler32:9d524891",
         "description": "HTMHTParked AOD dataset file index (15 of 15) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30019_file_index.json"
       },
       {
-        "checksum": "sha1:d3d74205a8a5a08e71f60336375d64cf9ce75923",
+        "checksum": "adler32:cf79e1b2",
         "description": "HTMHTParked AOD dataset file index (1 of 15) for access to data via CMS virtual machine",
         "size": 131193,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:d1bc12900eb78e3f8293b94871a6d78c80155f2a",
+        "checksum": "adler32:a43abfc5",
         "description": "HTMHTParked AOD dataset file index (2 of 15) for access to data via CMS virtual machine",
         "size": 16641,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:32937956e20848948a27f4f81e4d9529abcc77b8",
+        "checksum": "adler32:afe44a7a",
         "description": "HTMHTParked AOD dataset file index (3 of 15) for access to data via CMS virtual machine",
         "size": 258,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:04d068d690c8187b64178c156dffc6b8d1d1cf01",
+        "checksum": "adler32:7a352544",
         "description": "HTMHTParked AOD dataset file index (4 of 15) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20004_file_index.txt"
       },
       {
-        "checksum": "sha1:61a5d1036b2161c6bf78efd6da469eb4a4b16a19",
+        "checksum": "adler32:7ee5254c",
         "description": "HTMHTParked AOD dataset file index (5 of 15) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_20005_file_index.txt"
       },
       {
-        "checksum": "sha1:adbd59514312050b3bddf9234838c0409dad812a",
+        "checksum": "adler32:b8e9951e",
         "description": "HTMHTParked AOD dataset file index (6 of 15) for access to data via CMS virtual machine",
         "size": 129000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:ba81ad2e77c1fd8993800085d2c33b424936a7ec",
+        "checksum": "adler32:329f845f",
         "description": "HTMHTParked AOD dataset file index (7 of 15) for access to data via CMS virtual machine",
         "size": 129000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:e3c3aa86a8eecd796593234776984d873053f5b2",
+        "checksum": "adler32:dcc23f52",
         "description": "HTMHTParked AOD dataset file index (8 of 15) for access to data via CMS virtual machine",
         "size": 18834,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30002_file_index.txt"
       },
       {
-        "checksum": "sha1:7fdb723b5e4938197c114a0dcfbd787947d4d3b9",
+        "checksum": "adler32:77bf252c",
         "description": "HTMHTParked AOD dataset file index (9 of 15) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30005_file_index.txt"
       },
       {
-        "checksum": "sha1:bf19a0513aa9037fb2429e735cb982d8a2b5ec92",
+        "checksum": "adler32:a2a84a9f",
         "description": "HTMHTParked AOD dataset file index (10 of 15) for access to data via CMS virtual machine",
         "size": 258,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30006_file_index.txt"
       },
       {
-        "checksum": "sha1:d6698c2a0336baad331119df32320ad80c352f87",
+        "checksum": "adler32:799a253a",
         "description": "HTMHTParked AOD dataset file index (11 of 15) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30009_file_index.txt"
       },
       {
-        "checksum": "sha1:e1f7c8bd1070ae2275d106eb233e6d5480330eea",
+        "checksum": "adler32:a9384a5d",
         "description": "HTMHTParked AOD dataset file index (12 of 15) for access to data via CMS virtual machine",
         "size": 258,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30010_file_index.txt"
       },
       {
-        "checksum": "sha1:2275af32d5a8eed33a8a52ad8e27f7eaa9c94576",
+        "checksum": "adler32:82e5257d",
         "description": "HTMHTParked AOD dataset file index (13 of 15) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30012_file_index.txt"
       },
       {
-        "checksum": "sha1:35586a7f40e763bd03fe5cb53c9729114eb161d2",
+        "checksum": "adler32:81452571",
         "description": "HTMHTParked AOD dataset file index (14 of 15) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HTMHTParked_AOD_22Jan2013-v1_30015_file_index.txt"
       },
       {
-        "checksum": "sha1:9f0ca29b8b6414e764d7981feb9d851153af34f8",
+        "checksum": "adler32:74e72531",
         "description": "HTMHTParked AOD dataset file index (15 of 15) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
@@ -1575,14 +1575,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:14f287c4c8b58e60441d9097b94aca2b23a66afb",
+        "checksum": "adler32:a77b4c20",
         "description": "HcalNZS AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 20129,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/HcalNZS/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_HcalNZS_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:fd8525d5a65b327f97bfc52fbf083ccb1ecef764",
+        "checksum": "adler32:e9f1615a",
         "description": "HcalNZS AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 9250,
         "type": "index.txt",
@@ -1682,112 +1682,112 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:106f296883c7fdc70f9394d1aab78da4de55476b",
+        "checksum": "adler32:3c73b84e",
         "description": "JetHT AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
         "size": 106382,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:75a1ffdd23bbe2c0e25fed73a6d0a2840a0e2576",
+        "checksum": "adler32:1e7f877d",
         "description": "JetHT AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
         "size": 268652,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:fc6ec9904eb9295461f1a9625038e5950729e914",
+        "checksum": "adler32:eeb01553",
         "description": "JetHT AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
         "size": 1082,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:420a16b9da91821abb6a754c99a87e06d0eae339",
+        "checksum": "adler32:36534603",
         "description": "JetHT AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
         "size": 272,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:360f93f0696862d9599191e91d307a8562bca29a",
+        "checksum": "adler32:c4714552",
         "description": "JetHT AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
         "size": 272,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30004_file_index.json"
       },
       {
-        "checksum": "sha1:0911caec915033b1831391ec9bc5cc422c8094d3",
+        "checksum": "adler32:1d2e8bde",
         "description": "JetHT AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
         "size": 542,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30005_file_index.json"
       },
       {
-        "checksum": "sha1:899828ddcfa26cdc07262c316f71bc0e0c2f1eba",
+        "checksum": "adler32:136dcfcd",
         "description": "JetHT AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
         "size": 812,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30006_file_index.json"
       },
       {
-        "checksum": "sha1:7334f874fa96412d3ee7cc3fbd900f19b488fbc1",
+        "checksum": "adler32:39a71495",
         "description": "JetHT AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
         "size": 1082,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30007_file_index.json"
       },
       {
-        "checksum": "sha1:772b95bd7943eee3bf892c6674568a4b49eef527",
+        "checksum": "adler32:df5205d2",
         "description": "JetHT AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
         "size": 48462,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:835f179e61bc51ef5999261f81265ff2872e77f6",
+        "checksum": "adler32:42517c90",
         "description": "JetHT AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
         "size": 122385,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:7e8580b48cbc33ace96cf498540cab5985917b65",
+        "checksum": "adler32:e9628c97",
         "description": "JetHT AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
         "size": 492,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:edc424ccf873a5f13e56851206de6b606a944757",
+        "checksum": "adler32:74432337",
         "description": "JetHT AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
         "size": 123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30002_file_index.txt"
       },
       {
-        "checksum": "sha1:3b466f91e8b7ec6c9521e729e71fae1ddbc2bc08",
+        "checksum": "adler32:6eb52301",
         "description": "JetHT AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
         "size": 123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30004_file_index.txt"
       },
       {
-        "checksum": "sha1:1e654842a727ccdc93ead1f240850e86667e944d",
+        "checksum": "adler32:caa6466e",
         "description": "JetHT AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
         "size": 246,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30005_file_index.txt"
       },
       {
-        "checksum": "sha1:1203eb6ad1125e6761deaaabc35ec30aaa1c5abb",
+        "checksum": "adler32:becd694d",
         "description": "JetHT AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
         "size": 369,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetHT_AOD_22Jan2013-v1_30006_file_index.txt"
       },
       {
-        "checksum": "sha1:863f615e7b5c3cf324735e2bfa01224de236c90d",
+        "checksum": "adler32:ab638c47",
         "description": "JetHT AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
         "size": 492,
         "type": "index.txt",
@@ -1887,28 +1887,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2597f91621a520553b06f1cdf56100573095b828",
+        "checksum": "adler32:a8008a55",
         "description": "JetMon AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 129540,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetMon_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:29d1dcc4f1aa2ca1e0e543b9ab39ad509f73a862",
+        "checksum": "adler32:bd34e227",
         "description": "JetMon AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 92142,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetMon_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:2faafd1903cd48ce9fcd2eeb602456482e08f35a",
+        "checksum": "adler32:1f4698c7",
         "description": "JetMon AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 59272,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_JetMon_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:e83b31659e46dcb4aa93e2ebb2edbe9802cd0f39",
+        "checksum": "adler32:4f3a648c",
         "description": "JetMon AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 42160,
         "type": "index.txt",
@@ -2008,112 +2008,112 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cb1baae037e575d881e11c288f0b5826d9e2719c",
+        "checksum": "adler32:de559cfc",
         "description": "MET AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
         "size": 1609,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:b1122f4f96868b8a6e5702e019e6f7d5ef61f912",
+        "checksum": "adler32:1997a457",
         "description": "MET AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
         "size": 55746,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:76f920604183f13ec54146954f65bb6f1487e483",
+        "checksum": "adler32:5993fc54",
         "description": "MET AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
         "size": 269609,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:05ba824a7f17d78197dc45525c2b1de0fcc0e86f",
+        "checksum": "adler32:27788fc0",
         "description": "MET AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
         "size": 45562,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:16c0bda86965bae7511737bd974ed072feeba468",
+        "checksum": "adler32:d295458b",
         "description": "MET AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
         "size": 270,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30003_file_index.json"
       },
       {
-        "checksum": "sha1:a36dff9739c817c5d0fbb5d7638e2c0e6dc2c4e8",
+        "checksum": "adler32:14ae8922",
         "description": "MET AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
         "size": 538,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30004_file_index.json"
       },
       {
-        "checksum": "sha1:3c3d777ee8089d14de86be1ff3ead666a99c0da0",
+        "checksum": "adler32:ba304558",
         "description": "MET AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
         "size": 270,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30005_file_index.json"
       },
       {
-        "checksum": "sha1:2873da547fb403ff3699e792f6f11da6b6d43e12",
+        "checksum": "adler32:1ff845da",
         "description": "MET AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
         "size": 271,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_310000_file_index.json"
       },
       {
-        "checksum": "sha1:f863f8af44bf2bb1fc56c68e0d9c33ca17f6b71c",
+        "checksum": "adler32:7ab6ce1f",
         "description": "MET AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
         "size": 726,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:994d47935a636211dea7cb5a1c10ab7860ccb8e6",
+        "checksum": "adler32:984fd527",
         "description": "MET AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
         "size": 25168,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:fabe568df755e139b1628385a96404725414124e",
+        "checksum": "adler32:90b305bd",
         "description": "MET AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
         "size": 121726,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:4c548134108c49bc3e3df1a1d49d8231c09c0f5b",
+        "checksum": "adler32:8536ca4c",
         "description": "MET AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
         "size": 20570,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:4a172c12dcc7762a11eb5024b39fed4d3a32a5e2",
+        "checksum": "adler32:16e92273",
         "description": "MET AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
         "size": 121,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30003_file_index.txt"
       },
       {
-        "checksum": "sha1:fe0c7582c0547944dd331efed5e66b6550848835",
+        "checksum": "adler32:4549446a",
         "description": "MET AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
         "size": 242,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30004_file_index.txt"
       },
       {
-        "checksum": "sha1:c894a24c568cd026d67b57fd4401c9e29c136ae0",
+        "checksum": "adler32:13ea2260",
         "description": "MET AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
         "size": 121,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MET_AOD_22Jan2013-v1_30005_file_index.txt"
       },
       {
-        "checksum": "sha1:aa7c93534dce0a4abb2d8fa76c23920bf1627771",
+        "checksum": "adler32:331722a8",
         "description": "MET AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
         "size": 122,
         "type": "index.txt",
@@ -2213,28 +2213,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:30682825abf733f57c65b9f1af7e08097edcdf3d",
+        "checksum": "adler32:ef96001c",
         "description": "MinimumBias AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 104882,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MinimumBias_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:383878e75badc78751a0839a36f9f02c2a00f2a7",
+        "checksum": "adler32:905aae54",
         "description": "MinimumBias AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 276000,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MinimumBias_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:e94f34af9efc9173f6bd4324d701355076a1274b",
+        "checksum": "adler32:0af61388",
         "description": "MinimumBias AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 49020,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MinimumBias_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:2e79c24a67771f4393bd2a717a924fce3a9c8fe8",
+        "checksum": "adler32:9de2a3a5",
         "description": "MinimumBias AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 129000,
         "type": "index.txt",
@@ -2334,98 +2334,98 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:343804bc3ee45ee5ab8e7b288addddf19360c875",
+        "checksum": "adler32:701fbc55",
         "description": "MuEG AOD dataset file index (1 of 7) for access to data via CMS virtual machine",
         "size": 268733,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:863b22108e19b4ab00011a9ecaa2f90af1ca6eb3",
+        "checksum": "adler32:3bd4d959",
         "description": "MuEG AOD dataset file index (2 of 7) for access to data via CMS virtual machine",
         "size": 50574,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:953bd90b9402ee5c3fa0c9bfd72bebd3c7d21628",
+        "checksum": "adler32:4e27cff0",
         "description": "MuEG AOD dataset file index (3 of 7) for access to data via CMS virtual machine",
         "size": 809,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:ff52f4cdf1fbadac56cd45158c059ab8cd39a007",
+        "checksum": "adler32:4fef8b7e",
         "description": "MuEG AOD dataset file index (4 of 7) for access to data via CMS virtual machine",
         "size": 540,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20004_file_index.json"
       },
       {
-        "checksum": "sha1:3be4407d1a1df9d4ac54b8a4dd863cc0c4488659",
+        "checksum": "adler32:9a228a01",
         "description": "MuEG AOD dataset file index (5 of 7) for access to data via CMS virtual machine",
         "size": 540,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20007_file_index.json"
       },
       {
-        "checksum": "sha1:89129231be753b0ef4543a09897950b35b124196",
+        "checksum": "adler32:c2cdd07b",
         "description": "MuEG AOD dataset file index (6 of 7) for access to data via CMS virtual machine",
         "size": 809,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20009_file_index.json"
       },
       {
-        "checksum": "sha1:ef929852416a2be8853e60c2b0e33f2f2ce1e5d8",
+        "checksum": "adler32:7f411725",
         "description": "MuEG AOD dataset file index (7 of 7) for access to data via CMS virtual machine",
         "size": 1077,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:8719c0ddabf21029decc614d4e46eaa78715ee4e",
+        "checksum": "adler32:96362f97",
         "description": "MuEG AOD dataset file index (1 of 7) for access to data via CMS virtual machine",
         "size": 121878,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:a42dce1d57240ef7145e71da2e885ac9a899f4dd",
+        "checksum": "adler32:b24e9993",
         "description": "MuEG AOD dataset file index (2 of 7) for access to data via CMS virtual machine",
         "size": 22936,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:a95076cdec5e935354b9dc44b3524963320c530d",
+        "checksum": "adler32:9492689b",
         "description": "MuEG AOD dataset file index (3 of 7) for access to data via CMS virtual machine",
         "size": 366,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:cfb73c04e8d82acf0a0104c278248da2e8dcea49",
+        "checksum": "adler32:2fbf45c6",
         "description": "MuEG AOD dataset file index (4 of 7) for access to data via CMS virtual machine",
         "size": 244,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20004_file_index.txt"
       },
       {
-        "checksum": "sha1:149bd239b1d641383becfd20a6ad44881533f98c",
+        "checksum": "adler32:fd76456a",
         "description": "MuEG AOD dataset file index (5 of 7) for access to data via CMS virtual machine",
         "size": 244,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20007_file_index.txt"
       },
       {
-        "checksum": "sha1:365ed882b7b45204d45052581d023ddd298d5e2a",
+        "checksum": "adler32:dc0568e1",
         "description": "MuEG AOD dataset file index (6 of 7) for access to data via CMS virtual machine",
         "size": 366,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuEG_AOD_22Jan2013-v1_20009_file_index.txt"
       },
       {
-        "checksum": "sha1:30a08ea8897f5c6c66418de905886e3bb7975847",
+        "checksum": "adler32:43408c14",
         "description": "MuEG AOD dataset file index (7 of 7) for access to data via CMS virtual machine",
         "size": 488,
         "type": "index.txt",
@@ -2525,84 +2525,84 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3ee281d3b94af932ac19f7458f208e070e482327",
+        "checksum": "adler32:bbca72c4",
         "description": "MuHad AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
         "size": 178742,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:40101fbed68c9bb611d6115d515c50fffdaca389",
+        "checksum": "adler32:01ef45cc",
         "description": "MuHad AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
         "size": 272,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:837781357754c2be4688d0b88eb0557ff400296a",
+        "checksum": "adler32:7e7046b1",
         "description": "MuHad AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
         "size": 272,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_20004_file_index.json"
       },
       {
-        "checksum": "sha1:a3669efaca7e92d93d5a8ea9fec68d33566823b5",
+        "checksum": "adler32:680cf4f7",
         "description": "MuHad AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
         "size": 191161,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:bbade8b1bd566a87927ed1a42a523126fc184089",
+        "checksum": "adler32:3a25464a",
         "description": "MuHad AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
         "size": 272,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:ddb0b40406afb5a61f4db3008c733c296845fa0e",
+        "checksum": "adler32:0d778cfc",
         "description": "MuHad AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
         "size": 542,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:add076122cf26baa9157cffb98c9fabca615c8c4",
+        "checksum": "adler32:199e6fe9",
         "description": "MuHad AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
         "size": 81426,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:20895b84e804a7ef3b4d0c1a11fda50da7ffd827",
+        "checksum": "adler32:72e82335",
         "description": "MuHad AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
         "size": 123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:896bd0cfb054e34f2ab73ad27a47ff7296ae465b",
+        "checksum": "adler32:79d0238b",
         "description": "MuHad AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
         "size": 123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_20004_file_index.txt"
       },
       {
-        "checksum": "sha1:1dc2ecf82181e79c64651d36586b86eaa8c061a5",
+        "checksum": "adler32:9b23c4c0",
         "description": "MuHad AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
         "size": 87084,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:20f81caadbcee55aa6289d5ca09e00868b87d3fd",
+        "checksum": "adler32:78202372",
         "description": "MuHad AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
         "size": 123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuHad_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:238cb46355d89abd125266c4af646f6e40a61130",
+        "checksum": "adler32:126b472f",
         "description": "MuHad AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
         "size": 246,
         "type": "index.txt",
@@ -2702,154 +2702,154 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:87ae0aecc43f7e3af3c1d374e3861511487ef5c6",
+        "checksum": "adler32:cf07d7d5",
         "description": "MuOnia AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
         "size": 270731,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:c9554a864f64226e9d0b78a9dda114b6f68ee9fe",
+        "checksum": "adler32:088a4326",
         "description": "MuOnia AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
         "size": 152032,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:e8ed736302d81c507f56521e6fca8c654a07296d",
+        "checksum": "adler32:02b38ba9",
         "description": "MuOnia AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
         "size": 544,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20006_file_index.json"
       },
       {
-        "checksum": "sha1:33cfa0bb3083bb9d3d7fa3f546898ebb298f3d2b",
+        "checksum": "adler32:6d944626",
         "description": "MuOnia AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20007_file_index.json"
       },
       {
-        "checksum": "sha1:2ec8ccbe251d2a9f308f19a9aeb06b4dfd2ed86c",
+        "checksum": "adler32:0f298c29",
         "description": "MuOnia AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
         "size": 544,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20009_file_index.json"
       },
       {
-        "checksum": "sha1:dab8b48d4fcb73c4590db4105e7417107a09d147",
+        "checksum": "adler32:4c674630",
         "description": "MuOnia AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20016_file_index.json"
       },
       {
-        "checksum": "sha1:d0ffaa704306a47e9c801c95c73d428aa7f9ab11",
+        "checksum": "adler32:a5f346c1",
         "description": "MuOnia AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20018_file_index.json"
       },
       {
-        "checksum": "sha1:7f85fe7773d8f38fa54faa2a94c117419eef4361",
+        "checksum": "adler32:a35d46a1",
         "description": "MuOnia AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20020_file_index.json"
       },
       {
-        "checksum": "sha1:0a292dcaa889c43aae60bdce3ac5f05e5cce11b6",
+        "checksum": "adler32:49fc2043",
         "description": "MuOnia AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
         "size": 265852,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:9a17912a762573187b79d727e9f163db8184b470",
+        "checksum": "adler32:bb908c3e",
         "description": "MuOnia AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
         "size": 544,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_30003_file_index.json"
       },
       {
-        "checksum": "sha1:ce782e19cf8c7556d26a234d1c2b080a5b22fc70",
+        "checksum": "adler32:0a914737",
         "description": "MuOnia AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_30007_file_index.json"
       },
       {
-        "checksum": "sha1:8ad716067eac5224141b6f646936a72a33e7dd0b",
+        "checksum": "adler32:2e9a2f03",
         "description": "MuOnia AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
         "size": 123876,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:e66f1d5aba6027c5ac665abd34fe399b01957877",
+        "checksum": "adler32:0de530c1",
         "description": "MuOnia AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
         "size": 69564,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:175283a5e47f818c2be4b5647ea95dc5a04f5b7c",
+        "checksum": "adler32:940d4747",
         "description": "MuOnia AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
         "size": 248,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20006_file_index.txt"
       },
       {
-        "checksum": "sha1:57f26e7dfc255d87ab57b594a16652432cf26163",
+        "checksum": "adler32:a76c2387",
         "description": "MuOnia AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20007_file_index.txt"
       },
       {
-        "checksum": "sha1:d00490db2fb4adc2fa6d4d15df32c47a737ae1ea",
+        "checksum": "adler32:a04f474f",
         "description": "MuOnia AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
         "size": 248,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20009_file_index.txt"
       },
       {
-        "checksum": "sha1:ab3dfcd9163980cbcdfafd9c64848698c3dfad58",
+        "checksum": "adler32:a6d223ae",
         "description": "MuOnia AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20016_file_index.txt"
       },
       {
-        "checksum": "sha1:2b83464f2e9456a27695801be209da3f75bb90f1",
+        "checksum": "adler32:ada823dd",
         "description": "MuOnia AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20018_file_index.txt"
       },
       {
-        "checksum": "sha1:36b9bdf035b8ad09ad0e0b74d4109dc6116f4f95",
+        "checksum": "adler32:ac4623be",
         "description": "MuOnia AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_20020_file_index.txt"
       },
       {
-        "checksum": "sha1:24a655550adbcf1dc029d15e7bdc39fe3be63fb0",
+        "checksum": "adler32:3cfcc5c3",
         "description": "MuOnia AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
         "size": 121644,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:e15437fe3066e64041abda0316a2050ba6676d98",
+        "checksum": "adler32:b3c04780",
         "description": "MuOnia AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
         "size": 248,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOnia_AOD_22Jan2013-v1_30003_file_index.txt"
       },
       {
-        "checksum": "sha1:65a76e33b47f5e5dcb6d7209cf11c755a05b7d47",
+        "checksum": "adler32:b1c723f0",
         "description": "MuOnia AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
@@ -2949,210 +2949,210 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:19a29715507065e84cae443ff251ac597475226a",
+        "checksum": "adler32:0ce7d653",
         "description": "MuOniaParked AOD dataset file index (1 of 15) for access to data via CMS virtual machine",
         "size": 277278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:5c120290c17c9d9da0099947ab3bf114066a4ef2",
+        "checksum": "adler32:2afe4c6b",
         "description": "MuOniaParked AOD dataset file index (2 of 15) for access to data via CMS virtual machine",
         "size": 276725,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:f8a2db519a82ed4db16d37c3f9c37c4c4929d077",
+        "checksum": "adler32:6ec5e81b",
         "description": "MuOniaParked AOD dataset file index (3 of 15) for access to data via CMS virtual machine",
         "size": 268138,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:002970ed841711b56c2ab6f46fcfdc3069e32065",
+        "checksum": "adler32:23b354d7",
         "description": "MuOniaParked AOD dataset file index (4 of 15) for access to data via CMS virtual machine",
         "size": 256781,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:a5b607a56da556080709179926989245cbe6e57e",
+        "checksum": "adler32:58c248a6",
         "description": "MuOniaParked AOD dataset file index (5 of 15) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20013_file_index.json"
       },
       {
-        "checksum": "sha1:041dddc77afe2aba716b89124212c8e6c9d4fa89",
+        "checksum": "adler32:e7fb494b",
         "description": "MuOniaParked AOD dataset file index (6 of 15) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20014_file_index.json"
       },
       {
-        "checksum": "sha1:60be7da83d3bc18940a894c0830aceafa6772944",
+        "checksum": "adler32:860848a1",
         "description": "MuOniaParked AOD dataset file index (7 of 15) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20020_file_index.json"
       },
       {
-        "checksum": "sha1:810ad83f02f32c0c6206af7280c376661dde4823",
+        "checksum": "adler32:785748fb",
         "description": "MuOniaParked AOD dataset file index (8 of 15) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20025_file_index.json"
       },
       {
-        "checksum": "sha1:506c0b9deeab88392cc4a10a193e2a70738a71c0",
+        "checksum": "adler32:648e485b",
         "description": "MuOniaParked AOD dataset file index (9 of 15) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20030_file_index.json"
       },
       {
-        "checksum": "sha1:0d976041e5ed924c9f2278e62274b7955fedf1dc",
+        "checksum": "adler32:c9a64944",
         "description": "MuOniaParked AOD dataset file index (10 of 15) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20034_file_index.json"
       },
       {
-        "checksum": "sha1:85b2d95b8d26fa93e13b1dfbccd1be22fc628c51",
+        "checksum": "adler32:af8948fa",
         "description": "MuOniaParked AOD dataset file index (11 of 15) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20035_file_index.json"
       },
       {
-        "checksum": "sha1:f6d0e673e8be9735a57ecde0802fd525ec5837cf",
+        "checksum": "adler32:a01948ea",
         "description": "MuOniaParked AOD dataset file index (12 of 15) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20040_file_index.json"
       },
       {
-        "checksum": "sha1:f9cdc40b384925e10e5b277993a07b84f0e467a8",
+        "checksum": "adler32:4c9af32a",
         "description": "MuOniaParked AOD dataset file index (13 of 15) for access to data via CMS virtual machine",
         "size": 7786,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_210000_file_index.json"
       },
       {
-        "checksum": "sha1:7e4bec2f39f11bcb91aae52fcab81c8525b7614b",
+        "checksum": "adler32:16aae818",
         "description": "MuOniaParked AOD dataset file index (14 of 15) for access to data via CMS virtual machine",
         "size": 111633,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:9e29512722b182eec82db2a14278fa53a2963cd2",
+        "checksum": "adler32:9acf4909",
         "description": "MuOniaParked AOD dataset file index (15 of 15) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:e0347a096cd573e7e16788760d1769db5ae3605b",
+        "checksum": "adler32:f76bc583",
         "description": "MuOniaParked AOD dataset file index (1 of 15) for access to data via CMS virtual machine",
         "size": 130130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:d1b3fb3dabcc82fa5cdbff86308c98da9c3cf516",
+        "checksum": "adler32:cfa7807c",
         "description": "MuOniaParked AOD dataset file index (2 of 15) for access to data via CMS virtual machine",
         "size": 129870,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:d26920eb43d0df749a5e47d0867f14bfdc939f7e",
+        "checksum": "adler32:51f40ef9",
         "description": "MuOniaParked AOD dataset file index (3 of 15) for access to data via CMS virtual machine",
         "size": 125840,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:24e00fa24ceadcbf18bc703541b3a3a58c4948d5",
+        "checksum": "adler32:f4cbf48b",
         "description": "MuOniaParked AOD dataset file index (4 of 15) for access to data via CMS virtual machine",
         "size": 120510,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:41b126d6a88a34887e113494a4a49e5ca8f7b28e",
+        "checksum": "adler32:c8a6260c",
         "description": "MuOniaParked AOD dataset file index (5 of 15) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20013_file_index.txt"
       },
       {
-        "checksum": "sha1:9d58b138e27255c90bcfa1dd39ffb4d05b58cba3",
+        "checksum": "adler32:c68f2615",
         "description": "MuOniaParked AOD dataset file index (6 of 15) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20014_file_index.txt"
       },
       {
-        "checksum": "sha1:45ea4e18af45966801c715c54e7e610c9f88939b",
+        "checksum": "adler32:c0e925d9",
         "description": "MuOniaParked AOD dataset file index (7 of 15) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20020_file_index.txt"
       },
       {
-        "checksum": "sha1:2924973e0875c0971dcd55e8cea6b0701a34047d",
+        "checksum": "adler32:cce9263f",
         "description": "MuOniaParked AOD dataset file index (8 of 15) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20025_file_index.txt"
       },
       {
-        "checksum": "sha1:c9eb329049d766ff4531a135ed5546f24021dd02",
+        "checksum": "adler32:be6725ba",
         "description": "MuOniaParked AOD dataset file index (9 of 15) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20030_file_index.txt"
       },
       {
-        "checksum": "sha1:a06b3169d82ac95ee83a2af6ebaa06bb74d280fe",
+        "checksum": "adler32:c8ed2631",
         "description": "MuOniaParked AOD dataset file index (10 of 15) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20034_file_index.txt"
       },
       {
-        "checksum": "sha1:ea6495fa7c17e9637be7795e030b699852b8a972",
+        "checksum": "adler32:c748260b",
         "description": "MuOniaParked AOD dataset file index (11 of 15) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20035_file_index.txt"
       },
       {
-        "checksum": "sha1:060b703173916b2956d369b951b3587d56729afb",
+        "checksum": "adler32:c4732605",
         "description": "MuOniaParked AOD dataset file index (12 of 15) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_20040_file_index.txt"
       },
       {
-        "checksum": "sha1:a75390c906b726c425080d882b4bb45a04883f4f",
+        "checksum": "adler32:cfc83144",
         "description": "MuOniaParked AOD dataset file index (13 of 15) for access to data via CMS virtual machine",
         "size": 3668,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_210000_file_index.txt"
       },
       {
-        "checksum": "sha1:648adea111e5fb139212e414de1f9daf6c177699",
+        "checksum": "adler32:40c7ed25",
         "description": "MuOniaParked AOD dataset file index (14 of 15) for access to data via CMS virtual machine",
         "size": 52390,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_MuOniaParked_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:820348081e337f4d0e54db13cf23fe2a0bff916a",
+        "checksum": "adler32:c9862626",
         "description": "MuOniaParked AOD dataset file index (15 of 15) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
@@ -3252,28 +3252,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e1865621ef2d8aff1bd474ff471cb3a9f143d7c4",
+        "checksum": "adler32:3f57353f",
         "description": "NoBPTX AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 68808,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_NoBPTX_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:4e1e1c99a561aa82837579e63627a66a6e2724b1",
+        "checksum": "adler32:7d4b4604",
         "description": "NoBPTX AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 274,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_NoBPTX_AOD_22Jan2013-v1_310000_file_index.json"
       },
       {
-        "checksum": "sha1:088e3226261dace3c63c7de4c3532aae9990fa11",
+        "checksum": "adler32:9d4d2a82",
         "description": "NoBPTX AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 31496,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_NoBPTX_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:335b7d836e852be4cd23751e24a4ff3bab97b6a8",
+        "checksum": "adler32:b6762386",
         "description": "NoBPTX AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 125,
         "type": "index.txt",
@@ -3373,56 +3373,56 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e3ed59f5ce9ad66c6a1f7d60dfa88956ba7a6232",
+        "checksum": "adler32:cfca9662",
         "description": "PhotonHad AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 212352,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:d85daee389f142466e75c6d1428e9f64f750c56b",
+        "checksum": "adler32:726647b1",
         "description": "PhotonHad AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:b9d718ad95fb7d87c8fe5080fd0827d625fc9a40",
+        "checksum": "adler32:23aa93dc",
         "description": "PhotonHad AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 104944,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:f6cee9a9d6bcee5448b10d23dec70d9472cc5e3d",
+        "checksum": "adler32:b0b447ff",
         "description": "PhotonHad AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:a2fa2a04e9ca1308d4d793b8f29620894063f715",
+        "checksum": "adler32:fd3ccaac",
         "description": "PhotonHad AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 98425,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:76ba3b4b0372c7279d77e7efe6b2f63baa23592a",
+        "checksum": "adler32:3c062503",
         "description": "PhotonHad AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:c852480a9e211708443ebb7b44601034aaf01669",
+        "checksum": "adler32:c89f45b8",
         "description": "PhotonHad AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 48641,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_PhotonHad_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:6ae44f390092058846c7c35e32f99fb1cad0dc76",
+        "checksum": "adler32:3fcf2513",
         "description": "PhotonHad AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
@@ -3522,126 +3522,126 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:73587523907e27bfd889a02d6f3138180f40f38a",
+        "checksum": "adler32:14fe07fe",
         "description": "SingleElectron AOD dataset file index (1 of 9) for access to data via CMS virtual machine",
         "size": 279002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:fd4411ce71a550089e8e753017c66df756dcdd17",
+        "checksum": "adler32:1dce4548",
         "description": "SingleElectron AOD dataset file index (2 of 9) for access to data via CMS virtual machine",
         "size": 279002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:6ca9c01dd8bc39c1048a864d63de0a1cb21baf6d",
+        "checksum": "adler32:6ad6be9e",
         "description": "SingleElectron AOD dataset file index (3 of 9) for access to data via CMS virtual machine",
         "size": 236314,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:26e6966f2a2ffcf698ec9d7ca9275123ad51f062",
+        "checksum": "adler32:2c0d49ca",
         "description": "SingleElectron AOD dataset file index (4 of 9) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20012_file_index.json"
       },
       {
-        "checksum": "sha1:094c35333bc279aa254d31c71d559f5a36e840eb",
+        "checksum": "adler32:bfaab8b0",
         "description": "SingleElectron AOD dataset file index (5 of 9) for access to data via CMS virtual machine",
         "size": 294068,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:d09f22bdfdac745f1e8a67b0321d545a354a36e5",
+        "checksum": "adler32:22e1179e",
         "description": "SingleElectron AOD dataset file index (6 of 9) for access to data via CMS virtual machine",
         "size": 277328,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:82ec2d3404be9314c53805d7f97c5f061d17c21d",
+        "checksum": "adler32:1c8fb59a",
         "description": "SingleElectron AOD dataset file index (7 of 9) for access to data via CMS virtual machine",
         "size": 111602,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:57ea77134c959298936e861c5cf6e78522f73a5a",
+        "checksum": "adler32:56194a21",
         "description": "SingleElectron AOD dataset file index (8 of 9) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30005_file_index.json"
       },
       {
-        "checksum": "sha1:a62c9b900c9fc1f35bda4dbd51c57e5f90eca7a4",
+        "checksum": "adler32:0d56499d",
         "description": "SingleElectron AOD dataset file index (9 of 9) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30015_file_index.json"
       },
       {
-        "checksum": "sha1:3ceca2ac0abce9329bdbe111c3c55cb29de75e32",
+        "checksum": "adler32:dd6ec7f2",
         "description": "SingleElectron AOD dataset file index (1 of 9) for access to data via CMS virtual machine",
         "size": 132000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:06ef260173094be3248c980a70dc4900b81f096c",
+        "checksum": "adler32:c351e118",
         "description": "SingleElectron AOD dataset file index (2 of 9) for access to data via CMS virtual machine",
         "size": 132000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:a3df40506b514b7b7e953b7c392e9b3b0e65cdd4",
+        "checksum": "adler32:34dc3de7",
         "description": "SingleElectron AOD dataset file index (3 of 9) for access to data via CMS virtual machine",
         "size": 111804,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:f2084e8f44f1c2f6b26af0b58e7379d80c3d63cc",
+        "checksum": "adler32:3b8c271d",
         "description": "SingleElectron AOD dataset file index (4 of 9) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_20012_file_index.txt"
       },
       {
-        "checksum": "sha1:ec775d6485504d8f4ee761674674360d97bbcfe8",
+        "checksum": "adler32:a463242e",
         "description": "SingleElectron AOD dataset file index (5 of 9) for access to data via CMS virtual machine",
         "size": 139128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:ed2a547986b3cc59391a8e86ddee6c752f93b4f3",
+        "checksum": "adler32:5564c2f2",
         "description": "SingleElectron AOD dataset file index (6 of 9) for access to data via CMS virtual machine",
         "size": 131208,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:81111b99606b07e6b59db0860bb894a3aa313bcc",
+        "checksum": "adler32:373f11cb",
         "description": "SingleElectron AOD dataset file index (7 of 9) for access to data via CMS virtual machine",
         "size": 52800,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30002_file_index.txt"
       },
       {
-        "checksum": "sha1:1dada3bc59c2de5a9f437a50a95efadd46e20eb2",
+        "checksum": "adler32:42572749",
         "description": "SingleElectron AOD dataset file index (8 of 9) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleElectron_AOD_22Jan2013-v1_30005_file_index.txt"
       },
       {
-        "checksum": "sha1:1f83c55ca9beaa6614c91ff49537e9b2a0a64161",
+        "checksum": "adler32:37022705",
         "description": "SingleElectron AOD dataset file index (9 of 9) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
@@ -3741,294 +3741,294 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6591002d75ee47e53596d8331adb06bc9e1349bf",
+        "checksum": "adler32:f268a2b6",
         "description": "SingleMu AOD dataset file index (1 of 21) for access to data via CMS virtual machine",
         "size": 13379,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_110000_file_index.json"
       },
       {
-        "checksum": "sha1:0101ea17080b8f165cfad6fa8e1fd806fb5d001c",
+        "checksum": "adler32:1f0b72c5",
         "description": "SingleMu AOD dataset file index (2 of 21) for access to data via CMS virtual machine",
         "size": 279826,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:d7d57b8816ba548daa11895bb2b00ec1bddaea61",
+        "checksum": "adler32:030be4b4",
         "description": "SingleMu AOD dataset file index (3 of 21) for access to data via CMS virtual machine",
         "size": 272456,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:b8576e7c36278036e9d8a6b185804633a0d55953",
+        "checksum": "adler32:bce3ac0a",
         "description": "SingleMu AOD dataset file index (4 of 21) for access to data via CMS virtual machine",
         "size": 273002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:2533db18fba60295619c484adf559d873db4b6d3",
+        "checksum": "adler32:c7545151",
         "description": "SingleMu AOD dataset file index (5 of 21) for access to data via CMS virtual machine",
         "size": 171445,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:a0e226ece1bc87350b2dcfa3455bc7dacc9e3f7b",
+        "checksum": "adler32:1a26475a",
         "description": "SingleMu AOD dataset file index (6 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20008_file_index.json"
       },
       {
-        "checksum": "sha1:e1820f4630063647a77193935990304ea9bddf88",
+        "checksum": "adler32:8c7947de",
         "description": "SingleMu AOD dataset file index (7 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20009_file_index.json"
       },
       {
-        "checksum": "sha1:5a8c610b96eaddf1837ac2af6c1b2688ee3be24d",
+        "checksum": "adler32:471147ae",
         "description": "SingleMu AOD dataset file index (8 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20011_file_index.json"
       },
       {
-        "checksum": "sha1:03fd289489298e146d6d08f3e188e4af8bcc33ea",
+        "checksum": "adler32:a65f4819",
         "description": "SingleMu AOD dataset file index (9 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20012_file_index.json"
       },
       {
-        "checksum": "sha1:3be9b5a96eb215fed5ee05273568444a7dfe9e56",
+        "checksum": "adler32:a22247e3",
         "description": "SingleMu AOD dataset file index (10 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20014_file_index.json"
       },
       {
-        "checksum": "sha1:7ca16de483e20e878aae5b4648fc6bf65de74366",
+        "checksum": "adler32:d94b46eb",
         "description": "SingleMu AOD dataset file index (11 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20016_file_index.json"
       },
       {
-        "checksum": "sha1:eb81ac44faafc5532edf3db15ca386b9da389f7a",
+        "checksum": "adler32:2de847ac",
         "description": "SingleMu AOD dataset file index (12 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20020_file_index.json"
       },
       {
-        "checksum": "sha1:482bcf283c9a68131466ad65e73fc5a995638ea9",
+        "checksum": "adler32:3cc0476d",
         "description": "SingleMu AOD dataset file index (13 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20023_file_index.json"
       },
       {
-        "checksum": "sha1:eb95b4f616b0792f0cc40ae4c3a1486944336041",
+        "checksum": "adler32:15214719",
         "description": "SingleMu AOD dataset file index (14 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20025_file_index.json"
       },
       {
-        "checksum": "sha1:400a8a6c1707bf671bce461f96b625fd94dfc57b",
+        "checksum": "adler32:57ced52d",
         "description": "SingleMu AOD dataset file index (15 of 21) for access to data via CMS virtual machine",
         "size": 821,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20033_file_index.json"
       },
       {
-        "checksum": "sha1:50444d4c0e3e73f86b8b621100f752e30c4d0bc6",
+        "checksum": "adler32:70b747e9",
         "description": "SingleMu AOD dataset file index (16 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20036_file_index.json"
       },
       {
-        "checksum": "sha1:d8b8c2ef9d262c29ca867afd56dec70a0883b44b",
+        "checksum": "adler32:2bfc4790",
         "description": "SingleMu AOD dataset file index (17 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20040_file_index.json"
       },
       {
-        "checksum": "sha1:9440b8bc1ad47be2d9331e317676a6527bd86c31",
+        "checksum": "adler32:3637368b",
         "description": "SingleMu AOD dataset file index (18 of 21) for access to data via CMS virtual machine",
         "size": 145784,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:6bdba34bc275bd91aaf32106823e1cd7e918a393",
+        "checksum": "adler32:ee3a4723",
         "description": "SingleMu AOD dataset file index (19 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:d8409a0e6f15aa035543b375899c59dee2a94aa1",
+        "checksum": "adler32:8d5b8f14",
         "description": "SingleMu AOD dataset file index (20 of 21) for access to data via CMS virtual machine",
         "size": 548,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30003_file_index.json"
       },
       {
-        "checksum": "sha1:8a32b482864125f6aab77096e5f9293ba70c3372",
+        "checksum": "adler32:96a64834",
         "description": "SingleMu AOD dataset file index (21 of 21) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30004_file_index.json"
       },
       {
-        "checksum": "sha1:53e6c8b388710f9cfe5ec03932245b55c3cc13bc",
+        "checksum": "adler32:26961371",
         "description": "SingleMu AOD dataset file index (1 of 21) for access to data via CMS virtual machine",
         "size": 6223,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_110000_file_index.txt"
       },
       {
-        "checksum": "sha1:f6d3293108e46a345740f6be620b317499d71e6e",
+        "checksum": "adler32:b774c16a",
         "description": "SingleMu AOD dataset file index (2 of 21) for access to data via CMS virtual machine",
         "size": 129150,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:ca249484e8cead60cde45fec8cfb8ea89dd7ed2c",
+        "checksum": "adler32:8ed8e1ea",
         "description": "SingleMu AOD dataset file index (3 of 21) for access to data via CMS virtual machine",
         "size": 125748,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:9b2e90d24be1a44627e4278b8ace23273f60d32d",
+        "checksum": "adler32:cdf945e1",
         "description": "SingleMu AOD dataset file index (4 of 21) for access to data via CMS virtual machine",
         "size": 126000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:7a9ad52e03885a38a8578163eb56f748808a3bc1",
+        "checksum": "adler32:fbc6f0c8",
         "description": "SingleMu AOD dataset file index (5 of 21) for access to data via CMS virtual machine",
         "size": 79128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:8b9c92d236f4f07429582015c32d32d53b9e2354",
+        "checksum": "adler32:0b9724ad",
         "description": "SingleMu AOD dataset file index (6 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20008_file_index.txt"
       },
       {
-        "checksum": "sha1:ee2740fe7bec98006ab692f3bd4e1b428eb5ecda",
+        "checksum": "adler32:125624c0",
         "description": "SingleMu AOD dataset file index (7 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20009_file_index.txt"
       },
       {
-        "checksum": "sha1:ebb9787c7cbffb199596fc09fe83fffd3560ff5c",
+        "checksum": "adler32:114624cf",
         "description": "SingleMu AOD dataset file index (8 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20011_file_index.txt"
       },
       {
-        "checksum": "sha1:f4e4e0c55a81c85ba495bcbbf8aea639a5009b30",
+        "checksum": "adler32:10de24d4",
         "description": "SingleMu AOD dataset file index (9 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20012_file_index.txt"
       },
       {
-        "checksum": "sha1:7181f531e2b068a5b640127a36331f80d7100765",
+        "checksum": "adler32:0b0024a6",
         "description": "SingleMu AOD dataset file index (10 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20014_file_index.txt"
       },
       {
-        "checksum": "sha1:29f4d5c150f49edbddda3fbc592d58b820db0912",
+        "checksum": "adler32:0d7c248a",
         "description": "SingleMu AOD dataset file index (11 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20016_file_index.txt"
       },
       {
-        "checksum": "sha1:4ae0bef6324d860539b500a366018ad7783456da",
+        "checksum": "adler32:134b24e3",
         "description": "SingleMu AOD dataset file index (12 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20020_file_index.txt"
       },
       {
-        "checksum": "sha1:0080e4188622dc900e5872b15356558b575cbc63",
+        "checksum": "adler32:0cb624a0",
         "description": "SingleMu AOD dataset file index (13 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20023_file_index.txt"
       },
       {
-        "checksum": "sha1:c0e0e312a251ced755cc2b5dd886c059037b4b7c",
+        "checksum": "adler32:087e2477",
         "description": "SingleMu AOD dataset file index (14 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20025_file_index.txt"
       },
       {
-        "checksum": "sha1:fe44b6b571704eae4d77c8675e0f07ee938ee5b5",
+        "checksum": "adler32:28fc6ddd",
         "description": "SingleMu AOD dataset file index (15 of 21) for access to data via CMS virtual machine",
         "size": 378,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20033_file_index.txt"
       },
       {
-        "checksum": "sha1:bdecb6cae31b0bc4c9d38d54d7bab8bf4de9f713",
+        "checksum": "adler32:126d24e0",
         "description": "SingleMu AOD dataset file index (16 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20036_file_index.txt"
       },
       {
-        "checksum": "sha1:23e02c76ae7670fe7917b6739a95999df28f3df8",
+        "checksum": "adler32:0f2524cf",
         "description": "SingleMu AOD dataset file index (17 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_20040_file_index.txt"
       },
       {
-        "checksum": "sha1:9c2f1e53feac7dbf7e81d65c378d93888bd151b0",
+        "checksum": "adler32:62147736",
         "description": "SingleMu AOD dataset file index (18 of 21) for access to data via CMS virtual machine",
         "size": 67284,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:d59199b14aae289bff0aba044c19d0b2de50733f",
+        "checksum": "adler32:0dd024ac",
         "description": "SingleMu AOD dataset file index (19 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:c64b2fea01a44de4f7a15a89fd6f365a0a9d488a",
+        "checksum": "adler32:27864947",
         "description": "SingleMu AOD dataset file index (20 of 21) for access to data via CMS virtual machine",
         "size": 252,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SingleMu_AOD_22Jan2013-v1_30003_file_index.txt"
       },
       {
-        "checksum": "sha1:97a284d47ed5a73a7a7d84171853c338ee5b468a",
+        "checksum": "adler32:151124fd",
         "description": "SingleMu AOD dataset file index (21 of 21) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
@@ -4128,28 +4128,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e2a27781df4aec85c22227a65e880a04c5284ce5",
+        "checksum": "adler32:1d8c62d2",
         "description": "SinglePhoton AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 128529,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SinglePhoton_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:1e5a97167b85e0993b60e8fde4ca62928304c05e",
+        "checksum": "adler32:96e984e3",
         "description": "SinglePhoton AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 120774,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SinglePhoton_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:293ded8082a6baae2418062b1a05b087b9824649",
+        "checksum": "adler32:566b4ad8",
         "description": "SinglePhoton AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 60320,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_SinglePhoton_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:ca07d1b5a0235d78e16acf67d46eca9c3e1aeaa8",
+        "checksum": "adler32:04ff241a",
         "description": "SinglePhoton AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 56680,
         "type": "index.txt",
@@ -4249,308 +4249,308 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d42acacf92197d8599174b09b2e6ee5bacd86c80",
+        "checksum": "adler32:1982661f",
         "description": "TauParked AOD dataset file index (1 of 22) for access to data via CMS virtual machine",
         "size": 273728,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:a10819eb5615bb72f53dbf44f08bb9692112f368",
+        "checksum": "adler32:b2ba7c8b",
         "description": "TauParked AOD dataset file index (2 of 22) for access to data via CMS virtual machine",
         "size": 230710,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:b45b3d8fadd4d91e298d357d1a58cb55b2d67d03",
+        "checksum": "adler32:794b479d",
         "description": "TauParked AOD dataset file index (3 of 22) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:7fc03760498cf1bb98af61cfb66f358a0586481e",
+        "checksum": "adler32:59484789",
         "description": "TauParked AOD dataset file index (4 of 22) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20005_file_index.json"
       },
       {
-        "checksum": "sha1:865441b675d789d5e9cb1923bf393dfc6f135ac0",
+        "checksum": "adler32:3447d5c9",
         "description": "TauParked AOD dataset file index (5 of 22) for access to data via CMS virtual machine",
         "size": 824,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20009_file_index.json"
       },
       {
-        "checksum": "sha1:d8f7a0e7a63ae7464d71eca5c81199c119df560a",
+        "checksum": "adler32:63f2d52c",
         "description": "TauParked AOD dataset file index (6 of 22) for access to data via CMS virtual machine",
         "size": 824,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20010_file_index.json"
       },
       {
-        "checksum": "sha1:b6b49f2975ed535f6d3bbed8a65c347e556ae17a",
+        "checksum": "adler32:80a58f5e",
         "description": "TauParked AOD dataset file index (7 of 22) for access to data via CMS virtual machine",
         "size": 550,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20011_file_index.json"
       },
       {
-        "checksum": "sha1:006d45238e8771790e14d0e0b74483e87e3dfa9e",
+        "checksum": "adler32:759247be",
         "description": "TauParked AOD dataset file index (8 of 22) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20013_file_index.json"
       },
       {
-        "checksum": "sha1:96b4f20c0db97648b29f1c62aa5588d8faeeeb5d",
+        "checksum": "adler32:8a728f43",
         "description": "TauParked AOD dataset file index (9 of 22) for access to data via CMS virtual machine",
         "size": 550,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20014_file_index.json"
       },
       {
-        "checksum": "sha1:dabc85920dd0a2f31274bfafb950777f0a4e0630",
+        "checksum": "adler32:09c48f15",
         "description": "TauParked AOD dataset file index (10 of 22) for access to data via CMS virtual machine",
         "size": 550,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20015_file_index.json"
       },
       {
-        "checksum": "sha1:485e7504c657ed372b8ae19b3c7f415589503d75",
+        "checksum": "adler32:8e3a482f",
         "description": "TauParked AOD dataset file index (11 of 22) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20016_file_index.json"
       },
       {
-        "checksum": "sha1:42dc67f1d85bea95286166325d046a4b5ff1dfde",
+        "checksum": "adler32:11ef8e84",
         "description": "TauParked AOD dataset file index (12 of 22) for access to data via CMS virtual machine",
         "size": 550,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20017_file_index.json"
       },
       {
-        "checksum": "sha1:f1a411f43f347fcde2319201f1508291e1047754",
+        "checksum": "adler32:48204733",
         "description": "TauParked AOD dataset file index (13 of 22) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20018_file_index.json"
       },
       {
-        "checksum": "sha1:21694b783774f0508aa5ee189b710cb182f20260",
+        "checksum": "adler32:07dda29d",
         "description": "TauParked AOD dataset file index (14 of 22) for access to data via CMS virtual machine",
         "size": 275372,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:636c94f953699647f92b59ece6f4ac42d155ad69",
+        "checksum": "adler32:16416407",
         "description": "TauParked AOD dataset file index (15 of 22) for access to data via CMS virtual machine",
         "size": 149058,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:b34fe6b6c00124362bfa34645114cc6a2ecae508",
+        "checksum": "adler32:10104751",
         "description": "TauParked AOD dataset file index (16 of 22) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30004_file_index.json"
       },
       {
-        "checksum": "sha1:133de43850580cab2462ac206ef324c48d46dc1c",
+        "checksum": "adler32:388d4775",
         "description": "TauParked AOD dataset file index (17 of 22) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30006_file_index.json"
       },
       {
-        "checksum": "sha1:6e07620e6c0a2eb6c47dbbfb73703a433c802b0d",
+        "checksum": "adler32:953d47cf",
         "description": "TauParked AOD dataset file index (18 of 22) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30008_file_index.json"
       },
       {
-        "checksum": "sha1:4cbc25faf38a9943a5aad24820627fb98b51ce2f",
+        "checksum": "adler32:02ac46f1",
         "description": "TauParked AOD dataset file index (19 of 22) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30010_file_index.json"
       },
       {
-        "checksum": "sha1:70f290cad0dd31ea72424e8477aa2054acb1c918",
+        "checksum": "adler32:37374736",
         "description": "TauParked AOD dataset file index (20 of 22) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30011_file_index.json"
       },
       {
-        "checksum": "sha1:ad6a04115f31377a838ab3e81c2e17482a9f1740",
+        "checksum": "adler32:d1684829",
         "description": "TauParked AOD dataset file index (21 of 22) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30012_file_index.json"
       },
       {
-        "checksum": "sha1:571bf6c74b532a8b5089ed1140da69de53c16494",
+        "checksum": "adler32:54aa4777",
         "description": "TauParked AOD dataset file index (22 of 22) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30016_file_index.json"
       },
       {
-        "checksum": "sha1:4f3dc7fe07e1023942d6ca72081b945a3e7d9235",
+        "checksum": "adler32:63a25672",
         "description": "TauParked AOD dataset file index (1 of 22) for access to data via CMS virtual machine",
         "size": 126873,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:bf29d30fd83b0ca97faaf09532482b2879adeafd",
+        "checksum": "adler32:97bf92bc",
         "description": "TauParked AOD dataset file index (2 of 22) for access to data via CMS virtual machine",
         "size": 106934,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:b244dfc7adf157896c795b3a87a1846a86e75903",
+        "checksum": "adler32:378824e4",
         "description": "TauParked AOD dataset file index (3 of 22) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:b3f42873d02a645774a7c6579d8a580f4a65131c",
+        "checksum": "adler32:387e24f5",
         "description": "TauParked AOD dataset file index (4 of 22) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20005_file_index.txt"
       },
       {
-        "checksum": "sha1:5c8585d9230cb9a33a3469fe1a111a1af88cc56f",
+        "checksum": "adler32:72656ea1",
         "description": "TauParked AOD dataset file index (5 of 22) for access to data via CMS virtual machine",
         "size": 381,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20009_file_index.txt"
       },
       {
-        "checksum": "sha1:b5520aeb15bd205a09a9ff4edd8415488d8f7421",
+        "checksum": "adler32:97d76e97",
         "description": "TauParked AOD dataset file index (6 of 22) for access to data via CMS virtual machine",
         "size": 381,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20010_file_index.txt"
       },
       {
-        "checksum": "sha1:a9455f3caddea5cc1cad7ca7d9529c5d5ad9a33c",
+        "checksum": "adler32:db1b4a1f",
         "description": "TauParked AOD dataset file index (7 of 22) for access to data via CMS virtual machine",
         "size": 254,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20011_file_index.txt"
       },
       {
-        "checksum": "sha1:352153c465abec7e5f13990290cf49cde529c988",
+        "checksum": "adler32:39b32503",
         "description": "TauParked AOD dataset file index (8 of 22) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20013_file_index.txt"
       },
       {
-        "checksum": "sha1:2c89dd4eabad86600abd13985595ba327abb144e",
+        "checksum": "adler32:db494a01",
         "description": "TauParked AOD dataset file index (9 of 22) for access to data via CMS virtual machine",
         "size": 254,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20014_file_index.txt"
       },
       {
-        "checksum": "sha1:127259361a80afea0b9b1de2c0ce7cbb87a2b4ba",
+        "checksum": "adler32:db874a25",
         "description": "TauParked AOD dataset file index (10 of 22) for access to data via CMS virtual machine",
         "size": 254,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20015_file_index.txt"
       },
       {
-        "checksum": "sha1:0124c12fe236319db8c4435ddbb23a641309375e",
+        "checksum": "adler32:42c1255e",
         "description": "TauParked AOD dataset file index (11 of 22) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20016_file_index.txt"
       },
       {
-        "checksum": "sha1:135eb1599d79441ec1f5475dc2a6543dd286cc3e",
+        "checksum": "adler32:b2d249aa",
         "description": "TauParked AOD dataset file index (12 of 22) for access to data via CMS virtual machine",
         "size": 254,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20017_file_index.txt"
       },
       {
-        "checksum": "sha1:001458709ec6bd15ae97f1c1fea2bb2a32dd8ea7",
+        "checksum": "adler32:35ac24bc",
         "description": "TauParked AOD dataset file index (13 of 22) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_20018_file_index.txt"
       },
       {
-        "checksum": "sha1:9d76d1807da07fdfe3f906c710a5ed239d1851d9",
+        "checksum": "adler32:85e1f924",
         "description": "TauParked AOD dataset file index (14 of 22) for access to data via CMS virtual machine",
         "size": 127635,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:7399b9ab61d1941a96afb405332658e9209fa51d",
+        "checksum": "adler32:b0e17dfc",
         "description": "TauParked AOD dataset file index (15 of 22) for access to data via CMS virtual machine",
         "size": 69088,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:dbeb6a77dbb41d1bfb17ac093dd629265c66f3d2",
+        "checksum": "adler32:3bde2508",
         "description": "TauParked AOD dataset file index (16 of 22) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30004_file_index.txt"
       },
       {
-        "checksum": "sha1:9671dc43d4c884ee60264104dc44682db7e26fed",
+        "checksum": "adler32:3b0724ff",
         "description": "TauParked AOD dataset file index (17 of 22) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30006_file_index.txt"
       },
       {
-        "checksum": "sha1:da78353273157af4d87a33992bb0057e763cbfd0",
+        "checksum": "adler32:3d1124ff",
         "description": "TauParked AOD dataset file index (18 of 22) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30008_file_index.txt"
       },
       {
-        "checksum": "sha1:a4b90d5b9928fbbc1754dab1f9fe29254c978ff7",
+        "checksum": "adler32:327724b5",
         "description": "TauParked AOD dataset file index (19 of 22) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30010_file_index.txt"
       },
       {
-        "checksum": "sha1:7708a8c401d172e84a07527de4d918969eacc694",
+        "checksum": "adler32:33c924c3",
         "description": "TauParked AOD dataset file index (20 of 22) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30011_file_index.txt"
       },
       {
-        "checksum": "sha1:4209d4537d8b5ac6f9d68baf198ea5e226513821",
+        "checksum": "adler32:3a17250c",
         "description": "TauParked AOD dataset file index (21 of 22) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauParked_AOD_22Jan2013-v1_30012_file_index.txt"
       },
       {
-        "checksum": "sha1:0643088498c8ab193de28f49bbb278e892afa72a",
+        "checksum": "adler32:387f24e4",
         "description": "TauParked AOD dataset file index (22 of 22) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
@@ -4650,112 +4650,112 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b7524e8f3fc268894bd4a688bc2a9191f46737f2",
+        "checksum": "adler32:e327bae1",
         "description": "TauPlusX AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
         "size": 246247,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:4eb9a6ad832dd99c635658a69b6778d0b4783439",
+        "checksum": "adler32:eb60eaa9",
         "description": "TauPlusX AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
         "size": 280918,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:31ce374db1454b1fb507f2c1f0c6a8d532f98c53",
+        "checksum": "adler32:402ffd3d",
         "description": "TauPlusX AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
         "size": 273002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:647b38a2882d003a13223c7fa3f24a029592a0c5",
+        "checksum": "adler32:d12e1bfd",
         "description": "TauPlusX AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
         "size": 18839,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:3304415bf45e222618603437403652f9e691a4fc",
+        "checksum": "adler32:79d847ef",
         "description": "TauPlusX AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30004_file_index.json"
       },
       {
-        "checksum": "sha1:c77f6083d533cc7e2ecc61d84f0c9bea03fdf602",
+        "checksum": "adler32:2e4a4741",
         "description": "TauPlusX AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30005_file_index.json"
       },
       {
-        "checksum": "sha1:300fcab11967ae4a2d05a582a8e9460469e6a446",
+        "checksum": "adler32:71448e71",
         "description": "TauPlusX AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
         "size": 548,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30010_file_index.json"
       },
       {
-        "checksum": "sha1:3155b7a518e95ac79e132122b2a1e469d37cc6eb",
+        "checksum": "adler32:61328de5",
         "description": "TauPlusX AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
         "size": 548,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30020_file_index.json"
       },
       {
-        "checksum": "sha1:987d21595a1aeb03a6f7bd308bd44381fa7e8faa",
+        "checksum": "adler32:e325e2b8",
         "description": "TauPlusX AOD dataset file index (1 of 8) for access to data via CMS virtual machine",
         "size": 113652,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:89ea1cc8c2ae0c061759248f684deaecd2986e91",
+        "checksum": "adler32:60ed0e93",
         "description": "TauPlusX AOD dataset file index (2 of 8) for access to data via CMS virtual machine",
         "size": 129654,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:cb937bb2f44b0a69d0a423a6a39156742756679b",
+        "checksum": "adler32:16bff0e1",
         "description": "TauPlusX AOD dataset file index (3 of 8) for access to data via CMS virtual machine",
         "size": 126000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:eafb077608612f9d2ca264552912f664dc790b17",
+        "checksum": "adler32:8abedbf9",
         "description": "TauPlusX AOD dataset file index (4 of 8) for access to data via CMS virtual machine",
         "size": 8694,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30002_file_index.txt"
       },
       {
-        "checksum": "sha1:660dfcffc8fbdb94d0245b2b0f47f02eaca27258",
+        "checksum": "adler32:0fc424d5",
         "description": "TauPlusX AOD dataset file index (5 of 8) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30004_file_index.txt"
       },
       {
-        "checksum": "sha1:512ed9a05d0f8a91d5da8ec82f6860a610e7ea06",
+        "checksum": "adler32:0a302484",
         "description": "TauPlusX AOD dataset file index (6 of 8) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30005_file_index.txt"
       },
       {
-        "checksum": "sha1:9be4fd681a7360e9043f6945a0b3c46ace6cc473",
+        "checksum": "adler32:047f492b",
         "description": "TauPlusX AOD dataset file index (7 of 8) for access to data via CMS virtual machine",
         "size": 252,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_TauPlusX_AOD_22Jan2013-v1_30010_file_index.txt"
       },
       {
-        "checksum": "sha1:f9c1b15e4a569c7a90d8b1449d300615fdb83bb2",
+        "checksum": "adler32:0bbe4911",
         "description": "TauPlusX AOD dataset file index (8 of 8) for access to data via CMS virtual machine",
         "size": 252,
         "type": "index.txt",
@@ -4855,392 +4855,392 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:724d4d3ec257e407711d3fbdfd5da863efefb28e",
+        "checksum": "adler32:a6f6e853",
         "description": "VBF1Parked AOD dataset file index (1 of 28) for access to data via CMS virtual machine",
         "size": 277477,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:cce2833e9ac6b6c08363633182d34ac5f6fec16b",
+        "checksum": "adler32:bc2a0a48",
         "description": "VBF1Parked AOD dataset file index (2 of 28) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:b3fc3657db2c07975747f89ce32a26560ccc5b47",
+        "checksum": "adler32:3a1580b2",
         "description": "VBF1Parked AOD dataset file index (3 of 28) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:d0fe455c060ac045bbfb8b1dc66cdfbd404bc134",
+        "checksum": "adler32:deeb6457",
         "description": "VBF1Parked AOD dataset file index (4 of 28) for access to data via CMS virtual machine",
         "size": 275552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:47c7104d0f4a40b3fe41ec3116a07ab3499e833b",
+        "checksum": "adler32:3d55924a",
         "description": "VBF1Parked AOD dataset file index (5 of 28) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20004_file_index.json"
       },
       {
-        "checksum": "sha1:b8cc5a1a66ac820b9d8d8a85188ef843be77f172",
+        "checksum": "adler32:8f832270",
         "description": "VBF1Parked AOD dataset file index (6 of 28) for access to data via CMS virtual machine",
         "size": 25852,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20005_file_index.json"
       },
       {
-        "checksum": "sha1:25dbd81e1538f764434042d439c14a67cc4a2c92",
+        "checksum": "adler32:af6a4793",
         "description": "VBF1Parked AOD dataset file index (7 of 28) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20006_file_index.json"
       },
       {
-        "checksum": "sha1:343d8a79b04f4553065b475cd2d610e341f9e71a",
+        "checksum": "adler32:6e491d2d",
         "description": "VBF1Parked AOD dataset file index (8 of 28) for access to data via CMS virtual machine",
         "size": 1102,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20007_file_index.json"
       },
       {
-        "checksum": "sha1:d886ff69a5b447cca18d1dfad9834576666ed782",
+        "checksum": "adler32:dc958e84",
         "description": "VBF1Parked AOD dataset file index (9 of 28) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20008_file_index.json"
       },
       {
-        "checksum": "sha1:ca8dc5f3f0f5492e84caa0b03d9fd1723cceb4a3",
+        "checksum": "adler32:ecfc8dd4",
         "description": "VBF1Parked AOD dataset file index (10 of 28) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20009_file_index.json"
       },
       {
-        "checksum": "sha1:b93c897cfb4cba5a175fa58334cfa056893c5448",
+        "checksum": "adler32:b1dd8edc",
         "description": "VBF1Parked AOD dataset file index (11 of 28) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20010_file_index.json"
       },
       {
-        "checksum": "sha1:93578cef4612a2f6af4bc44430652079c20c2246",
+        "checksum": "adler32:e7ab47a8",
         "description": "VBF1Parked AOD dataset file index (12 of 28) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20011_file_index.json"
       },
       {
-        "checksum": "sha1:4af708dc8d31a5eba1f9c54bd7a41a2b97643285",
+        "checksum": "adler32:c2cb47ac",
         "description": "VBF1Parked AOD dataset file index (13 of 28) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20012_file_index.json"
       },
       {
-        "checksum": "sha1:178ddd964b0f89c8a0e56cc7de73629d2c3bda04",
+        "checksum": "adler32:0eb1d451",
         "description": "VBF1Parked AOD dataset file index (14 of 28) for access to data via CMS virtual machine",
         "size": 827,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20013_file_index.json"
       },
       {
-        "checksum": "sha1:35196c005e7bfab1c24833caf76a8f3b3ad39845",
+        "checksum": "adler32:1a43d625",
         "description": "VBF1Parked AOD dataset file index (15 of 28) for access to data via CMS virtual machine",
         "size": 827,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20015_file_index.json"
       },
       {
-        "checksum": "sha1:e1a78d792b99598efc175f738b3dc84c768a75e1",
+        "checksum": "adler32:3db5d4e9",
         "description": "VBF1Parked AOD dataset file index (16 of 28) for access to data via CMS virtual machine",
         "size": 827,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20016_file_index.json"
       },
       {
-        "checksum": "sha1:bf16f1ba204870c546911ce3716c040a7efb6b2d",
+        "checksum": "adler32:afeff9bf",
         "description": "VBF1Parked AOD dataset file index (17 of 28) for access to data via CMS virtual machine",
         "size": 275277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:a4b848aaf4d8a4c33415272b1283caeccebaef77",
+        "checksum": "adler32:d083a612",
         "description": "VBF1Parked AOD dataset file index (18 of 28) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:70480b5716b30da27f8f532df497349ec607a3fd",
+        "checksum": "adler32:f639d3ee",
         "description": "VBF1Parked AOD dataset file index (19 of 28) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:6e3ed6271c1a885f392e38decdf61bf5f3f517a5",
+        "checksum": "adler32:c5b18afb",
         "description": "VBF1Parked AOD dataset file index (20 of 28) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30003_file_index.json"
       },
       {
-        "checksum": "sha1:5a9c9c284b6f7e4a06d9da1d5646351035fa81a3",
+        "checksum": "adler32:e73f21e0",
         "description": "VBF1Parked AOD dataset file index (21 of 28) for access to data via CMS virtual machine",
         "size": 275277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30004_file_index.json"
       },
       {
-        "checksum": "sha1:8d438cd63f154ba086d07dfdb8cb03d8b1398fde",
+        "checksum": "adler32:febb0a9c",
         "description": "VBF1Parked AOD dataset file index (22 of 28) for access to data via CMS virtual machine",
         "size": 275277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30005_file_index.json"
       },
       {
-        "checksum": "sha1:e7be6d623cc00a95d9dc079df259aae470de12ba",
+        "checksum": "adler32:7ed4d34b",
         "description": "VBF1Parked AOD dataset file index (23 of 28) for access to data via CMS virtual machine",
         "size": 204877,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30006_file_index.json"
       },
       {
-        "checksum": "sha1:42079e4c9130978d7c66438d40a8990f9e919e21",
+        "checksum": "adler32:b0974799",
         "description": "VBF1Parked AOD dataset file index (24 of 28) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30013_file_index.json"
       },
       {
-        "checksum": "sha1:3cdea6969331a75162d4bd61aec77ce01ae7064c",
+        "checksum": "adler32:cede47b3",
         "description": "VBF1Parked AOD dataset file index (25 of 28) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30015_file_index.json"
       },
       {
-        "checksum": "sha1:b19d016f93812f7da69fc4d51f84f46d48bd8ce1",
+        "checksum": "adler32:913b4750",
         "description": "VBF1Parked AOD dataset file index (26 of 28) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30017_file_index.json"
       },
       {
-        "checksum": "sha1:20247a41e1c7a5b4b103b9e122b8f7ce85c2a36c",
+        "checksum": "adler32:6f198f28",
         "description": "VBF1Parked AOD dataset file index (27 of 28) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30025_file_index.json"
       },
       {
-        "checksum": "sha1:205ccef6d4a09e41640fe74697aa6674689d0495",
+        "checksum": "adler32:ebc147ac",
         "description": "VBF1Parked AOD dataset file index (28 of 28) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30026_file_index.json"
       },
       {
-        "checksum": "sha1:c9b7e531ba6f5461e87cad038e4bff2da5edfec9",
+        "checksum": "adler32:9483eb32",
         "description": "VBF1Parked AOD dataset file index (1 of 28) for access to data via CMS virtual machine",
         "size": 129152,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:a372380854d8a5e813853549058888ae95eaad7e",
+        "checksum": "adler32:1bbcf677",
         "description": "VBF1Parked AOD dataset file index (2 of 28) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:3a4ecba11af8b89e90d5930cfad3a832f0da2a7f",
+        "checksum": "adler32:98b3b54a",
         "description": "VBF1Parked AOD dataset file index (3 of 28) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:48d705695d9f1f4635d933928989ef01d0e3dce0",
+        "checksum": "adler32:65ad2451",
         "description": "VBF1Parked AOD dataset file index (4 of 28) for access to data via CMS virtual machine",
         "size": 128256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:cb9a10fb1f18a524179125ed0a1e08e954074573",
+        "checksum": "adler32:ac70c2f8",
         "description": "VBF1Parked AOD dataset file index (5 of 28) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20004_file_index.txt"
       },
       {
-        "checksum": "sha1:df641352fe5f98d6b61e11b4153b1fdf9affbb74",
+        "checksum": "adler32:9831894c",
         "description": "VBF1Parked AOD dataset file index (6 of 28) for access to data via CMS virtual machine",
         "size": 12032,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20005_file_index.txt"
       },
       {
-        "checksum": "sha1:9d865fb117b844e0b06fb55920297744ba12618a",
+        "checksum": "adler32:45f124d2",
         "description": "VBF1Parked AOD dataset file index (7 of 28) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20006_file_index.txt"
       },
       {
-        "checksum": "sha1:358ce91a4e2689639a7a3c58c9ad79ed02f3b596",
+        "checksum": "adler32:8da99353",
         "description": "VBF1Parked AOD dataset file index (8 of 28) for access to data via CMS virtual machine",
         "size": 512,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20007_file_index.txt"
       },
       {
-        "checksum": "sha1:324d984fc43ebe62521f24aa0e9b942096b3d413",
+        "checksum": "adler32:f3e24980",
         "description": "VBF1Parked AOD dataset file index (9 of 28) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20008_file_index.txt"
       },
       {
-        "checksum": "sha1:daeaa0e4d8393ef880e1d0c8dce3337d154701bc",
+        "checksum": "adler32:d9154967",
         "description": "VBF1Parked AOD dataset file index (10 of 28) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20009_file_index.txt"
       },
       {
-        "checksum": "sha1:64d53fdfe58cbbc47baf9fe6c3f23d7b3ad88aa0",
+        "checksum": "adler32:e54c49a6",
         "description": "VBF1Parked AOD dataset file index (11 of 28) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20010_file_index.txt"
       },
       {
-        "checksum": "sha1:927fe64a3a1980e850b03e3fbe0a1cae255b7b15",
+        "checksum": "adler32:421424b2",
         "description": "VBF1Parked AOD dataset file index (12 of 28) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20011_file_index.txt"
       },
       {
-        "checksum": "sha1:e427f49d25013f6b348d4137da286dfb7adcaf67",
+        "checksum": "adler32:48cc24dd",
         "description": "VBF1Parked AOD dataset file index (13 of 28) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20012_file_index.txt"
       },
       {
-        "checksum": "sha1:48b7ab5195c758e24c72d5dac507f2f967c2b5f5",
+        "checksum": "adler32:ed4d6e0e",
         "description": "VBF1Parked AOD dataset file index (14 of 28) for access to data via CMS virtual machine",
         "size": 384,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20013_file_index.txt"
       },
       {
-        "checksum": "sha1:0b4c0d577b8f6ebc2abaaef40d0af45ab17e910f",
+        "checksum": "adler32:1c0f6edc",
         "description": "VBF1Parked AOD dataset file index (15 of 28) for access to data via CMS virtual machine",
         "size": 384,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20015_file_index.txt"
       },
       {
-        "checksum": "sha1:44b203beb8d4d3fb67421b2ae66a304a45ff1995",
+        "checksum": "adler32:e7166e12",
         "description": "VBF1Parked AOD dataset file index (16 of 28) for access to data via CMS virtual machine",
         "size": 384,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_20016_file_index.txt"
       },
       {
-        "checksum": "sha1:778dd66bb84526d2dd4227a921af1f9f49950fee",
+        "checksum": "adler32:9a99f306",
         "description": "VBF1Parked AOD dataset file index (17 of 28) for access to data via CMS virtual machine",
         "size": 128128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:79ebbcf98e50e48beb151a6e207d331e0a2d908d",
+        "checksum": "adler32:29a5c2bf",
         "description": "VBF1Parked AOD dataset file index (18 of 28) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:2c7b9e9a5a4489e7c97a7672f3e259bcf343e01c",
+        "checksum": "adler32:f818dd5a",
         "description": "VBF1Parked AOD dataset file index (19 of 28) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30002_file_index.txt"
       },
       {
-        "checksum": "sha1:ab9490c60be96547c30e057a6f8775882dcb2021",
+        "checksum": "adler32:b498bc67",
         "description": "VBF1Parked AOD dataset file index (20 of 28) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30003_file_index.txt"
       },
       {
-        "checksum": "sha1:54e48f1d27a0dcd6bed9e515359d777323c87058",
+        "checksum": "adler32:731a09e4",
         "description": "VBF1Parked AOD dataset file index (21 of 28) for access to data via CMS virtual machine",
         "size": 128128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30004_file_index.txt"
       },
       {
-        "checksum": "sha1:e3bd8eb380684a83586b1a3daea843106b6c652e",
+        "checksum": "adler32:50c90014",
         "description": "VBF1Parked AOD dataset file index (22 of 28) for access to data via CMS virtual machine",
         "size": 128128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30005_file_index.txt"
       },
       {
-        "checksum": "sha1:1c2f6214672a7eeecaf028c89e36b3ebb65242e6",
+        "checksum": "adler32:9295213e",
         "description": "VBF1Parked AOD dataset file index (23 of 28) for access to data via CMS virtual machine",
         "size": 95360,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30006_file_index.txt"
       },
       {
-        "checksum": "sha1:9bf6c5515bdba1ff783198986575eba627007cf7",
+        "checksum": "adler32:43db24d8",
         "description": "VBF1Parked AOD dataset file index (24 of 28) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30013_file_index.txt"
       },
       {
-        "checksum": "sha1:17b9526598de4cbb32abca13c0fbe1e7c076ea6e",
+        "checksum": "adler32:404124cb",
         "description": "VBF1Parked AOD dataset file index (25 of 28) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30015_file_index.txt"
       },
       {
-        "checksum": "sha1:ba0dbaf167f0a858735ffd665ccc3905126f3d19",
+        "checksum": "adler32:42b024b3",
         "description": "VBF1Parked AOD dataset file index (26 of 28) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30017_file_index.txt"
       },
       {
-        "checksum": "sha1:c010837f7280d1cbe2c12bca99e948d0723232f2",
+        "checksum": "adler32:18de49e9",
         "description": "VBF1Parked AOD dataset file index (27 of 28) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012B_VBF1Parked_AOD_22Jan2013-v1_30025_file_index.txt"
       },
       {
-        "checksum": "sha1:004e684e2deda83cfd5b931220125d1f70bb2ea1",
+        "checksum": "adler32:403b24ad",
         "description": "VBF1Parked AOD dataset file index (28 of 28) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",

--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012C.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Run2012C.json
@@ -38,196 +38,196 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6abe6079b80213c4020c1af4cebf9f0a5a5601b2",
+        "checksum": "adler32:4f1ef9b4",
         "description": "BJetPlusX AOD dataset file index (1 of 14) for access to data via CMS virtual machine",
         "size": 274002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:67bb00e6fa8b621cca1d351faf64ee896b572948",
+        "checksum": "adler32:cacf7913",
         "description": "BJetPlusX AOD dataset file index (2 of 14) for access to data via CMS virtual machine",
         "size": 82202,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:b043f35132f9f67428f54f4797303d6e35f99b54",
+        "checksum": "adler32:873747a6",
         "description": "BJetPlusX AOD dataset file index (3 of 14) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20008_file_index.json"
       },
       {
-        "checksum": "sha1:025de0e359324a512133151a8da72db303b237d5",
+        "checksum": "adler32:29388e09",
         "description": "BJetPlusX AOD dataset file index (4 of 14) for access to data via CMS virtual machine",
         "size": 550,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20011_file_index.json"
       },
       {
-        "checksum": "sha1:3118251b8ca6fd7b38a85543dc816136b0b3bba9",
+        "checksum": "adler32:2b96e6cb",
         "description": "BJetPlusX AOD dataset file index (5 of 14) for access to data via CMS virtual machine",
         "size": 285784,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:27a787abf11ebf44b9c5a1298d0e701635aa5a50",
+        "checksum": "adler32:0c8b1082",
         "description": "BJetPlusX AOD dataset file index (6 of 14) for access to data via CMS virtual machine",
         "size": 200022,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:ec9beb865e5633c889e95204cef956cea4b4082c",
+        "checksum": "adler32:65e21beb",
         "description": "BJetPlusX AOD dataset file index (7 of 14) for access to data via CMS virtual machine",
         "size": 1098,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30003_file_index.json"
       },
       {
-        "checksum": "sha1:842010021dfefa7f1fff1614eccc7f735bb65e19",
+        "checksum": "adler32:89758e7a",
         "description": "BJetPlusX AOD dataset file index (8 of 14) for access to data via CMS virtual machine",
         "size": 550,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30006_file_index.json"
       },
       {
-        "checksum": "sha1:2c5c8fc123c52a69f8416b4f4b610d8eb8844f46",
+        "checksum": "adler32:59b78e3d",
         "description": "BJetPlusX AOD dataset file index (9 of 14) for access to data via CMS virtual machine",
         "size": 550,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30007_file_index.json"
       },
       {
-        "checksum": "sha1:13a8753b537b1f3cc77c6a5c014e0ce3c9febf50",
+        "checksum": "adler32:de0a4837",
         "description": "BJetPlusX AOD dataset file index (10 of 14) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30009_file_index.json"
       },
       {
-        "checksum": "sha1:ff46c2cf19b6ef71100b0d36542179ba8f7d1bb6",
+        "checksum": "adler32:0c2b481c",
         "description": "BJetPlusX AOD dataset file index (11 of 14) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30011_file_index.json"
       },
       {
-        "checksum": "sha1:da7c2c856403290feda3cd355ca1418e4f0b7de5",
+        "checksum": "adler32:7b7047a5",
         "description": "BJetPlusX AOD dataset file index (12 of 14) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30012_file_index.json"
       },
       {
-        "checksum": "sha1:bc106b37c951f1b2f4c2a5502db5e871a5e2fdbf",
+        "checksum": "adler32:220dd556",
         "description": "BJetPlusX AOD dataset file index (13 of 14) for access to data via CMS virtual machine",
         "size": 824,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30013_file_index.json"
       },
       {
-        "checksum": "sha1:67f8133a205c0e042418eeaef83d0913bf882c3b",
+        "checksum": "adler32:860247ad",
         "description": "BJetPlusX AOD dataset file index (14 of 14) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30015_file_index.json"
       },
       {
-        "checksum": "sha1:c17cea88ae2eadf0ac4d009a7262f48e67406bba",
+        "checksum": "adler32:abd1de4c",
         "description": "BJetPlusX AOD dataset file index (1 of 14) for access to data via CMS virtual machine",
         "size": 127000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:5a36e161a243d64991c19f3cd76a866bd63873c7",
+        "checksum": "adler32:0ad1354c",
         "description": "BJetPlusX AOD dataset file index (2 of 14) for access to data via CMS virtual machine",
         "size": 38100,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:63f190b942327e247fda2913a7b06b21960610ef",
+        "checksum": "adler32:32ae24d9",
         "description": "BJetPlusX AOD dataset file index (3 of 14) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20008_file_index.txt"
       },
       {
-        "checksum": "sha1:7f23e34ca5f2ffe964a9bf26f1b106c539da2b6c",
+        "checksum": "adler32:9133497f",
         "description": "BJetPlusX AOD dataset file index (4 of 14) for access to data via CMS virtual machine",
         "size": 254,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_20011_file_index.txt"
       },
       {
-        "checksum": "sha1:aae00fa57e451b4349d4cc803cf6eba7b25ef976",
+        "checksum": "adler32:d3511120",
         "description": "BJetPlusX AOD dataset file index (5 of 14) for access to data via CMS virtual machine",
         "size": 132461,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:21d9708db012eb3e26c58a3249cbc269f1a29c5a",
+        "checksum": "adler32:021d1b86",
         "description": "BJetPlusX AOD dataset file index (6 of 14) for access to data via CMS virtual machine",
         "size": 92710,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:d3d0245659a79af3b1144be62226141cf962c5fd",
+        "checksum": "adler32:28de92e2",
         "description": "BJetPlusX AOD dataset file index (7 of 14) for access to data via CMS virtual machine",
         "size": 508,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30003_file_index.txt"
       },
       {
-        "checksum": "sha1:481168c509e863522ab64a14d8799730e7704a5b",
+        "checksum": "adler32:a9344977",
         "description": "BJetPlusX AOD dataset file index (8 of 14) for access to data via CMS virtual machine",
         "size": 254,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30006_file_index.txt"
       },
       {
-        "checksum": "sha1:7793711ff35307d1ea9025c62383ba4a56d3da20",
+        "checksum": "adler32:9e724979",
         "description": "BJetPlusX AOD dataset file index (9 of 14) for access to data via CMS virtual machine",
         "size": 254,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30007_file_index.txt"
       },
       {
-        "checksum": "sha1:857533795309d33a03de67bf8d427e0efebc5703",
+        "checksum": "adler32:37e1250e",
         "description": "BJetPlusX AOD dataset file index (10 of 14) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30009_file_index.txt"
       },
       {
-        "checksum": "sha1:674996383820b75013c860fa9eadbdb3c03666e2",
+        "checksum": "adler32:31f424c1",
         "description": "BJetPlusX AOD dataset file index (11 of 14) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30011_file_index.txt"
       },
       {
-        "checksum": "sha1:e345f66f588a784b225eab7c196e4be107cb17f2",
+        "checksum": "adler32:2e4624dd",
         "description": "BJetPlusX AOD dataset file index (12 of 14) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30012_file_index.txt"
       },
       {
-        "checksum": "sha1:5d8f92b46affd3096e6967af987c3d0ed3171f78",
+        "checksum": "adler32:74046e73",
         "description": "BJetPlusX AOD dataset file index (13 of 14) for access to data via CMS virtual machine",
         "size": 381,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BJetPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BJetPlusX_AOD_22Jan2013-v1_30013_file_index.txt"
       },
       {
-        "checksum": "sha1:6f9970294d621093a9893854d9aab460aa8d73e8",
+        "checksum": "adler32:32ae24e2",
         "description": "BJetPlusX AOD dataset file index (14 of 14) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
@@ -327,28 +327,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3aec41aa9172deae9676bd5aa6833d4135e407a0",
+        "checksum": "adler32:5b136ce0",
         "description": "BTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 134502,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BTag_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:1a6a0858ae17ead608170a38dac40f0da288e105",
+        "checksum": "adler32:d86bee71",
         "description": "BTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 76398,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BTag_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:4491698cb2a68e478fd9bc6e7adb066327e88f14",
+        "checksum": "adler32:4bce345d",
         "description": "BTag AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 61000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/BTag/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_BTag_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:bca5a01932e34868bbbd8719a25a40eecf6cf2bc",
+        "checksum": "adler32:6d5ebbda",
         "description": "BTag AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 34648,
         "type": "index.txt",
@@ -448,84 +448,84 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0f94f05816da2ccc5b53a7b8ea454491805915a9",
+        "checksum": "adler32:cd039931",
         "description": "Commissioning AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
         "size": 190707,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:fb3947446c444f881054f3354ce4c9cb5020857a",
+        "checksum": "adler32:72c592f0",
         "description": "Commissioning AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
         "size": 557,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:af34e061c07e744ec3e12bc64ea98fc4629e2dd2",
+        "checksum": "adler32:0b4ae368",
         "description": "Commissioning AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
         "size": 22276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_210000_file_index.json"
       },
       {
-        "checksum": "sha1:070ff55543771e966067be186ce9dc2e08c220eb",
+        "checksum": "adler32:1cb3970c",
         "description": "Commissioning AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
         "size": 128716,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:35750ef2fe839abcbff3e28d3b7c97bf525fac3c",
+        "checksum": "adler32:1f9db706",
         "description": "Commissioning AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
         "size": 1664,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_30006_file_index.json"
       },
       {
-        "checksum": "sha1:f62d051db48707c5cb759fe25bc9be73e8cf0cd8",
+        "checksum": "adler32:4d7f14b9",
         "description": "Commissioning AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
         "size": 21485,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_310000_file_index.json"
       },
       {
-        "checksum": "sha1:54a72844651a1ed391e4c1c19e1692b444cf35de",
+        "checksum": "adler32:4a3b570d",
         "description": "Commissioning AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
         "size": 89866,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:600487ac8afddb3e9ffbf7567e0c7cdd531a3598",
+        "checksum": "adler32:f6dc4dac",
         "description": "Commissioning AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
         "size": 262,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:d3784ba9420c878547d683448ea55750e07eda69",
+        "checksum": "adler32:b8e631d3",
         "description": "Commissioning AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
         "size": 10560,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_210000_file_index.txt"
       },
       {
-        "checksum": "sha1:c3bdd25e68f332c7cf4ea187dbefb03d1f6cc643",
+        "checksum": "adler32:525d63d6",
         "description": "Commissioning AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
         "size": 60653,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:33f6640e7349852bfc1b6483109d515327c115bf",
+        "checksum": "adler32:2a50e981",
         "description": "Commissioning AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
         "size": 786,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/Commissioning/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_Commissioning_AOD_22Jan2013-v1_30006_file_index.txt"
       },
       {
-        "checksum": "sha1:8b06ac253a2818ffa61fdd6aa40023c6cc0cf01f",
+        "checksum": "adler32:b5bec135",
         "description": "Commissioning AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
         "size": 10164,
         "type": "index.txt",
@@ -625,70 +625,70 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:accb9721ab6d12d85d4f936aea824bbe9bf74f34",
+        "checksum": "adler32:2f1b2d67",
         "description": "DoubleElectron AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
         "size": 293510,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:bfe8098ed82d2374a8de7c22be74d3dc6804c4b9",
+        "checksum": "adler32:fae44063",
         "description": "DoubleElectron AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
         "size": 279002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:39cbc007f3c42a61cac43ddebec8ffc06b672162",
+        "checksum": "adler32:e3240377",
         "description": "DoubleElectron AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
         "size": 93467,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:a640209a8cd935e65b1f9f600e77fabbbe514d4f",
+        "checksum": "adler32:77344a1b",
         "description": "DoubleElectron AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:defa30235dc08279b500e638556e5d83f962360a",
+        "checksum": "adler32:404949de",
         "description": "DoubleElectron AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20011_file_index.json"
       },
       {
-        "checksum": "sha1:9a4dcb65e4a4063befad780e69c4cbc2994f6561",
+        "checksum": "adler32:b8035120",
         "description": "DoubleElectron AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
         "size": 138864,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:7d7e89b65575a93a92a1df9e451c1956d58a9c55",
+        "checksum": "adler32:c77e597f",
         "description": "DoubleElectron AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
         "size": 132000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:4228c1ee18182171a2c1217e201dfe9f3663533e",
+        "checksum": "adler32:f4e219ce",
         "description": "DoubleElectron AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
         "size": 44220,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:aa85e51c32e8ac8c0703211e0d4922502335f075",
+        "checksum": "adler32:38cb271c",
         "description": "DoubleElectron AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleElectron_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:357b2a5c0c423ad29e478299fc339f84925ab593",
+        "checksum": "adler32:33ee270b",
         "description": "DoubleElectron AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
@@ -788,182 +788,182 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:70412c223a8d3637876a499fc483624349a54a37",
+        "checksum": "adler32:cffaa217",
         "description": "DoubleMuParked AOD dataset file index (1 of 13) for access to data via CMS virtual machine",
         "size": 279560,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:9af8f6396a78d3829f5d0fef76fde459d910aa3f",
+        "checksum": "adler32:3523fd2b",
         "description": "DoubleMuParked AOD dataset file index (2 of 13) for access to data via CMS virtual machine",
         "size": 279002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:f750b5d52c7e19b3a596bf361a96e80564f74b43",
+        "checksum": "adler32:18236427",
         "description": "DoubleMuParked AOD dataset file index (3 of 13) for access to data via CMS virtual machine",
         "size": 144245,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10002_file_index.json"
       },
       {
-        "checksum": "sha1:79617391212de40148d8324f4436a90974c87d26",
+        "checksum": "adler32:1d6849af",
         "description": "DoubleMuParked AOD dataset file index (4 of 13) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10003_file_index.json"
       },
       {
-        "checksum": "sha1:35e93f6289cf113e8814ee50948dc5a45908c499",
+        "checksum": "adler32:1d1d49c4",
         "description": "DoubleMuParked AOD dataset file index (5 of 13) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10010_file_index.json"
       },
       {
-        "checksum": "sha1:894d3e82c3a880c942d6d598e178fc17c5b64ceb",
+        "checksum": "adler32:5e9edcb6",
         "description": "DoubleMuParked AOD dataset file index (6 of 13) for access to data via CMS virtual machine",
         "size": 839,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10011_file_index.json"
       },
       {
-        "checksum": "sha1:927e2dd5d5e2b14faac07024a68eaf87f2cf161b",
+        "checksum": "adler32:1bf34994",
         "description": "DoubleMuParked AOD dataset file index (7 of 13) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10013_file_index.json"
       },
       {
-        "checksum": "sha1:0684d38e32d976f65934a6d125db4519c1d89688",
+        "checksum": "adler32:4f1f49f3",
         "description": "DoubleMuParked AOD dataset file index (8 of 13) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10016_file_index.json"
       },
       {
-        "checksum": "sha1:6b70aa3198220734c9ad0bed3c6e22d27621f905",
+        "checksum": "adler32:35a849f9",
         "description": "DoubleMuParked AOD dataset file index (9 of 13) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10018_file_index.json"
       },
       {
-        "checksum": "sha1:55166b3f0ec26941f04d651ad7c88faa25ecf86c",
+        "checksum": "adler32:2249256e",
         "description": "DoubleMuParked AOD dataset file index (10 of 13) for access to data via CMS virtual machine",
         "size": 1118,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10021_file_index.json"
       },
       {
-        "checksum": "sha1:289765662ee80460a3eba4a7ca71ceba03941d24",
+        "checksum": "adler32:40bd49e9",
         "description": "DoubleMuParked AOD dataset file index (11 of 13) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10022_file_index.json"
       },
       {
-        "checksum": "sha1:1aeae857858ae9b76cc432b6058af429f6eb984f",
+        "checksum": "adler32:8a3f93db",
         "description": "DoubleMuParked AOD dataset file index (12 of 13) for access to data via CMS virtual machine",
         "size": 560,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10024_file_index.json"
       },
       {
-        "checksum": "sha1:fac31f021db539ff78a385fe17c16c9d857baab8",
+        "checksum": "adler32:de039dc4",
         "description": "DoubleMuParked AOD dataset file index (13 of 13) for access to data via CMS virtual machine",
         "size": 107696,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:dc808c84f1b0e417834e42bb76ca9d327e05e76c",
+        "checksum": "adler32:3abbc7e0",
         "description": "DoubleMuParked AOD dataset file index (1 of 13) for access to data via CMS virtual machine",
         "size": 132264,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:faf4ca78be099646de16afe6f2b925d46080f792",
+        "checksum": "adler32:22287354",
         "description": "DoubleMuParked AOD dataset file index (2 of 13) for access to data via CMS virtual machine",
         "size": 132000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:90064eae55becae580ad806e09f4d224ad7b076a",
+        "checksum": "adler32:4b06d544",
         "description": "DoubleMuParked AOD dataset file index (3 of 13) for access to data via CMS virtual machine",
         "size": 68244,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10002_file_index.txt"
       },
       {
-        "checksum": "sha1:cf02465b253f47775dd6faf9e3ea258aaaf5b087",
+        "checksum": "adler32:2c5526f1",
         "description": "DoubleMuParked AOD dataset file index (4 of 13) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10003_file_index.txt"
       },
       {
-        "checksum": "sha1:56581c2499251b326c6e777dba7a3984692f9263",
+        "checksum": "adler32:2cb22709",
         "description": "DoubleMuParked AOD dataset file index (5 of 13) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10010_file_index.txt"
       },
       {
-        "checksum": "sha1:a16ff0d1efc12526afa6562413e8db109e2e2b72",
+        "checksum": "adler32:efbf74ed",
         "description": "DoubleMuParked AOD dataset file index (6 of 13) for access to data via CMS virtual machine",
         "size": 396,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10011_file_index.txt"
       },
       {
-        "checksum": "sha1:b90bd07cf361427847b97a5ab295bec882a0dd78",
+        "checksum": "adler32:2a4b26e0",
         "description": "DoubleMuParked AOD dataset file index (7 of 13) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10013_file_index.txt"
       },
       {
-        "checksum": "sha1:bee7b9c3f39dc502a4c1f91bbf27600a6e973036",
+        "checksum": "adler32:2dc72706",
         "description": "DoubleMuParked AOD dataset file index (8 of 13) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10016_file_index.txt"
       },
       {
-        "checksum": "sha1:391341f9ca2ed863abb6ad9b34d65761a5780445",
+        "checksum": "adler32:30d72726",
         "description": "DoubleMuParked AOD dataset file index (9 of 13) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10018_file_index.txt"
       },
       {
-        "checksum": "sha1:de32f67bfe6d38347590e325ded83cad393327b4",
+        "checksum": "adler32:ffc89be0",
         "description": "DoubleMuParked AOD dataset file index (10 of 13) for access to data via CMS virtual machine",
         "size": 528,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10021_file_index.txt"
       },
       {
-        "checksum": "sha1:2eb230cb5df042dbc7a326d1fb12f4a5196ac9c1",
+        "checksum": "adler32:32ad2710",
         "description": "DoubleMuParked AOD dataset file index (11 of 13) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10022_file_index.txt"
       },
       {
-        "checksum": "sha1:6ffba6148e86fc5d05bcdc50a8e3e4b00368494a",
+        "checksum": "adler32:8cab4e0a",
         "description": "DoubleMuParked AOD dataset file index (12 of 13) for access to data via CMS virtual machine",
         "size": 264,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoubleMuParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoubleMuParked_AOD_22Jan2013-v1_10024_file_index.txt"
       },
       {
-        "checksum": "sha1:14e062c5dbd239423d2eaf1cfbfb780d1868a967",
+        "checksum": "adler32:e286c723",
         "description": "DoubleMuParked AOD dataset file index (13 of 13) for access to data via CMS virtual machine",
         "size": 50952,
         "type": "index.txt",
@@ -1063,154 +1063,154 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c6e3a8ea7c5f01620cf0d104521f35f4c863f008",
+        "checksum": "adler32:00a9e3d4",
         "description": "DoublePhoton AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
         "size": 97783,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_20000_file_index.json"
       },
       {
-        "checksum": "sha1:9e554b95798b7df955cc70c1ed2d87920a253897",
+        "checksum": "adler32:0a8579fa",
         "description": "DoublePhoton AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
         "size": 277278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30000_file_index.json"
       },
       {
-        "checksum": "sha1:c19a08c97f4d188d747bff0289b89d703c06d173",
+        "checksum": "adler32:1bdbf9d9",
         "description": "DoublePhoton AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
         "size": 277002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30001_file_index.json"
       },
       {
-        "checksum": "sha1:f87949dafc731a9789f7f7bac2e3429211fded28",
+        "checksum": "adler32:e416fb6a",
         "description": "DoublePhoton AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
         "size": 98891,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30002_file_index.json"
       },
       {
-        "checksum": "sha1:c43370701d3bde6ebccf0b57ee51834f5a040246",
+        "checksum": "adler32:acb4493d",
         "description": "DoublePhoton AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30004_file_index.json"
       },
       {
-        "checksum": "sha1:55759b6a0a620098883fc617afe557400921787e",
+        "checksum": "adler32:8ba54901",
         "description": "DoublePhoton AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30007_file_index.json"
       },
       {
-        "checksum": "sha1:9af8e43beff5d76083878a9e2901f76673008896",
+        "checksum": "adler32:27134888",
         "description": "DoublePhoton AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30009_file_index.json"
       },
       {
-        "checksum": "sha1:72eed27b170348089d66df9a86849f59fda06663",
+        "checksum": "adler32:3d5b91f6",
         "description": "DoublePhoton AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
         "size": 556,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30019_file_index.json"
       },
       {
-        "checksum": "sha1:1398e24cc7f7e28a29ed1f5054af5e8827423b75",
+        "checksum": "adler32:aefb494f",
         "description": "DoublePhoton AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30020_file_index.json"
       },
       {
-        "checksum": "sha1:b0a4f176491ad0861ff2887b7b1d0258f6c8cd3b",
+        "checksum": "adler32:8d4548f5",
         "description": "DoublePhoton AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30023_file_index.json"
       },
       {
-        "checksum": "sha1:e2b2f137caedc6cf500e32a19c2c1c5a52dc39ce",
+        "checksum": "adler32:de324947",
         "description": "DoublePhoton AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30028_file_index.json"
       },
       {
-        "checksum": "sha1:f4823cf61827444369d6351276e47244ef9319ac",
+        "checksum": "adler32:aeb3ae97",
         "description": "DoublePhoton AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
         "size": 45890,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:ff81f2a3a960cb1c03027f80d3386ec1358d981a",
+        "checksum": "adler32:ad447b71",
         "description": "DoublePhoton AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
         "size": 130130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:613c11ced65e41b1bbac6c510f76c14eeaa08d59",
+        "checksum": "adler32:6f3f4170",
         "description": "DoublePhoton AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
         "size": 130000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:bed214546b366291d30a25ccc2fd282ec48e12dd",
+        "checksum": "adler32:8e8d4562",
         "description": "DoublePhoton AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
         "size": 46410,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30002_file_index.txt"
       },
       {
-        "checksum": "sha1:5caea083c7394073c22a0b79cc025cced9b2500d",
+        "checksum": "adler32:d6682657",
         "description": "DoublePhoton AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30004_file_index.txt"
       },
       {
-        "checksum": "sha1:465b5279972158eda0a9a91b9ca0ec4d0ff4ba24",
+        "checksum": "adler32:d5e32644",
         "description": "DoublePhoton AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30007_file_index.txt"
       },
       {
-        "checksum": "sha1:fc3fa562f94bba17822778e2ca9d1fc8be4ce7ad",
+        "checksum": "adler32:d26c2630",
         "description": "DoublePhoton AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30009_file_index.txt"
       },
       {
-        "checksum": "sha1:678e874363e45743d9e4038b432172af5d07bfb3",
+        "checksum": "adler32:31d14cbe",
         "description": "DoublePhoton AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
         "size": 260,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30019_file_index.txt"
       },
       {
-        "checksum": "sha1:ac5474a0b3beaa15d9deb952cf56fcef9ad62dc5",
+        "checksum": "adler32:d6d02665",
         "description": "DoublePhoton AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30020_file_index.txt"
       },
       {
-        "checksum": "sha1:f2dbdc1e08fc0a2333ca4cf753b8ac51c264a3af",
+        "checksum": "adler32:d4e62631",
         "description": "DoublePhoton AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhoton/AOD/22Jan2013-v2/file-indexes/CMS_Run2012C_DoublePhoton_AOD_22Jan2013-v2_30023_file_index.txt"
       },
       {
-        "checksum": "sha1:03292fde22b9c590f2c8b8e03ccf997d035c69a3",
+        "checksum": "adler32:d9bb2640",
         "description": "DoublePhoton AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
@@ -1310,28 +1310,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:53fb661eb8e1bd575995974bf876921faae75d5f",
+        "checksum": "adler32:a27fd8f0",
         "description": "DoublePhotonHighPt AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 153105,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoublePhotonHighPt_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:010cadedd848b0553f5b94ce1f1586cc341dda8b",
+        "checksum": "adler32:335c0fa3",
         "description": "DoublePhotonHighPt AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 269984,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoublePhotonHighPt_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:cdda5039ad473d79cf1e6a13a3f565f1e497b5e0",
+        "checksum": "adler32:c24bfd46",
         "description": "DoublePhotonHighPt AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 73576,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/DoublePhotonHighPt/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_DoublePhotonHighPt_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:92822cdeea5b632b02422e66d312d1e2af1d2fd4",
+        "checksum": "adler32:c114a38a",
         "description": "DoublePhotonHighPt AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 129744,
         "type": "index.txt",
@@ -1431,84 +1431,84 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9483079d4b9705c8339e77c6cc8dbcd81aeac3d5",
+        "checksum": "adler32:18dc6899",
         "description": "ElectronHad AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
         "size": 283454,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:0b43505d59ecbb913982a7528e0f1e21123b4a2f",
+        "checksum": "adler32:ebd24e2f",
         "description": "ElectronHad AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
         "size": 162290,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:b0430c9c1166cd2325855384a0615a1a84a340c3",
+        "checksum": "adler32:c49547f8",
         "description": "ElectronHad AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10002_file_index.json"
       },
       {
-        "checksum": "sha1:c4021dc0440336f8f7dd34bfda8630dc360baee2",
+        "checksum": "adler32:bfcd4921",
         "description": "ElectronHad AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10004_file_index.json"
       },
       {
-        "checksum": "sha1:b64929e55abe0d1109a57554f7fb067f561eab40",
+        "checksum": "adler32:00a3487e",
         "description": "ElectronHad AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10011_file_index.json"
       },
       {
-        "checksum": "sha1:7a7c7670fd3434174da529803550a163354e95ed",
+        "checksum": "adler32:b940493a",
         "description": "ElectronHad AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10014_file_index.json"
       },
       {
-        "checksum": "sha1:d1dce61fa4023eae86e0253335882d264d03fba3",
+        "checksum": "adler32:6ace13cc",
         "description": "ElectronHad AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
         "size": 132483,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:5f219d68b30389eec2666f261d31e0556a57e731",
+        "checksum": "adler32:67c790d5",
         "description": "ElectronHad AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
         "size": 75852,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:29d5d847ebc3e2a7fe0653f56c8cb1f9445935e7",
+        "checksum": "adler32:9a0125ab",
         "description": "ElectronHad AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10002_file_index.txt"
       },
       {
-        "checksum": "sha1:36fc95175fe58588db9841dab53ef126f48d5f1e",
+        "checksum": "adler32:97aa25ba",
         "description": "ElectronHad AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10004_file_index.txt"
       },
       {
-        "checksum": "sha1:e6c6273fc7c3703f93a9bd0613515f5eef6408bb",
+        "checksum": "adler32:9d9625e7",
         "description": "ElectronHad AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/ElectronHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_ElectronHad_AOD_22Jan2013-v1_10011_file_index.txt"
       },
       {
-        "checksum": "sha1:81b76b6135f1cc3734079a42d1f73cb8d29e9ed7",
+        "checksum": "adler32:a2ea25e8",
         "description": "ElectronHad AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
@@ -1608,378 +1608,378 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1086c34d1376bd7867dae12e35bd2a394ef5be1c",
+        "checksum": "adler32:6ab706ca",
         "description": "HTMHTParked AOD dataset file index (1 of 27) for access to data via CMS virtual machine",
         "size": 288145,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:dfd8f2012dc1c296694422c07d9adfaf9e9e7a1a",
+        "checksum": "adler32:b1c72681",
         "description": "HTMHTParked AOD dataset file index (2 of 27) for access to data via CMS virtual machine",
         "size": 274898,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:e73dcfc53ec9491a97ca9c01f09c6a99617710c0",
+        "checksum": "adler32:ccffd445",
         "description": "HTMHTParked AOD dataset file index (3 of 27) for access to data via CMS virtual machine",
         "size": 125306,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:517fc6391f44c7c8d72f83ced81332ffe7b6b70c",
+        "checksum": "adler32:764348c1",
         "description": "HTMHTParked AOD dataset file index (4 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:3ed05521cfe93acc2d3c69680ad24fa7452c2114",
+        "checksum": "adler32:711e48b5",
         "description": "HTMHTParked AOD dataset file index (5 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20004_file_index.json"
       },
       {
-        "checksum": "sha1:f6292a596f4040c6bf1c3c5b5298db7a647ce8cf",
+        "checksum": "adler32:843e474d",
         "description": "HTMHTParked AOD dataset file index (6 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20005_file_index.json"
       },
       {
-        "checksum": "sha1:626ec6b546c13335ec855dede57a09c08d7277cc",
+        "checksum": "adler32:bcaed614",
         "description": "HTMHTParked AOD dataset file index (7 of 27) for access to data via CMS virtual machine",
         "size": 830,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20008_file_index.json"
       },
       {
-        "checksum": "sha1:031b57715379c93e4d87a85ac3881aecaa63bb74",
+        "checksum": "adler32:0272480c",
         "description": "HTMHTParked AOD dataset file index (8 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20009_file_index.json"
       },
       {
-        "checksum": "sha1:53b8671b943ba3d1e7ebe973d1527ebdd902ef22",
+        "checksum": "adler32:30be4855",
         "description": "HTMHTParked AOD dataset file index (9 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20011_file_index.json"
       },
       {
-        "checksum": "sha1:6e8f120be6a617f05abdc3e9238b60e04265fc96",
+        "checksum": "adler32:130a480d",
         "description": "HTMHTParked AOD dataset file index (10 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20016_file_index.json"
       },
       {
-        "checksum": "sha1:d3d3185ded3580ae72b933f251c60da0170771dd",
+        "checksum": "adler32:53a14874",
         "description": "HTMHTParked AOD dataset file index (11 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20019_file_index.json"
       },
       {
-        "checksum": "sha1:75d80d16425576217bf65d4830f951d951fe5717",
+        "checksum": "adler32:9f449002",
         "description": "HTMHTParked AOD dataset file index (12 of 27) for access to data via CMS virtual machine",
         "size": 554,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20020_file_index.json"
       },
       {
-        "checksum": "sha1:6530da1914a17ec62adacd20a2066b3c2831aff9",
+        "checksum": "adler32:1bff4821",
         "description": "HTMHTParked AOD dataset file index (13 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20021_file_index.json"
       },
       {
-        "checksum": "sha1:f2abf5fc441167e95e6af37b180008b6c44a6983",
+        "checksum": "adler32:fb8808ac",
         "description": "HTMHTParked AOD dataset file index (14 of 27) for access to data via CMS virtual machine",
         "size": 4970,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20022_file_index.json"
       },
       {
-        "checksum": "sha1:36952388af1d84ca16bea2e170c7e5e696c2ab1c",
+        "checksum": "adler32:27faa4f5",
         "description": "HTMHTParked AOD dataset file index (15 of 27) for access to data via CMS virtual machine",
         "size": 3603,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_210000_file_index.json"
       },
       {
-        "checksum": "sha1:794d77c72fc35271ad57c44e5f9fb7b3e0b01758",
+        "checksum": "adler32:031e9d85",
         "description": "HTMHTParked AOD dataset file index (16 of 27) for access to data via CMS virtual machine",
         "size": 275174,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:ac23acce2e43d4fc03ee1cffc47b34d9eaff41c0",
+        "checksum": "adler32:e69f7545",
         "description": "HTMHTParked AOD dataset file index (17 of 27) for access to data via CMS virtual machine",
         "size": 276002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:12872a4079ae92613e8bc255a55cf62a20348b9f",
+        "checksum": "adler32:9dfff5e5",
         "description": "HTMHTParked AOD dataset file index (18 of 27) for access to data via CMS virtual machine",
         "size": 224390,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:964348477fa067a24f03d216548cdb54b6fd2849",
+        "checksum": "adler32:501b4871",
         "description": "HTMHTParked AOD dataset file index (19 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30003_file_index.json"
       },
       {
-        "checksum": "sha1:bc7f1cdf660f8a84b030dd80450c74ef450dbbff",
+        "checksum": "adler32:04f347fa",
         "description": "HTMHTParked AOD dataset file index (20 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30007_file_index.json"
       },
       {
-        "checksum": "sha1:de9bbf8db796a19070b89521e24c0ea9ba8f6eb3",
+        "checksum": "adler32:94fe8f02",
         "description": "HTMHTParked AOD dataset file index (21 of 27) for access to data via CMS virtual machine",
         "size": 554,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30009_file_index.json"
       },
       {
-        "checksum": "sha1:945f619917daefb730f4667e0f6c4db9405c8474",
+        "checksum": "adler32:65ca485e",
         "description": "HTMHTParked AOD dataset file index (22 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30010_file_index.json"
       },
       {
-        "checksum": "sha1:71db905fbe862f70097e909446b7d9c9e1872c1d",
+        "checksum": "adler32:4bfa484b",
         "description": "HTMHTParked AOD dataset file index (23 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30013_file_index.json"
       },
       {
-        "checksum": "sha1:eefd3d161ea6bfee82490719700b46f584184004",
+        "checksum": "adler32:5eac485a",
         "description": "HTMHTParked AOD dataset file index (24 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30015_file_index.json"
       },
       {
-        "checksum": "sha1:21ce98cd2df3cbeaba25b82ac169bec074a1ff9f",
+        "checksum": "adler32:ee728f4e",
         "description": "HTMHTParked AOD dataset file index (25 of 27) for access to data via CMS virtual machine",
         "size": 554,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30018_file_index.json"
       },
       {
-        "checksum": "sha1:2b2a561e4c58e5dc345f30d7f0581b4bb6467f56",
+        "checksum": "adler32:85298f7f",
         "description": "HTMHTParked AOD dataset file index (26 of 27) for access to data via CMS virtual machine",
         "size": 554,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30019_file_index.json"
       },
       {
-        "checksum": "sha1:2be6d329dfef344efc06ec874c37b1da1b6b0066",
+        "checksum": "adler32:6165488a",
         "description": "HTMHTParked AOD dataset file index (27 of 27) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30028_file_index.json"
       },
       {
-        "checksum": "sha1:7e5907eb6b005d5ed31d31f35b5f2a44c54d680a",
+        "checksum": "adler32:20961a39",
         "description": "HTMHTParked AOD dataset file index (1 of 27) for access to data via CMS virtual machine",
         "size": 134676,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:1d0be6b91d814e245cf490d85a2746d5b568d676",
+        "checksum": "adler32:cd4ce826",
         "description": "HTMHTParked AOD dataset file index (2 of 27) for access to data via CMS virtual machine",
         "size": 128484,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:b2c18282d8d5b394200a89c4f7d14c114cad33a3",
+        "checksum": "adler32:61b4138e",
         "description": "HTMHTParked AOD dataset file index (3 of 27) for access to data via CMS virtual machine",
         "size": 58566,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:8852020b281ff8ef9e04f4e4aa38feb0e925d995",
+        "checksum": "adler32:80a8258b",
         "description": "HTMHTParked AOD dataset file index (4 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:f6e1e0c8dfb9c82b9ebe6aedd758d5190194c46a",
+        "checksum": "adler32:7c5a2579",
         "description": "HTMHTParked AOD dataset file index (5 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20004_file_index.txt"
       },
       {
-        "checksum": "sha1:fab60be7606640fb4f6f33a0921ae0f802010405",
+        "checksum": "adler32:75d32519",
         "description": "HTMHTParked AOD dataset file index (6 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20005_file_index.txt"
       },
       {
-        "checksum": "sha1:71522690b918ea5352d0ae7d187cd9a78b69f772",
+        "checksum": "adler32:debc6fdf",
         "description": "HTMHTParked AOD dataset file index (7 of 27) for access to data via CMS virtual machine",
         "size": 387,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20008_file_index.txt"
       },
       {
-        "checksum": "sha1:c79f704c6b00e7a59d4cc07d0007bf6fc96ba075",
+        "checksum": "adler32:7c512556",
         "description": "HTMHTParked AOD dataset file index (8 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20009_file_index.txt"
       },
       {
-        "checksum": "sha1:bf7f663b196cfc150f3848368ce805ab7944309e",
+        "checksum": "adler32:7cab2567",
         "description": "HTMHTParked AOD dataset file index (9 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20011_file_index.txt"
       },
       {
-        "checksum": "sha1:40569b0715d6f2124c451bccde94c03f744411f6",
+        "checksum": "adler32:79042541",
         "description": "HTMHTParked AOD dataset file index (10 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20016_file_index.txt"
       },
       {
-        "checksum": "sha1:ec858de2ae3a84fcd915c16c38a8939652448c60",
+        "checksum": "adler32:7fba256a",
         "description": "HTMHTParked AOD dataset file index (11 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20019_file_index.txt"
       },
       {
-        "checksum": "sha1:817bc2aefb1caebb27d3cc56cec3e6df83f269be",
+        "checksum": "adler32:bda54ac3",
         "description": "HTMHTParked AOD dataset file index (12 of 27) for access to data via CMS virtual machine",
         "size": 258,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20020_file_index.txt"
       },
       {
-        "checksum": "sha1:b5c01b4560eab91ecda781dc22f9f74dfde81b69",
+        "checksum": "adler32:7f6c2557",
         "description": "HTMHTParked AOD dataset file index (13 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20021_file_index.txt"
       },
       {
-        "checksum": "sha1:cd579d75184fce23e618b6f7b3332042997be2f2",
+        "checksum": "adler32:e20e9fe8",
         "description": "HTMHTParked AOD dataset file index (14 of 27) for access to data via CMS virtual machine",
         "size": 2322,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_20022_file_index.txt"
       },
       {
-        "checksum": "sha1:1091ad8278045245154a841126b50a6f06192e39",
+        "checksum": "adler32:fc04e7b3",
         "description": "HTMHTParked AOD dataset file index (15 of 27) for access to data via CMS virtual machine",
         "size": 1690,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_210000_file_index.txt"
       },
       {
-        "checksum": "sha1:e99b3317f390756af187eb44b84359fd24e07eb8",
+        "checksum": "adler32:9dbf1e2d",
         "description": "HTMHTParked AOD dataset file index (16 of 27) for access to data via CMS virtual machine",
         "size": 128613,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:3ba6d2f9ee60347fdd5645e042aa99bf8dbaf46b",
+        "checksum": "adler32:329c9395",
         "description": "HTMHTParked AOD dataset file index (17 of 27) for access to data via CMS virtual machine",
         "size": 129000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:ef8d6424442955e82cc909601bb3bc6087220e41",
+        "checksum": "adler32:8c814007",
         "description": "HTMHTParked AOD dataset file index (18 of 27) for access to data via CMS virtual machine",
         "size": 104877,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30002_file_index.txt"
       },
       {
-        "checksum": "sha1:d169500414bdfbe24535393dc513f159b656ee2d",
+        "checksum": "adler32:7ac32561",
         "description": "HTMHTParked AOD dataset file index (19 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30003_file_index.txt"
       },
       {
-        "checksum": "sha1:5f1ebfc92ff67a543393ecce4163cb1362269885",
+        "checksum": "adler32:79ae2542",
         "description": "HTMHTParked AOD dataset file index (20 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30007_file_index.txt"
       },
       {
-        "checksum": "sha1:edac3316a4af3c92aa8931ece9a9f164e57db49e",
+        "checksum": "adler32:95774a21",
         "description": "HTMHTParked AOD dataset file index (21 of 27) for access to data via CMS virtual machine",
         "size": 258,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30009_file_index.txt"
       },
       {
-        "checksum": "sha1:8c2eb2c6e960c3eeac189c951945f889a6b2d560",
+        "checksum": "adler32:7cb72546",
         "description": "HTMHTParked AOD dataset file index (22 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30010_file_index.txt"
       },
       {
-        "checksum": "sha1:450c4b565afa79f341ba3f6e945dcfb43b648ab3",
+        "checksum": "adler32:7bb82546",
         "description": "HTMHTParked AOD dataset file index (23 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30013_file_index.txt"
       },
       {
-        "checksum": "sha1:3b47fe4476248f9bab62bb676c50f0770d1b9fd2",
+        "checksum": "adler32:7b9e2548",
         "description": "HTMHTParked AOD dataset file index (24 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30015_file_index.txt"
       },
       {
-        "checksum": "sha1:0d2261ce5a675f32f98ca0e08300d32000aa0a02",
+        "checksum": "adler32:c78d4a8b",
         "description": "HTMHTParked AOD dataset file index (25 of 27) for access to data via CMS virtual machine",
         "size": 258,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30018_file_index.txt"
       },
       {
-        "checksum": "sha1:a0c5f878e4da1837c622d1a5d898b0a891551e78",
+        "checksum": "adler32:c0344a8f",
         "description": "HTMHTParked AOD dataset file index (26 of 27) for access to data via CMS virtual machine",
         "size": 258,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HTMHTParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HTMHTParked_AOD_22Jan2013-v1_30019_file_index.txt"
       },
       {
-        "checksum": "sha1:ff511c50080cf42a47225f0521b64ed127b265be",
+        "checksum": "adler32:7fda2572",
         "description": "HTMHTParked AOD dataset file index (27 of 27) for access to data via CMS virtual machine",
         "size": 129,
         "type": "index.txt",
@@ -2079,14 +2079,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:db9006837969a88bf06462df5d26a1945d3e23eb",
+        "checksum": "adler32:44e5f0a7",
         "description": "HcalNZS AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 30738,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/HcalNZS/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_HcalNZS_AOD_22Jan2013-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:0101fbd40dc58b24bf761a9564cf17ba51c0f1e7",
+        "checksum": "adler32:a699d1c0",
         "description": "HcalNZS AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 14125,
         "type": "index.txt",
@@ -2186,168 +2186,168 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cefa1412f85f423d4b569cb0630fb5174a320988",
+        "checksum": "adler32:85cac668",
         "description": "JetHT AOD dataset file index (1 of 12) for access to data via CMS virtual machine",
         "size": 269462,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:aaaba812349c0e561081b4603155c34987148246",
+        "checksum": "adler32:6436233c",
         "description": "JetHT AOD dataset file index (2 of 12) for access to data via CMS virtual machine",
         "size": 269732,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:2aae691d5f3fef3a0d3edc2568f9b16c7d83efd3",
+        "checksum": "adler32:cfa85be7",
         "description": "JetHT AOD dataset file index (3 of 12) for access to data via CMS virtual machine",
         "size": 48062,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:2b195896c48d92933448673103c9496d2f2147b9",
+        "checksum": "adler32:0df88ae1",
         "description": "JetHT AOD dataset file index (4 of 12) for access to data via CMS virtual machine",
         "size": 542,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20005_file_index.json"
       },
       {
-        "checksum": "sha1:1c33db5c50a328fe871d0e6a0bab774246a7652b",
+        "checksum": "adler32:cdcc4576",
         "description": "JetHT AOD dataset file index (5 of 12) for access to data via CMS virtual machine",
         "size": 272,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20007_file_index.json"
       },
       {
-        "checksum": "sha1:557c29102d9b2b0d5dfe45539a72a812d78362c1",
+        "checksum": "adler32:ff20a053",
         "description": "JetHT AOD dataset file index (6 of 12) for access to data via CMS virtual machine",
         "size": 1622,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20008_file_index.json"
       },
       {
-        "checksum": "sha1:6263dc74edb3b42315ed29555af42b6ab3f2972b",
+        "checksum": "adler32:c0a58b46",
         "description": "JetHT AOD dataset file index (7 of 12) for access to data via CMS virtual machine",
         "size": 542,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20010_file_index.json"
       },
       {
-        "checksum": "sha1:384e427af92ed4568a41aab3c98b8c16c442f895",
+        "checksum": "adler32:c2fb8b09",
         "description": "JetHT AOD dataset file index (8 of 12) for access to data via CMS virtual machine",
         "size": 542,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20014_file_index.json"
       },
       {
-        "checksum": "sha1:df1084d0dfc9211c48ba7f9a18a209ebe0a0cc51",
+        "checksum": "adler32:fbc4458e",
         "description": "JetHT AOD dataset file index (9 of 12) for access to data via CMS virtual machine",
         "size": 272,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20015_file_index.json"
       },
       {
-        "checksum": "sha1:3f9fe5dc1b27d8b085ed4f75d27eedcc53e87962",
+        "checksum": "adler32:21ad460a",
         "description": "JetHT AOD dataset file index (10 of 12) for access to data via CMS virtual machine",
         "size": 272,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20016_file_index.json"
       },
       {
-        "checksum": "sha1:1ca805b44cc8bb17202fe472839bdcc0682dffe2",
+        "checksum": "adler32:24e445e1",
         "description": "JetHT AOD dataset file index (11 of 12) for access to data via CMS virtual machine",
         "size": 272,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20018_file_index.json"
       },
       {
-        "checksum": "sha1:b88eb2cbab86234f02800434af11969b545674c8",
+        "checksum": "adler32:7f5928fa",
         "description": "JetHT AOD dataset file index (12 of 12) for access to data via CMS virtual machine",
         "size": 5132,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:97c8b1f79c57aa69469b8046c4f7b33705d264c8",
+        "checksum": "adler32:f4781960",
         "description": "JetHT AOD dataset file index (1 of 12) for access to data via CMS virtual machine",
         "size": 122754,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:45982a5bf09e302b9c8757a0ffeb8601050eae9b",
+        "checksum": "adler32:0718462d",
         "description": "JetHT AOD dataset file index (2 of 12) for access to data via CMS virtual machine",
         "size": 122877,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:3c34fcd1f75a76d49177562199a3f71c587f3ee9",
+        "checksum": "adler32:d9b978d5",
         "description": "JetHT AOD dataset file index (3 of 12) for access to data via CMS virtual machine",
         "size": 21894,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:1604a857ea33ee7d9be670913084b369f4c0c7c3",
+        "checksum": "adler32:be3c464a",
         "description": "JetHT AOD dataset file index (4 of 12) for access to data via CMS virtual machine",
         "size": 246,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20005_file_index.txt"
       },
       {
-        "checksum": "sha1:8fea91ed74eca1cfde13f3fe705108ca7870d1ea",
+        "checksum": "adler32:71a6231e",
         "description": "JetHT AOD dataset file index (5 of 12) for access to data via CMS virtual machine",
         "size": 123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20007_file_index.txt"
       },
       {
-        "checksum": "sha1:acce68027389354cf7ea3d31f0cf5149d499fa1a",
+        "checksum": "adler32:ccc1d24a",
         "description": "JetHT AOD dataset file index (6 of 12) for access to data via CMS virtual machine",
         "size": 738,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20008_file_index.txt"
       },
       {
-        "checksum": "sha1:e07d39ac875a056466e694ccc4325f5dedd5b14a",
+        "checksum": "adler32:cc914632",
         "description": "JetHT AOD dataset file index (7 of 12) for access to data via CMS virtual machine",
         "size": 246,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20010_file_index.txt"
       },
       {
-        "checksum": "sha1:ff185033ee025c939e975d3fd0d645695f0503a2",
+        "checksum": "adler32:ab07462d",
         "description": "JetHT AOD dataset file index (8 of 12) for access to data via CMS virtual machine",
         "size": 246,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20014_file_index.txt"
       },
       {
-        "checksum": "sha1:c72d50e5ef6f6aa840817e4f1a8e367f87142659",
+        "checksum": "adler32:6d7622fd",
         "description": "JetHT AOD dataset file index (9 of 12) for access to data via CMS virtual machine",
         "size": 123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20015_file_index.txt"
       },
       {
-        "checksum": "sha1:2c216665b0ccaf7b8ce3bf20b1cc10db11047e2d",
+        "checksum": "adler32:77c22359",
         "description": "JetHT AOD dataset file index (10 of 12) for access to data via CMS virtual machine",
         "size": 123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20016_file_index.txt"
       },
       {
-        "checksum": "sha1:511893499357b620bd66f6a5aca91a8b713b77da",
+        "checksum": "adler32:7388232e",
         "description": "JetHT AOD dataset file index (11 of 12) for access to data via CMS virtual machine",
         "size": 123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetHT/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetHT_AOD_22Jan2013-v1_20018_file_index.txt"
       },
       {
-        "checksum": "sha1:01b55194bf3e9a6b641815ed693ac65a4513f452",
+        "checksum": "adler32:14bd9cd3",
         "description": "JetHT AOD dataset file index (12 of 12) for access to data via CMS virtual machine",
         "size": 2337,
         "type": "index.txt",
@@ -2447,28 +2447,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e2564e74abb92537bf098e9005a5d29677ccd1b3",
+        "checksum": "adler32:98c8e3a7",
         "description": "JetMon AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 256639,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetMon_AOD_22Jan2013-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:9a8cd8bda56aff521e9f1feb05e0d3fa0990b6c6",
+        "checksum": "adler32:208de772",
         "description": "JetMon AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 1899,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetMon_AOD_22Jan2013-v1_110000_file_index.json"
       },
       {
-        "checksum": "sha1:d9d5ce9535420e59469f8ceba96e809fd74f1dba",
+        "checksum": "adler32:0c270f3f",
         "description": "JetMon AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 117428,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/JetMon/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_JetMon_AOD_22Jan2013-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:f3f2d2882466ac1007d1e0db2b75c0973d4e4705",
+        "checksum": "adler32:02f6fa4e",
         "description": "JetMon AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 875,
         "type": "index.txt",
@@ -2568,84 +2568,84 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:64d377d2a2d16eaad995909d0b7f122025a9156d",
+        "checksum": "adler32:0d6a92f6",
         "description": "MET AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
         "size": 272826,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:0303f5570d76fe6d9804470a5852e1384c4e0537",
+        "checksum": "adler32:c094a134",
         "description": "MET AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
         "size": 203682,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:5c8fdc636f6da2b78379038834726ce40b1a2b13",
+        "checksum": "adler32:395d449e",
         "description": "MET AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
         "size": 270,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10007_file_index.json"
       },
       {
-        "checksum": "sha1:71d3bf97370dced33828c80474f82fe984f5fdf2",
+        "checksum": "adler32:46c244b8",
         "description": "MET AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
         "size": 270,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10008_file_index.json"
       },
       {
-        "checksum": "sha1:21186fb77ac2d567aca7d909cc099f7f79e5eeb7",
+        "checksum": "adler32:877e8b0d",
         "description": "MET AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
         "size": 538,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10015_file_index.json"
       },
       {
-        "checksum": "sha1:449e6fac786d2ff5df2863dbc03b5d72851e217b",
+        "checksum": "adler32:b51b148c",
         "description": "MET AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
         "size": 1078,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_110000_file_index.json"
       },
       {
-        "checksum": "sha1:89b54453cc5414b892526a933c98654dfae1a8c5",
+        "checksum": "adler32:ef045528",
         "description": "MET AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
         "size": 123178,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:9aed61e1a50435c1a730136a4a237be63d8eb51e",
+        "checksum": "adler32:a8edda16",
         "description": "MET AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
         "size": 91960,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:7dd022083ba299d6df5618c6342bc32a0853fc98",
+        "checksum": "adler32:0ca3222f",
         "description": "MET AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
         "size": 121,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10007_file_index.txt"
       },
       {
-        "checksum": "sha1:75c17f2a5342a703b5941dabd80ceecba2903a38",
+        "checksum": "adler32:0fe62239",
         "description": "MET AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
         "size": 121,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10008_file_index.txt"
       },
       {
-        "checksum": "sha1:87ba26edd806ee09d4110a80f089b1c6af5d3b3a",
+        "checksum": "adler32:8f094510",
         "description": "MET AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
         "size": 242,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MET/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MET_AOD_22Jan2013-v1_10015_file_index.txt"
       },
       {
-        "checksum": "sha1:cbc1b44d882ced750e216aecdd47c8e178554415",
+        "checksum": "adler32:876a8a32",
         "description": "MET AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
         "size": 488,
         "type": "index.txt",
@@ -2745,28 +2745,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:004f313645b71a9f86107c8f04a46dbf90920153",
+        "checksum": "adler32:2e48cae1",
         "description": "MinimumBias AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 276001,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MinimumBias_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:24c6131f375cc044f36dafe1143d47de7a09266e",
+        "checksum": "adler32:8fdad531",
         "description": "MinimumBias AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 276001,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MinimumBias_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:72ea612056817d5da7428230a898ebba56e9116a",
+        "checksum": "adler32:8e16b312",
         "description": "MinimumBias AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 129000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MinimumBias/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MinimumBias_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:48f31c964d561ccba11a72e8611fe69e16fdcc3e",
+        "checksum": "adler32:8d8ab5a1",
         "description": "MinimumBias AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 129000,
         "type": "index.txt",
@@ -2866,84 +2866,84 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a28f89d4b4f05bee24cb8a0b18e20612382e5fd3",
+        "checksum": "adler32:676cbb42",
         "description": "MuEG AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
         "size": 268733,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:9cd0911421b909b1142468419b591ae535262abb",
+        "checksum": "adler32:8227dcea",
         "description": "MuEG AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
         "size": 205249,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:8cae9414f395be246469d28c117094d962877af2",
+        "checksum": "adler32:1bd14631",
         "description": "MuEG AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
         "size": 271,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:df392da0e4520908d10aa36748db93e2979a738d",
+        "checksum": "adler32:11a8463d",
         "description": "MuEG AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
         "size": 271,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20011_file_index.json"
       },
       {
-        "checksum": "sha1:f1bc20c0d384e8197a731c9d0d9a91b2a1034fb7",
+        "checksum": "adler32:30a345d7",
         "description": "MuEG AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
         "size": 271,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20013_file_index.json"
       },
       {
-        "checksum": "sha1:b01c2d717b3098b42e5a2ca5728f7846600f8594",
+        "checksum": "adler32:db59c38f",
         "description": "MuEG AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
         "size": 9686,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:f3eadd27f49ce99c93d2725107a0cc1b7028e988",
+        "checksum": "adler32:6ff93611",
         "description": "MuEG AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
         "size": 121878,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:6747d5317e1dfe656198741f17d66e5b916f390f",
+        "checksum": "adler32:147b1407",
         "description": "MuEG AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
         "size": 93086,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:b1473a21fc1ea28eccbbf66ed1349c6cf29d3a7b",
+        "checksum": "adler32:441a2316",
         "description": "MuEG AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
         "size": 122,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:f4231dbf91a4da0e293f9c4c7e9e39ecb6286932",
+        "checksum": "adler32:48dc232d",
         "description": "MuEG AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
         "size": 122,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20011_file_index.txt"
       },
       {
-        "checksum": "sha1:46dfaa3b49c9cf89d6ca1f1e4876ca56b36f44b2",
+        "checksum": "adler32:3e3122ad",
         "description": "MuEG AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
         "size": 122,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuEG/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuEG_AOD_22Jan2013-v1_20013_file_index.txt"
       },
       {
-        "checksum": "sha1:a20f67035faadecc805db01a8dfebd8cea104494",
+        "checksum": "adler32:fbbae7d6",
         "description": "MuEG AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
         "size": 4392,
         "type": "index.txt",
@@ -3043,126 +3043,126 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6e837544362a8132bf82d2c9346db2394879c99b",
+        "checksum": "adler32:d458de19",
         "description": "MuHad AOD dataset file index (1 of 9) for access to data via CMS virtual machine",
         "size": 96930,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:54d476d265458f857cc59b5ccc056cf31354b57e",
+        "checksum": "adler32:f07e801f",
         "description": "MuHad AOD dataset file index (2 of 9) for access to data via CMS virtual machine",
         "size": 270002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:f77d11e5da281303c1f583d6d4b387036ee510fb",
+        "checksum": "adler32:44cdfb76",
         "description": "MuHad AOD dataset file index (3 of 9) for access to data via CMS virtual machine",
         "size": 119882,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:4e568241843db01eb36a2c3f4db47d36387b5c16",
+        "checksum": "adler32:a9108c00",
         "description": "MuHad AOD dataset file index (4 of 9) for access to data via CMS virtual machine",
         "size": 542,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:7dec5b56f7f061dd42268e2328bdccc6c1430499",
+        "checksum": "adler32:be5b4718",
         "description": "MuHad AOD dataset file index (5 of 9) for access to data via CMS virtual machine",
         "size": 272,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30003_file_index.json"
       },
       {
-        "checksum": "sha1:b5c7149f6b867b9f1d0812a6b5cea8405beb8744",
+        "checksum": "adler32:2b708bec",
         "description": "MuHad AOD dataset file index (6 of 9) for access to data via CMS virtual machine",
         "size": 542,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30004_file_index.json"
       },
       {
-        "checksum": "sha1:6f011451a3c1ba9b06ef60a72cc8b25b56a99bd8",
+        "checksum": "adler32:5e46466f",
         "description": "MuHad AOD dataset file index (7 of 9) for access to data via CMS virtual machine",
         "size": 272,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30005_file_index.json"
       },
       {
-        "checksum": "sha1:a48b5ab355081a663cfee9b96e18013c6c0c46d4",
+        "checksum": "adler32:e8a545de",
         "description": "MuHad AOD dataset file index (8 of 9) for access to data via CMS virtual machine",
         "size": 272,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30007_file_index.json"
       },
       {
-        "checksum": "sha1:df1cd23d183693460e1d2b305d6240075159734e",
+        "checksum": "adler32:9f408ce4",
         "description": "MuHad AOD dataset file index (9 of 9) for access to data via CMS virtual machine",
         "size": 542,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30008_file_index.json"
       },
       {
-        "checksum": "sha1:e8fa372bb20d7c24e2c52bc1bec3c7a80350bfaa",
+        "checksum": "adler32:29849714",
         "description": "MuHad AOD dataset file index (1 of 9) for access to data via CMS virtual machine",
         "size": 44157,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:4dfcf3a80773fd8e9ead5e58f8f46f11870d7f56",
+        "checksum": "adler32:7c4712ec",
         "description": "MuHad AOD dataset file index (2 of 9) for access to data via CMS virtual machine",
         "size": 123000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:d6a674c7eee086835c4666707e4034deb33b6266",
+        "checksum": "adler32:70ef4f06",
         "description": "MuHad AOD dataset file index (3 of 9) for access to data via CMS virtual machine",
         "size": 54612,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:cd4c683927f4749549caa822edc30af04a0db0e9",
+        "checksum": "adler32:0d8f46d4",
         "description": "MuHad AOD dataset file index (4 of 9) for access to data via CMS virtual machine",
         "size": 246,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30002_file_index.txt"
       },
       {
-        "checksum": "sha1:dfc3cadd29139e81085ff9053ed63f23b1acc239",
+        "checksum": "adler32:7e4223af",
         "description": "MuHad AOD dataset file index (5 of 9) for access to data via CMS virtual machine",
         "size": 123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30003_file_index.txt"
       },
       {
-        "checksum": "sha1:2d1837d22ba8522edcd52eb96663ad73c2d9ccd6",
+        "checksum": "adler32:003c46cd",
         "description": "MuHad AOD dataset file index (6 of 9) for access to data via CMS virtual machine",
         "size": 246,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30004_file_index.txt"
       },
       {
-        "checksum": "sha1:cd98e9fbda6ac9ca8791d8962f3f6df769903359",
+        "checksum": "adler32:792e2376",
         "description": "MuHad AOD dataset file index (7 of 9) for access to data via CMS virtual machine",
         "size": 123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30005_file_index.txt"
       },
       {
-        "checksum": "sha1:98c234b82c23431ac94bc09d54a45ae40a45b4ae",
+        "checksum": "adler32:7ac02363",
         "description": "MuHad AOD dataset file index (8 of 9) for access to data via CMS virtual machine",
         "size": 123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuHad_AOD_22Jan2013-v1_30007_file_index.txt"
       },
       {
-        "checksum": "sha1:6465ff203a900f6a156c3341be5f680439d105bb",
+        "checksum": "adler32:20b2472e",
         "description": "MuHad AOD dataset file index (9 of 9) for access to data via CMS virtual machine",
         "size": 246,
         "type": "index.txt",
@@ -3262,252 +3262,252 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0100ba6ec965d7f3715b39987aae33a2de002c0f",
+        "checksum": "adler32:7780c31c",
         "description": "MuOnia AOD dataset file index (1 of 18) for access to data via CMS virtual machine",
         "size": 283197,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:54b18114b94ecd062a3173f044fccd632c6533b1",
+        "checksum": "adler32:8a81b078",
         "description": "MuOnia AOD dataset file index (2 of 18) for access to data via CMS virtual machine",
         "size": 271002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:a5ddc1853a83f17bc0803c7daa2840c8d6f446da",
+        "checksum": "adler32:ee313c37",
         "description": "MuOnia AOD dataset file index (3 of 18) for access to data via CMS virtual machine",
         "size": 271273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10002_file_index.json"
       },
       {
-        "checksum": "sha1:2051a9fbe58dd815054eab884621f8e27cfd984a",
+        "checksum": "adler32:5bd3e2c7",
         "description": "MuOnia AOD dataset file index (4 of 18) for access to data via CMS virtual machine",
         "size": 271002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10003_file_index.json"
       },
       {
-        "checksum": "sha1:8ff58faa84eac2b4a639dc2ea2efe19865881c22",
+        "checksum": "adler32:a39dfd5b",
         "description": "MuOnia AOD dataset file index (5 of 18) for access to data via CMS virtual machine",
         "size": 87263,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10004_file_index.json"
       },
       {
-        "checksum": "sha1:70c8d066333e553f11fdaa9eababe93f07a52c48",
+        "checksum": "adler32:9482464f",
         "description": "MuOnia AOD dataset file index (6 of 18) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10007_file_index.json"
       },
       {
-        "checksum": "sha1:fc729c045bc400bd425986c697d378d1354c00da",
+        "checksum": "adler32:6c384667",
         "description": "MuOnia AOD dataset file index (7 of 18) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10011_file_index.json"
       },
       {
-        "checksum": "sha1:bdf11d2365ac0ad80e0e7226f058a0ae48073898",
+        "checksum": "adler32:3718461c",
         "description": "MuOnia AOD dataset file index (8 of 18) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10016_file_index.json"
       },
       {
-        "checksum": "sha1:c98194e697250c2fe7c21df738f187bf4cc7a1a6",
+        "checksum": "adler32:a7514684",
         "description": "MuOnia AOD dataset file index (9 of 18) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10017_file_index.json"
       },
       {
-        "checksum": "sha1:05c02076bf3ec16733e9b852e2cbfd5226983a98",
+        "checksum": "adler32:e2778ca3",
         "description": "MuOnia AOD dataset file index (10 of 18) for access to data via CMS virtual machine",
         "size": 544,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10019_file_index.json"
       },
       {
-        "checksum": "sha1:34d73389af71dce5dd2765720ddb486b1432fb32",
+        "checksum": "adler32:e0a846be",
         "description": "MuOnia AOD dataset file index (11 of 18) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10024_file_index.json"
       },
       {
-        "checksum": "sha1:5f9de8f10428cf6e9bb8fdd36090efb6822f84b8",
+        "checksum": "adler32:d5eb46e0",
         "description": "MuOnia AOD dataset file index (12 of 18) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10027_file_index.json"
       },
       {
-        "checksum": "sha1:e903d74def5cde9adef4313c0335e913dfc80d6a",
+        "checksum": "adler32:86f74683",
         "description": "MuOnia AOD dataset file index (13 of 18) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10033_file_index.json"
       },
       {
-        "checksum": "sha1:9450a681418eb37a76232002a63892b0d4e27b3e",
+        "checksum": "adler32:2b7a4608",
         "description": "MuOnia AOD dataset file index (14 of 18) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10040_file_index.json"
       },
       {
-        "checksum": "sha1:b12779ca3e30b8e6204a7fe5f7c8a2f69dcc493e",
+        "checksum": "adler32:456f4649",
         "description": "MuOnia AOD dataset file index (15 of 18) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10049_file_index.json"
       },
       {
-        "checksum": "sha1:72fb7e730a447b3a910be594710db3d76981057c",
+        "checksum": "adler32:c65846c7",
         "description": "MuOnia AOD dataset file index (16 of 18) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10051_file_index.json"
       },
       {
-        "checksum": "sha1:a30596def71e83f7610be7b85563425afcfa57c1",
+        "checksum": "adler32:a361466f",
         "description": "MuOnia AOD dataset file index (17 of 18) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10053_file_index.json"
       },
       {
-        "checksum": "sha1:b20607f2786b9007cbe31127187f767baba57591",
+        "checksum": "adler32:5a03460a",
         "description": "MuOnia AOD dataset file index (18 of 18) for access to data via CMS virtual machine",
         "size": 273,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10055_file_index.json"
       },
       {
-        "checksum": "sha1:bb200246bc668519a227404c4cf9c13f13f2b2e3",
+        "checksum": "adler32:86c6c6ee",
         "description": "MuOnia AOD dataset file index (1 of 18) for access to data via CMS virtual machine",
         "size": 129580,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:ed653f396474b79af8d56407de99c460a3c9d17c",
+        "checksum": "adler32:54b4a302",
         "description": "MuOnia AOD dataset file index (2 of 18) for access to data via CMS virtual machine",
         "size": 124000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:19df02712894382ed30a51f2dde631c9c55bb5cf",
+        "checksum": "adler32:b8e6e73f",
         "description": "MuOnia AOD dataset file index (3 of 18) for access to data via CMS virtual machine",
         "size": 124124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10002_file_index.txt"
       },
       {
-        "checksum": "sha1:76531169284ae6addb3998dd0d5c49f7f289117a",
+        "checksum": "adler32:96a3bbdd",
         "description": "MuOnia AOD dataset file index (4 of 18) for access to data via CMS virtual machine",
         "size": 124000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10003_file_index.txt"
       },
       {
-        "checksum": "sha1:3d50c9e6c2ff05d9868a388a3a982e4edeb8219e",
+        "checksum": "adler32:3003e331",
         "description": "MuOnia AOD dataset file index (5 of 18) for access to data via CMS virtual machine",
         "size": 39928,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10004_file_index.txt"
       },
       {
-        "checksum": "sha1:40a4b32dddf539f1ba3b5fe294565faa1d46c138",
+        "checksum": "adler32:a7ee2386",
         "description": "MuOnia AOD dataset file index (6 of 18) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10007_file_index.txt"
       },
       {
-        "checksum": "sha1:06cc0eebe9756aec8af4f6cb79f8b2faeb54fd42",
+        "checksum": "adler32:a8fb23b8",
         "description": "MuOnia AOD dataset file index (7 of 18) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10011_file_index.txt"
       },
       {
-        "checksum": "sha1:98e64a2ef1d64895a1b07212af3dd19fb579fdb4",
+        "checksum": "adler32:acca23b6",
         "description": "MuOnia AOD dataset file index (8 of 18) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10016_file_index.txt"
       },
       {
-        "checksum": "sha1:0d71089df293642c2c9a5b02d6f1b5e5800abbd7",
+        "checksum": "adler32:a96e23a3",
         "description": "MuOnia AOD dataset file index (9 of 18) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10017_file_index.txt"
       },
       {
-        "checksum": "sha1:67afad1e80edaa325b199c53f81eb8dac8ba5e0a",
+        "checksum": "adler32:b4ce4780",
         "description": "MuOnia AOD dataset file index (10 of 18) for access to data via CMS virtual machine",
         "size": 248,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10019_file_index.txt"
       },
       {
-        "checksum": "sha1:c039cbf9cdc928423890a9cb99065d775c8bef74",
+        "checksum": "adler32:a88b239c",
         "description": "MuOnia AOD dataset file index (11 of 18) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10024_file_index.txt"
       },
       {
-        "checksum": "sha1:705bbdb04a1768caf2556ff485b8f4a64f8e2fa8",
+        "checksum": "adler32:ac3b23c9",
         "description": "MuOnia AOD dataset file index (12 of 18) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10027_file_index.txt"
       },
       {
-        "checksum": "sha1:a19e8f0a1c2422a1bb73161d03cd3d50f94988c6",
+        "checksum": "adler32:a76523b9",
         "description": "MuOnia AOD dataset file index (13 of 18) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10033_file_index.txt"
       },
       {
-        "checksum": "sha1:e8b7a15e3788d736885a5537c8b18a62b0c026bc",
+        "checksum": "adler32:ab6c23af",
         "description": "MuOnia AOD dataset file index (14 of 18) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10040_file_index.txt"
       },
       {
-        "checksum": "sha1:f98f287eea8bb867152640e63fdbea8c02797c65",
+        "checksum": "adler32:adcc23d2",
         "description": "MuOnia AOD dataset file index (15 of 18) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10049_file_index.txt"
       },
       {
-        "checksum": "sha1:026cf417dcf1d943050d7464ff286f2592a1b58a",
+        "checksum": "adler32:a7de23b8",
         "description": "MuOnia AOD dataset file index (16 of 18) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10051_file_index.txt"
       },
       {
-        "checksum": "sha1:9352f84519c6aa732e87e6a4e8f1caa329ad462a",
+        "checksum": "adler32:a8682391",
         "description": "MuOnia AOD dataset file index (17 of 18) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOnia/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOnia_AOD_22Jan2013-v1_10053_file_index.txt"
       },
       {
-        "checksum": "sha1:b30c01e3f2d0553dd4d77738daa78c71c17f67eb",
+        "checksum": "adler32:a45d2380",
         "description": "MuOnia AOD dataset file index (18 of 18) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
@@ -3607,714 +3607,714 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:54677e1e54d0d714835c804200ebb50536b71614",
+        "checksum": "adler32:3148dde8",
         "description": "MuOniaParked AOD dataset file index (1 of 51) for access to data via CMS virtual machine",
         "size": 366471,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:1684809d89ad5c7a78132b94e383382d7d9cc754",
+        "checksum": "adler32:6ae6c476",
         "description": "MuOniaParked AOD dataset file index (2 of 51) for access to data via CMS virtual machine",
         "size": 275063,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:5e1df510e05276b493d4e97c95f110119714203c",
+        "checksum": "adler32:401df50b",
         "description": "MuOniaParked AOD dataset file index (3 of 51) for access to data via CMS virtual machine",
         "size": 97783,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:4fa232d13ce39f703bdeb35594caf4fb2edbe8d4",
+        "checksum": "adler32:136d4815",
         "description": "MuOniaParked AOD dataset file index (4 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20004_file_index.json"
       },
       {
-        "checksum": "sha1:7c572c564df7dc3b573ce5762751fae328365592",
+        "checksum": "adler32:12599138",
         "description": "MuOniaParked AOD dataset file index (5 of 51) for access to data via CMS virtual machine",
         "size": 556,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20007_file_index.json"
       },
       {
-        "checksum": "sha1:118f3f2cd052f1a866323ce3bc18a6dd9be972cd",
+        "checksum": "adler32:8a039196",
         "description": "MuOniaParked AOD dataset file index (6 of 51) for access to data via CMS virtual machine",
         "size": 556,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20011_file_index.json"
       },
       {
-        "checksum": "sha1:b59cc0b2acd59a0bb2746713e400df3b154e9d9e",
+        "checksum": "adler32:464e9082",
         "description": "MuOniaParked AOD dataset file index (7 of 51) for access to data via CMS virtual machine",
         "size": 556,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20012_file_index.json"
       },
       {
-        "checksum": "sha1:471945c2c1979b9a8e120407cecf26958d5ff446",
+        "checksum": "adler32:55b8489c",
         "description": "MuOniaParked AOD dataset file index (8 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20013_file_index.json"
       },
       {
-        "checksum": "sha1:c46730f6fcd53343bc08ee35905d4279447e82f2",
+        "checksum": "adler32:db1adab4",
         "description": "MuOniaParked AOD dataset file index (9 of 51) for access to data via CMS virtual machine",
         "size": 833,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20014_file_index.json"
       },
       {
-        "checksum": "sha1:30538fa086cadca6efa924dd33b831d3ae16961d",
+        "checksum": "adler32:55b048a9",
         "description": "MuOniaParked AOD dataset file index (10 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20015_file_index.json"
       },
       {
-        "checksum": "sha1:128e9f8c142300c9f0dda88fb1091adaa0e82def",
+        "checksum": "adler32:93d091c0",
         "description": "MuOniaParked AOD dataset file index (11 of 51) for access to data via CMS virtual machine",
         "size": 556,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20016_file_index.json"
       },
       {
-        "checksum": "sha1:3cb93b70857e74596823e0f22de6503a47691e92",
+        "checksum": "adler32:111149a6",
         "description": "MuOniaParked AOD dataset file index (12 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20017_file_index.json"
       },
       {
-        "checksum": "sha1:4f3b005a7b20e1a7ccdfd553dff1ee1410004b18",
+        "checksum": "adler32:8b00490b",
         "description": "MuOniaParked AOD dataset file index (13 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20018_file_index.json"
       },
       {
-        "checksum": "sha1:670e90aefcd21488824eb74440585cc77345dda7",
+        "checksum": "adler32:85ff48e3",
         "description": "MuOniaParked AOD dataset file index (14 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20019_file_index.json"
       },
       {
-        "checksum": "sha1:b392a6695fb25bf9c22ae5d53ca7a54f02ae6eff",
+        "checksum": "adler32:a08f861a",
         "description": "MuOniaParked AOD dataset file index (15 of 51) for access to data via CMS virtual machine",
         "size": 8341,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_210000_file_index.json"
       },
       {
-        "checksum": "sha1:11591427a72cf2fb835dacc2b44c65f101a79707",
+        "checksum": "adler32:38283d1f",
         "description": "MuOniaParked AOD dataset file index (16 of 51) for access to data via CMS virtual machine",
         "size": 14958,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_230000_file_index.json"
       },
       {
-        "checksum": "sha1:f318f574a43ef97fc183cfc1c800e17eae2f8df1",
+        "checksum": "adler32:12033c72",
         "description": "MuOniaParked AOD dataset file index (17 of 51) for access to data via CMS virtual machine",
         "size": 446248,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:acb031ff60875ee6234287514191eb5ffea0859b",
+        "checksum": "adler32:94920153",
         "description": "MuOniaParked AOD dataset file index (18 of 51) for access to data via CMS virtual machine",
         "size": 277279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:754f320ae96be40648fd38df00fdc3ead7b56807",
+        "checksum": "adler32:363f9021",
         "description": "MuOniaParked AOD dataset file index (19 of 51) for access to data via CMS virtual machine",
         "size": 277002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:bfc249821a2346d98554c3cbf63f1852982f3cd9",
+        "checksum": "adler32:dcc384b4",
         "description": "MuOniaParked AOD dataset file index (20 of 51) for access to data via CMS virtual machine",
         "size": 277002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30003_file_index.json"
       },
       {
-        "checksum": "sha1:5f587035450851b8d7f6f246a7bf29f0bf4d8791",
+        "checksum": "adler32:79279cea",
         "description": "MuOniaParked AOD dataset file index (21 of 51) for access to data via CMS virtual machine",
         "size": 249579,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30004_file_index.json"
       },
       {
-        "checksum": "sha1:13e9f0a99d2ac31fb2cdff654e3030470a5c5639",
+        "checksum": "adler32:132a5930",
         "description": "MuOniaParked AOD dataset file index (22 of 51) for access to data via CMS virtual machine",
         "size": 269522,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30005_file_index.json"
       },
       {
-        "checksum": "sha1:14b778023dcab0e6ebf7071d878a45d504be5e66",
+        "checksum": "adler32:7095c085",
         "description": "MuOniaParked AOD dataset file index (23 of 51) for access to data via CMS virtual machine",
         "size": 100552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30006_file_index.json"
       },
       {
-        "checksum": "sha1:b1ac86545506484aab768f7062cd1238a3b6879c",
+        "checksum": "adler32:902e48f4",
         "description": "MuOniaParked AOD dataset file index (24 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30007_file_index.json"
       },
       {
-        "checksum": "sha1:56a94498eac268e26b183b13b4e8795de1ff420c",
+        "checksum": "adler32:226b90f3",
         "description": "MuOniaParked AOD dataset file index (25 of 51) for access to data via CMS virtual machine",
         "size": 556,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30009_file_index.json"
       },
       {
-        "checksum": "sha1:0565bb85e561f3bea28063e2d22eaf0e5734149f",
+        "checksum": "adler32:9dd6490a",
         "description": "MuOniaParked AOD dataset file index (26 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30011_file_index.json"
       },
       {
-        "checksum": "sha1:7bfa80cfee57c80f1fe7b8f4d61b9c5ec10d881e",
+        "checksum": "adler32:1ad0483d",
         "description": "MuOniaParked AOD dataset file index (27 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30012_file_index.json"
       },
       {
-        "checksum": "sha1:9c897b173e3cbddcd8caddc1c59d86f39cdf4d81",
+        "checksum": "adler32:4aea4883",
         "description": "MuOniaParked AOD dataset file index (28 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30015_file_index.json"
       },
       {
-        "checksum": "sha1:ada26ff35ffd24ed00fece256a1a838a066a536a",
+        "checksum": "adler32:72b448ac",
         "description": "MuOniaParked AOD dataset file index (29 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30016_file_index.json"
       },
       {
-        "checksum": "sha1:e1e8d5958f4f148aef62eb1dbf4e43875ba122c7",
+        "checksum": "adler32:021891f2",
         "description": "MuOniaParked AOD dataset file index (30 of 51) for access to data via CMS virtual machine",
         "size": 556,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30017_file_index.json"
       },
       {
-        "checksum": "sha1:abb43b8ecae2b161684ddb1409f48e3b4a7de630",
+        "checksum": "adler32:0f0d49a7",
         "description": "MuOniaParked AOD dataset file index (31 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30020_file_index.json"
       },
       {
-        "checksum": "sha1:577658bdc43aa7fac9fa31b5932d145c829cef6d",
+        "checksum": "adler32:9df948cb",
         "description": "MuOniaParked AOD dataset file index (32 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30022_file_index.json"
       },
       {
-        "checksum": "sha1:61be0d6a26648c5a2aedf6ba968376991d98848e",
+        "checksum": "adler32:708148c6",
         "description": "MuOniaParked AOD dataset file index (33 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30024_file_index.json"
       },
       {
-        "checksum": "sha1:87cbb870fbcbba9ff6d944168cdbc3771e3f1f06",
+        "checksum": "adler32:ab1948fc",
         "description": "MuOniaParked AOD dataset file index (34 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30026_file_index.json"
       },
       {
-        "checksum": "sha1:430e40848d71f3a766a38eaf0cb2413863a3308e",
+        "checksum": "adler32:fa8d225b",
         "description": "MuOniaParked AOD dataset file index (35 of 51) for access to data via CMS virtual machine",
         "size": 1110,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30029_file_index.json"
       },
       {
-        "checksum": "sha1:870d2b2dba817071da180674ffe72ae6cea6ebf6",
+        "checksum": "adler32:f59f23a0",
         "description": "MuOniaParked AOD dataset file index (36 of 51) for access to data via CMS virtual machine",
         "size": 1110,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30032_file_index.json"
       },
       {
-        "checksum": "sha1:a5dd35469c69d33073c86b52a19e2da7d98417d5",
+        "checksum": "adler32:7f0248cd",
         "description": "MuOniaParked AOD dataset file index (37 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30034_file_index.json"
       },
       {
-        "checksum": "sha1:01502b9426c5dc737845dcd9968dc4d348a14ec5",
+        "checksum": "adler32:793b48b9",
         "description": "MuOniaParked AOD dataset file index (38 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30036_file_index.json"
       },
       {
-        "checksum": "sha1:a5e1f867337ac52fba91405575e5d8889cd7999f",
+        "checksum": "adler32:a287491b",
         "description": "MuOniaParked AOD dataset file index (39 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30038_file_index.json"
       },
       {
-        "checksum": "sha1:15aaeaa12771d2e7c8fe1ff7bcc57bdf508eb702",
+        "checksum": "adler32:1d734857",
         "description": "MuOniaParked AOD dataset file index (40 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30039_file_index.json"
       },
       {
-        "checksum": "sha1:32056bdb394a877e7ab43c069cde4743371bafd7",
+        "checksum": "adler32:0893928b",
         "description": "MuOniaParked AOD dataset file index (41 of 51) for access to data via CMS virtual machine",
         "size": 556,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30041_file_index.json"
       },
       {
-        "checksum": "sha1:53e0ee6a667b74471d30dd2261aec50ec85a2ad2",
+        "checksum": "adler32:9d4d48ee",
         "description": "MuOniaParked AOD dataset file index (42 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30044_file_index.json"
       },
       {
-        "checksum": "sha1:b9bd9f847738a9d77903a73031f4dbbfad03bb2d",
+        "checksum": "adler32:24da9081",
         "description": "MuOniaParked AOD dataset file index (43 of 51) for access to data via CMS virtual machine",
         "size": 556,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30049_file_index.json"
       },
       {
-        "checksum": "sha1:0bcab46e9be100767573eb3193c2cfc2360e5495",
+        "checksum": "adler32:f22ad9ce",
         "description": "MuOniaParked AOD dataset file index (44 of 51) for access to data via CMS virtual machine",
         "size": 833,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30051_file_index.json"
       },
       {
-        "checksum": "sha1:34a30c2539bb797482abd818579bf7bb79b257b9",
+        "checksum": "adler32:36da911d",
         "description": "MuOniaParked AOD dataset file index (45 of 51) for access to data via CMS virtual machine",
         "size": 556,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30054_file_index.json"
       },
       {
-        "checksum": "sha1:ff2d328276757064a6717811743305a8dba062a0",
+        "checksum": "adler32:7df648f9",
         "description": "MuOniaParked AOD dataset file index (46 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30055_file_index.json"
       },
       {
-        "checksum": "sha1:0aa4d63f432c8cc5ca3c8c819b35662e786860a8",
+        "checksum": "adler32:f9729041",
         "description": "MuOniaParked AOD dataset file index (47 of 51) for access to data via CMS virtual machine",
         "size": 556,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30057_file_index.json"
       },
       {
-        "checksum": "sha1:4ac2c016930c83622530592682f909bd204a43b7",
+        "checksum": "adler32:db074938",
         "description": "MuOniaParked AOD dataset file index (48 of 51) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30059_file_index.json"
       },
       {
-        "checksum": "sha1:c89d9e122a739cdda261d4815e5e929f2f0fbac8",
+        "checksum": "adler32:994e31c4",
         "description": "MuOniaParked AOD dataset file index (49 of 51) for access to data via CMS virtual machine",
         "size": 10010,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_310000_file_index.json"
       },
       {
-        "checksum": "sha1:1f58657d64bdcf14a2ef4831df19e288190ff59a",
+        "checksum": "adler32:362eda58",
         "description": "MuOniaParked AOD dataset file index (50 of 51) for access to data via CMS virtual machine",
         "size": 836,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_320000_file_index.json"
       },
       {
-        "checksum": "sha1:3633de359e880e0368c7b3befbc3027cad76f98e",
+        "checksum": "adler32:73ded560",
         "description": "MuOniaParked AOD dataset file index (51 of 51) for access to data via CMS virtual machine",
         "size": 2772,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_330000_file_index.json"
       },
       {
-        "checksum": "sha1:25b6f6b748de5e84500cc4075e37175270088aa9",
+        "checksum": "adler32:8e47a215",
         "description": "MuOniaParked AOD dataset file index (1 of 51) for access to data via CMS virtual machine",
         "size": 171990,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:a20c481ac0c4c845761804603543dd714602c24c",
+        "checksum": "adler32:72dbabe8",
         "description": "MuOniaParked AOD dataset file index (2 of 51) for access to data via CMS virtual machine",
         "size": 129090,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:86e1da201c9c5beec9fe9522d4cf5d5744606ac7",
+        "checksum": "adler32:4c939118",
         "description": "MuOniaParked AOD dataset file index (3 of 51) for access to data via CMS virtual machine",
         "size": 45890,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:9e09f0d52cc6e8eb173856b5c3e8d362d565f9e1",
+        "checksum": "adler32:c05a25c5",
         "description": "MuOniaParked AOD dataset file index (4 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20004_file_index.txt"
       },
       {
-        "checksum": "sha1:19775327bb326022fc2701837956374b0cccbd3d",
+        "checksum": "adler32:e87a4c30",
         "description": "MuOniaParked AOD dataset file index (5 of 51) for access to data via CMS virtual machine",
         "size": 260,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20007_file_index.txt"
       },
       {
-        "checksum": "sha1:a78e209857ad6f7d1698855cd0aad5612807707c",
+        "checksum": "adler32:d6b94c07",
         "description": "MuOniaParked AOD dataset file index (6 of 51) for access to data via CMS virtual machine",
         "size": 260,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20011_file_index.txt"
       },
       {
-        "checksum": "sha1:ed0337fc0b91172be3d7ea5823ce6fadb7cd6d5a",
+        "checksum": "adler32:de634bc6",
         "description": "MuOniaParked AOD dataset file index (7 of 51) for access to data via CMS virtual machine",
         "size": 260,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20012_file_index.txt"
       },
       {
-        "checksum": "sha1:c14d9b028ef31a436ca636a7f401abe31211a86f",
+        "checksum": "adler32:c761260a",
         "description": "MuOniaParked AOD dataset file index (8 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20013_file_index.txt"
       },
       {
-        "checksum": "sha1:e6198ec9aa153bceae36e1b9a57f1e64a3233268",
+        "checksum": "adler32:a44e729c",
         "description": "MuOniaParked AOD dataset file index (9 of 51) for access to data via CMS virtual machine",
         "size": 390,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20014_file_index.txt"
       },
       {
-        "checksum": "sha1:febd1fdeb75ef3a91e07e47e5455a0be59a9cc46",
+        "checksum": "adler32:c9002615",
         "description": "MuOniaParked AOD dataset file index (10 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20015_file_index.txt"
       },
       {
-        "checksum": "sha1:7b09bd6b79eda79a7e39e3a34ee4cf415d5ac160",
+        "checksum": "adler32:fd504c73",
         "description": "MuOniaParked AOD dataset file index (11 of 51) for access to data via CMS virtual machine",
         "size": 260,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20016_file_index.txt"
       },
       {
-        "checksum": "sha1:51eed3c211bdf5c90cc302ebf737a39ea48e7006",
+        "checksum": "adler32:cde02647",
         "description": "MuOniaParked AOD dataset file index (12 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20017_file_index.txt"
       },
       {
-        "checksum": "sha1:fb5c16cea63a03a2bc96690b0ea2bd289235fab7",
+        "checksum": "adler32:ce00263d",
         "description": "MuOniaParked AOD dataset file index (13 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20018_file_index.txt"
       },
       {
-        "checksum": "sha1:2f84358a1081475ece96033095f84022afec62bc",
+        "checksum": "adler32:c5a82613",
         "description": "MuOniaParked AOD dataset file index (14 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_20019_file_index.txt"
       },
       {
-        "checksum": "sha1:96072c5674327e31030f286f75270ea4dd5fa494",
+        "checksum": "adler32:be287d9c",
         "description": "MuOniaParked AOD dataset file index (15 of 51) for access to data via CMS virtual machine",
         "size": 3930,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_210000_file_index.txt"
       },
       {
-        "checksum": "sha1:1b59d7ff70142e57eac755cd17d45f3e0df3e07a",
+        "checksum": "adler32:fc750ebe",
         "description": "MuOniaParked AOD dataset file index (16 of 51) for access to data via CMS virtual machine",
         "size": 7074,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_230000_file_index.txt"
       },
       {
-        "checksum": "sha1:af39afaf50ce67d7b292cba6d76e6b3592b13e15",
+        "checksum": "adler32:2ab37650",
         "description": "MuOniaParked AOD dataset file index (17 of 51) for access to data via CMS virtual machine",
         "size": 209430,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:55a164ead5f1e28a00fc4b7c5072d16ed66ada13",
+        "checksum": "adler32:8c53d98f",
         "description": "MuOniaParked AOD dataset file index (18 of 51) for access to data via CMS virtual machine",
         "size": 130130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:2552a1fc3522c015e687f203969f89ae4523d4fc",
+        "checksum": "adler32:52b9a422",
         "description": "MuOniaParked AOD dataset file index (19 of 51) for access to data via CMS virtual machine",
         "size": 130000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30002_file_index.txt"
       },
       {
-        "checksum": "sha1:ca22ce43d4600dd3560878749df83ee0d02bbb7d",
+        "checksum": "adler32:fdc3a2a7",
         "description": "MuOniaParked AOD dataset file index (20 of 51) for access to data via CMS virtual machine",
         "size": 130000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30003_file_index.txt"
       },
       {
-        "checksum": "sha1:85581685b53db20961b216f059856a3bfd55542b",
+        "checksum": "adler32:be7cf4ac",
         "description": "MuOniaParked AOD dataset file index (21 of 51) for access to data via CMS virtual machine",
         "size": 117130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30004_file_index.txt"
       },
       {
-        "checksum": "sha1:b5db1aaf048da6486b854ede10951a887bf5c34e",
+        "checksum": "adler32:d9a1d5f6",
         "description": "MuOniaParked AOD dataset file index (22 of 51) for access to data via CMS virtual machine",
         "size": 126490,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30005_file_index.txt"
       },
       {
-        "checksum": "sha1:6389347b7002c54134edfcbe482863ef7dfa7b5a",
+        "checksum": "adler32:09f10b82",
         "description": "MuOniaParked AOD dataset file index (23 of 51) for access to data via CMS virtual machine",
         "size": 47190,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30006_file_index.txt"
       },
       {
-        "checksum": "sha1:feeb0c36fb62b929785984bfa49ef760e9be17a1",
+        "checksum": "adler32:c95c2621",
         "description": "MuOniaParked AOD dataset file index (24 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30007_file_index.txt"
       },
       {
-        "checksum": "sha1:b62cd1797caff7dceb0dc7cd9bdf3169cc62d0e7",
+        "checksum": "adler32:fa524c32",
         "description": "MuOniaParked AOD dataset file index (25 of 51) for access to data via CMS virtual machine",
         "size": 260,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30009_file_index.txt"
       },
       {
-        "checksum": "sha1:f6c539dc108fad86e377fcbee08c818c68c861f2",
+        "checksum": "adler32:c9de2623",
         "description": "MuOniaParked AOD dataset file index (26 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30011_file_index.txt"
       },
       {
-        "checksum": "sha1:cc0cfc2d8d39223350597ef25faabea404cae4aa",
+        "checksum": "adler32:c0c225e1",
         "description": "MuOniaParked AOD dataset file index (27 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30012_file_index.txt"
       },
       {
-        "checksum": "sha1:1d7faf4121127aae23ce7cbed19983381c404b0d",
+        "checksum": "adler32:c50c25f6",
         "description": "MuOniaParked AOD dataset file index (28 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30015_file_index.txt"
       },
       {
-        "checksum": "sha1:15c434954571142fe2b1417040aab98134064130",
+        "checksum": "adler32:c6e925f9",
         "description": "MuOniaParked AOD dataset file index (29 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30016_file_index.txt"
       },
       {
-        "checksum": "sha1:858aa4c19aaeeec6d39edc93b95c2e932604f675",
+        "checksum": "adler32:fd574c4c",
         "description": "MuOniaParked AOD dataset file index (30 of 51) for access to data via CMS virtual machine",
         "size": 260,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30017_file_index.txt"
       },
       {
-        "checksum": "sha1:5da444ee1fd795b98b8b3204477980cdf248cc01",
+        "checksum": "adler32:cc452647",
         "description": "MuOniaParked AOD dataset file index (31 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30020_file_index.txt"
       },
       {
-        "checksum": "sha1:df6ca430c211c055a5f7fe4b2572894b849dbc32",
+        "checksum": "adler32:c49725eb",
         "description": "MuOniaParked AOD dataset file index (32 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30022_file_index.txt"
       },
       {
-        "checksum": "sha1:41ec74c246cd6342686bd392d1b5009334a415da",
+        "checksum": "adler32:c4c62611",
         "description": "MuOniaParked AOD dataset file index (33 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30024_file_index.txt"
       },
       {
-        "checksum": "sha1:9b1fdb00effef67abb02ed48a6bd9180fee3bc3f",
+        "checksum": "adler32:c6ba260d",
         "description": "MuOniaParked AOD dataset file index (34 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30026_file_index.txt"
       },
       {
-        "checksum": "sha1:4f7a148f757df7341b4e74575231c7638c75e26c",
+        "checksum": "adler32:44989846",
         "description": "MuOniaParked AOD dataset file index (35 of 51) for access to data via CMS virtual machine",
         "size": 520,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30029_file_index.txt"
       },
       {
-        "checksum": "sha1:52b92318adaeacbf96dd23790b635a44fca566c3",
+        "checksum": "adler32:76af98b3",
         "description": "MuOniaParked AOD dataset file index (36 of 51) for access to data via CMS virtual machine",
         "size": 520,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30032_file_index.txt"
       },
       {
-        "checksum": "sha1:60090b35bbd1c8345f82d58bc7d521d2be480edb",
+        "checksum": "adler32:c7c5260e",
         "description": "MuOniaParked AOD dataset file index (37 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30034_file_index.txt"
       },
       {
-        "checksum": "sha1:7b7381d938b3cd3611d6c68051b9db6e7236d8fe",
+        "checksum": "adler32:c74925fe",
         "description": "MuOniaParked AOD dataset file index (38 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30036_file_index.txt"
       },
       {
-        "checksum": "sha1:f1879ebdb1e483cde8e53c7baa01dc401efa38b3",
+        "checksum": "adler32:ca0a2631",
         "description": "MuOniaParked AOD dataset file index (39 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30038_file_index.txt"
       },
       {
-        "checksum": "sha1:889337ed93ce41647b2a84d185322b0173dbd156",
+        "checksum": "adler32:c6592601",
         "description": "MuOniaParked AOD dataset file index (40 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30039_file_index.txt"
       },
       {
-        "checksum": "sha1:3077a5f427a5694827fae3a98a51f09461296f84",
+        "checksum": "adler32:07d44c67",
         "description": "MuOniaParked AOD dataset file index (41 of 51) for access to data via CMS virtual machine",
         "size": 260,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30041_file_index.txt"
       },
       {
-        "checksum": "sha1:2130b139641e9f2829ca424f5a410325a4ff4843",
+        "checksum": "adler32:c41d2608",
         "description": "MuOniaParked AOD dataset file index (42 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30044_file_index.txt"
       },
       {
-        "checksum": "sha1:174a81a746250d9e9d6787ee61ef227529afd883",
+        "checksum": "adler32:dce14bf2",
         "description": "MuOniaParked AOD dataset file index (43 of 51) for access to data via CMS virtual machine",
         "size": 260,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30049_file_index.txt"
       },
       {
-        "checksum": "sha1:b4f5a620b7fa060dcd05d1dbc2ad607bd0d28eee",
+        "checksum": "adler32:a194727f",
         "description": "MuOniaParked AOD dataset file index (44 of 51) for access to data via CMS virtual machine",
         "size": 390,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30051_file_index.txt"
       },
       {
-        "checksum": "sha1:550919cdc14e728ac5deb9061727676db7d71715",
+        "checksum": "adler32:de774c27",
         "description": "MuOniaParked AOD dataset file index (45 of 51) for access to data via CMS virtual machine",
         "size": 260,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30054_file_index.txt"
       },
       {
-        "checksum": "sha1:22b5c99a77da8ced40512f0072b51e641b4f7eea",
+        "checksum": "adler32:cb222636",
         "description": "MuOniaParked AOD dataset file index (46 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30055_file_index.txt"
       },
       {
-        "checksum": "sha1:ebd81630e59b1e748ebb4e0b82dbc2f708b6ee83",
+        "checksum": "adler32:d77b4c04",
         "description": "MuOniaParked AOD dataset file index (47 of 51) for access to data via CMS virtual machine",
         "size": 260,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30057_file_index.txt"
       },
       {
-        "checksum": "sha1:8429406df6ffdac45d995a3bb1511481decff55b",
+        "checksum": "adler32:c7d62616",
         "description": "MuOniaParked AOD dataset file index (48 of 51) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_30059_file_index.txt"
       },
       {
-        "checksum": "sha1:e17b5c350d0cf77c7e189ac53acdafcf1d4157f3",
+        "checksum": "adler32:b9b95f10",
         "description": "MuOniaParked AOD dataset file index (49 of 51) for access to data via CMS virtual machine",
         "size": 4716,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_310000_file_index.txt"
       },
       {
-        "checksum": "sha1:ce51e02c8937bc2352d04926633a0f7087004122",
+        "checksum": "adler32:511872b3",
         "description": "MuOniaParked AOD dataset file index (50 of 51) for access to data via CMS virtual machine",
         "size": 393,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/MuOniaParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_MuOniaParked_AOD_22Jan2013-v1_320000_file_index.txt"
       },
       {
-        "checksum": "sha1:2b446945cef6d74fdf31d7907306ef90bd87d245",
+        "checksum": "adler32:289f7f44",
         "description": "MuOniaParked AOD dataset file index (51 of 51) for access to data via CMS virtual machine",
         "size": 1310,
         "type": "index.txt",
@@ -4414,28 +4414,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f74b2679546194502142e35e578a23e16a7d2323",
+        "checksum": "adler32:245e4622",
         "description": "NoBPTX AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 271,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_NoBPTX_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:fa3af5483837844a305472f26d91c65abc629e17",
+        "checksum": "adler32:c92c4fa4",
         "description": "NoBPTX AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 65019,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_NoBPTX_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:3228705761b72b53fa28e0371b64687d2f801f97",
+        "checksum": "adler32:97ee2395",
         "description": "NoBPTX AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 124,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/NoBPTX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_NoBPTX_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:f7c70b13494e395d154814419c453ae1aacd4c93",
+        "checksum": "adler32:a91f2d00",
         "description": "NoBPTX AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 29760,
         "type": "index.txt",
@@ -4535,42 +4535,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e8273fdb3b713e249ff309ea0bfdd3e6cf1e53d5",
+        "checksum": "adler32:7789a752",
         "description": "PhotonHad AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 189610,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_PhotonHad_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:796059214835a30cacfc0de391385277f3699446",
+        "checksum": "adler32:5678473f",
         "description": "PhotonHad AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_PhotonHad_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:9d24563e7734aaddfaaf29e754c45d9c922cac72",
+        "checksum": "adler32:0a4618d9",
         "description": "PhotonHad AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 234545,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_PhotonHad_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:27e69f0d6a431cc0b1859a89489752f88d686310",
+        "checksum": "adler32:5d11e62d",
         "description": "PhotonHad AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 87884,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_PhotonHad_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:22f99ffd269812a6ce7df11873afb81919bf86c8",
+        "checksum": "adler32:363024b6",
         "description": "PhotonHad AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/PhotonHad/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_PhotonHad_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:2454473f41d8841961ae585f7b608d6cd916a23f",
+        "checksum": "adler32:bcfd7698",
         "description": "PhotonHad AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 108712,
         "type": "index.txt",
@@ -4670,210 +4670,210 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fb1757c0a4e49ef37988ef493424b92f026778e6",
+        "checksum": "adler32:4162243d",
         "description": "SingleElectron AOD dataset file index (1 of 15) for access to data via CMS virtual machine",
         "size": 39061,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:3253a1378b5f17535a504afdd2ab5278cc1ad7bb",
+        "checksum": "adler32:c3eb9724",
         "description": "SingleElectron AOD dataset file index (2 of 15) for access to data via CMS virtual machine",
         "size": 277886,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:4491830075330679e8983ad7a260e84794777f52",
+        "checksum": "adler32:ec177474",
         "description": "SingleElectron AOD dataset file index (3 of 15) for access to data via CMS virtual machine",
         "size": 278723,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:d93f522d9ec4a3914aa112865dc077d7e29a902a",
+        "checksum": "adler32:eaca5edd",
         "description": "SingleElectron AOD dataset file index (4 of 15) for access to data via CMS virtual machine",
         "size": 277328,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:52f826bb6154ae4320092b03613358526f7ff5ca",
+        "checksum": "adler32:33f6d859",
         "description": "SingleElectron AOD dataset file index (5 of 15) for access to data via CMS virtual machine",
         "size": 146477,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:736559a635b5fafe98ecda8597d618244eb383c1",
+        "checksum": "adler32:3c9e49e7",
         "description": "SingleElectron AOD dataset file index (6 of 15) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20008_file_index.json"
       },
       {
-        "checksum": "sha1:5b202feb22931b4c8d31c1615bcd241ff0784da1",
+        "checksum": "adler32:040852c3",
         "description": "SingleElectron AOD dataset file index (7 of 15) for access to data via CMS virtual machine",
         "size": 302996,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:03972ae796197a002e9681d23197bd0697c467d3",
+        "checksum": "adler32:11249218",
         "description": "SingleElectron AOD dataset file index (8 of 15) for access to data via CMS virtual machine",
         "size": 278723,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:e3ac8bcf82004d9834720ad92e4ba249ed9a3a87",
+        "checksum": "adler32:42fee20c",
         "description": "SingleElectron AOD dataset file index (9 of 15) for access to data via CMS virtual machine",
         "size": 279002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:65c65a8e13983eab0261389ef33df7802f4d58df",
+        "checksum": "adler32:7cab155f",
         "description": "SingleElectron AOD dataset file index (10 of 15) for access to data via CMS virtual machine",
         "size": 268121,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30003_file_index.json"
       },
       {
-        "checksum": "sha1:fe40d45472f06dfcf9646c6889482c9c3db7d0ac",
+        "checksum": "adler32:172c4975",
         "description": "SingleElectron AOD dataset file index (11 of 15) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30004_file_index.json"
       },
       {
-        "checksum": "sha1:0e8d77ecf5040d3eb25d443055a3fff4dc629ab1",
+        "checksum": "adler32:ffce497c",
         "description": "SingleElectron AOD dataset file index (12 of 15) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30014_file_index.json"
       },
       {
-        "checksum": "sha1:f894eed3a84cb761a6d003bb0f82b16940a64037",
+        "checksum": "adler32:6581934f",
         "description": "SingleElectron AOD dataset file index (13 of 15) for access to data via CMS virtual machine",
         "size": 560,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30024_file_index.json"
       },
       {
-        "checksum": "sha1:b4aeea8478afd9e89aae0333384e3953dcad377f",
+        "checksum": "adler32:5d1f4a21",
         "description": "SingleElectron AOD dataset file index (14 of 15) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30027_file_index.json"
       },
       {
-        "checksum": "sha1:b57788f0bd30a8cb6aa7d5a7322adf6f7ca257ce",
+        "checksum": "adler32:1df64af2",
         "description": "SingleElectron AOD dataset file index (15 of 15) for access to data via CMS virtual machine",
         "size": 281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30030_file_index.json"
       },
       {
-        "checksum": "sha1:9a51fbb4a25d0988d5a0d19ed84a51593395b682",
+        "checksum": "adler32:44a0605c",
         "description": "SingleElectron AOD dataset file index (1 of 15) for access to data via CMS virtual machine",
         "size": 18480,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:83943067d03d94eeb543cde727b69fb12eef91f0",
+        "checksum": "adler32:91640af9",
         "description": "SingleElectron AOD dataset file index (2 of 15) for access to data via CMS virtual machine",
         "size": 131472,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:8202cd4a7285722da31db8dc3e692015a4648ad0",
+        "checksum": "adler32:67818820",
         "description": "SingleElectron AOD dataset file index (3 of 15) for access to data via CMS virtual machine",
         "size": 131868,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:c7091b49a27cae2e2749a7ea26dc0d56cb1e3fc9",
+        "checksum": "adler32:70a8f065",
         "description": "SingleElectron AOD dataset file index (4 of 15) for access to data via CMS virtual machine",
         "size": 131208,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:9e31c62056507851dbf120366ede78d778c4f971",
+        "checksum": "adler32:69684c78",
         "description": "SingleElectron AOD dataset file index (5 of 15) for access to data via CMS virtual machine",
         "size": 69300,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:55642a2535c4ba82be6718bd379e704708b8d11a",
+        "checksum": "adler32:36832719",
         "description": "SingleElectron AOD dataset file index (6 of 15) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_20008_file_index.txt"
       },
       {
-        "checksum": "sha1:0ac4beb9615a36b9d1740ab0a50289290b360975",
+        "checksum": "adler32:6d3eba83",
         "description": "SingleElectron AOD dataset file index (7 of 15) for access to data via CMS virtual machine",
         "size": 143352,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:b9983be93c31672e56b3fb206a0c0a99761176fc",
+        "checksum": "adler32:cbfa92f7",
         "description": "SingleElectron AOD dataset file index (8 of 15) for access to data via CMS virtual machine",
         "size": 131868,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:8ebee88ba32cbbac857b7dafd00400450ba760c3",
+        "checksum": "adler32:448dbe92",
         "description": "SingleElectron AOD dataset file index (9 of 15) for access to data via CMS virtual machine",
         "size": 132000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30002_file_index.txt"
       },
       {
-        "checksum": "sha1:466ad2061e26fc73d0ff7f0f455cc00e97a2ec6d",
+        "checksum": "adler32:76d6fd58",
         "description": "SingleElectron AOD dataset file index (10 of 15) for access to data via CMS virtual machine",
         "size": 126852,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30003_file_index.txt"
       },
       {
-        "checksum": "sha1:44b453eae62d41a4a3e0a0e9503529a47f3f4452",
+        "checksum": "adler32:339926d7",
         "description": "SingleElectron AOD dataset file index (11 of 15) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30004_file_index.txt"
       },
       {
-        "checksum": "sha1:0f346736934f60919ea5072fc334f5e99cdae873",
+        "checksum": "adler32:34ca26f6",
         "description": "SingleElectron AOD dataset file index (12 of 15) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30014_file_index.txt"
       },
       {
-        "checksum": "sha1:f7fb156bafd51a1cdefa97249815d2e139cf49c3",
+        "checksum": "adler32:a2194e31",
         "description": "SingleElectron AOD dataset file index (13 of 15) for access to data via CMS virtual machine",
         "size": 264,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30024_file_index.txt"
       },
       {
-        "checksum": "sha1:0653f2c01e91e7287a3a9cddae28488367779d64",
+        "checksum": "adler32:3c05273a",
         "description": "SingleElectron AOD dataset file index (14 of 15) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleElectron/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleElectron_AOD_22Jan2013-v1_30027_file_index.txt"
       },
       {
-        "checksum": "sha1:6d1e31ba8cadeae6bbf621f12de2b465219e9dfd",
+        "checksum": "adler32:3c142742",
         "description": "SingleElectron AOD dataset file index (15 of 15) for access to data via CMS virtual machine",
         "size": 132,
         "type": "index.txt",
@@ -4973,336 +4973,336 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:11e1c433a3bd1654a2bd50af07a8ecbbb0c29878",
+        "checksum": "adler32:a584ffeb",
         "description": "SingleMu AOD dataset file index (1 of 24) for access to data via CMS virtual machine",
         "size": 287197,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:1a0e4b60eeff2ae49b5735b8e085845bfc9047a6",
+        "checksum": "adler32:f04f9813",
         "description": "SingleMu AOD dataset file index (2 of 24) for access to data via CMS virtual machine",
         "size": 273002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:02baf5fa1893a53697b06f2b9b34ea45f2ee0f90",
+        "checksum": "adler32:b86ac400",
         "description": "SingleMu AOD dataset file index (3 of 24) for access to data via CMS virtual machine",
         "size": 273275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:ea7a61ecd75ff5311b702454148517cccaa875ff",
+        "checksum": "adler32:377fecfd",
         "description": "SingleMu AOD dataset file index (4 of 24) for access to data via CMS virtual machine",
         "size": 273275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:36f7b1d70227a82f5c6b78c9be50519edcde071f",
+        "checksum": "adler32:b283011b",
         "description": "SingleMu AOD dataset file index (5 of 24) for access to data via CMS virtual machine",
         "size": 272456,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20004_file_index.json"
       },
       {
-        "checksum": "sha1:f9ab9803a001d132231b25fdfcb1f57198927375",
+        "checksum": "adler32:652e9f04",
         "description": "SingleMu AOD dataset file index (6 of 24) for access to data via CMS virtual machine",
         "size": 37948,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20005_file_index.json"
       },
       {
-        "checksum": "sha1:228f51f5df365b87e3061d4068003f474cf17ef3",
+        "checksum": "adler32:3d228f3a",
         "description": "SingleMu AOD dataset file index (7 of 24) for access to data via CMS virtual machine",
         "size": 548,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20006_file_index.json"
       },
       {
-        "checksum": "sha1:9f2cbb8162662d1ba0f732a148b689ab7c37955e",
+        "checksum": "adler32:96a34806",
         "description": "SingleMu AOD dataset file index (8 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20008_file_index.json"
       },
       {
-        "checksum": "sha1:6eabd17d1d5f3a09be107e92ebc97bef2c4a95d4",
+        "checksum": "adler32:8ae747fb",
         "description": "SingleMu AOD dataset file index (9 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20017_file_index.json"
       },
       {
-        "checksum": "sha1:d03cc53d5b3d9ebe064205ed46858d498624c321",
+        "checksum": "adler32:4da94783",
         "description": "SingleMu AOD dataset file index (10 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20018_file_index.json"
       },
       {
-        "checksum": "sha1:72cb03dffa6d76566d2fd389ce366e184b9a8786",
+        "checksum": "adler32:a809481a",
         "description": "SingleMu AOD dataset file index (11 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20021_file_index.json"
       },
       {
-        "checksum": "sha1:880080e0c789ffc9f0221fd2da27466f5b6a6916",
+        "checksum": "adler32:3bf9477a",
         "description": "SingleMu AOD dataset file index (12 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20030_file_index.json"
       },
       {
-        "checksum": "sha1:db345a1888f3f3a73a3d7421e1ffd94bc8b20dae",
+        "checksum": "adler32:75a047c3",
         "description": "SingleMu AOD dataset file index (13 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20040_file_index.json"
       },
       {
-        "checksum": "sha1:b7436fb13b5ddcda5854f4d37a57e9afcb207f21",
+        "checksum": "adler32:6bb34802",
         "description": "SingleMu AOD dataset file index (14 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20045_file_index.json"
       },
       {
-        "checksum": "sha1:52a993a6a15276b347c476c89edc37c3fc57df79",
+        "checksum": "adler32:813b4810",
         "description": "SingleMu AOD dataset file index (15 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20046_file_index.json"
       },
       {
-        "checksum": "sha1:de92c10dd047f348a0239cf0edc33ccde9c4c1bc",
+        "checksum": "adler32:2843478a",
         "description": "SingleMu AOD dataset file index (16 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20048_file_index.json"
       },
       {
-        "checksum": "sha1:b023e74c9b4eb7c1f8e9f3df754af06369b0067d",
+        "checksum": "adler32:7d69465b",
         "description": "SingleMu AOD dataset file index (17 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20055_file_index.json"
       },
       {
-        "checksum": "sha1:65379d91d3a174dd5016ed5c5f88add7c3036f30",
+        "checksum": "adler32:a2d44821",
         "description": "SingleMu AOD dataset file index (18 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20058_file_index.json"
       },
       {
-        "checksum": "sha1:b6c4d3b1653354b63869b1c1444368be3e1d9f71",
+        "checksum": "adler32:23244763",
         "description": "SingleMu AOD dataset file index (19 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20059_file_index.json"
       },
       {
-        "checksum": "sha1:52d6c5cc10d6b6ebd4a7934bbab15d43cd0d3b80",
+        "checksum": "adler32:9239120e",
         "description": "SingleMu AOD dataset file index (20 of 24) for access to data via CMS virtual machine",
         "size": 262627,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:e17f478303fcd64159d967251a787245ce4cdb4c",
+        "checksum": "adler32:35414757",
         "description": "SingleMu AOD dataset file index (21 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30004_file_index.json"
       },
       {
-        "checksum": "sha1:19fc8f1b1cf2060640aede52840a551bd7d5116e",
+        "checksum": "adler32:f5d446fc",
         "description": "SingleMu AOD dataset file index (22 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30007_file_index.json"
       },
       {
-        "checksum": "sha1:dd33dc0afdef59882472f3ffd661abdec9fbdac4",
+        "checksum": "adler32:c32f482e",
         "description": "SingleMu AOD dataset file index (23 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30008_file_index.json"
       },
       {
-        "checksum": "sha1:3692a6253985e3c6ffb74253b8a105dcb31a2323",
+        "checksum": "adler32:ef9f46e7",
         "description": "SingleMu AOD dataset file index (24 of 24) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30010_file_index.json"
       },
       {
-        "checksum": "sha1:4787517f5fe591bba6c108273c8efe1a56d692e1",
+        "checksum": "adler32:ce54a544",
         "description": "SingleMu AOD dataset file index (1 of 24) for access to data via CMS virtual machine",
         "size": 132552,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:27c4fee3a4102b1abbfaaf103586eae45c3511aa",
+        "checksum": "adler32:7e374152",
         "description": "SingleMu AOD dataset file index (2 of 24) for access to data via CMS virtual machine",
         "size": 126000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:5384fd5109b7f423a585071dc8031d1b827e3c0d",
+        "checksum": "adler32:911b5657",
         "description": "SingleMu AOD dataset file index (3 of 24) for access to data via CMS virtual machine",
         "size": 126126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:d1bf3a442e03cc2cdc797ec51cee0750ed2b436e",
+        "checksum": "adler32:7a3e6caa",
         "description": "SingleMu AOD dataset file index (4 of 24) for access to data via CMS virtual machine",
         "size": 126126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:371d6ea436bdd88ab3f7d8ac611920ecf3092f23",
+        "checksum": "adler32:9347f067",
         "description": "SingleMu AOD dataset file index (5 of 24) for access to data via CMS virtual machine",
         "size": 125748,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20004_file_index.txt"
       },
       {
-        "checksum": "sha1:dbdcae89cb70380d15ee6e92b604e72a480ac6d8",
+        "checksum": "adler32:83eaf02e",
         "description": "SingleMu AOD dataset file index (6 of 24) for access to data via CMS virtual machine",
         "size": 17514,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20005_file_index.txt"
       },
       {
-        "checksum": "sha1:20a5f02c4cc1af29cc6f69a1f8a6d101c6a38ac1",
+        "checksum": "adler32:393e497b",
         "description": "SingleMu AOD dataset file index (7 of 24) for access to data via CMS virtual machine",
         "size": 252,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20006_file_index.txt"
       },
       {
-        "checksum": "sha1:01bd10d058f7b299f80cc88c1bf2b39c8944776f",
+        "checksum": "adler32:116324d3",
         "description": "SingleMu AOD dataset file index (8 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20008_file_index.txt"
       },
       {
-        "checksum": "sha1:f4157630df5bdf558550eb7b1b80db4f4b2be72c",
+        "checksum": "adler32:0e2624ce",
         "description": "SingleMu AOD dataset file index (9 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20017_file_index.txt"
       },
       {
-        "checksum": "sha1:b674e23c673b5032f3f4cf584ca23f47799b3e3a",
+        "checksum": "adler32:0fc124a9",
         "description": "SingleMu AOD dataset file index (10 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20018_file_index.txt"
       },
       {
-        "checksum": "sha1:750bf4809dda04075c5ee23a7ae6b9474b987ec4",
+        "checksum": "adler32:151d24df",
         "description": "SingleMu AOD dataset file index (11 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20021_file_index.txt"
       },
       {
-        "checksum": "sha1:94614af58eea36a9212af49e0913b10ca008b4f2",
+        "checksum": "adler32:112e24af",
         "description": "SingleMu AOD dataset file index (12 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20030_file_index.txt"
       },
       {
-        "checksum": "sha1:0398babe954e4fbb8aba4392a9b71d7ea95d4486",
+        "checksum": "adler32:0cca24b1",
         "description": "SingleMu AOD dataset file index (13 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20040_file_index.txt"
       },
       {
-        "checksum": "sha1:e0071fb1e8dc877c6a2bbe90b62324f2b8e87bfd",
+        "checksum": "adler32:148b24fa",
         "description": "SingleMu AOD dataset file index (14 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20045_file_index.txt"
       },
       {
-        "checksum": "sha1:9058af1430df4a2d3bf24a355423ff3f98d5e457",
+        "checksum": "adler32:15fd24f8",
         "description": "SingleMu AOD dataset file index (15 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20046_file_index.txt"
       },
       {
-        "checksum": "sha1:0060fd7feececb733b152aba76dcbd5ae9f71983",
+        "checksum": "adler32:0e8a24c8",
         "description": "SingleMu AOD dataset file index (16 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20048_file_index.txt"
       },
       {
-        "checksum": "sha1:69e73d19c0144b787074bd94dfa4935884a490b6",
+        "checksum": "adler32:08002460",
         "description": "SingleMu AOD dataset file index (17 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20055_file_index.txt"
       },
       {
-        "checksum": "sha1:8e6826f0eec400fd6aea139d1801b727646d75bd",
+        "checksum": "adler32:136d24e1",
         "description": "SingleMu AOD dataset file index (18 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20058_file_index.txt"
       },
       {
-        "checksum": "sha1:9376b7d75a8aa6e74b9fb9a420aa9e9384a710ac",
+        "checksum": "adler32:0e5e24ad",
         "description": "SingleMu AOD dataset file index (19 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_20059_file_index.txt"
       },
       {
-        "checksum": "sha1:6aa3c1cb5ddbb93ce9638cb7a72bd3ae20c893bb",
+        "checksum": "adler32:a5bcd0a5",
         "description": "SingleMu AOD dataset file index (20 of 24) for access to data via CMS virtual machine",
         "size": 121212,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:711070e4ff3f8608523c942ff37978d11c177baa",
+        "checksum": "adler32:0bf82490",
         "description": "SingleMu AOD dataset file index (21 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30004_file_index.txt"
       },
       {
-        "checksum": "sha1:a1d84d4a2e53cf8f6dba375212a94aa5b45ba113",
+        "checksum": "adler32:0abb2480",
         "description": "SingleMu AOD dataset file index (22 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30007_file_index.txt"
       },
       {
-        "checksum": "sha1:cb27b7b9142587b271cae29b08d53a5b6256bc4b",
+        "checksum": "adler32:126c24d1",
         "description": "SingleMu AOD dataset file index (23 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SingleMu/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SingleMu_AOD_22Jan2013-v1_30008_file_index.txt"
       },
       {
-        "checksum": "sha1:10bd2575384bd3b4fea6a9de3269d0706f893f55",
+        "checksum": "adler32:08d62472",
         "description": "SingleMu AOD dataset file index (24 of 24) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
@@ -5402,84 +5402,84 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:28efa2f11573a7ecf8e1b559f1de818d3255fabc",
+        "checksum": "adler32:6f574f3e",
         "description": "SinglePhoton AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
         "size": 276448,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:c342d38d4b1524e3bf563353a61ae7e32eb5e492",
+        "checksum": "adler32:fa3034c2",
         "description": "SinglePhoton AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
         "size": 170080,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:c7e6915e43d1873e1675a79a7feac0b7fe785090",
+        "checksum": "adler32:dbe14949",
         "description": "SinglePhoton AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20006_file_index.json"
       },
       {
-        "checksum": "sha1:b919dfd2edda3fbed5d302590b578da51b808fb2",
+        "checksum": "adler32:162a4869",
         "description": "SinglePhoton AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
         "size": 279,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20009_file_index.json"
       },
       {
-        "checksum": "sha1:cec7ce4c6c97808fda80dc5b5afa4e2506c2e3ca",
+        "checksum": "adler32:ba09921a",
         "description": "SinglePhoton AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
         "size": 556,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20015_file_index.json"
       },
       {
-        "checksum": "sha1:4d7a16afeaebdab2e7889f6e1b546512414db9a5",
+        "checksum": "adler32:ef144854",
         "description": "SinglePhoton AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
         "size": 278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:b3a90ff871a3e666a9938dd595d16d1f870d7ab7",
+        "checksum": "adler32:a4ed6449",
         "description": "SinglePhoton AOD dataset file index (1 of 6) for access to data via CMS virtual machine",
         "size": 129740,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:74d4120e48d2a83060487272e5f203e2866d2752",
+        "checksum": "adler32:3f30e3cc",
         "description": "SinglePhoton AOD dataset file index (2 of 6) for access to data via CMS virtual machine",
         "size": 79820,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:8489ae4dbce406e2d3c6a3ca5cddc2ac822355b2",
+        "checksum": "adler32:d5472634",
         "description": "SinglePhoton AOD dataset file index (3 of 6) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20006_file_index.txt"
       },
       {
-        "checksum": "sha1:51c8077afff0fbe728d2cb3561afa8eb04f83623",
+        "checksum": "adler32:d52e262a",
         "description": "SinglePhoton AOD dataset file index (4 of 6) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20009_file_index.txt"
       },
       {
-        "checksum": "sha1:5fced397590302355166ba08bb0e8befdc2476f7",
+        "checksum": "adler32:27844cd0",
         "description": "SinglePhoton AOD dataset file index (5 of 6) for access to data via CMS virtual machine",
         "size": 260,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/SinglePhoton/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_SinglePhoton_AOD_22Jan2013-v1_20015_file_index.txt"
       },
       {
-        "checksum": "sha1:59fa52924b8670bfd8db87c26480c698089f70b0",
+        "checksum": "adler32:d53b2633",
         "description": "SinglePhoton AOD dataset file index (6 of 6) for access to data via CMS virtual machine",
         "size": 130,
         "type": "index.txt",
@@ -5579,182 +5579,182 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a90f9afcb0ed78a938ab51f44c3157e77b25773b",
+        "checksum": "adler32:75ecb50f",
         "description": "TauParked AOD dataset file index (1 of 13) for access to data via CMS virtual machine",
         "size": 6577,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:0d12e81308557c2f0db82bf208716d7f6d7ea3ec",
+        "checksum": "adler32:d46cfc10",
         "description": "TauParked AOD dataset file index (2 of 13) for access to data via CMS virtual machine",
         "size": 289345,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:caf2024c2e46d0a302bb3c837890c291bf81c797",
+        "checksum": "adler32:e41ba98b",
         "description": "TauParked AOD dataset file index (3 of 13) for access to data via CMS virtual machine",
         "size": 269344,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:34b5eb0300ebf4dd62b2670aac1fc12bcac43ca1",
+        "checksum": "adler32:c26389cf",
         "description": "TauParked AOD dataset file index (4 of 13) for access to data via CMS virtual machine",
         "size": 274002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:afaaa0c3117ddf9d857951710bead3e732f2122d",
+        "checksum": "adler32:2102cf06",
         "description": "TauParked AOD dataset file index (5 of 13) for access to data via CMS virtual machine",
         "size": 274002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:fdde044aae8bb5bff985dd305ee4ca999343194f",
+        "checksum": "adler32:8d62528e",
         "description": "TauParked AOD dataset file index (6 of 13) for access to data via CMS virtual machine",
         "size": 92614,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20004_file_index.json"
       },
       {
-        "checksum": "sha1:da5164134460654da395aaa1ed067df175bc8cce",
+        "checksum": "adler32:cf2d480d",
         "description": "TauParked AOD dataset file index (7 of 13) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20012_file_index.json"
       },
       {
-        "checksum": "sha1:5aeec4a8704aa5f6af08fe5f79b84000420cdd3f",
+        "checksum": "adler32:33454795",
         "description": "TauParked AOD dataset file index (8 of 13) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20028_file_index.json"
       },
       {
-        "checksum": "sha1:c7d09f537609867325094bd8feba5d8717fc8515",
+        "checksum": "adler32:818947d2",
         "description": "TauParked AOD dataset file index (9 of 13) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20039_file_index.json"
       },
       {
-        "checksum": "sha1:80aea84ee27fd945b90664b2283712318a2f2a19",
+        "checksum": "adler32:ac888ea2",
         "description": "TauParked AOD dataset file index (10 of 13) for access to data via CMS virtual machine",
         "size": 550,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20043_file_index.json"
       },
       {
-        "checksum": "sha1:8eab8c27755164e7b02233aaf66dbbdbccf79651",
+        "checksum": "adler32:fe7b900d",
         "description": "TauParked AOD dataset file index (11 of 13) for access to data via CMS virtual machine",
         "size": 550,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20046_file_index.json"
       },
       {
-        "checksum": "sha1:d5d1c44121a92cc9ab5dc942f69bcf5b9259300b",
+        "checksum": "adler32:8c8c47ac",
         "description": "TauParked AOD dataset file index (12 of 13) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20048_file_index.json"
       },
       {
-        "checksum": "sha1:6e19f176434c9255bd95deffe16ef22cb248c70a",
+        "checksum": "adler32:f9e9488d",
         "description": "TauParked AOD dataset file index (13 of 13) for access to data via CMS virtual machine",
         "size": 276,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20050_file_index.json"
       },
       {
-        "checksum": "sha1:91751a03438708e83394e110673cb156d8c05357",
+        "checksum": "adler32:87767aca",
         "description": "TauParked AOD dataset file index (1 of 13) for access to data via CMS virtual machine",
         "size": 3048,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:3ecad24403fc71ce61fd33883c8eb66c36392a26",
+        "checksum": "adler32:15d06d25",
         "description": "TauParked AOD dataset file index (2 of 13) for access to data via CMS virtual machine",
         "size": 134112,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:55344d5c3d1490f306b9ea43fd5df4fba67619e4",
+        "checksum": "adler32:599cdeaa",
         "description": "TauParked AOD dataset file index (3 of 13) for access to data via CMS virtual machine",
         "size": 124841,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:9e6ff5f99dd18db7d07e91d11fb7241e6b33c8ef",
+        "checksum": "adler32:03af6a99",
         "description": "TauParked AOD dataset file index (4 of 13) for access to data via CMS virtual machine",
         "size": 127000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:98c27ca8e0b37aaef3fcef6e79abd05cf57c1eb4",
+        "checksum": "adler32:61e49ac1",
         "description": "TauParked AOD dataset file index (5 of 13) for access to data via CMS virtual machine",
         "size": 127000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:db2ed3755219a32428cd5b3cc3382b21870ff306",
+        "checksum": "adler32:ad3be719",
         "description": "TauParked AOD dataset file index (6 of 13) for access to data via CMS virtual machine",
         "size": 42926,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20004_file_index.txt"
       },
       {
-        "checksum": "sha1:c6bc7a1bb0341dfcc6525788297ad5e3211eeb9f",
+        "checksum": "adler32:3d6e2502",
         "description": "TauParked AOD dataset file index (7 of 13) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20012_file_index.txt"
       },
       {
-        "checksum": "sha1:c3554f22046c2a1a70acc6465e222583c1dbafd4",
+        "checksum": "adler32:3eeb2520",
         "description": "TauParked AOD dataset file index (8 of 13) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20028_file_index.txt"
       },
       {
-        "checksum": "sha1:d29a91c048bcb580f613c1c5eb7bd031f851f73b",
+        "checksum": "adler32:4231251c",
         "description": "TauParked AOD dataset file index (9 of 13) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20039_file_index.txt"
       },
       {
-        "checksum": "sha1:aa73b6556f71d572b4e632652deb8d749c7fdae7",
+        "checksum": "adler32:d03049f3",
         "description": "TauParked AOD dataset file index (10 of 13) for access to data via CMS virtual machine",
         "size": 254,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20043_file_index.txt"
       },
       {
-        "checksum": "sha1:1479d71798de46ec83439920cbb8db05194d76b3",
+        "checksum": "adler32:f3534a49",
         "description": "TauParked AOD dataset file index (11 of 13) for access to data via CMS virtual machine",
         "size": 254,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20046_file_index.txt"
       },
       {
-        "checksum": "sha1:25877a7df7b95852dff466a183b7723c36ad7821",
+        "checksum": "adler32:3cfa24e7",
         "description": "TauParked AOD dataset file index (12 of 13) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauParked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauParked_AOD_22Jan2013-v1_20048_file_index.txt"
       },
       {
-        "checksum": "sha1:64816b998c4b0abc83a47eac2003f7072c8da74f",
+        "checksum": "adler32:40ac2549",
         "description": "TauParked AOD dataset file index (13 of 13) for access to data via CMS virtual machine",
         "size": 127,
         "type": "index.txt",
@@ -5854,196 +5854,196 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:174e7add5e2b92b1e1f0a61782728b03a04d6253",
+        "checksum": "adler32:6b173383",
         "description": "TauPlusX AOD dataset file index (1 of 14) for access to data via CMS virtual machine",
         "size": 223862,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:f6a04b8f87cd1977da82d34464023d16649a7322",
+        "checksum": "adler32:1e7621a9",
         "description": "TauPlusX AOD dataset file index (2 of 14) for access to data via CMS virtual machine",
         "size": 146876,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:9d92ddf9fb6f6ef7c08098fceacc9f6cb53915f6",
+        "checksum": "adler32:7ed647b5",
         "description": "TauPlusX AOD dataset file index (3 of 14) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_20004_file_index.json"
       },
       {
-        "checksum": "sha1:619dad4dd803b2c3f13fee6b00ea2ae99905945a",
+        "checksum": "adler32:35b6cb17",
         "description": "TauPlusX AOD dataset file index (4 of 14) for access to data via CMS virtual machine",
         "size": 439527,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_210000_file_index.json"
       },
       {
-        "checksum": "sha1:d265df0f7544cb3e5b82449654de2c9ebe66afbe",
+        "checksum": "adler32:a69a1de0",
         "description": "TauPlusX AOD dataset file index (5 of 14) for access to data via CMS virtual machine",
         "size": 171697,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_210001_file_index.json"
       },
       {
-        "checksum": "sha1:11fca40e5eeea9b23dfe892d22773f36e54f5024",
+        "checksum": "adler32:6257fd56",
         "description": "TauPlusX AOD dataset file index (6 of 14) for access to data via CMS virtual machine",
         "size": 287743,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:ce0d19c669cdc2475a052bc1360a4f2f0db0ef0a",
+        "checksum": "adler32:3d02a281",
         "description": "TauPlusX AOD dataset file index (7 of 14) for access to data via CMS virtual machine",
         "size": 225227,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:056111799399c25eabe315da42afcdfaaf6f1a0d",
+        "checksum": "adler32:e096839f",
         "description": "TauPlusX AOD dataset file index (8 of 14) for access to data via CMS virtual machine",
         "size": 107837,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:ff21eaec0fc7040104c902a8771d2aba37d1ffd9",
+        "checksum": "adler32:2f044734",
         "description": "TauPlusX AOD dataset file index (9 of 14) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30004_file_index.json"
       },
       {
-        "checksum": "sha1:404f2c4d38012de3a23767f5deeb160d0b843032",
+        "checksum": "adler32:38164752",
         "description": "TauPlusX AOD dataset file index (10 of 14) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30008_file_index.json"
       },
       {
-        "checksum": "sha1:6310b6d3ec5decd2a075b3b6896c7f72aa683c36",
+        "checksum": "adler32:6c548da8",
         "description": "TauPlusX AOD dataset file index (11 of 14) for access to data via CMS virtual machine",
         "size": 548,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30022_file_index.json"
       },
       {
-        "checksum": "sha1:aeb56647d6b93e084c5c59746c167be498ff4220",
+        "checksum": "adler32:24ce475d",
         "description": "TauPlusX AOD dataset file index (12 of 14) for access to data via CMS virtual machine",
         "size": 275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30026_file_index.json"
       },
       {
-        "checksum": "sha1:5010a15a5ad85cbd6d1c19d1dc034951e4430823",
+        "checksum": "adler32:c792c245",
         "description": "TauPlusX AOD dataset file index (13 of 14) for access to data via CMS virtual machine",
         "size": 381389,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_310000_file_index.json"
       },
       {
-        "checksum": "sha1:ff8ab29c9482feedac9817f45a1356718331507f",
+        "checksum": "adler32:8d43f9b1",
         "description": "TauPlusX AOD dataset file index (14 of 14) for access to data via CMS virtual machine",
         "size": 160514,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_310001_file_index.json"
       },
       {
-        "checksum": "sha1:363c068f3131455449516ab3bc8bdf966b0a9efc",
+        "checksum": "adler32:65a144a8",
         "description": "TauPlusX AOD dataset file index (1 of 14) for access to data via CMS virtual machine",
         "size": 103320,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:480b137ca0459be257eaf509cb61e52a220371fa",
+        "checksum": "adler32:a1cef928",
         "description": "TauPlusX AOD dataset file index (2 of 14) for access to data via CMS virtual machine",
         "size": 67788,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:ed3b54ddf6b31af29c0dac0106cdadc9eb503f90",
+        "checksum": "adler32:106f24a3",
         "description": "TauPlusX AOD dataset file index (3 of 14) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_20004_file_index.txt"
       },
       {
-        "checksum": "sha1:30bb476564c763458151b3a0d046f9af4a5142da",
+        "checksum": "adler32:70644baf",
         "description": "TauPlusX AOD dataset file index (4 of 14) for access to data via CMS virtual machine",
         "size": 204470,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_210000_file_index.txt"
       },
       {
-        "checksum": "sha1:9e5305fcf1586462ab8be4f65357f183e659cbbf",
+        "checksum": "adler32:90075ed2",
         "description": "TauPlusX AOD dataset file index (5 of 14) for access to data via CMS virtual machine",
         "size": 79883,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_210001_file_index.txt"
       },
       {
-        "checksum": "sha1:2033c875cdec7fbd07fe755b76140d8ba0ba75ca",
+        "checksum": "adler32:bdcfae7a",
         "description": "TauPlusX AOD dataset file index (6 of 14) for access to data via CMS virtual machine",
         "size": 132804,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:08e9b7ac131064afe645b51b7942f5e607b4e46b",
+        "checksum": "adler32:de450461",
         "description": "TauPlusX AOD dataset file index (7 of 14) for access to data via CMS virtual machine",
         "size": 103950,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:e26810a4711388941f5922b52f7ae5db2da7e1a5",
+        "checksum": "adler32:0bb286dc",
         "description": "TauPlusX AOD dataset file index (8 of 14) for access to data via CMS virtual machine",
         "size": 49770,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30002_file_index.txt"
       },
       {
-        "checksum": "sha1:e7c601066c1820a5967fe72cd8772b3bef763e02",
+        "checksum": "adler32:0ad0247c",
         "description": "TauPlusX AOD dataset file index (9 of 14) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30004_file_index.txt"
       },
       {
-        "checksum": "sha1:32801ecd02df6295862709fba6cb28832e8747c4",
+        "checksum": "adler32:0dca2490",
         "description": "TauPlusX AOD dataset file index (10 of 14) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30008_file_index.txt"
       },
       {
-        "checksum": "sha1:f40a9f36ef7d9eae3ecfb05d8513c214fb21c3fc",
+        "checksum": "adler32:057248fb",
         "description": "TauPlusX AOD dataset file index (11 of 14) for access to data via CMS virtual machine",
         "size": 252,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30022_file_index.txt"
       },
       {
-        "checksum": "sha1:2f8533c4e6652d867e1604583965c7863871f1f0",
+        "checksum": "adler32:0e8924ab",
         "description": "TauPlusX AOD dataset file index (12 of 14) for access to data via CMS virtual machine",
         "size": 126,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_30026_file_index.txt"
       },
       {
-        "checksum": "sha1:4a55cb7afabac8e88220b1286b68104f00899dab",
+        "checksum": "adler32:9895af99",
         "description": "TauPlusX AOD dataset file index (13 of 14) for access to data via CMS virtual machine",
         "size": 177419,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/TauPlusX/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_TauPlusX_AOD_22Jan2013-v1_310000_file_index.txt"
       },
       {
-        "checksum": "sha1:fb11688e602218b12acc5966834c2612a1d3ee84",
+        "checksum": "adler32:e1669118",
         "description": "TauPlusX AOD dataset file index (14 of 14) for access to data via CMS virtual machine",
         "size": 74676,
         "type": "index.txt",
@@ -6143,686 +6143,686 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:76264a05c8b4d1b5b11bab29dac961f86fd9d6d6",
+        "checksum": "adler32:8c44f553",
         "description": "VBF1Parked AOD dataset file index (1 of 49) for access to data via CMS virtual machine",
         "size": 279127,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:0c4ed2bb9a4e9a6920e954c050bc46ef51808740",
+        "checksum": "adler32:49766adf",
         "description": "VBF1Parked AOD dataset file index (2 of 49) for access to data via CMS virtual machine",
         "size": 275552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:271316e1bb53d767d57bad4ee339c13946f4650c",
+        "checksum": "adler32:125f320c",
         "description": "VBF1Parked AOD dataset file index (3 of 49) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:fd53ee5a8c2ade5bca1eb76b447eba89cd7fbbac",
+        "checksum": "adler32:81c4b2ca",
         "description": "VBF1Parked AOD dataset file index (4 of 49) for access to data via CMS virtual machine",
         "size": 275827,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:6e8547c1715e11bdca1f42ef6ca01c34ac865011",
+        "checksum": "adler32:ef89a4b3",
         "description": "VBF1Parked AOD dataset file index (5 of 49) for access to data via CMS virtual machine",
         "size": 275277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20004_file_index.json"
       },
       {
-        "checksum": "sha1:e58b4e914d0e5838b60f89127bb026eed5967e42",
+        "checksum": "adler32:dffc41e6",
         "description": "VBF1Parked AOD dataset file index (6 of 49) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20005_file_index.json"
       },
       {
-        "checksum": "sha1:76eaf87caf457e926809840a17524c1da8214ba2",
+        "checksum": "adler32:d0cc63c7",
         "description": "VBF1Parked AOD dataset file index (7 of 49) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20006_file_index.json"
       },
       {
-        "checksum": "sha1:4fc8070f0b358ea5ebc0942e0ae4bf1c293d28b8",
+        "checksum": "adler32:fb95cb8e",
         "description": "VBF1Parked AOD dataset file index (8 of 49) for access to data via CMS virtual machine",
         "size": 274727,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20007_file_index.json"
       },
       {
-        "checksum": "sha1:d858df9a3697402c305c5789302f5174fce5e822",
+        "checksum": "adler32:7484b51b",
         "description": "VBF1Parked AOD dataset file index (9 of 49) for access to data via CMS virtual machine",
         "size": 214227,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20008_file_index.json"
       },
       {
-        "checksum": "sha1:9d84f24386b76b610192aa4fd37104a142655b8a",
+        "checksum": "adler32:ffb64806",
         "description": "VBF1Parked AOD dataset file index (10 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20015_file_index.json"
       },
       {
-        "checksum": "sha1:d17945455babd780499061f8d80c03c5a0d344a9",
+        "checksum": "adler32:8baf1bf2",
         "description": "VBF1Parked AOD dataset file index (11 of 49) for access to data via CMS virtual machine",
         "size": 1102,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20017_file_index.json"
       },
       {
-        "checksum": "sha1:8c9062311880fa44afb3928d4b316e6e6c5564ce",
+        "checksum": "adler32:4d65d616",
         "description": "VBF1Parked AOD dataset file index (12 of 49) for access to data via CMS virtual machine",
         "size": 827,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20023_file_index.json"
       },
       {
-        "checksum": "sha1:11e633e074a5d59362fad303aaa6ad57cbc6f160",
+        "checksum": "adler32:bc568e09",
         "description": "VBF1Parked AOD dataset file index (13 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20024_file_index.json"
       },
       {
-        "checksum": "sha1:cb4821640b786b94a149e8053121b1d64232a3a0",
+        "checksum": "adler32:99748e97",
         "description": "VBF1Parked AOD dataset file index (14 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20029_file_index.json"
       },
       {
-        "checksum": "sha1:1b61cc0ada572dbfee86bedbfddb96ef9724103a",
+        "checksum": "adler32:5adf4707",
         "description": "VBF1Parked AOD dataset file index (15 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20032_file_index.json"
       },
       {
-        "checksum": "sha1:a2a5f3c8add607085f6e635d9a31e2e4e18d0cf0",
+        "checksum": "adler32:87794776",
         "description": "VBF1Parked AOD dataset file index (16 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20033_file_index.json"
       },
       {
-        "checksum": "sha1:054ae1b87ccd6301259e8b0430b99ba126856330",
+        "checksum": "adler32:bd618eb6",
         "description": "VBF1Parked AOD dataset file index (17 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20035_file_index.json"
       },
       {
-        "checksum": "sha1:595b4c3ab2355d7c3d4157fdf462e28d894631d1",
+        "checksum": "adler32:cc0b47b2",
         "description": "VBF1Parked AOD dataset file index (18 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20036_file_index.json"
       },
       {
-        "checksum": "sha1:893bac5f5be76cc03c3d9b4d07307e569b6d4a57",
+        "checksum": "adler32:ad0947db",
         "description": "VBF1Parked AOD dataset file index (19 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20037_file_index.json"
       },
       {
-        "checksum": "sha1:9140a1502983c585dbbe9818ee7902fb7f467129",
+        "checksum": "adler32:70ad4746",
         "description": "VBF1Parked AOD dataset file index (20 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20038_file_index.json"
       },
       {
-        "checksum": "sha1:9bc66c6581195fa37b147cb404c353b51ff20b40",
+        "checksum": "adler32:e46b8ef1",
         "description": "VBF1Parked AOD dataset file index (21 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20040_file_index.json"
       },
       {
-        "checksum": "sha1:337512fca9f00697484cac67faf31e5e2c7ba4fc",
+        "checksum": "adler32:358c4728",
         "description": "VBF1Parked AOD dataset file index (22 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20042_file_index.json"
       },
       {
-        "checksum": "sha1:69821c759f1f8170b271ad62ebdce33ac476c649",
+        "checksum": "adler32:d9af9d74",
         "description": "VBF1Parked AOD dataset file index (23 of 49) for access to data via CMS virtual machine",
         "size": 277752,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:ec9a9be10e82cf62bea652145db2723b3689cb30",
+        "checksum": "adler32:8f657756",
         "description": "VBF1Parked AOD dataset file index (24 of 49) for access to data via CMS virtual machine",
         "size": 275552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30001_file_index.json"
       },
       {
-        "checksum": "sha1:079919541fcd89daaf1b2a330cd5e08c6e138b36",
+        "checksum": "adler32:59171d2f",
         "description": "VBF1Parked AOD dataset file index (25 of 49) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30002_file_index.json"
       },
       {
-        "checksum": "sha1:cc80c2bc1091f994082f26d546ec36ec5e8f783d",
+        "checksum": "adler32:e8862bb8",
         "description": "VBF1Parked AOD dataset file index (26 of 49) for access to data via CMS virtual machine",
         "size": 275277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30003_file_index.json"
       },
       {
-        "checksum": "sha1:69811601668700d7a137695cca7fff40a11b23c1",
+        "checksum": "adler32:8c124b90",
         "description": "VBF1Parked AOD dataset file index (27 of 49) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30004_file_index.json"
       },
       {
-        "checksum": "sha1:e2af5fe17b59a19ae4205dad2e831e8505ab6889",
+        "checksum": "adler32:dbc23f8b",
         "description": "VBF1Parked AOD dataset file index (28 of 49) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30005_file_index.json"
       },
       {
-        "checksum": "sha1:da712d059077f379405012fc91fbd8205fc3ebb6",
+        "checksum": "adler32:d6cc1054",
         "description": "VBF1Parked AOD dataset file index (29 of 49) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30006_file_index.json"
       },
       {
-        "checksum": "sha1:0e996ed8bd671b08cf5c5e0223222b3e8b455b76",
+        "checksum": "adler32:ac0a158b",
         "description": "VBF1Parked AOD dataset file index (30 of 49) for access to data via CMS virtual machine",
         "size": 275552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30007_file_index.json"
       },
       {
-        "checksum": "sha1:9132ed564efbaf80833e8340806be9dd049a7d25",
+        "checksum": "adler32:c8b71134",
         "description": "VBF1Parked AOD dataset file index (31 of 49) for access to data via CMS virtual machine",
         "size": 275002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30008_file_index.json"
       },
       {
-        "checksum": "sha1:d6e1ca231bad3ca83606a00ff75d82280c13ab63",
+        "checksum": "adler32:c5e95f7d",
         "description": "VBF1Parked AOD dataset file index (32 of 49) for access to data via CMS virtual machine",
         "size": 261252,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30009_file_index.json"
       },
       {
-        "checksum": "sha1:4956e1a21b2e88217cb93ae75696e3b08bec4c7f",
+        "checksum": "adler32:5cc9487b",
         "description": "VBF1Parked AOD dataset file index (33 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30012_file_index.json"
       },
       {
-        "checksum": "sha1:0cb602d6c225ab554553d12f585e41cf22aa051f",
+        "checksum": "adler32:11ea8ecb",
         "description": "VBF1Parked AOD dataset file index (34 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30015_file_index.json"
       },
       {
-        "checksum": "sha1:d0b65e5225be527d2be1430f4a7d5c0189f53460",
+        "checksum": "adler32:93058e74",
         "description": "VBF1Parked AOD dataset file index (35 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30017_file_index.json"
       },
       {
-        "checksum": "sha1:3fcf7fbd07845188d69339ba99c008b01f218997",
+        "checksum": "adler32:cd8c47a2",
         "description": "VBF1Parked AOD dataset file index (36 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30019_file_index.json"
       },
       {
-        "checksum": "sha1:af83b80a6afe34592f82e34ce4619c6112e181ca",
+        "checksum": "adler32:ea228eee",
         "description": "VBF1Parked AOD dataset file index (37 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30023_file_index.json"
       },
       {
-        "checksum": "sha1:1409111173539dc0bfec190a91dd6358ebc4cc03",
+        "checksum": "adler32:97424772",
         "description": "VBF1Parked AOD dataset file index (38 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30024_file_index.json"
       },
       {
-        "checksum": "sha1:e77cc92eee219f2b40553f49f4b7e2c9a940eb80",
+        "checksum": "adler32:92d88efc",
         "description": "VBF1Parked AOD dataset file index (39 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30026_file_index.json"
       },
       {
-        "checksum": "sha1:fd5ae25fab7f96f28a6eb516a244e225ee9a1605",
+        "checksum": "adler32:658c8e84",
         "description": "VBF1Parked AOD dataset file index (40 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30028_file_index.json"
       },
       {
-        "checksum": "sha1:1c2738ef80c267150bf4cd7d6b3c2f0eb261b504",
+        "checksum": "adler32:b1c8d611",
         "description": "VBF1Parked AOD dataset file index (41 of 49) for access to data via CMS virtual machine",
         "size": 827,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30031_file_index.json"
       },
       {
-        "checksum": "sha1:6727298dd1723ce4e8d181f06d8de1bbf152983d",
+        "checksum": "adler32:aef3478a",
         "description": "VBF1Parked AOD dataset file index (42 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30032_file_index.json"
       },
       {
-        "checksum": "sha1:1b9cdce68ad9c6e4bef50fd6a2688cf8611eb50b",
+        "checksum": "adler32:88764732",
         "description": "VBF1Parked AOD dataset file index (43 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30033_file_index.json"
       },
       {
-        "checksum": "sha1:72e8963345c9e930a2239c641a78f404ed4b444d",
+        "checksum": "adler32:a71a8eef",
         "description": "VBF1Parked AOD dataset file index (44 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30035_file_index.json"
       },
       {
-        "checksum": "sha1:9ace8fe9899285f6f1402a706c38dd46dfdfe205",
+        "checksum": "adler32:acee8f4e",
         "description": "VBF1Parked AOD dataset file index (45 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30036_file_index.json"
       },
       {
-        "checksum": "sha1:89ba47aa7b59917e8b71bf852532615c11786947",
+        "checksum": "adler32:b4dd8f20",
         "description": "VBF1Parked AOD dataset file index (46 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30038_file_index.json"
       },
       {
-        "checksum": "sha1:a83beb24a595362f928adc6761b3611fba3b363e",
+        "checksum": "adler32:2357484d",
         "description": "VBF1Parked AOD dataset file index (47 of 49) for access to data via CMS virtual machine",
         "size": 277,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30039_file_index.json"
       },
       {
-        "checksum": "sha1:38b0c52d5182ea1a5b834b7322a77659c3866e6a",
+        "checksum": "adler32:410cd70d",
         "description": "VBF1Parked AOD dataset file index (48 of 49) for access to data via CMS virtual machine",
         "size": 827,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30041_file_index.json"
       },
       {
-        "checksum": "sha1:d910ae6d93f5672d73022b4b6bfdf4f3bda44222",
+        "checksum": "adler32:761d8f03",
         "description": "VBF1Parked AOD dataset file index (49 of 49) for access to data via CMS virtual machine",
         "size": 552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30043_file_index.json"
       },
       {
-        "checksum": "sha1:3fadcfa2c1911dcf005978ef8420046b4633085f",
+        "checksum": "adler32:980bfbbb",
         "description": "VBF1Parked AOD dataset file index (1 of 49) for access to data via CMS virtual machine",
         "size": 129920,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:5b5601cd2e888ca9b80d90dbad732a080d3dc563",
+        "checksum": "adler32:dbae23f6",
         "description": "VBF1Parked AOD dataset file index (2 of 49) for access to data via CMS virtual machine",
         "size": 128256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:c97a184432c04d1852ee7d5be21be22818fac941",
+        "checksum": "adler32:38550b9a",
         "description": "VBF1Parked AOD dataset file index (3 of 49) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:0f286cc66e16ee67b45fcd68c2da5bac37ac996f",
+        "checksum": "adler32:ed185153",
         "description": "VBF1Parked AOD dataset file index (4 of 49) for access to data via CMS virtual machine",
         "size": 128384,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:7750e320f93af9b917cbe6c43a6f7050aab7729f",
+        "checksum": "adler32:8c7341ba",
         "description": "VBF1Parked AOD dataset file index (5 of 49) for access to data via CMS virtual machine",
         "size": 128128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20004_file_index.txt"
       },
       {
-        "checksum": "sha1:2430cb490ed28d0165fafab6dc074520b221912f",
+        "checksum": "adler32:b24d1d43",
         "description": "VBF1Parked AOD dataset file index (6 of 49) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20005_file_index.txt"
       },
       {
-        "checksum": "sha1:4c1bfad42d00901340656896afab6cf7b4eaac97",
+        "checksum": "adler32:ea2f2c37",
         "description": "VBF1Parked AOD dataset file index (7 of 49) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20006_file_index.txt"
       },
       {
-        "checksum": "sha1:b48c515bb7506e010da41688c9b61fa1b550c3de",
+        "checksum": "adler32:c16ee3ef",
         "description": "VBF1Parked AOD dataset file index (8 of 49) for access to data via CMS virtual machine",
         "size": 127872,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20007_file_index.txt"
       },
       {
-        "checksum": "sha1:654ca390aaf687c5e18b7b39c6de97a7ca5862c7",
+        "checksum": "adler32:f8e43eaa",
         "description": "VBF1Parked AOD dataset file index (9 of 49) for access to data via CMS virtual machine",
         "size": 99712,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20008_file_index.txt"
       },
       {
-        "checksum": "sha1:ca8f66a00a8a243f21722e2226598f48afba2182",
+        "checksum": "adler32:485724f2",
         "description": "VBF1Parked AOD dataset file index (10 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20015_file_index.txt"
       },
       {
-        "checksum": "sha1:9ea978881e0e4e93464c5457bc3e9a6f19559292",
+        "checksum": "adler32:1c4292c8",
         "description": "VBF1Parked AOD dataset file index (11 of 49) for access to data via CMS virtual machine",
         "size": 512,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20017_file_index.txt"
       },
       {
-        "checksum": "sha1:d0dd4b2f75973fdbdf64e722fe25203272177522",
+        "checksum": "adler32:fb846e5e",
         "description": "VBF1Parked AOD dataset file index (12 of 49) for access to data via CMS virtual machine",
         "size": 384,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20023_file_index.txt"
       },
       {
-        "checksum": "sha1:5fc420dba959965f16a6327fe9444741dac23431",
+        "checksum": "adler32:deb0495e",
         "description": "VBF1Parked AOD dataset file index (13 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20024_file_index.txt"
       },
       {
-        "checksum": "sha1:8022b0a487a21ddd760b36665443f63396162869",
+        "checksum": "adler32:078d49a6",
         "description": "VBF1Parked AOD dataset file index (14 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20029_file_index.txt"
       },
       {
-        "checksum": "sha1:2b9bd3c35b06c24b9e72c834722e540262e7efd8",
+        "checksum": "adler32:400424a4",
         "description": "VBF1Parked AOD dataset file index (15 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20032_file_index.txt"
       },
       {
-        "checksum": "sha1:1650ad9f03ecc4897e73bdab286c93fc933c1e9b",
+        "checksum": "adler32:450f24d9",
         "description": "VBF1Parked AOD dataset file index (16 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20033_file_index.txt"
       },
       {
-        "checksum": "sha1:b22624f23885a6c4ce071ab6546d8f03fc9adc7f",
+        "checksum": "adler32:ffb549ae",
         "description": "VBF1Parked AOD dataset file index (17 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20035_file_index.txt"
       },
       {
-        "checksum": "sha1:0fdc10c7cefff3562846035b6dd36c4fa9c93fb1",
+        "checksum": "adler32:499624d8",
         "description": "VBF1Parked AOD dataset file index (18 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20036_file_index.txt"
       },
       {
-        "checksum": "sha1:619998301eb8a5bbaf62c030c64484d81690fa99",
+        "checksum": "adler32:4dc02518",
         "description": "VBF1Parked AOD dataset file index (19 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20037_file_index.txt"
       },
       {
-        "checksum": "sha1:39c4b559f10a254860ac26613cff6ee1af0d3c85",
+        "checksum": "adler32:446d24ca",
         "description": "VBF1Parked AOD dataset file index (20 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20038_file_index.txt"
       },
       {
-        "checksum": "sha1:dc84b810fe55c1845cdc4b2bb7923df706abaf85",
+        "checksum": "adler32:038049c7",
         "description": "VBF1Parked AOD dataset file index (21 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20040_file_index.txt"
       },
       {
-        "checksum": "sha1:00686dd9a26a6224b2bea009b78cc20db8d805bb",
+        "checksum": "adler32:463a24e8",
         "description": "VBF1Parked AOD dataset file index (22 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_20042_file_index.txt"
       },
       {
-        "checksum": "sha1:d9ae7d668a5654258058f6b213ea26448c233976",
+        "checksum": "adler32:cd8b4f25",
         "description": "VBF1Parked AOD dataset file index (23 of 49) for access to data via CMS virtual machine",
         "size": 129280,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:bb2616ed2e83c0cc64419576adad43e85b43049a",
+        "checksum": "adler32:1f292ecb",
         "description": "VBF1Parked AOD dataset file index (24 of 49) for access to data via CMS virtual machine",
         "size": 128256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30001_file_index.txt"
       },
       {
-        "checksum": "sha1:83cc24e462e82954db39fb970b22f9a4e4f89fe1",
+        "checksum": "adler32:a49d0219",
         "description": "VBF1Parked AOD dataset file index (25 of 49) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30002_file_index.txt"
       },
       {
-        "checksum": "sha1:06b77271868834f7cb9667edbbde41adee351e32",
+        "checksum": "adler32:e6920f60",
         "description": "VBF1Parked AOD dataset file index (26 of 49) for access to data via CMS virtual machine",
         "size": 128128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30003_file_index.txt"
       },
       {
-        "checksum": "sha1:9897d1c21d096f6ba0b73a10a3b334c0cacc419f",
+        "checksum": "adler32:4a191cb1",
         "description": "VBF1Parked AOD dataset file index (27 of 49) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30004_file_index.txt"
       },
       {
-        "checksum": "sha1:ff26d948abfa3de8a44f428f409ae3f41ecb2698",
+        "checksum": "adler32:e2cc1b8a",
         "description": "VBF1Parked AOD dataset file index (28 of 49) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30005_file_index.txt"
       },
       {
-        "checksum": "sha1:d68dffcf6577352de1f2e435fa6353c375fc950f",
+        "checksum": "adler32:d1ee027f",
         "description": "VBF1Parked AOD dataset file index (29 of 49) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30006_file_index.txt"
       },
       {
-        "checksum": "sha1:5bef45714fe9dd19ea9afcfc936d64767366ac5f",
+        "checksum": "adler32:e1409313",
         "description": "VBF1Parked AOD dataset file index (30 of 49) for access to data via CMS virtual machine",
         "size": 128256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30007_file_index.txt"
       },
       {
-        "checksum": "sha1:4ecff52b6e6946b69e04cc71b6f6ee42ddee8d19",
+        "checksum": "adler32:b6e90a73",
         "description": "VBF1Parked AOD dataset file index (31 of 49) for access to data via CMS virtual machine",
         "size": 128000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30008_file_index.txt"
       },
       {
-        "checksum": "sha1:f39a4b8f5afcb31b744cd508569c64ac2fb2f97b",
+        "checksum": "adler32:526bf334",
         "description": "VBF1Parked AOD dataset file index (32 of 49) for access to data via CMS virtual machine",
         "size": 121600,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30009_file_index.txt"
       },
       {
-        "checksum": "sha1:4c93e1e1af0a5a3ab71712b528ae709533c6238f",
+        "checksum": "adler32:463d24fc",
         "description": "VBF1Parked AOD dataset file index (33 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30012_file_index.txt"
       },
       {
-        "checksum": "sha1:f58a390c4f423b6b9f97507c56d3c33167e3ea59",
+        "checksum": "adler32:026a49c7",
         "description": "VBF1Parked AOD dataset file index (34 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30015_file_index.txt"
       },
       {
-        "checksum": "sha1:3cd3504f882cfe1aa14831342f4f2fb26419dbd7",
+        "checksum": "adler32:f1d24999",
         "description": "VBF1Parked AOD dataset file index (35 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30017_file_index.txt"
       },
       {
-        "checksum": "sha1:15d355bd5b047c22664a5ecdd4bc6792b0fa668a",
+        "checksum": "adler32:43e424c4",
         "description": "VBF1Parked AOD dataset file index (36 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30019_file_index.txt"
       },
       {
-        "checksum": "sha1:c8e2c7ac1b3734b9f6a00fd02293af3b04e169c5",
+        "checksum": "adler32:ecda49a7",
         "description": "VBF1Parked AOD dataset file index (37 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30023_file_index.txt"
       },
       {
-        "checksum": "sha1:ccb46d4a129d2d7397cf18261ae107d62d0ac0df",
+        "checksum": "adler32:407224c3",
         "description": "VBF1Parked AOD dataset file index (38 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30024_file_index.txt"
       },
       {
-        "checksum": "sha1:d283c4af4feea6aff5448ed935164dae152fc340",
+        "checksum": "adler32:f27d4983",
         "description": "VBF1Parked AOD dataset file index (39 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30026_file_index.txt"
       },
       {
-        "checksum": "sha1:47ae69d202b3509c7f2c4ac2f2e0f3fb9f65ed39",
+        "checksum": "adler32:f42749c1",
         "description": "VBF1Parked AOD dataset file index (40 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30028_file_index.txt"
       },
       {
-        "checksum": "sha1:283b8ef06d3478491f7b4b14030e08282781e0b2",
+        "checksum": "adler32:12de6e83",
         "description": "VBF1Parked AOD dataset file index (41 of 49) for access to data via CMS virtual machine",
         "size": 384,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30031_file_index.txt"
       },
       {
-        "checksum": "sha1:2a6214a6e0384254d33a2405d7e9da6caea34897",
+        "checksum": "adler32:45a824ce",
         "description": "VBF1Parked AOD dataset file index (42 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30032_file_index.txt"
       },
       {
-        "checksum": "sha1:483b668b7735755bc03c98a2265ac599d41ff7ab",
+        "checksum": "adler32:408924a1",
         "description": "VBF1Parked AOD dataset file index (43 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30033_file_index.txt"
       },
       {
-        "checksum": "sha1:b4f631cad8588de7f5b179adcbf669330c958e62",
+        "checksum": "adler32:19ad4a08",
         "description": "VBF1Parked AOD dataset file index (44 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30035_file_index.txt"
       },
       {
-        "checksum": "sha1:acf5e117ed4ddf56526393746c013fc26d6b7dd3",
+        "checksum": "adler32:255049fa",
         "description": "VBF1Parked AOD dataset file index (45 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30036_file_index.txt"
       },
       {
-        "checksum": "sha1:9c579f132ec71ca750939161ce12b6eb00a3f9f2",
+        "checksum": "adler32:fdd049b4",
         "description": "VBF1Parked AOD dataset file index (46 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30038_file_index.txt"
       },
       {
-        "checksum": "sha1:3487d1bcf0e58abb863df35df8c87f609c715997",
+        "checksum": "adler32:4d682511",
         "description": "VBF1Parked AOD dataset file index (47 of 49) for access to data via CMS virtual machine",
         "size": 128,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30039_file_index.txt"
       },
       {
-        "checksum": "sha1:8963ebda38bf714f2be29ced67bff2661d009ae8",
+        "checksum": "adler32:89036f11",
         "description": "VBF1Parked AOD dataset file index (48 of 49) for access to data via CMS virtual machine",
         "size": 384,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012C/VBF1Parked/AOD/22Jan2013-v1/file-indexes/CMS_Run2012C_VBF1Parked_AOD_22Jan2013-v1_30041_file_index.txt"
       },
       {
-        "checksum": "sha1:c5debcd95bd6d7a11f2695a43c3e52ea21f86025",
+        "checksum": "adler32:eb4e49a3",
         "description": "VBF1Parked AOD dataset file index (49 of 49) for access to data via CMS virtual machine",
         "size": 256,
         "type": "index.txt",

--- a/cernopendata/modules/fixtures/data/records/cms-reco-configuration-files-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-reco-configuration-files-2012.json
@@ -29,7 +29,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a1109d2b609a6e01086ab312c6f94e409f4fb410",
+        "checksum": "adler32:bae343fd",
         "size": 4598,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_HTMHTParked.py"
       }
@@ -77,7 +77,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c94f43b43c644f7d6c26de550d53e11af8a7edd1",
+        "checksum": "adler32:4d3a4346",
         "size": 4595,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_TauPlusX.py"
       }
@@ -125,7 +125,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:82c93e94be30241bce941fee71da051125a84a1b",
+        "checksum": "adler32:ffe428e8",
         "size": 6103,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MuOniaParked.py"
       }
@@ -173,7 +173,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:57405e705c0290478d5f9ad190179c51a1002edb",
+        "checksum": "adler32:ef6e41e0",
         "size": 4592,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_JetHT.py"
       }
@@ -221,7 +221,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e8b783ab728a0fba965e7de3fe846e192a340017",
+        "checksum": "adler32:65068dea",
         "size": 4049,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MuEG.py"
       }
@@ -269,7 +269,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fa81e82d88b5642a1e247c518b994840a6354033",
+        "checksum": "adler32:81c49003",
         "size": 4055,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_VBF1Parked.py"
       }
@@ -317,7 +317,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:99777d13433970e29d0299c974950886f7580e98",
+        "checksum": "adler32:62f285b2",
         "size": 5587,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_Commissioning.py"
       }
@@ -365,7 +365,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:84a1caed05488fbcac01638be70f8c929a612c39",
+        "checksum": "adler32:1d228e6c",
         "size": 4050,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MuHad.py"
       }
@@ -413,7 +413,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d726f30a9a4ab6c9b465a32afa1a11e9a9de0ca1",
+        "checksum": "adler32:2291816d",
         "size": 8819,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_SingleMu.py"
       }
@@ -461,7 +461,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ecca56f6a90489539cae8400a1f842517b742e8a",
+        "checksum": "adler32:78df426e",
         "size": 4593,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_JetMon.py"
       }
@@ -509,7 +509,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c9e33404bc903c5a5debd45f9dd1e76a9c2a3ad3",
+        "checksum": "adler32:0f318e6b",
         "size": 4050,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MuHad.py"
       }
@@ -557,7 +557,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:65d90d17c56f237cde126e00a47300252e615239",
+        "checksum": "adler32:e82a43a5",
         "size": 4596,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_PhotonHad.py"
       }
@@ -605,7 +605,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f27a9ccf775ef434b7c1138bd8c74c277c19344b",
+        "checksum": "adler32:f83343a6",
         "size": 4596,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_PhotonHad.py"
       }
@@ -653,7 +653,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8cc6201017aeed94c9147b86192cc62b9f9b8485",
+        "checksum": "adler32:fdb14106",
         "size": 4590,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MET.py"
       }
@@ -701,7 +701,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fa3b2aa94fb00082a432cbb2721a7da367ef6cee",
+        "checksum": "adler32:2634417e",
         "size": 4591,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_BTag.py"
       }
@@ -749,7 +749,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7505ddab2d5cac66d6200794760667f488b4a374",
+        "checksum": "adler32:a296916f",
         "size": 4057,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_DoublePhoton.py"
       }
@@ -797,7 +797,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:108d1c316f5af363bd736841c15edaa79420f903",
+        "checksum": "adler32:96118ffe",
         "size": 4054,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_BJetPlusX.py"
       }
@@ -845,7 +845,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4c8ad74176458573c579b593a21899446e0e1d66",
+        "checksum": "adler32:46b2e70e",
         "size": 7384,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MinimumBias.py"
       }
@@ -893,7 +893,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fde5feeb8292c404a3a215d21274eedf7868e1ce",
+        "checksum": "adler32:2c8d93b3",
         "size": 4063,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_DoublePhotonHighPt.py"
       }
@@ -941,7 +941,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c3e22543f70842d779dedba38fef73bee13ace56",
+        "checksum": "adler32:d5b9b73c",
         "size": 6624,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_SingleElectron.py"
       }
@@ -989,7 +989,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4acc9a56757ffa339e8eddcbfd65541c609939c0",
+        "checksum": "adler32:3b58d920",
         "size": 6638,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MuOnia.py"
       }
@@ -1037,7 +1037,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:86ccf2172dd13c1c664bb2c1418dcbf71213a9a9",
+        "checksum": "adler32:5d424347",
         "size": 4595,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_TauPlusX.py"
       }
@@ -1085,7 +1085,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9eeba45f6067c4741dd2252211a1f4de16cec27c",
+        "checksum": "adler32:28d0cd30",
         "size": 5817,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_HcalNZS.py"
       }
@@ -1133,7 +1133,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0a790bd7a1aeff7218fedc851b0626e55a4a72d8",
+        "checksum": "adler32:784590e5",
         "size": 4056,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_ElectronHad.py"
       }
@@ -1181,7 +1181,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d2f48240e699582f7ae317484d2d6df495d6eb0f",
+        "checksum": "adler32:9791b72f",
         "size": 6624,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_DoubleElectron.py"
       }
@@ -1229,7 +1229,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1e1fca069177835f58a6cce2466f66f5939b3c4a",
+        "checksum": "adler32:4a8f44fb",
         "size": 4599,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_SinglePhoton.py"
       }
@@ -1277,7 +1277,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8e1e56d8a816e34b9fee7d0bd9e128e5020a63db",
+        "checksum": "adler32:2be4e70d",
         "size": 7384,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MinimumBias.py"
       }
@@ -1325,7 +1325,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:41ed5c90cc26ceaacf363029eca7626f1f95cbf9",
+        "checksum": "adler32:4f1e85b1",
         "size": 5587,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_Commissioning.py"
       }
@@ -1373,7 +1373,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ee14fe7072f7cf935d82abae78141cef8c378609",
+        "checksum": "adler32:4871421b",
         "size": 4593,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_NoBPTX.py"
       }
@@ -1421,7 +1421,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1b50945fa95b576347bd193e0c9fdf98b0bab33e",
+        "checksum": "adler32:3638417f",
         "size": 4591,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_BTag.py"
       }
@@ -1469,7 +1469,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f115cfe99882a447cefbca1a52019b6e3d52fa26",
+        "checksum": "adler32:aad843fc",
         "size": 4598,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_HTMHTParked.py"
       }
@@ -1517,7 +1517,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:611adc60addc51f8ae74be55ef76591d6eea0b79",
+        "checksum": "adler32:15d628e9",
         "size": 6103,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MuOniaParked.py"
       }
@@ -1565,7 +1565,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d9d771771a9665bd76fb0f266267882c3055c1e6",
+        "checksum": "adler32:73ce9002",
         "size": 4055,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_VBF1Parked.py"
       }
@@ -1613,7 +1613,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1bc4e297f1c7a042e50d7ea0fccd31dc844f3b12",
+        "checksum": "adler32:c5a86b68",
         "size": 8768,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_DoubleMuParked.py"
       }
@@ -1661,7 +1661,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:46a9be4470ae8f02de474b7f0e2f4c027a0055e7",
+        "checksum": "adler32:863c90e6",
         "size": 4056,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_ElectronHad.py"
       }
@@ -1709,7 +1709,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:06230305494acbd4c55b404ce2690e56cafa0f42",
+        "checksum": "adler32:68d9426d",
         "size": 4593,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_JetMon.py"
       }
@@ -1757,7 +1757,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:683849573316907e298d22e2bf5966558d5c2c48",
+        "checksum": "adler32:54a0901e",
         "size": 4054,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_TauParked.py"
       }
@@ -1805,7 +1805,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bbcb175d68a761ade609076b1d4abab79958891d",
+        "checksum": "adler32:2362d91f",
         "size": 6638,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_MuOnia.py"
       }
@@ -1853,7 +1853,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d2c4203f0523288b336a4fa296c8d1e97ddd2f96",
+        "checksum": "adler32:a5686b67",
         "size": 8768,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_DoubleMuParked.py"
       }
@@ -1901,7 +1901,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ffea94dd64fb030cc38ba468c132e58d5f720c0a",
+        "checksum": "adler32:430a816e",
         "size": 8819,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_SingleMu.py"
       }
@@ -1949,7 +1949,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:95ce0078c37819187ddfb26986e44c480ba07262",
+        "checksum": "adler32:1427cd2f",
         "size": 5817,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_HcalNZS.py"
       }
@@ -1997,7 +1997,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1cd161c74cce9e0e2d943c5911e7731ed7a9edd8",
+        "checksum": "adler32:5877421c",
         "size": 4593,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_NoBPTX.py"
       }
@@ -2045,7 +2045,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ad2b37c194384d09190ab27b7a6e86d707c68d42",
+        "checksum": "adler32:b08e9170",
         "size": 4057,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_DoublePhoton.py"
       }
@@ -2093,7 +2093,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9f698b518a9595650b6af4c026c22dd75c6a8c88",
+        "checksum": "adler32:7fb1b72e",
         "size": 6624,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_DoubleElectron.py"
       }
@@ -2141,7 +2141,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ed03624aed0b4de7998415dae0937f2474367a5c",
+        "checksum": "adler32:ed99b73d",
         "size": 6624,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_SingleElectron.py"
       }
@@ -2189,7 +2189,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b0863f3b3273e26f432eb52b7c416e808d2204d0",
+        "checksum": "adler32:72f68deb",
         "size": 4049,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MuEG.py"
       }
@@ -2237,7 +2237,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f8fc4b97601995dbcc0fc8721d591062b35548db",
+        "checksum": "adler32:46ab901d",
         "size": 4054,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_TauParked.py"
       }
@@ -2285,7 +2285,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dd7d9604058b1d1ea8abe07e55167a0e8f83ff83",
+        "checksum": "adler32:df6941df",
         "size": 4592,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_JetHT.py"
       }
@@ -2333,7 +2333,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:12cfe74631425f7ecfab2e333022128f0deafebb",
+        "checksum": "adler32:3a8344fa",
         "size": 4599,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_SinglePhoton.py"
       }
@@ -2381,7 +2381,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dad3163f63ad52e68405abeca4be310b27a58f40",
+        "checksum": "adler32:881c8ffd",
         "size": 4054,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012B_BJetPlusX.py"
       }
@@ -2429,7 +2429,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5e9726c92536a9cecd1029f208e172844b3a12d7",
+        "checksum": "adler32:0dc34107",
         "size": 4590,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_MET.py"
       }
@@ -2477,7 +2477,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8955f09cc519d1079e08dc953971b2a845c539cb",
+        "checksum": "adler32:3a8b93b4",
         "size": 4063,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/configuration-files/2012/reco_2012C_DoublePhotonHighPt.py"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2012.json
@@ -40,28 +40,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:107b1f8adb6c90dbab944e18884f7b87e230aa3e",
+        "checksum": "adler32:f8154ec4",
         "description": "BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 4873,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:7536cb92fabb64b7223ba09c1b3304bafba1ca57",
+        "checksum": "adler32:81721ea6",
         "description": "BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 8353,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:fb13c177e9dac683657dfc8246065a994ad5dbf1",
+        "checksum": "adler32:aa016d60",
         "description": "BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 2814,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:c5bb4f134beaff2671987dfca6ab57224bc878f6",
+        "checksum": "adler32:9c70e25e",
         "description": "BBH_HToTauTau_M_125_TuneZ2star_8TeV_pythia6_tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 4824,
         "type": "index.txt",
@@ -166,28 +166,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:62d3d443a1f216bd8a0c1ed7c30ca28526972ab9",
+        "checksum": "adler32:7904a2fd",
         "description": "Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 17005,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:4769511be2dbee993aac63b6e24fe7eafcc8cc88",
+        "checksum": "adler32:d0c5cccc",
         "description": "Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 18046,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:56bfb0e17a08130bd7742762bd81eaebb08542b2",
+        "checksum": "adler32:dc290ea4",
         "description": "Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 9800,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:c15d5b6be467aa06c93701dfac0ddc544d5bf5e4",
+        "checksum": "adler32:4cbfce80",
         "description": "Diphoton2Jets_EW4_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 10400,
         "type": "index.txt",
@@ -342,14 +342,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d8dfa49f4e05b87edd37345d6973df8e7c4396ea",
+        "checksum": "adler32:4559d751",
         "description": "DiPhotonBorn_Pt-10To25_8TeV_ext-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 32352,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DiPhotonBorn_Pt-10To25_8TeV_ext-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DiPhotonBorn_Pt-10To25_8TeV_ext-pythia6_AODSIM_PU_RD1_START53_V7N-v2_10000_file_index.json"
       },
       {
-        "checksum": "sha1:51cfed3c00b289246d11f6d85147c2d6949b4ce0",
+        "checksum": "adler32:4dcaf59c",
         "description": "DiPhotonBorn_Pt-10To25_8TeV_ext-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 18240,
         "type": "index.txt",
@@ -447,14 +447,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b455d7c38626c5c7be6c29efbf18bf459106e846",
+        "checksum": "adler32:413b7179",
         "description": "DiPhotonBorn_Pt-250ToInf_8TeV_ext-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 37291,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DiPhotonBorn_Pt-250ToInf_8TeV_ext-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DiPhotonBorn_Pt-250ToInf_8TeV_ext-pythia6_AODSIM_PU_RD1_START53_V7N-v2_10000_file_index.json"
       },
       {
-        "checksum": "sha1:a821d72f90e4e62e992a0ee0c0580eafb714bb96",
+        "checksum": "adler32:e5aea059",
         "description": "DiPhotonBorn_Pt-250ToInf_8TeV_ext-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 21120,
         "type": "index.txt",
@@ -552,14 +552,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:436916937c76eccd036f7ad0101abbc08edd00ec",
+        "checksum": "adler32:8d9a921e",
         "description": "DiPhotonBorn_Pt-25To250_8TeV_ext-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 34815,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DiPhotonBorn_Pt-25To250_8TeV_ext-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DiPhotonBorn_Pt-25To250_8TeV_ext-pythia6_AODSIM_PU_RD1_START53_V7N-v2_10000_file_index.json"
       },
       {
-        "checksum": "sha1:60b84cef7700a941b29fc83ea2360ae73056d940",
+        "checksum": "adler32:7dc7b3fe",
         "description": "DiPhotonBorn_Pt-25To250_8TeV_ext-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 19673,
         "type": "index.txt",
@@ -664,14 +664,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:02a332c249ae383c4463b81149d60c9b1894e8eb",
+        "checksum": "adler32:281f5650",
         "description": "DiPhotonBox_Pt-10To25_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 14278,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DiPhotonBox_Pt-10To25_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DiPhotonBox_Pt-10To25_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:058571a53f3812e98bd3bbc8ea7b34205cab4f3f",
+        "checksum": "adler32:a1d885b3",
         "description": "DiPhotonBox_Pt-10To25_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 7955,
         "type": "index.txt",
@@ -776,14 +776,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fab27366feca461f57677d93b493bd375442d273",
+        "checksum": "adler32:2ff5ad5d",
         "description": "DiPhotonBox_Pt-250ToInf_8TeV_ext-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 33802,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DiPhotonBox_Pt-250ToInf_8TeV_ext-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DiPhotonBox_Pt-250ToInf_8TeV_ext-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:40c5155e48183c5c896c628744903b76361629f5",
+        "checksum": "adler32:f05b2bf2",
         "description": "DiPhotonBox_Pt-250ToInf_8TeV_ext-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 19100,
         "type": "index.txt",
@@ -888,14 +888,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6ff6891d2eb6da969f8828cd98ea4723828e84bf",
+        "checksum": "adler32:86360c53",
         "description": "DiPhotonBox_Pt-25To250_8TeV_ext-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 29657,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DiPhotonBox_Pt-25To250_8TeV_ext-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DiPhotonBox_Pt-25To250_8TeV_ext-pythia6_AODSIM_PU_RD1_START53_V7N-v2_10000_file_index.json"
       },
       {
-        "checksum": "sha1:cc552cc4bf91c82fdbcc97c9b7fbfbd6008673f2",
+        "checksum": "adler32:18eb2919",
         "description": "DiPhotonBox_Pt-25To250_8TeV_ext-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 16720,
         "type": "index.txt",
@@ -1000,14 +1000,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b0f2ed65292151b5d52cea9d141128c5748f2c14",
+        "checksum": "adler32:af1954c7",
         "description": "DiPhotonJets_7TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 31106,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DiPhotonJets_7TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DiPhotonJets_7TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:c2040c941861547c7f3b3309c6716c0861293897",
+        "checksum": "adler32:5e0471ed",
         "description": "DiPhotonJets_7TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 16992,
         "type": "index.txt",
@@ -1112,14 +1112,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fd7b1361307ab21b6cc2ca3434471fb6c21b56b6",
+        "checksum": "adler32:991bb94a",
         "description": "DiPhotonJets_8TeV-madgraph-tarball-v2 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 34841,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DiPhotonJets_8TeV-madgraph-tarball-v2/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DiPhotonJets_8TeV-madgraph-tarball-v2_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:d2ea07a85c0208569d3eca43f278b4d5db65d5fb",
+        "checksum": "adler32:4b47bfbb",
         "description": "DiPhotonJets_8TeV-madgraph-tarball-v2 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 19552,
         "type": "index.txt",
@@ -1224,28 +1224,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fa02ac7d16e2d8d8f10cba254aaa9fe678232070",
+        "checksum": "adler32:194e546b",
         "description": "DiPhotonJetsBox_M60_8TeV-sherpa AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 328673,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DiPhotonJetsBox_M60_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DiPhotonJetsBox_M60_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:68e9a76052220b51cc6ceae025e20304899bbab9",
+        "checksum": "adler32:f94e79bb",
         "description": "DiPhotonJetsBox_M60_8TeV-sherpa AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 109558,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DiPhotonJetsBox_M60_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DiPhotonJetsBox_M60_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:5cc1b753dbdc6cca904d5640d04e5d7d90b49416",
+        "checksum": "adler32:1aa26b9a",
         "description": "DiPhotonJetsBox_M60_8TeV-sherpa AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 181818,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DiPhotonJetsBox_M60_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DiPhotonJetsBox_M60_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:7d740439a9002c0ad77a0e16e609f65335d3eb32",
+        "checksum": "adler32:a69fd2ff",
         "description": "DiPhotonJetsBox_M60_8TeV-sherpa AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 60606,
         "type": "index.txt",
@@ -1350,14 +1350,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f96f47ea2c72873f830c7546a6f43c2ef6f027f0",
+        "checksum": "adler32:bb64954a",
         "description": "DiPhotonJets_M0_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10792,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DiPhotonJets_M0_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DiPhotonJets_M0_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:d601a6bba11c0519a19f36367da07b303918e574",
+        "checksum": "adler32:014c2650",
         "description": "DiPhotonJets_M0_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5940,
         "type": "index.txt",
@@ -1459,14 +1459,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5228364b45a04b14998d5b9880cb20443d91b79a",
+        "checksum": "adler32:e04f09f7",
         "description": "DoubleElectron_FlatPt-5To300_gun AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 554401,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DoubleElectron_FlatPt-5To300_gun/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DoubleElectron_FlatPt-5To300_gun_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:1f6d26f503bba667a38a404193b43f31ee5dfa47",
+        "checksum": "adler32:059c11d5",
         "description": "DoubleElectron_FlatPt-5To300_gun AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 307440,
         "type": "index.txt",
@@ -1571,14 +1571,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d2d640185ee30063051306e71ac1e26556858b5f",
+        "checksum": "adler32:aa5afd8b",
         "description": "DY1JetsToLL_M-10To50_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 217120,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-10To50_TuneZ2Star_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-10To50_TuneZ2Star_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:34ac703d72713364602abfeedbc39206f6bc850f",
+        "checksum": "adler32:e565cbdc",
         "description": "DY1JetsToLL_M-10To50_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 124068,
         "type": "index.txt",
@@ -1683,98 +1683,98 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9453afb48a69a921ab989d0d4c0cf5469e33bd5e",
+        "checksum": "adler32:ed215b6a",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (1 of 7) for access to data via CMS virtual machine",
         "size": 331670,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:4f678afea023ff1d80880c58db3e1afe58634734",
+        "checksum": "adler32:650ffa57",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (2 of 7) for access to data via CMS virtual machine",
         "size": 332002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:13c90b26c5e396de1eaf1981b387afa93817b22d",
+        "checksum": "adler32:cf5ca7ed",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (3 of 7) for access to data via CMS virtual machine",
         "size": 332002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_10002_file_index.json"
       },
       {
-        "checksum": "sha1:00f0650b15c15ff6bc716b82cd8c141b114b9ac3",
+        "checksum": "adler32:53f02bd3",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (4 of 7) for access to data via CMS virtual machine",
         "size": 211153,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_10003_file_index.json"
       },
       {
-        "checksum": "sha1:c6db9762e1fc8fec68c533a679e6962318f0e376",
+        "checksum": "adler32:2623a1b4",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (5 of 7) for access to data via CMS virtual machine",
         "size": 331670,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:05a29b20f846e948c34c5c027275eb82ba47080f",
+        "checksum": "adler32:77e2cb39",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (6 of 7) for access to data via CMS virtual machine",
         "size": 332002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:dead21a04affb3b28719a13fe9904c14bd711dc8",
+        "checksum": "adler32:a7fcd8af",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (7 of 7) for access to data via CMS virtual machine",
         "size": 77690,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:9bab2f650467e62a9d5395e4273680c581ebfd7e",
+        "checksum": "adler32:fe747d1b",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (1 of 7) for access to data via CMS virtual machine",
         "size": 184815,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:eeea8adb02166f9c31082150d6e534394beb4ce1",
+        "checksum": "adler32:d01edc4f",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (2 of 7) for access to data via CMS virtual machine",
         "size": 185000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:3a013d67922b0e5fb4affffc10cc2d0bac0b392a",
+        "checksum": "adler32:468db70a",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (3 of 7) for access to data via CMS virtual machine",
         "size": 185000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_10002_file_index.txt"
       },
       {
-        "checksum": "sha1:f5d03aa1288e53d623ac1801b33b4143c556fe6c",
+        "checksum": "adler32:095ade8a",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (4 of 7) for access to data via CMS virtual machine",
         "size": 117660,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_10003_file_index.txt"
       },
       {
-        "checksum": "sha1:f3213ee828325cb5fe0fcca83505cbed58ad103e",
+        "checksum": "adler32:f3b8a10c",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (5 of 7) for access to data via CMS virtual machine",
         "size": 184815,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:22051f76e7111cf1b7acb13ad376faf399365499",
+        "checksum": "adler32:d0fdcdc4",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (6 of 7) for access to data via CMS virtual machine",
         "size": 185000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY1JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY1JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:afdc1c376282697d5e61551ba87b57000558b61f",
+        "checksum": "adler32:f8fb75c2",
         "description": "DY1JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (7 of 7) for access to data via CMS virtual machine",
         "size": 43290,
         "type": "index.txt",
@@ -1879,14 +1879,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e0878ef0df5fb309d5d6962bbb56a4dbf5e2119c",
+        "checksum": "adler32:86399d3e",
         "description": "DY2JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 192562,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY2JetsToLL_M-50_8TeV_ext-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY2JetsToLL_M-50_8TeV_ext-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:46629aee07a7ef97c5c63a74ca4622d6bbdd07e7",
+        "checksum": "adler32:fa30ae11",
         "description": "DY2JetsToLL_M-50_8TeV_ext-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 107300,
         "type": "index.txt",
@@ -1991,14 +1991,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8002494d330a06bc78c42e43dd1ce14caa25e2d6",
+        "checksum": "adler32:400dcc2b",
         "description": "DY2JetsToLL_M-50_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 708511,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY2JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY2JetsToLL_M-50_TuneZ2Star_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:e107242de6a7a7bff5b600a880d080931c0dd7ab",
+        "checksum": "adler32:204e33d1",
         "description": "DY2JetsToLL_M-50_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 401280,
         "type": "index.txt",
@@ -2103,28 +2103,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cf3d56d4b1b3b58609d20a58cc6f4b2f415371ea",
+        "checksum": "adler32:b7fcfa6a",
         "description": "DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 443719,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:cce67ae1938b50d324699d105064ca47a4526254",
+        "checksum": "adler32:ff736bfd",
         "description": "DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 180009,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_010000_file_index.json"
       },
       {
-        "checksum": "sha1:b2dc319d201639e26982f96a46f0c93e7dfb25e8",
+        "checksum": "adler32:e3198e94",
         "description": "DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 251520,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:23da7fc5999b3cfbe3aa653681024f5d10e750c7",
+        "checksum": "adler32:2f069e49",
         "description": "DY3JetsToLL_M-50_TuneZ2Star_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 102483,
         "type": "index.txt",
@@ -2229,14 +2229,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:49bbc6d10f032391b35c38505909f243f621e695",
+        "checksum": "adler32:fafbb05c",
         "description": "DY4JetsToLL_M-50_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 213571,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DY4JetsToLL_M-50_TuneZ2Star_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DY4JetsToLL_M-50_TuneZ2Star_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:75c85fc54a8db75806b8e9276bda2a858841f185",
+        "checksum": "adler32:885c18d4",
         "description": "DY4JetsToLL_M-50_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 120960,
         "type": "index.txt",
@@ -2341,154 +2341,154 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d9563e2430d070d3ac8781cba2e6670b51772ff6",
+        "checksum": "adler32:3850f98c",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
         "size": 343658,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:775b8cf645e283782bb6fa591aea15bee66178e4",
+        "checksum": "adler32:1297c095",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
         "size": 344002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:8a8f29eda407ce189b5ce2b8776692dde30c30fe",
+        "checksum": "adler32:9ad913d1",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
         "size": 344002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10002_file_index.json"
       },
       {
-        "checksum": "sha1:34e392101f59f14755e88181afe1ce1e4cbb402d",
+        "checksum": "adler32:48a60b48",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
         "size": 344002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10003_file_index.json"
       },
       {
-        "checksum": "sha1:fd89490bc06a80f96bccdbb05d27c7981fdb0fdf",
+        "checksum": "adler32:cbd73837",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
         "size": 344002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10004_file_index.json"
       },
       {
-        "checksum": "sha1:a7ae35dc3604831359f07dde291b86d00cd99e50",
+        "checksum": "adler32:3f6423a5",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
         "size": 344002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10005_file_index.json"
       },
       {
-        "checksum": "sha1:bbfc1724367359bb2ae446a84f7972d698e02745",
+        "checksum": "adler32:b6cf4be9",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
         "size": 344002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10006_file_index.json"
       },
       {
-        "checksum": "sha1:129196e2793da849e9bb0b4e8c7e7f4494a33492",
+        "checksum": "adler32:251d7eff",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
         "size": 344002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10007_file_index.json"
       },
       {
-        "checksum": "sha1:0f10451a5fb52d3c3d869e9058dc6cb08592474c",
+        "checksum": "adler32:7b397d42",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
         "size": 344002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10008_file_index.json"
       },
       {
-        "checksum": "sha1:46cf04dccb0b879e7df225268d20cc3ce0047b91",
+        "checksum": "adler32:b1b6a15f",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
         "size": 344002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10009_file_index.json"
       },
       {
-        "checksum": "sha1:3d5f091c08d3bbb526e2e689188d66bd4f2f164b",
+        "checksum": "adler32:02576230",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
         "size": 57794,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10010_file_index.json"
       },
       {
-        "checksum": "sha1:e5a70bec3a3e9ae5881ad9bb3ef3637654a17343",
+        "checksum": "adler32:d190eaf2",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
         "size": 196803,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:540e2d6992ec1abc83603177ef83cd5ea9747335",
+        "checksum": "adler32:32c5e056",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
         "size": 197000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:3443b60916fd0b5959e34a76a832edbc43f5c0c1",
+        "checksum": "adler32:b3a80936",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
         "size": 197000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10002_file_index.txt"
       },
       {
-        "checksum": "sha1:6e83078b0f95b35766960c4a01c3600d79e47c35",
+        "checksum": "adler32:c1ab0890",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
         "size": 197000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10003_file_index.txt"
       },
       {
-        "checksum": "sha1:edec5b6f59777f89af548d2d9169c916acb1fb53",
+        "checksum": "adler32:7d2a1c09",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
         "size": 197000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10004_file_index.txt"
       },
       {
-        "checksum": "sha1:b7aa450266c0da058287cf788ccbb121bcdbef92",
+        "checksum": "adler32:2bd415c2",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
         "size": 197000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10005_file_index.txt"
       },
       {
-        "checksum": "sha1:d24dc7f92e2a9dd797703325cd30b436f077f861",
+        "checksum": "adler32:8f4030c2",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
         "size": 197000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10006_file_index.txt"
       },
       {
-        "checksum": "sha1:ad097e9d569d17d245e69d9ac32ee7b7c1d2280c",
+        "checksum": "adler32:97a74858",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
         "size": 197000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10007_file_index.txt"
       },
       {
-        "checksum": "sha1:317c6fdda010edfad621a48a0de0a3d7e857b8ad",
+        "checksum": "adler32:bd8a4556",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
         "size": 197000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10008_file_index.txt"
       },
       {
-        "checksum": "sha1:26b4c99dedd147c995308c949e570020901aaa2c",
+        "checksum": "adler32:afdb60a7",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
         "size": 197000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10009_file_index.txt"
       },
       {
-        "checksum": "sha1:2b922bb8ea084d6fd934606929b1b27d7c4fb4e7",
+        "checksum": "adler32:5857d429",
         "description": "DYJets_0p0_1p2_2p10_3p15_4p15_CT10_8TeV-sherpa AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
         "size": 33096,
         "type": "index.txt",
@@ -2593,28 +2593,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e1a09900b38f6c075064145dfe2e23f95e8280cf",
+        "checksum": "adler32:96cc2d50",
         "description": "DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 107882,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:e421f7677138b07eb7ac412e21e6a96221f1267a",
+        "checksum": "adler32:fac0d93d",
         "description": "DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 43501,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:e0541411efb7226a16c286c9cd9d01a8d4847b4b",
+        "checksum": "adler32:db8865bd",
         "description": "DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 62310,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:e9104db0d60cfd406d0c81c1f327fc63d95f754e",
+        "checksum": "adler32:5c720007",
         "description": "DYJetsToLL_M10-50_PtZ-100_TuneZ2star_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 25125,
         "type": "index.txt",
@@ -2719,28 +2719,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5ced562601c7794a8ed9a4f97032cc1ca0c4368b",
+        "checksum": "adler32:706bdc19",
         "description": "DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 67901,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:b882eb10caff7c591efbae9dc8e7c349bd9e0354",
+        "checksum": "adler32:993f6762",
         "description": "DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 101851,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:bca7383bf28c88a8e41aa707e601ce4d47bed52c",
+        "checksum": "adler32:3232cc79",
         "description": "DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 39382,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:61125ad9401485666477e77b2d75bff42aa8ad73",
+        "checksum": "adler32:03733e5f",
         "description": "DYJetsToLL_M10-50_PtZ70-100_TuneZ2star_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 59073,
         "type": "index.txt",
@@ -2845,28 +2845,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d50f5574208abcba58a4a753e86eab90d5d94225",
+        "checksum": "adler32:80ad79b6",
         "description": "DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 137903,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:c3a38a1c0b5e46a9bddce5075d3b77e1aac42ae2",
+        "checksum": "adler32:a3efc38b",
         "description": "DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 17329,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:c7ff29d75d72a2cf99ceffc8cb373b860b2702f9",
+        "checksum": "adler32:4f783c18",
         "description": "DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 81748,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:6e8d4d16d40a4d9b7c9e43aae1e53ed3ecdf86ea",
+        "checksum": "adler32:bd4056ae",
         "description": "DYJetsToLL_M-10to50_HT-200to400_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 10272,
         "type": "index.txt",
@@ -2971,28 +2971,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:da443c64a2a4ddef52749232d7d936f91807ed01",
+        "checksum": "adler32:dab9ea9d",
         "description": "DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 57762,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:89e98c1c19fc1736f5cc89ee77c7f29152c87a27",
+        "checksum": "adler32:c8b8fe93",
         "description": "DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 42239,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:6a3865d6c8783879a5fcf4aa84f82d93c309627f",
+        "checksum": "adler32:0dc57644",
         "description": "DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 34240,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:aa85bd9f3b20f161d14aede6a9fd306f1ec5030b",
+        "checksum": "adler32:c16852b9",
         "description": "DYJetsToLL_M-10to50_HT-400toInf_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 25038,
         "type": "index.txt",
@@ -3097,14 +3097,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:76ccdfb82485cafcb8bfe2f0dae7cf3836e0b618",
+        "checksum": "adler32:f87ff773",
         "description": "DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 121451,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball/AODSIM/No_PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball_AODSIM_No_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:7b633336cd55a5c83563bdfeb0bcf02086c6b2a4",
+        "checksum": "adler32:210d6609",
         "description": "DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 70296,
         "type": "index.txt",
@@ -3209,42 +3209,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:570c5fd7227c429d0b34e1c11f0e81b406f11c54",
+        "checksum": "adler32:5a2f868f",
         "description": "DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 345656,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:27130733cf76fbf7118125fe868f413df675a998",
+        "checksum": "adler32:276584b0",
         "description": "DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 346002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball_AODSIM_PU_RD1_START53_V7N-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:ca93b0444131af212dac8678a321e4bfde2a4850",
+        "checksum": "adler32:96a2aa45",
         "description": "DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 145322,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball_AODSIM_PU_RD1_START53_V7N-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:fd8937005660f2f3a420970856bf961fd4d00afe",
+        "checksum": "adler32:88f75136",
         "description": "DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 198801,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:1cfcda9765bbf8ced58e623c1919bce12256d7c0",
+        "checksum": "adler32:2e055d57",
         "description": "DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 199000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball_AODSIM_PU_RD1_START53_V7N-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:40a114e92c0b0d45f08df35e3bd44e41ec6cf93f",
+        "checksum": "adler32:fb0356a6",
         "description": "DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 83580,
         "type": "index.txt",
@@ -3349,28 +3349,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2e5984abe3b7506fd02163c59f6634d78057a508",
+        "checksum": "adler32:fc344ed3",
         "description": "DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 579622,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:f562aff935ed71d664f52ccd97e6beb0113b8d66",
+        "checksum": "adler32:aea06003",
         "description": "DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 320837,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff_AODSIM_PU_S10_START53_V19-v1_00001_file_index.json"
       },
       {
-        "checksum": "sha1:507a8a3ad6be181991045bd60eb46f0c6e6c8f07",
+        "checksum": "adler32:7bea2ec3",
         "description": "DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 346184,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:1406cd4746caa21f01051df1599f90883a62f81a",
+        "checksum": "adler32:d0baf5af",
         "description": "DYJetsToLL_M-50_TuneZ2Star_8TeV-madgraph-tarball-tauola-tauPolarOff AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 191622,
         "type": "index.txt",
@@ -3475,14 +3475,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:90e1f2f25f1c9ba40661d4975e2be302c75b7953",
+        "checksum": "adler32:87af62fc",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 117426,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/ExtFlat10_PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_ExtFlat10_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:6eac40fe4b69487d4c0484cda67484c00c532cdf",
+        "checksum": "adler32:76837e69",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 69208,
         "type": "index.txt",
@@ -3587,14 +3587,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e825134a1974fb8ccfdef192c1cbc876f49a7784",
+        "checksum": "adler32:0c506952",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 129240,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/ExtFlat20_PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_ExtFlat20_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:b9866e56c84f1afe50304f5836864c109759118b",
+        "checksum": "adler32:43eb00e2",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 76171,
         "type": "index.txt",
@@ -3699,28 +3699,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9d9eaaa2447eaa0badbf2503b1b9fbe062e2648a",
+        "checksum": "adler32:69d0b21b",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 110266,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/ExtFlat30_PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_ExtFlat30_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:2085b126a9b5553b04e36cea6df8f270c4e416be",
+        "checksum": "adler32:27742456",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 26850,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/ExtFlat30_PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_ExtFlat30_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:7701b8246efa57ac0c308de483fae502cff14dd8",
+        "checksum": "adler32:24e171f0",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 64988,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/ExtFlat30_PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_ExtFlat30_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:e932b372d9e96fa4349963ecc32a4553ec74ae06",
+        "checksum": "adler32:dffa1bc3",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 15825,
         "type": "index.txt",
@@ -3825,28 +3825,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5de6441c2e159ca38b4b5d08b55c0d07205a3e63",
+        "checksum": "adler32:87614677",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 180011,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/NewG4Phys_PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_NewG4Phys_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:990b3e069ecc0ae4d4300b84959a8750f9ffc8b8",
+        "checksum": "adler32:c72c15c6",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 180076,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/NewG4Phys_PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_NewG4Phys_PU_RD1_START53_V7N-v1_010000_file_index.json"
       },
       {
-        "checksum": "sha1:e64744975bfaef883fe7d00964ab4e4c04f06e03",
+        "checksum": "adler32:b952e54f",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 106344,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/NewG4Phys_PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_NewG4Phys_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:b25185f83d5824b3a1c07e1cf27df0927708b9a7",
+        "checksum": "adler32:6c7bf76b",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 106636,
         "type": "index.txt",
@@ -3951,70 +3951,70 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2db41989991e9eda7443ef6ea8473be56658a2d5",
+        "checksum": "adler32:bc50fb2a",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
         "size": 347654,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v3_10000_file_index.json"
       },
       {
-        "checksum": "sha1:dcb901422e96ef057173de7ee28626c43302b8f3",
+        "checksum": "adler32:232de2c5",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
         "size": 200450,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v3_10001_file_index.json"
       },
       {
-        "checksum": "sha1:23dc2ea515661d44987f9d715addb383786e58a1",
+        "checksum": "adler32:d9f90186",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
         "size": 347654,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v3_20000_file_index.json"
       },
       {
-        "checksum": "sha1:b6768f5a28ce0eb3d47c6684bfe55103c6f2a988",
+        "checksum": "adler32:c0afd4c3",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
         "size": 348002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v3_20001_file_index.json"
       },
       {
-        "checksum": "sha1:ca444dd49b9e4b8d50f177856d6c89e1fe5a8ccc",
+        "checksum": "adler32:a6cf2847",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
         "size": 122149,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v3_20002_file_index.json"
       },
       {
-        "checksum": "sha1:eb5c3405c67bfbce356acf271f0bb864971d1802",
+        "checksum": "adler32:80ca88f6",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
         "size": 200799,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v3_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:5135bf6772970c28eb8e570fa346989df82957e6",
+        "checksum": "adler32:ba7654dc",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
         "size": 115776,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v3_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:16e9c3154667c75c26466b2ec8840a2097f63805",
+        "checksum": "adler32:8eb7941e",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
         "size": 200799,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v3_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:f32fd35c91b7129636749b96066f99e6f229bfba",
+        "checksum": "adler32:1d7b0c79",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
         "size": 201000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v3_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:f0eed79f2169ce566f3d618c26bcb78e98162bac",
+        "checksum": "adler32:f59ae766",
         "description": "DYToEE_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
         "size": 70551,
         "type": "index.txt",
@@ -4119,14 +4119,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5c00146a21011772a53fa3a2513ea8dcf202e84e",
+        "checksum": "adler32:b8c0930b",
         "description": "DYToMuMu_M-15To50_Tune4C_8TeV-pythia8 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 21906,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-15To50_Tune4C_8TeV-pythia8/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-15To50_Tune4C_8TeV-pythia8_AODSIM_NoPileUp_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:b5c1df5f170be7b3450ca033b635831fe8003713",
+        "checksum": "adler32:777cd050",
         "description": "DYToMuMu_M-15To50_Tune4C_8TeV-pythia8 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12350,
         "type": "index.txt",
@@ -4231,14 +4231,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b3037639aba8087f6ef738505d47f65d91a917e9",
+        "checksum": "adler32:caf3a12f",
         "description": "DYToMuMu_M-15To50_Tune4C_8TeV-pythia8 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 96147,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-15To50_Tune4C_8TeV-pythia8/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-15To50_Tune4C_8TeV-pythia8_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:c07b4197478c8d428a01a01b2c45d14d2f49a3fa",
+        "checksum": "adler32:1ba5f2f8",
         "description": "DYToMuMu_M-15To50_Tune4C_8TeV-pythia8 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 53956,
         "type": "index.txt",
@@ -4343,14 +4343,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b57b74c6cf76de693a2d4435bbbf4b017a53b68e",
+        "checksum": "adler32:63437b07",
         "description": "DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 23529,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6_AODSIM_NoPileUp_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:044dc7186d175028a98491db670982f5a0f4b1da",
+        "checksum": "adler32:9f42312d",
         "description": "DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 13386,
         "type": "index.txt",
@@ -4455,14 +4455,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e6fbed87dc57325a799aca4e90806a053f1bb220",
+        "checksum": "adler32:f41eb598",
         "description": "DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 134868,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:820048c7cc71ab36a12e1184d4cb0f4a0a57376b",
+        "checksum": "adler32:2cb748b4",
         "description": "DYToMuMu_M-15To50_TuneZ2star_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 76416,
         "type": "index.txt",
@@ -4567,28 +4567,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dd0322da63dfaaef7e4a3305aa55dd268a1b5b2c",
+        "checksum": "adler32:ae114bab",
         "description": "DYToMuMu_M-20_CT10_8TeV-powheg-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 1006994,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-20_CT10_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-20_CT10_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:402765d0fb9f9274b1f91e980689e71c227d4625",
+        "checksum": "adler32:3d7ac11e",
         "description": "DYToMuMu_M-20_CT10_8TeV-powheg-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 430753,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-20_CT10_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-20_CT10_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_00001_file_index.json"
       },
       {
-        "checksum": "sha1:652235699bf01c88596143e1f1ae539d00945032",
+        "checksum": "adler32:e8b46c52",
         "description": "DYToMuMu_M-20_CT10_8TeV-powheg-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 566433,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-20_CT10_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-20_CT10_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:06a2af68e34cce51dee0612e54521523358e12f9",
+        "checksum": "adler32:c0635553",
         "description": "DYToMuMu_M-20_CT10_8TeV-powheg-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 242298,
         "type": "index.txt",
@@ -4693,56 +4693,56 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c41c852e48150ff0b280223313afb2d484c1dad6",
+        "checksum": "adler32:1e42fe11",
         "description": "DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 349652,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:bcfef699ba3d6a7238a4ca338ffdd387bc252beb",
+        "checksum": "adler32:a69e246e",
         "description": "DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 350002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:f534260560bfb3e82e41c1d09881bccbc098a914",
+        "checksum": "adler32:2066dfb6",
         "description": "DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 350002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10002_file_index.json"
       },
       {
-        "checksum": "sha1:e8b894b4b3f9c43fc9204481387ebb8b391b317b",
+        "checksum": "adler32:a5d740e4",
         "description": "DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 214900,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10003_file_index.json"
       },
       {
-        "checksum": "sha1:30fe4341a70dca516bc447bdddb5a73870e16222",
+        "checksum": "adler32:96d57ade",
         "description": "DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 202797,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:c8c7ca8f16b360695d9959efd71cf9c8d03517da",
+        "checksum": "adler32:f52094de",
         "description": "DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 203000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:48f47f327f2e785a046b1b09ae72ed20e7dc04f1",
+        "checksum": "adler32:d76f786f",
         "description": "DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 203000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10002_file_index.txt"
       },
       {
-        "checksum": "sha1:d8a281f689978aa7a33cd099d0c471e77daac96c",
+        "checksum": "adler32:e3a2ba66",
         "description": "DYToMuMu_M-20_CT10_TuneZ2star_v2_8TeV-powheg-pythia6 AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 124642,
         "type": "index.txt",
@@ -4847,28 +4847,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b34ed301d5900425fd47edc4a85f01b58b97c00b",
+        "checksum": "adler32:61dd6f87",
         "description": "DYToMuMu_M-6To15_Tune4C_8TeV-pythia8 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 21841,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-6To15_Tune4C_8TeV-pythia8/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-6To15_Tune4C_8TeV-pythia8_AODSIM_NoPileUp_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:1fae908d8fa21d5decaf710fd1f95d040f879641",
+        "checksum": "adler32:d612ae06",
         "description": "DYToMuMu_M-6To15_Tune4C_8TeV-pythia8 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 4370,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-6To15_Tune4C_8TeV-pythia8/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-6To15_Tune4C_8TeV-pythia8_AODSIM_NoPileUp_START53_V19-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:b1d58632035a37a15722d89f7ce72a6cc49a79ea",
+        "checksum": "adler32:dae0b7fa",
         "description": "DYToMuMu_M-6To15_Tune4C_8TeV-pythia8 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 12285,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-6To15_Tune4C_8TeV-pythia8/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-6To15_Tune4C_8TeV-pythia8_AODSIM_NoPileUp_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:57bb7c8f63f113bfa2f8083dc044e6aa2b01f976",
+        "checksum": "adler32:b202f128",
         "description": "DYToMuMu_M-6To15_Tune4C_8TeV-pythia8 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2457,
         "type": "index.txt",
@@ -4973,28 +4973,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4eabefd4b9ef9893793b8a6e454700a85e469cc3",
+        "checksum": "adler32:f6eb8037",
         "description": "DYToMuMu_M-6To15_Tune4C_8TeV-pythia8 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 88845,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-6To15_Tune4C_8TeV-pythia8/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-6To15_Tune4C_8TeV-pythia8_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:99b6cac3d830152e6f2494b4859c70ca7bf74113",
+        "checksum": "adler32:a7e212c8",
         "description": "DYToMuMu_M-6To15_Tune4C_8TeV-pythia8 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 11357,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-6To15_Tune4C_8TeV-pythia8/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-6To15_Tune4C_8TeV-pythia8_AODSIM_PU_S10_START53_V19-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:ba055b47f47b0225b118864111c172c83b2875d6",
+        "checksum": "adler32:91bad985",
         "description": "DYToMuMu_M-6To15_Tune4C_8TeV-pythia8 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 49742,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-6To15_Tune4C_8TeV-pythia8/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-6To15_Tune4C_8TeV-pythia8_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:97bcb230c54e1dd84d6e16457020f5ebc52dae64",
+        "checksum": "adler32:9c3385c4",
         "description": "DYToMuMu_M-6To15_Tune4C_8TeV-pythia8 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 6358,
         "type": "index.txt",
@@ -5099,14 +5099,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e91dace5503f1eb1b7a1f6c775f069a6af2003dc",
+        "checksum": "adler32:9439bd76",
         "description": "DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 33944,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6_AODSIM_NoPileUp_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:59b20f3ea3b722590c934f108bf8911b6c0ac7bb",
+        "checksum": "adler32:76625ea1",
         "description": "DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 19300,
         "type": "index.txt",
@@ -5211,14 +5211,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6d30813363fe3c3d012c747a8665ccb20b91b30d",
+        "checksum": "adler32:53cc622a",
         "description": "DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 126030,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:65039422e725171ad0defdd63c0e54382daf3c70",
+        "checksum": "adler32:bbc34943",
         "description": "DYToMuMu_M-6To15_TuneZ2star_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 71243,
         "type": "index.txt",
@@ -5320,14 +5320,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c8dcfd6a6095cc26764724846dc091ec24d08247",
+        "checksum": "adler32:716c691e",
         "description": "EtabToPsi2SPhi_8TeV-pythia6-evtgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 15274,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/EtabToPsi2SPhi_8TeV-pythia6-evtgen/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_EtabToPsi2SPhi_8TeV-pythia6-evtgen_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:4f7a4f33e17d55e8b91d810a91653ea6e7007876",
+        "checksum": "adler32:95983a69",
         "description": "EtabToPsi2SPhi_8TeV-pythia6-evtgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 8510,
         "type": "index.txt",
@@ -5432,14 +5432,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6c616157d64a348e548d46bab672b094f9bc828d",
+        "checksum": "adler32:9b3e56d9",
         "description": "GammaGammaToEE_Elastic_Pt15_8TeV-lpair AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4034,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GammaGammaToEE_Elastic_Pt15_8TeV-lpair/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GammaGammaToEE_Elastic_Pt15_8TeV-lpair_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:fac23bc4497770d71b8d5718c7e2e090040e8cc8",
+        "checksum": "adler32:24e6b9c6",
         "description": "GammaGammaToEE_Elastic_Pt15_8TeV-lpair AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2268,
         "type": "index.txt",
@@ -5544,14 +5544,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d05007556787c610d3b752cd16e15c1b4fdadad1",
+        "checksum": "adler32:1527d2f4",
         "description": "GammaGammaToEE_Inel-Inel_Pt15_8TeV-lpair AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 1692,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GammaGammaToEE_Inel-Inel_Pt15_8TeV-lpair/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GammaGammaToEE_Inel-Inel_Pt15_8TeV-lpair_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:7720cdc3efdbba423d3e46faf708a38dd228194f",
+        "checksum": "adler32:47c425cc",
         "description": "GammaGammaToEE_Inel-Inel_Pt15_8TeV-lpair AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 955,
         "type": "index.txt",
@@ -5656,14 +5656,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:06cbc81da6c346bd9aa09e1f39c1556a4d40c4cb",
+        "checksum": "adler32:667922c5",
         "description": "GammaGammaToEE_SingleDiss-pmod11_Pt15_8TeV-lpair AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3808,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GammaGammaToEE_SingleDiss-pmod11_Pt15_8TeV-lpair/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GammaGammaToEE_SingleDiss-pmod11_Pt15_8TeV-lpair_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:952977901de01a24b31664826f5ed461dcc16a11",
+        "checksum": "adler32:53b1a72c",
         "description": "GammaGammaToEE_SingleDiss-pmod11_Pt15_8TeV-lpair AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2189,
         "type": "index.txt",
@@ -5768,14 +5768,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:36e60083a99cda6f58b5d045fc6c806606b9dcdc",
+        "checksum": "adler32:419407cf",
         "description": "GammaGammaToMuMu_Elastic_Pt15_8TeV-lpair AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3719,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GammaGammaToMuMu_Elastic_Pt15_8TeV-lpair/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GammaGammaToMuMu_Elastic_Pt15_8TeV-lpair_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:79dac8b1e3cfda6aef9013f049f7cfb154a3cc8a",
+        "checksum": "adler32:07148bf6",
         "description": "GammaGammaToMuMu_Elastic_Pt15_8TeV-lpair AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2101,
         "type": "index.txt",
@@ -5880,28 +5880,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:161fc18016a2d613d9314a8f219d5d48a003d27d",
+        "checksum": "adler32:09e45e56",
         "description": "GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 341,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:14a67779d94b98a4cf4a3aca6a5712d377797db8",
+        "checksum": "adler32:4475d66b",
         "description": "GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 1701,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:8ff06f9d478130dcb9dcd50ef670ef5368bd1224",
+        "checksum": "adler32:a9403bad",
         "description": "GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 193,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:f11192fc40f4fcc6da5734297be73add39918a01",
+        "checksum": "adler32:ce102a45",
         "description": "GammaGammaToMuMu_Inel-Inel_Pt15_8TeV-lpair AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 965,
         "type": "index.txt",
@@ -6006,14 +6006,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9d3365d122f9571b50746025810a9ce954e46ee7",
+        "checksum": "adler32:fdbd2bbb",
         "description": "GammaGammaToMuMu_SingleDiss-pmod11_Pt15_8TeV-lpair AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3830,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GammaGammaToMuMu_SingleDiss-pmod11_Pt15_8TeV-lpair/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GammaGammaToMuMu_SingleDiss-pmod11_Pt15_8TeV-lpair_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:cd93c8624c343aac4df0ee807013633773651136",
+        "checksum": "adler32:1f7eb120",
         "description": "GammaGammaToMuMu_SingleDiss-pmod11_Pt15_8TeV-lpair AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2211,
         "type": "index.txt",
@@ -6118,14 +6118,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2fa670933b6020f375a003fb46f4db6e37e786c9",
+        "checksum": "adler32:a1767f6e",
         "description": "GammaGammaToTauTau_SingleDiss-pmod11_Pt25_8TeV-lpair AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5000,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GammaGammaToTauTau_SingleDiss-pmod11_Pt25_8TeV-lpair/AODSIM/castor_PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GammaGammaToTauTau_SingleDiss-pmod11_Pt25_8TeV-lpair_AODSIM_castor_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:a83bb5b5c4ab5900a55bb471bb4517aae4bafa8b",
+        "checksum": "adler32:8ff89f73",
         "description": "GammaGammaToTauTau_SingleDiss-pmod11_Pt25_8TeV-lpair AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2940,
         "type": "index.txt",
@@ -6230,14 +6230,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:981abb7b5a562c88ad4e4e3bb666e80ed4849f1b",
+        "checksum": "adler32:0da4394f",
         "description": "GG4J_HT-0To300_TuneZ2star_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 71446,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GG4J_HT-0To300_TuneZ2star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GG4J_HT-0To300_TuneZ2star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:0371a6394ffde59f8dd1a7cef2d019aff2fbdc98",
+        "checksum": "adler32:45bbbf0b",
         "description": "GG4J_HT-0To300_TuneZ2star_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 40280,
         "type": "index.txt",
@@ -6342,28 +6342,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d88e01e18a24d431c911a5da7f9288a1142ff7b1",
+        "checksum": "adler32:4c916c80",
         "description": "GG4J_HT-300To700_TuneZ2star_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 40682,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GG4J_HT-300To700_TuneZ2star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GG4J_HT-300To700_TuneZ2star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:b20b1f34fc79df57e81fcbe5d2f90513f89cfe29",
+        "checksum": "adler32:7f7f4ee5",
         "description": "GG4J_HT-300To700_TuneZ2star_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 11528,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GG4J_HT-300To700_TuneZ2star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GG4J_HT-300To700_TuneZ2star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:a0ea31889fb28b1d14ceb51580fbbfa0356e9b5a",
+        "checksum": "adler32:62d6405a",
         "description": "GG4J_HT-300To700_TuneZ2star_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 23040,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GG4J_HT-300To700_TuneZ2star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GG4J_HT-300To700_TuneZ2star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:4e067912fc71cdc2566f3afcb9540a8447be9413",
+        "checksum": "adler32:c3b6b8fa",
         "description": "GG4J_HT-300To700_TuneZ2star_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 6528,
         "type": "index.txt",
@@ -6468,14 +6468,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bbc5a5f092ad8b13f6db8e0a6f7b6d77d67d95d0",
+        "checksum": "adler32:b89bf27a",
         "description": "GG4J_HT-700ToInf_TuneZ2star_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 33563,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GG4J_HT-700ToInf_TuneZ2star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GG4J_HT-700ToInf_TuneZ2star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:378e7b33eee355153e7124b2201b09684661933a",
+        "checksum": "adler32:fd55a798",
         "description": "GG4J_HT-700ToInf_TuneZ2star_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 19008,
         "type": "index.txt",
@@ -6580,28 +6580,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:53de6f8cbf179ac9f01479a079adbe3183fef957",
+        "checksum": "adler32:0b1ad6e9",
         "description": "ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 6284,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph_AODSIM_PU_RD1_START53_V7N-v2_00000_file_index.json"
       },
       {
-        "checksum": "sha1:bc0f5442720070205dda84acecff6d2bb39d8073",
+        "checksum": "adler32:a115b12e",
         "description": "ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 5236,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph_AODSIM_PU_RD1_START53_V7N-v2_30000_file_index.json"
       },
       {
-        "checksum": "sha1:583bc290e408204aba1c9aadf402d9fcfc2fe8c6",
+        "checksum": "adler32:ba216970",
         "description": "ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 3636,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph_AODSIM_PU_RD1_START53_V7N-v2_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:5e17cfb9b2be569e08ee5d7c30577d0ac5e70020",
+        "checksum": "adler32:1a15abc7",
         "description": "ggHToMuMuGamma-MH125_mll-0To50_Dalitz_8TeV_madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 3030,
         "type": "index.txt",
@@ -6706,56 +6706,56 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bc5528f7d0f390b717bd76eb8fe62b8ab955d272",
+        "checksum": "adler32:13a12a7f",
         "description": "GJet_M80_doubleEMEnriched_8TeV-sherpa AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 334667,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_M80_doubleEMEnriched_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_M80_doubleEMEnriched_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:d2b9fff11f20a0fa0cf6ee6ec73edc2c44113254",
+        "checksum": "adler32:60a19350",
         "description": "GJet_M80_doubleEMEnriched_8TeV-sherpa AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 256947,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_M80_doubleEMEnriched_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_M80_doubleEMEnriched_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:01e9ca5d8246b83c036a50382e85cab14d879a4c",
+        "checksum": "adler32:d66d38a9",
         "description": "GJet_M80_doubleEMEnriched_8TeV-sherpa AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 334667,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_M80_doubleEMEnriched_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_M80_doubleEMEnriched_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:2b1988e50cddaf38f9aef87c8c091a899d63091d",
+        "checksum": "adler32:726a6966",
         "description": "GJet_M80_doubleEMEnriched_8TeV-sherpa AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 295807,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_M80_doubleEMEnriched_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_M80_doubleEMEnriched_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:4911157b30c4c36035e0966643207d8a2d1716b3",
+        "checksum": "adler32:5c196add",
         "description": "GJet_M80_doubleEMEnriched_8TeV-sherpa AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 187812,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_M80_doubleEMEnriched_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_M80_doubleEMEnriched_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:4766945d006a05ac6fc0f2b01a8e282e03b53d8d",
+        "checksum": "adler32:0723df82",
         "description": "GJet_M80_doubleEMEnriched_8TeV-sherpa AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 144196,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_M80_doubleEMEnriched_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_M80_doubleEMEnriched_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:44e11472e2b8c3fed82ea5d8f3d38c6aab815e11",
+        "checksum": "adler32:6e30753f",
         "description": "GJet_M80_doubleEMEnriched_8TeV-sherpa AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 187812,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_M80_doubleEMEnriched_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_M80_doubleEMEnriched_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:d0df79aa75d92a733cf2670db81faaa098d5c0aa",
+        "checksum": "adler32:1ce12ca6",
         "description": "GJet_M80_doubleEMEnriched_8TeV-sherpa AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 166004,
         "type": "index.txt",
@@ -6860,28 +6860,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:77f4cf77c47d6a5bfb5bb30f199b7491d4190bae",
+        "checksum": "adler32:14637ece",
         "description": "GJet_M80_nofilter_8TeV-sherpa AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 163501,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_M80_nofilter_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_M80_nofilter_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:335652f5c2136b4084de670fc050fc9dc42953bd",
+        "checksum": "adler32:34b3e8f6",
         "description": "GJet_M80_nofilter_8TeV-sherpa AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 139631,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_M80_nofilter_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_M80_nofilter_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:ab8b4d3506c01405bdde9ed467f7f57dfd94e8ff",
+        "checksum": "adler32:74593c0f",
         "description": "GJet_M80_nofilter_8TeV-sherpa AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 90000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_M80_nofilter_8TeV-sherpa/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_M80_nofilter_8TeV-sherpa_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:25336a1be35d0039e82dfabb15bb73cb4fb21f71",
+        "checksum": "adler32:4a2d6a80",
         "description": "GJet_M80_nofilter_8TeV-sherpa AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 76860,
         "type": "index.txt",
@@ -6986,42 +6986,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cb3d8e9d5153706252fbd6de6ed1d0c4b6943bcd",
+        "checksum": "adler32:c50447ef",
         "description": "GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 352649,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:7895a6e22a0c625be662fb05c000dbb774097cce",
+        "checksum": "adler32:3ed5e47e",
         "description": "GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 154262,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:d1a8d4975c5b64147543ebf1461c8a7a57b6a9a7",
+        "checksum": "adler32:8fdfcf34",
         "description": "GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 217803,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:c7c08759b893770cfdab5c1e245dabfdf88f38a8",
+        "checksum": "adler32:1d39de10",
         "description": "GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 205794,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:1c2e893156dd3683059a756bd76288048e826e6b",
+        "checksum": "adler32:40e310bc",
         "description": "GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 90022,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:621a62d997b7c57351788967fc810e729f614abe",
+        "checksum": "adler32:2983c628",
         "description": "GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext2-pythia6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 127102,
         "type": "index.txt",
@@ -7126,28 +7126,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6e7feba89b9dab56623acde8be40e84e2a0afe12",
+        "checksum": "adler32:a18a572d",
         "description": "GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 351650,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:a695832e2e6571a8aa19b1b305c8608d46364cdf",
+        "checksum": "adler32:25494935",
         "description": "GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 193249,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:3e7907c058bf540b333181c22d17053041f3099f",
+        "checksum": "adler32:c01f8109",
         "description": "GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 204795,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:d6b265b60a81e62ede600d98a439dadc4f85366b",
+        "checksum": "adler32:94eec1e6",
         "description": "GJet_Pt40_doubleEMEnriched_TuneZ2star_8TeV_ext-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 112545,
         "type": "index.txt",
@@ -7252,14 +7252,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3fc4ac9b45a8a56b8faea6b4e344dc410e5a4181",
+        "checksum": "adler32:8703df79",
         "description": "GJets_HT-100To200_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 300707,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJets_HT-100To200_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJets_HT-100To200_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:e1dbacfa295ea82085569f4cd2b4b0f89758cf07",
+        "checksum": "adler32:edde7df7",
         "description": "GJets_HT-100To200_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 166348,
         "type": "index.txt",
@@ -7364,28 +7364,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b0a2fad832c53b14dddee4f2555d6254a4911766",
+        "checksum": "adler32:76c5fd4b",
         "description": "GJets_HT-40To100_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 327674,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJets_HT-40To100_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJets_HT-40To100_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:3ffc9fa502b503c863405e454967524edc5a1a37",
+        "checksum": "adler32:4a1fc30f",
         "description": "GJets_HT-40To100_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 276506,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJets_HT-40To100_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJets_HT-40To100_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:79574fd722484c6eb7f16054ad576df663a45a6a",
+        "checksum": "adler32:7b4b0d40",
         "description": "GJets_HT-40To100_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 180819,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GJets_HT-40To100_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GJets_HT-40To100_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:a5f6e8d3512803f4c75300e4f3f823f3c605a29d",
+        "checksum": "adler32:0df8d35d",
         "description": "GJets_HT-40To100_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 152583,
         "type": "index.txt",
@@ -7483,42 +7483,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6e6c9994831575c77d0736fa16da6574d17ac2e7",
+        "checksum": "adler32:c244b561",
         "description": "GluGluHToGG_M-125_8TeV-pythia6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 50514,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluHToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluHToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_00000_file_index.json"
       },
       {
-        "checksum": "sha1:7ff4f82c6d5714b2525b62b6732849142a70785c",
+        "checksum": "adler32:c22d2bc7",
         "description": "GluGluHToGG_M-125_8TeV-pythia6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 46249,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluHToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluHToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_10000_file_index.json"
       },
       {
-        "checksum": "sha1:21fc7038933a38dd510c34d030f35a3562604846",
+        "checksum": "adler32:c8ee0502",
         "description": "GluGluHToGG_M-125_8TeV-pythia6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 63962,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluHToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluHToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_20000_file_index.json"
       },
       {
-        "checksum": "sha1:5e762dbb2ae841bb137a904f6f7547061fb8e772",
+        "checksum": "adler32:b298f7bc",
         "description": "GluGluHToGG_M-125_8TeV-pythia6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 27874,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluHToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluHToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:a4471c5be50d843f6027e99a394e2b8c9b4f59a4",
+        "checksum": "adler32:be592f2f",
         "description": "GluGluHToGG_M-125_8TeV-pythia6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 25521,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluHToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluHToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:5fc4aa20b733bc60fff61b3fc9039425088c7645",
+        "checksum": "adler32:12a6bfa0",
         "description": "GluGluHToGG_M-125_8TeV-pythia6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 35295,
         "type": "index.txt",
@@ -7623,28 +7623,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ecf8727584b52aec957d16fb725a697b1c95b016",
+        "checksum": "adler32:6ccbd969",
         "description": "GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 33464,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:103d8c6877414432bc330749d49ff37a6d7111fa",
+        "checksum": "adler32:32b72e9a",
         "description": "GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 48673,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:f86b2effc78fe52c14718ea1205ff9de16f4b6a8",
+        "checksum": "adler32:cbde9466",
         "description": "GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 18909,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:ddbf2c52641bcd4045ff82f0d3561877c0972ae1",
+        "checksum": "adler32:319fdc94",
         "description": "GluGluTo2e2mu_Contin_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 27504,
         "type": "index.txt",
@@ -7749,28 +7749,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:24e8b0346b6e22052dab6750d753ae31e7037385",
+        "checksum": "adler32:42da934f",
         "description": "GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 83782,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:2801cb5fe83c035e115b1a376daf623967eae12b",
+        "checksum": "adler32:865ed609",
         "description": "GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 3552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:a75f9c91ae4980bce3a9140914d8bd0ec4d18b31",
+        "checksum": "adler32:0da7d87f",
         "description": "GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 49088,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:27e6420a88f34cc9f5fa9231f0d61d999773e65c",
+        "checksum": "adler32:b1097dc7",
         "description": "GluGluTo2e2mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2080,
         "type": "index.txt",
@@ -7875,28 +7875,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9e05871d22e294a449f37a8cde887e8c6fac81c0",
+        "checksum": "adler32:954931ed",
         "description": "GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 75462,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:e4ac5557c59283ef1a968950adff6113c205bc1b",
+        "checksum": "adler32:49b41b2a",
         "description": "GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 4804,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:3b9907ac0cfad4f0917d6d9301cec46b82592204",
+        "checksum": "adler32:4fa4ad6f",
         "description": "GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 43120,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:9fa1dd724eeaf99c0a0ab0b9a89872a1493a6fd0",
+        "checksum": "adler32:ccbe3a04",
         "description": "GluGluTo2e2mu_SMH_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2744,
         "type": "index.txt",
@@ -8001,14 +8001,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d6371de2c0b3c5d091812408410e227a48117fdd",
+        "checksum": "adler32:c2990b23",
         "description": "GluGluTo2L2Nu_Bkgd_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12168,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2L2Nu_Bkgd_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2L2Nu_Bkgd_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:e424a6ff20e36584c60b151698baa646f1bd122c",
+        "checksum": "adler32:974f36b2",
         "description": "GluGluTo2L2Nu_Bkgd_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6876,
         "type": "index.txt",
@@ -8113,14 +8113,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:162bceef9a474552bc1adc35e9c20ed2b2c4dcff",
+        "checksum": "adler32:fbd1f370",
         "description": "GluGluTo2L2Nu_Bkgd_down_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12007,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2L2Nu_Bkgd_down_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2L2Nu_Bkgd_down_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:9a3b7a0ec64bad5beff83dd80e622cf413cc31c0",
+        "checksum": "adler32:2fde438e",
         "description": "GluGluTo2L2Nu_Bkgd_down_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6860,
         "type": "index.txt",
@@ -8225,14 +8225,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cd5a47299587b1edc7615ace7cb8b5a7ce57d70a",
+        "checksum": "adler32:d00adadb",
         "description": "GluGluTo2L2Nu_Bkgd_up_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 11936,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2L2Nu_Bkgd_up_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2L2Nu_Bkgd_up_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:8ebca8611a513e0976267fe499835ab1ec454335",
+        "checksum": "adler32:da4e280c",
         "description": "GluGluTo2L2Nu_Bkgd_up_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6790,
         "type": "index.txt",
@@ -8337,14 +8337,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:685a9dbc293025ac60a63361de0a9490ffc90415",
+        "checksum": "adler32:140bca76",
         "description": "GluGluTo2L2Nu_Signal_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 11902,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2L2Nu_Signal_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2L2Nu_Signal_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:36aff9d4241aea407c0af589bce1bac919984f69",
+        "checksum": "adler32:aaf51a9c",
         "description": "GluGluTo2L2Nu_Signal_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6755,
         "type": "index.txt",
@@ -8449,14 +8449,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ad7c2d5b5a9a7a8c575214d96a2a4c4653811457",
+        "checksum": "adler32:1b3615cb",
         "description": "GluGluTo2L2Nu_Signal_down_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12076,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2L2Nu_Signal_down_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2L2Nu_Signal_down_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:481d4ac5f460528ed9ca4561c4a48213f6755dfc",
+        "checksum": "adler32:6c1564df",
         "description": "GluGluTo2L2Nu_Signal_down_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6930,
         "type": "index.txt",
@@ -8561,14 +8561,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:096494b0ed57feb9486eb82d36772913e75a4800",
+        "checksum": "adler32:c3ed3c93",
         "description": "GluGluTo2L2Nu_SignalplusBkgd_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12182,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2L2Nu_SignalplusBkgd_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2L2Nu_SignalplusBkgd_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:eb336484f9d917e1b64040d9aea0429601f85515",
+        "checksum": "adler32:a1f88b89",
         "description": "GluGluTo2L2Nu_SignalplusBkgd_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 7035,
         "type": "index.txt",
@@ -8673,14 +8673,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4e367ed449293111a1f3793f4b71484ed231e893",
+        "checksum": "adler32:65513049",
         "description": "GluGluTo2L2Nu_SignalplusBkgd_down_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12003,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2L2Nu_SignalplusBkgd_down_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2L2Nu_SignalplusBkgd_down_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:03c773254130516c84378c044ec229c577fa05c1",
+        "checksum": "adler32:666e9ac1",
         "description": "GluGluTo2L2Nu_SignalplusBkgd_down_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 7004,
         "type": "index.txt",
@@ -8785,14 +8785,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:942ff4efc7ae3989784e2dfe0b3f6cd2a0c6480f",
+        "checksum": "adler32:68edcb50",
         "description": "GluGluTo2L2Nu_SignalplusBkgd_up_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12638,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2L2Nu_SignalplusBkgd_up_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2L2Nu_SignalplusBkgd_up_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:346ebcd7f1f4599edffd48d272862d0c513d7b64",
+        "checksum": "adler32:533ef7b5",
         "description": "GluGluTo2L2Nu_SignalplusBkgd_up_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 7344,
         "type": "index.txt",
@@ -8897,14 +8897,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dfb5de1b1c1314f9792f153ccf1e5313d7b40580",
+        "checksum": "adler32:f48e15e8",
         "description": "GluGluTo2L2Nu_Signal_up_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 13036,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo2L2Nu_Signal_up_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo2L2Nu_Signal_up_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:772e8a1b0d2e08e44011e06498e99dc430480f90",
+        "checksum": "adler32:add6fbfc",
         "description": "GluGluTo2L2Nu_Signal_up_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 7448,
         "type": "index.txt",
@@ -9009,28 +9009,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:518d216a4843d7fde2a767f30bc65c75a54053c0",
+        "checksum": "adler32:f389cde8",
         "description": "GluGluTo4e_Contin_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 6367,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4e_Contin_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4e_Contin_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:045576dfe0a52602dabcea0d4a29d93d0a92575a",
+        "checksum": "adler32:b48d18d6",
         "description": "GluGluTo4e_Contin_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 32831,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4e_Contin_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4e_Contin_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:66026c0b0670358072b97e0a8166a96fbca204ea",
+        "checksum": "adler32:1c204071",
         "description": "GluGluTo4e_Contin_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 3572,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4e_Contin_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4e_Contin_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:8ac99dd9cd0fe003f3cbd25154ec390dd1e7ec5f",
+        "checksum": "adler32:2b63f3cf",
         "description": "GluGluTo4e_Contin_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 18424,
         "type": "index.txt",
@@ -9135,28 +9135,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3ee1ba7568b85af861601da412a23708103e4e7f",
+        "checksum": "adler32:d0dcf7f4",
         "description": "GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 7394,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:54a60d5e0f1be079b9dcd8bb059ae08535356953",
+        "checksum": "adler32:cba14a66",
         "description": "GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 35554,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:e50813cafb90129c6e90316ccbb346649fbdffe8",
+        "checksum": "adler32:4ac8252e",
         "description": "GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 4305,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:60cec8b2de54e933278913268a1fcbad0079b382",
+        "checksum": "adler32:9024bd7f",
         "description": "GluGluTo4e_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 20705,
         "type": "index.txt",
@@ -9261,28 +9261,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ab7609206e21b433e6e0e5a14c430a91a0e87a47",
+        "checksum": "adler32:61e794af",
         "description": "GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 27882,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:ad73b57ec2e7d0311d45ea38a53effbdcbf63213",
+        "checksum": "adler32:71a5a852",
         "description": "GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 8162,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:0488169a7edb58497dde85de2ed7dc96364c7133",
+        "checksum": "adler32:39b0900d",
         "description": "GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 15826,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:5c7ae90757b61876fc6a418455c36fb69e596118",
+        "checksum": "adler32:4b7e6ec1",
         "description": "GluGluTo4e_SMH_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 4632,
         "type": "index.txt",
@@ -9380,28 +9380,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cc353206ed07b023b2523e55014a822bfd1e89f6",
+        "checksum": "adler32:74ec7bdd",
         "description": "GluGluTo4L_Contin_8TeV-gg2vv315-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 21905,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4L_Contin_8TeV-gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4L_Contin_8TeV-gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v3_00000_file_index.json"
       },
       {
-        "checksum": "sha1:6dc0359fc02f8bdea307a21d506478680a8ea027",
+        "checksum": "adler32:bec9556b",
         "description": "GluGluTo4L_Contin_8TeV-gg2vv315-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 27379,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4L_Contin_8TeV-gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4L_Contin_8TeV-gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v3_010000_file_index.json"
       },
       {
-        "checksum": "sha1:dec7df985219563bca6dc4f8d352b000afb5b85c",
+        "checksum": "adler32:3b18c4d2",
         "description": "GluGluTo4L_Contin_8TeV-gg2vv315-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 12350,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4L_Contin_8TeV-gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4L_Contin_8TeV-gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v3_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:379e0dab779b49c4bb934c58dc3d8deb5cc6446e",
+        "checksum": "adler32:17287821",
         "description": "GluGluTo4L_Contin_8TeV-gg2vv315-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 15471,
         "type": "index.txt",
@@ -9506,42 +9506,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1532c9ad8aa196fe6503b8859601be9eae784f76",
+        "checksum": "adler32:20015b73",
         "description": "GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 38369,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:deb0bdb1898cc6cdda7787fa690f4e41a8d1b57f",
+        "checksum": "adler32:3cd258e0",
         "description": "GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 25328,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_010000_file_index.json"
       },
       {
-        "checksum": "sha1:5e64ec97995a3158dc5e2171e585ee9dd0df8ccd",
+        "checksum": "adler32:1c1c24bb",
         "description": "GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 31592,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_110000_file_index.json"
       },
       {
-        "checksum": "sha1:a1240b6a3c2ba5dee84e6897832b9c51e6e55e91",
+        "checksum": "adler32:294ac3a6",
         "description": "GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 22345,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:2e3323cfd28b4ade2599ff9d6f43331fcbf9094b",
+        "checksum": "adler32:0375c3b7",
         "description": "GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 14832,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_010000_file_index.txt"
       },
       {
-        "checksum": "sha1:609e997547f7cc6cbde8514a157651112effa492",
+        "checksum": "adler32:65d43494",
         "description": "GluGluTo4L_HContinInterf_M-125p6_8TeV-gg2vv315-pythia6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 18540,
         "type": "index.txt",
@@ -9646,14 +9646,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7413a3aef1228a67d15cdaad14aa550f101dab4d",
+        "checksum": "adler32:922c9afe",
         "description": "GluGluTo4L_H_M-125p6_8TeV-gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 36381,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4L_H_M-125p6_8TeV-gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4L_H_M-125p6_8TeV-gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:b5eb5a3cc0e4f09d32399ef0f647274c5e45da3b",
+        "checksum": "adler32:cd934966",
         "description": "GluGluTo4L_H_M-125p6_8TeV-gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 20651,
         "type": "index.txt",
@@ -9758,28 +9758,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ed7b90eb10692b0cb05657fdda0ef98ba80c3055",
+        "checksum": "adler32:c0e3ae89",
         "description": "GluGluTo4mu_Contin_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 4370,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4mu_Contin_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4mu_Contin_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:638387394ba3fae6c3973622ef4cf32541022445",
+        "checksum": "adler32:f2f127ed",
         "description": "GluGluTo4mu_Contin_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 39314,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4mu_Contin_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4mu_Contin_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:856120b35ad54681fde127c5cbb640fbfbf8830b",
+        "checksum": "adler32:00e5ef19",
         "description": "GluGluTo4mu_Contin_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 2457,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4mu_Contin_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4mu_Contin_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:13cc7a2e6b5b808a5a523b0cec23f3fdd25a0d09",
+        "checksum": "adler32:75ed6f88",
         "description": "GluGluTo4mu_Contin_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 22113,
         "type": "index.txt",
@@ -9884,28 +9884,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:afcc791d540f4c55950aeae5531fbe48830f412e",
+        "checksum": "adler32:3a5fa2f4",
         "description": "GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 14475,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:081003c18a310be7dca455a8fb4f342432e2aec3",
+        "checksum": "adler32:d9332506",
         "description": "GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 30713,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:05355fb0c5b7a3d6f86fc5eba82aa7c995062418",
+        "checksum": "adler32:c7c32167",
         "description": "GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 8446,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:937466e580ad065ebadba6efa42fb448cfba71a0",
+        "checksum": "adler32:31167b8b",
         "description": "GluGluTo4mu_SMHContinInterf_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 17922,
         "type": "index.txt",
@@ -10010,28 +10010,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ddd73fc2ad139dd20e4fe7727586a5ecc9719a64",
+        "checksum": "adler32:194ba5b6",
         "description": "GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 35465,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:66f2f0259a4a66b243a07673453c7395421594da",
+        "checksum": "adler32:74be541d",
         "description": "GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 7845,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:a8cf3a61d8c923df1bdba78e0a067d543e87b136",
+        "checksum": "adler32:c784b6fc",
         "description": "GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 20176,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:fea3f1059cecb425386068f87647ff3e64c8dd09",
+        "checksum": "adler32:9cc43eb4",
         "description": "GluGluTo4mu_SMH_M-125p6_8TeV-MCFM67-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 4462,
         "type": "index.txt",
@@ -10136,14 +10136,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:16756ffb1abb1e788fee5f0b2c4401143b9424d9",
+        "checksum": "adler32:0ef9e236",
         "description": "GluGluToHHTo2B2G_M-125_8TeV-madgraph-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5472,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2G_M-125_8TeV-madgraph-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2G_M-125_8TeV-madgraph-pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:2c01a30944841feb06661df3fb99b2bac2043aa9",
+        "checksum": "adler32:d94cbaf4",
         "description": "GluGluToHHTo2B2G_M-125_8TeV-madgraph-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3120,
         "type": "index.txt",
@@ -10248,28 +10248,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:99469e1d42310d532670e38aa2f7e03434d663c3",
+        "checksum": "adler32:b19722e3",
         "description": "GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 1051,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:b551ba38d8d4a4d56a84a01891863b2e2a1d381a",
+        "checksum": "adler32:e6234d8b",
         "description": "GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 4900,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:ad079dc812a0e347a965f1300557ba8e0fadf8e5",
+        "checksum": "adler32:dde7bbac",
         "description": "GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 609,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:f677a7ffc7032dc77cc08d61115a1c5e66109b30",
+        "checksum": "adler32:1b756cde",
         "description": "GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2842,
         "type": "index.txt",
@@ -10374,14 +10374,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:af509040e0237b126e081705080bd31e51b56fee",
+        "checksum": "adler32:96c8eb3f",
         "description": "GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:417e6100e433793cbd6d3dbfa1bebd8003ab998b",
+        "checksum": "adler32:334a2c99",
         "description": "GluGluToHHTo2B2G_mH-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2639,
         "type": "index.txt",
@@ -10486,14 +10486,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bc452805fa887cb1e8914dc33a1c5cc49f9ed2ff",
+        "checksum": "adler32:76e691ab",
         "description": "GluGluToHHTo2B2Tau_M-125_8TeV-madgraph-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5161,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2Tau_M-125_8TeV-madgraph-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2Tau_M-125_8TeV-madgraph-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:e365cd065b68eec73b9c2868625e515f5b3078bb",
+        "checksum": "adler32:eb9c8a98",
         "description": "GluGluToHHTo2B2Tau_M-125_8TeV-madgraph-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2955,
         "type": "index.txt",
@@ -10598,14 +10598,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d217daaa7e5b0106c310d7ea21bd260ed6afaeae",
+        "checksum": "adler32:0c5d5b96",
         "description": "GluGluToHHTo2B2Tau_mH-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4930,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2Tau_mH-125_8TeV-madgraph-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2Tau_mH-125_8TeV-madgraph-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:3416a2b05d054f174eecd4d2d7cd5af60c2380b2",
+        "checksum": "adler32:78cf7807",
         "description": "GluGluToHHTo2B2Tau_mH-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2870,
         "type": "index.txt",
@@ -10710,14 +10710,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e1ab12a705e78181785d259b9a4765a02d226649",
+        "checksum": "adler32:4414d875",
         "description": "GluGluToHHTo2B2WToJJLNu_mH-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5357,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2WToJJLNu_mH-125_8TeV-madgraph-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2WToJJLNu_mH-125_8TeV-madgraph-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:fda0cffc47d6783c108510b20a837e9ae9888a38",
+        "checksum": "adler32:73aad057",
         "description": "GluGluToHHTo2B2WToJJLNu_mH-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3150,
         "type": "index.txt",
@@ -10822,14 +10822,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:30acfd0f27520f89a97b31ec04a775fcf793acf5",
+        "checksum": "adler32:61a6b069",
         "description": "GluGluToHHTo2B2WToLNuLNu_M-125_8TeV-madgraph-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5252,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2WToLNuLNu_M-125_8TeV-madgraph-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2WToLNuLNu_M-125_8TeV-madgraph-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:43eb17aa87c5c1adf6819b69967836f453e0c070",
+        "checksum": "adler32:f0c0a95d",
         "description": "GluGluToHHTo2B2WToLNuLNu_M-125_8TeV-madgraph-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3045,
         "type": "index.txt",
@@ -10934,14 +10934,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:26eeb134c6b0d3be6cd3be78c641589fe4715c39",
+        "checksum": "adler32:559a7b4c",
         "description": "GluGluToHHTo2B2WToLNuLNu_mH-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5014,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2WToLNuLNu_mH-125_8TeV-madgraph-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2WToLNuLNu_mH-125_8TeV-madgraph-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:ccb6adc009a03bb3492a47bad8f597a4831685ee",
+        "checksum": "adler32:aca195c5",
         "description": "GluGluToHHTo2B2WToLNuLNu_mH-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2954,
         "type": "index.txt",
@@ -11046,28 +11046,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bfd2914ed00eb8358783b1cabd91fea067d15828",
+        "checksum": "adler32:df678b1c",
         "description": "GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 8789,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:cde9ea901a0f6a263388c4c76860d62695e30f95",
+        "checksum": "adler32:3ed98764",
         "description": "GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 1410,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6_AODSIM_PU_S10_START53_V19-v1_010000_file_index.json"
       },
       {
-        "checksum": "sha1:603e2a9246a72c29c45b0e645ffe1e51eb9628bf",
+        "checksum": "adler32:3dba2d56",
         "description": "GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 5125,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:fed53a251d8b97617dbd61723940bd40461bf6dd",
+        "checksum": "adler32:622efda6",
         "description": "GluGluToHHTo2B2WToLNuQQbar_M-125_8TeV-madgraph-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 824,
         "type": "index.txt",
@@ -11172,28 +11172,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:edacea30df5805d920aec734cc0f1de01f954655",
+        "checksum": "adler32:7301cc4a",
         "description": "GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 723,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:7491aad64972c68043ea11855128872c79c11cb0",
+        "checksum": "adler32:fe4427ff",
         "description": "GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 10107,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:ed87db322837e31458c67eb03508299b8abc442a",
+        "checksum": "adler32:155e872f",
         "description": "GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 428,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:1c56f912a13e21a8cfd69f94d0770d2f138f24ac",
+        "checksum": "adler32:a90d64d4",
         "description": "GluGluTohhTo4b_non-resonant-mh-125_8TeV-madgraph-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 5992,
         "type": "index.txt",
@@ -11298,14 +11298,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b09942e4bb2fcfba8af154f838c3b7f003f8d32f",
+        "checksum": "adler32:7a0bbe42",
         "description": "GluGluToHToBB_M-125_8TeV-powheg-pythia6_ext AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 140152,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToBB_M-125_8TeV-powheg-pythia6_ext/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToBB_M-125_8TeV-powheg-pythia6_ext_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:6cefaafe362ee3f9694e6bd2c40806b3a8e97e54",
+        "checksum": "adler32:2a7ea35a",
         "description": "GluGluToHToBB_M-125_8TeV-powheg-pythia6_ext AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 79734,
         "type": "index.txt",
@@ -11410,28 +11410,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b87a9fe860e08b4ead172dcb43a32f3098507300",
+        "checksum": "adler32:60b18aad",
         "description": "GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 9833,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:39939ea373b982f8f73ecd1c213ecbec63551f5d",
+        "checksum": "adler32:b7d5bb45",
         "description": "GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 4409,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:b9102b5f010aa8c39b5a92ec9cfd1da12657e678",
+        "checksum": "adler32:0272a50a",
         "description": "GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 5568,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:9e63b96105e74a26d9737b7b1521b10c717128e9",
+        "checksum": "adler32:98defaaa",
         "description": "GluGluToHToGG_M-125_8TeV-minloHJJ-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2496,
         "type": "index.txt",
@@ -11536,28 +11536,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ec1e6b50b52c8c2dab2dda62073e8e54a670c99f",
+        "checksum": "adler32:11419e7a",
         "description": "GluGluToHToGG_M-125_8TeV-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 7121,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToGG_M-125_8TeV-powheg15-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToGG_M-125_8TeV-powheg15-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:0ea64e595e21af93be7a51668f5b6dc22b46e095",
+        "checksum": "adler32:3520e881",
         "description": "GluGluToHToGG_M-125_8TeV-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2714,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToGG_M-125_8TeV-powheg15-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToGG_M-125_8TeV-powheg15-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:0f2c1107fa6be6549abf013f5e4f70690acaf88b",
+        "checksum": "adler32:9376cdc0",
         "description": "GluGluToHToGG_M-125_8TeV-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 4032,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToGG_M-125_8TeV-powheg15-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToGG_M-125_8TeV-powheg15-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:5707707f69b3ac36e4e3190b3707c0f5c3058255",
+        "checksum": "adler32:54b8d4cc",
         "description": "GluGluToHToGG_M-125_8TeV-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 1536,
         "type": "index.txt",
@@ -11662,14 +11662,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e591707035379eac819443c48f430174e65247cf",
+        "checksum": "adler32:0915e765",
         "description": "GluGluToHToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 18524,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToGG_M-125_8TeV-powheg-pythia6/AODSIM/Ext30_PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToGG_M-125_8TeV-powheg-pythia6_AODSIM_Ext30_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:17e1ef7bc3dec287b58e5a5a84e48e24dfc4deaf",
+        "checksum": "adler32:555da36f",
         "description": "GluGluToHToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10584,
         "type": "index.txt",
@@ -11774,14 +11774,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9ec68ae421645d72485398ab523ff6da50084eef",
+        "checksum": "adler32:47d47c53",
         "description": "GluGluToHToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 20822,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToGG_M-125_8TeV-powheg-pythia6/AODSIM/ExtFlat30_PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToGG_M-125_8TeV-powheg-pythia6_AODSIM_ExtFlat30_PU_RD1_START53_V7N-v2_20000_file_index.json"
       },
       {
-        "checksum": "sha1:e8f8d69ada0ccc1c63d5a8087e1c84948115d99e",
+        "checksum": "adler32:c8067076",
         "description": "GluGluToHToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12000,
         "type": "index.txt",
@@ -11886,14 +11886,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e2b1094b61e8e5ce4a98e2d8d4fd2205cc107d79",
+        "checksum": "adler32:276a0633",
         "description": "GluGluToHToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 19432,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToGG_M-125_8TeV-powheg-pythia6/AODSIM/NewG4Phys_PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToGG_M-125_8TeV-powheg-pythia6_AODSIM_NewG4Phys_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:4b67a275d3adf720fa34e48190396dd2586d73d5",
+        "checksum": "adler32:4409857c",
         "description": "GluGluToHToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 11200,
         "type": "index.txt",
@@ -11998,14 +11998,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9a01be83b68f524dc584db69907112cea88d5c7e",
+        "checksum": "adler32:266fbef6",
         "description": "GluGluToHToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4420,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToGG_M-125_8TeV-powheg-pythia6/AODSIM/No_PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToGG_M-125_8TeV-powheg-pythia6_AODSIM_No_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:136e057c82f8ee145d6cd7f185bb50c314bfda7f",
+        "checksum": "adler32:eee60210",
         "description": "GluGluToHToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2509,
         "type": "index.txt",
@@ -12110,14 +12110,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:16d305360899eac6906bae92813dc92cc4ca2f7b",
+        "checksum": "adler32:91f0b394",
         "description": "GluGluToHToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4382,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToGG_M-125_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToGG_M-125_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:3cb7a41740d51d951367902dab90e5227e7c1266",
+        "checksum": "adler32:ca4bf435",
         "description": "GluGluToHToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2470,
         "type": "index.txt",
@@ -12222,14 +12222,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9c160801733027d00ecffa6b7dff6ea191ca2277",
+        "checksum": "adler32:1829549b",
         "description": "GluGluToHToInvisible_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 11354,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToInvisible_M-125_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToInvisible_M-125_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:4e308229222303a8113f8792b25b4fc39893e909",
+        "checksum": "adler32:dcdce374",
         "description": "GluGluToHToInvisible_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6501,
         "type": "index.txt",
@@ -12334,14 +12334,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:461cfefd1c09338cff089b2c9ba51ed302a56cef",
+        "checksum": "adler32:3914d3d4",
         "description": "GluGluToHToMM_M-125_TuneZ2star_8TeV-minloHJJ-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 15353,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToMM_M-125_TuneZ2star_8TeV-minloHJJ-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToMM_M-125_TuneZ2star_8TeV-minloHJJ-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:37494e4a5a4ed47a3ecb5c33cff73c80536fab0c",
+        "checksum": "adler32:2c25040e",
         "description": "GluGluToHToMM_M-125_TuneZ2star_8TeV-minloHJJ-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 9030,
         "type": "index.txt",
@@ -12446,28 +12446,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:272cf55e36c23da326a366b663179868fc031ae8",
+        "checksum": "adler32:5a7f49de",
         "description": "GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 2102,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:30d1f2cb897c6f7ab950b832b86a391c034ac64a",
+        "checksum": "adler32:6852738a",
         "description": "GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 13302,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:83465c9f0efce168002d6ed9bce1e69e4291f029",
+        "checksum": "adler32:c3e679df",
         "description": "GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 1218,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:c71b28fa79a25c1ce9cdcaf6130ea2c4c32cc2b2",
+        "checksum": "adler32:3bc756a4",
         "description": "GluGluToHToTauTau_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 7714,
         "type": "index.txt",
@@ -12572,14 +12572,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0b07c2064df91273bb4c7af93e9015b7bea7ff72",
+        "checksum": "adler32:d3a4a079",
         "description": "GluGluToHToTauTau_M-125_8TeV-powheg-pythia6-tauPolarOff AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 19769,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToTauTau_M-125_8TeV-powheg-pythia6-tauPolarOff/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToTauTau_M-125_8TeV-powheg-pythia6-tauPolarOff_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:6769204008fcb28eb10aefd83ba7ffddcdaa9eaf",
+        "checksum": "adler32:b1f91543",
         "description": "GluGluToHToTauTau_M-125_8TeV-powheg-pythia6-tauPolarOff AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 11536,
         "type": "index.txt",
@@ -12684,14 +12684,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c7309b4085ea4fbd56273b30b718528bfe2f0359",
+        "checksum": "adler32:6728829e",
         "description": "GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 13416,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:719a7067fb50c8e095ad25ebb617fadc79855a55",
+        "checksum": "adler32:d1b3695f",
         "description": "GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 7828,
         "type": "index.txt",
@@ -12796,28 +12796,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:96d15db2d6ec95b6b2264e539d5ba72dd435a856",
+        "checksum": "adler32:38902d02",
         "description": "GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 1082,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:7730ab6b73105a8ced4544d2021fd8a5de098f99",
+        "checksum": "adler32:0cd410b7",
         "description": "GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 6481,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:46cc128204f15d74f3bfbbf0dae7821fb1e11909",
+        "checksum": "adler32:9168c60c",
         "description": "GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 639,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:aea4f24ebd124035523ecbb8b619d41450a6a9a5",
+        "checksum": "adler32:2292a62c",
         "description": "GluGluToHToWWToLAndTau2NuQQ_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 3834,
         "type": "index.txt",
@@ -12922,14 +12922,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3ecb872de7bf888c4fe83c554a9f792d19e10a1f",
+        "checksum": "adler32:3fed7c1d",
         "description": "GluGluToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 18901,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:b27ebc78c3b8fd902324feee91f4064647756ae5",
+        "checksum": "adler32:87c33de4",
         "description": "GluGluToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10962,
         "type": "index.txt",
@@ -13034,28 +13034,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5bffef9262cecdb44cb66cd378261a9aade4be9f",
+        "checksum": "adler32:e1924536",
         "description": "GluGluToHToZG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 3033,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZG_M-125_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZG_M-125_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v3_00000_file_index.json"
       },
       {
-        "checksum": "sha1:17ca30b8b5ef48c11d6cc6c5a3e762b339f467b0",
+        "checksum": "adler32:b1e68a9b",
         "description": "GluGluToHToZG_M-125_8TeV-powheg-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2359,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZG_M-125_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZG_M-125_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v3_10000_file_index.json"
       },
       {
-        "checksum": "sha1:a6266c043d4e553d77d329be5310ad0f2407eb31",
+        "checksum": "adler32:52e70e12",
         "description": "GluGluToHToZG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 1710,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZG_M-125_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZG_M-125_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v3_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:08ecd254181ee3eab333be9b33953528841b94d0",
+        "checksum": "adler32:956198ac",
         "description": "GluGluToHToZG_M-125_8TeV-powheg-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 1330,
         "type": "index.txt",
@@ -13160,28 +13160,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8a6fcc769d9530a0534b33e9b2aacb2569309fbb",
+        "checksum": "adler32:88db009c",
         "description": "GluGluToHToZG_M-125_8TeV-powheg-pythia8175 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 3742,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZG_M-125_8TeV-powheg-pythia8175/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZG_M-125_8TeV-powheg-pythia8175_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:773312c758569d15b7967892dc8393b2d79bb42b",
+        "checksum": "adler32:45ba17e8",
         "description": "GluGluToHToZG_M-125_8TeV-powheg-pythia8175 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 1022,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZG_M-125_8TeV-powheg-pythia8175/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZG_M-125_8TeV-powheg-pythia8175_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:9125f9d3cb6cd6760941d77007aa8dded8a8da8c",
+        "checksum": "adler32:bc1086d6",
         "description": "GluGluToHToZG_M-125_8TeV-powheg-pythia8175 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 2123,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZG_M-125_8TeV-powheg-pythia8175/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZG_M-125_8TeV-powheg-pythia8175_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:f663e6610f4829b7d1a841c55670aedd92bce021",
+        "checksum": "adler32:c381b055",
         "description": "GluGluToHToZG_M-125_8TeV-powheg-pythia8175 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 579,
         "type": "index.txt",
@@ -13286,28 +13286,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:95f5815a79eecc050feb6967417352036acbbbbf",
+        "checksum": "adler32:bceb01b0",
         "description": "GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 12003,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:9fae173f59d19c3bf36b626e0633488ab00a3cc0",
+        "checksum": "adler32:7ed21273",
         "description": "GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2826,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:28a328bf6bd95f58d3b202f1a905fe05efb79dd2",
+        "checksum": "adler32:b8526fcf",
         "description": "GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 7004,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:4be0b3830ff3b879708ea34a9a8eca1ce521d7dd",
+        "checksum": "adler32:d48bfda0",
         "description": "GluGluToHToZZTo2L2Nu_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 1648,
         "type": "index.txt",
@@ -13412,28 +13412,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1f11056122b85189f6abb4e493613983aebe373f",
+        "checksum": "adler32:4ead5781",
         "description": "GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 4930,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:568aa059957cbb5b886fcc6bfdd8f309a39f03a9",
+        "checksum": "adler32:30af63c2",
         "description": "GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 7745,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:75db83cd554e90b1131df7d97c01c33801746c45",
+        "checksum": "adler32:7032740d",
         "description": "GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 2870,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:44bd54250f8fcb00ee9022d30ddfbf1327768f27",
+        "checksum": "adler32:6d396cd2",
         "description": "GluGluToHToZZTo2L2Q_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 4510,
         "type": "index.txt",
@@ -13538,28 +13538,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e61891074fd0a542d1e0b541eef4be4e7636f0a2",
+        "checksum": "adler32:e127b706",
         "description": "GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 10852,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:b78aad0aba012fd123ae61953988a14913beb1bc",
+        "checksum": "adler32:034d8a14",
         "description": "GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 4202,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:2554dd03324beb4ba2c9fff3b630f041bb1e45ac",
+        "checksum": "adler32:15f99084",
         "description": "GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 6293,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:89c33c05647c27650f2dfcade0a5da9529a2154f",
+        "checksum": "adler32:f2d9ed8a",
         "description": "GluGluToHToZZTo4L_M-125_8TeV-minloHJJ-pythia6-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2436,
         "type": "index.txt",
@@ -13664,14 +13664,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:73df8c5850cfffd9f0d63273529c0255dbfac093",
+        "checksum": "adler32:b746ec65",
         "description": "GluGluToHToZZTo4L_M-125_8TeV-powheg15-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12006,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToHToZZTo4L_M-125_8TeV-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToHToZZTo4L_M-125_8TeV-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:fbdf46c18382fb975a9c5620c9f3129c47dbd198",
+        "checksum": "adler32:6815321f",
         "description": "GluGluToHToZZTo4L_M-125_8TeV-powheg15-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6860,
         "type": "index.txt",
@@ -13776,14 +13776,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:48e51f62a0f46d1d53ed52a0af86d973ce0dbe1a",
+        "checksum": "adler32:ee198e00",
         "description": "GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 16877,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:b786461f2b8a1ade5f22cdb507f758745be596fb",
+        "checksum": "adler32:7d8a7afb",
         "description": "GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10260,
         "type": "index.txt",
@@ -13888,14 +13888,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:018ef54f9b71f9d96039e137abf1d510d16293a9",
+        "checksum": "adler32:46a6b4e9",
         "description": "GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 14328,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:8ad65deaeb016195d08766b79dc2b23363d65f07",
+        "checksum": "adler32:4bad9670",
         "description": "GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 8740,
         "type": "index.txt",
@@ -14000,14 +14000,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:df6b608be8c6abd73349bdd3e46afeb65aa7caff",
+        "checksum": "adler32:ee985f18",
         "description": "GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 8558,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:96ea8d5f2e31b99e12f2e44690f150954542fdfb",
+        "checksum": "adler32:8b4046a2",
         "description": "GluGluToWWTo2L2Nu_1xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5175,
         "type": "index.txt",
@@ -14112,14 +14112,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dd065beaed3a2a1c991a0a6f39e1d92837c99056",
+        "checksum": "adler32:03595b00",
         "description": "GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 15794,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:34c5ecfbcce2f45258c363c359985a0c6a779aed",
+        "checksum": "adler32:be68b109",
         "description": "GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-0to140_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 9618,
         "type": "index.txt",
@@ -14224,14 +14224,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:962de895999b9c957061955cd76e36471d3f41ef",
+        "checksum": "adler32:c300ddcf",
         "description": "GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 11720,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:49e7057ee9e3619d8736d3a1f13866689fb66531",
+        "checksum": "adler32:1c1dadcf",
         "description": "GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-140to300_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 7161,
         "type": "index.txt",
@@ -14336,14 +14336,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:382367e7a393650ee25aa4011256f4b795d0424f",
+        "checksum": "adler32:cb72a0bf",
         "description": "GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 26112,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:0db8737d9c90a651d576005212fdd4429f21b273",
+        "checksum": "adler32:f1402ff6",
         "description": "GluGluToWWTo2L2Nu_25xHWidthContinInterf_M-125_mWW-300_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 15820,
         "type": "index.txt",
@@ -14448,14 +14448,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d54699e7497d31b145d1cdfb9d1d7932c94061b3",
+        "checksum": "adler32:0e14704c",
         "description": "GluGluToWWTo2L2Nu_Contin_mWW-0to300_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 14201,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToWWTo2L2Nu_Contin_mWW-0to300_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToWWTo2L2Nu_Contin_mWW-0to300_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:5b40e4986dfb37644ff5be579963c0798865a7a1",
+        "checksum": "adler32:a29209a2",
         "description": "GluGluToWWTo2L2Nu_Contin_mWW-0to300_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 8320,
         "type": "index.txt",
@@ -14560,14 +14560,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d5422234921bf6225eb8458ccb51681c57cb131a",
+        "checksum": "adler32:dcd4c0a4",
         "description": "GluGluToWWTo2L2Nu_Contin_mWW-300_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 18306,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToWWTo2L2Nu_Contin_mWW-300_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToWWTo2L2Nu_Contin_mWW-300_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:0e217b5c6dcdf5bac8db7735a600edd5e92905c8",
+        "checksum": "adler32:ea2bc9ee",
         "description": "GluGluToWWTo2L2Nu_Contin_mWW-300_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10660,
         "type": "index.txt",
@@ -14672,14 +14672,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0586858c53c4441d7f6fb19afdc6c5f13c7ce664",
+        "checksum": "adler32:7039e39f",
         "description": "GluGluToWWTo2L2Nu_Signal_25xHWidth_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 8144,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/GluGluToWWTo2L2Nu_Signal_25xHWidth_8TeV_gg2vv315-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_GluGluToWWTo2L2Nu_Signal_25xHWidth_8TeV_gg2vv315-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:5aa1a162838ec31132e2db5f26f533454a63bde1",
+        "checksum": "adler32:282bc979",
         "description": "GluGluToWWTo2L2Nu_Signal_25xHWidth_8TeV_gg2vv315-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4761,
         "type": "index.txt",
@@ -14784,28 +14784,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:06c7494661c96e2aa1c99e0ae3b02259deed5f20",
+        "checksum": "adler32:a8387f39",
         "description": "G_Pt-120to170_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 47237,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-120to170_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-120to170_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:db2819abad66072f94a340b7731fcd8c412c2501",
+        "checksum": "adler32:69ae777a",
         "description": "G_Pt-120to170_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 28477,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-120to170_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-120to170_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:85ba89a19083b4ef3ceedf37cc81b6a5102586aa",
+        "checksum": "adler32:d6ae9988",
         "description": "G_Pt-120to170_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 26508,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-120to170_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-120to170_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:fba3f2f9794262b342319c3977f004b65ec6643b",
+        "checksum": "adler32:84480fd8",
         "description": "G_Pt-120to170_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 15980,
         "type": "index.txt",
@@ -14910,28 +14910,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5c4d9f26e9df0e29986dbb05a78b9d67fc4bb194",
+        "checksum": "adler32:5e238208",
         "description": "G_Pt-1400to1800_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 19210,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-1400to1800_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-1400to1800_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:0e12103e095522facb84675c3dc070efb9f18c52",
+        "checksum": "adler32:cb2d2d64",
         "description": "G_Pt-1400to1800_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 58302,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-1400to1800_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-1400to1800_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:fae5a5b1ec71cbc6e61b67e6ec6a3325362e079a",
+        "checksum": "adler32:c3a3dcc4",
         "description": "G_Pt-1400to1800_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 10830,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-1400to1800_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-1400to1800_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:7793efd67a4d7f1e47b9258289d6716501b2acbd",
+        "checksum": "adler32:91810339",
         "description": "G_Pt-1400to1800_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 32870,
         "type": "index.txt",
@@ -15036,28 +15036,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fc475a8b28e9502326877fb7ac447209f7ae4da7",
+        "checksum": "adler32:06a78500",
         "description": "G_Pt-170to300_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 61306,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-170to300_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-170to300_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:679d291fb20350218ac4296fc91031d2683ddaab",
+        "checksum": "adler32:55cbf1e9",
         "description": "G_Pt-170to300_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 13066,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-170to300_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-170to300_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:0fb23bf14a191192327ce53daa54d5934e4bb331",
+        "checksum": "adler32:ebe501ea",
         "description": "G_Pt-170to300_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 34404,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-170to300_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-170to300_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:e5b04eae1e84bf60ba9795802a63e94aeed44ca0",
+        "checksum": "adler32:de55bbba",
         "description": "G_Pt-170to300_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 7332,
         "type": "index.txt",
@@ -15162,28 +15162,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b6c896f924f2128fd08ee4020d79e86cb8454ffe",
+        "checksum": "adler32:33ed97b8",
         "description": "G_Pt-1800_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 21185,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-1800_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-1800_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:2f5b5bd67167ce577d373c3b15d9a8d286f141cf",
+        "checksum": "adler32:5ef09336",
         "description": "G_Pt-1800_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 59582,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-1800_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-1800_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:bba7f05c05732375319291ac58328d28efc575b3",
+        "checksum": "adler32:bdbe070b",
         "description": "G_Pt-1800_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 11776,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-1800_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-1800_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:1861444731660d648df601e15894140d7c3d852e",
+        "checksum": "adler32:284f70ed",
         "description": "G_Pt-1800_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 33120,
         "type": "index.txt",
@@ -15288,14 +15288,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d4d539f7fd473d864c16aeb094f80be193d3c2ae",
+        "checksum": "adler32:e77e16ec",
         "description": "G_Pt-300to470_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 68341,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-300to470_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-300to470_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:fe4980e3f966f02b57e9a09df9210686e99a52ff",
+        "checksum": "adler32:02b2bd4d",
         "description": "G_Pt-300to470_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 38352,
         "type": "index.txt",
@@ -15400,28 +15400,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:33d17009303b179f70c41ec1abdb3b5b6db8e916",
+        "checksum": "adler32:cc646746",
         "description": "G_Pt-30to50_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 10657,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-30to50_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-30to50_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:566f7c78e642df93fac79a1f5114cbd8571349ca",
+        "checksum": "adler32:540d8b38",
         "description": "G_Pt-30to50_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 55612,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-30to50_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-30to50_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:19b64f5e3605860bb4c7bc7791a21729aa750ef2",
+        "checksum": "adler32:a8c71e15",
         "description": "G_Pt-30to50_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 5952,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-30to50_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-30to50_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:d1d726c8f4fa98b4bc063a01de9f01d3e3b297e7",
+        "checksum": "adler32:82f62c4c",
         "description": "G_Pt-30to50_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 31062,
         "type": "index.txt",
@@ -15526,28 +15526,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9e93f06d206ae04e0cf56f35603d634783fbc285",
+        "checksum": "adler32:485b4360",
         "description": "G_Pt-470to800_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 34842,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-470to800_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-470to800_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:d4841d7cff7ef70a97037cd7a5e7eea0c45a9201",
+        "checksum": "adler32:fb33e7e9",
         "description": "G_Pt-470to800_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 39196,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-470to800_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-470to800_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:42918f329a52f22269c5a66707d49142ed37adda",
+        "checksum": "adler32:8f405069",
         "description": "G_Pt-470to800_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 19552,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-470to800_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-470to800_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:793ae4a48952e78c5f89736785f48cdc149eb60d",
+        "checksum": "adler32:7136398f",
         "description": "G_Pt-470to800_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 21996,
         "type": "index.txt",
@@ -15652,28 +15652,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b565b719d13112237ec12e68d84180a079581034",
+        "checksum": "adler32:b8a09eff",
         "description": "G_Pt-50to80_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 37964,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-50to80_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-50to80_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:7121714ab8bc36b3d116dde2b9b2385bc927cf44",
+        "checksum": "adler32:aec6615e",
         "description": "G_Pt-50to80_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 28304,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-50to80_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-50to80_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:c55bd1ae9d6515ad8211b5bff7bba2312d52c4ed",
+        "checksum": "adler32:89be5e3e",
         "description": "G_Pt-50to80_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 21204,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-50to80_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-50to80_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:1e38dd0814f714154f21eb2a5965edde46bd6b3f",
+        "checksum": "adler32:99fef374",
         "description": "G_Pt-50to80_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 15810,
         "type": "index.txt",
@@ -15778,28 +15778,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ee361b26efe4d42cea594b505d7d18d2e2df809d",
+        "checksum": "adler32:88d15c72",
         "description": "G_Pt-800to1400_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 49057,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-800to1400_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-800to1400_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:ae729abfea05593e2ae647383920929baa5f6fb8",
+        "checksum": "adler32:899caf45",
         "description": "G_Pt-800to1400_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 30577,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-800to1400_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-800to1400_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:79195ab162c6177c72aea722f2410ee8ebaa98b8",
+        "checksum": "adler32:e09cd198",
         "description": "G_Pt-800to1400_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 27594,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-800to1400_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-800to1400_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:38480f30fdc19929be45520639721a3cb2a42193",
+        "checksum": "adler32:b436791e",
         "description": "G_Pt-800to1400_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 17199,
         "type": "index.txt",
@@ -15904,28 +15904,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:99da25b0994b8b28ce83f6a7df99e12368d47389",
+        "checksum": "adler32:60ca5c7b",
         "description": "G_Pt-80to120_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 9686,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-80to120_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-80to120_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:e2e71aa5ed8ec77e4be2473ca51662d6eb7f7477",
+        "checksum": "adler32:8b68665f",
         "description": "G_Pt-80to120_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 61122,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-80to120_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-80to120_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:493036f61ffd2f8c97ba9ddfac136b3e942909a2",
+        "checksum": "adler32:ffdc7903",
         "description": "G_Pt-80to120_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 5423,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/G_Pt-80to120_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_G_Pt-80to120_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:a5e5725a863ff84e984b5a245622b65be2b5a4ef",
+        "checksum": "adler32:b4a1df39",
         "description": "G_Pt-80to120_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 34221,
         "type": "index.txt",
@@ -16030,28 +16030,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6b23cceb3087232909e54f340f2be40d5a5eb1bc",
+        "checksum": "adler32:b339b1be",
         "description": "LminusNubarVBF_Mqq-120_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 114563,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LminusNubarVBF_Mqq-120_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LminusNubarVBF_Mqq-120_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:79e14831c934b3b5abbc141362e55bcfe1303e01",
+        "checksum": "adler32:842321e4",
         "description": "LminusNubarVBF_Mqq-120_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 97196,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LminusNubarVBF_Mqq-120_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LminusNubarVBF_Mqq-120_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:95e48385447afca70bc7c12879cc5819889353b3",
+        "checksum": "adler32:3908b032",
         "description": "LminusNubarVBF_Mqq-120_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 64141,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LminusNubarVBF_Mqq-120_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LminusNubarVBF_Mqq-120_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:5a6135af5f2a0339278e50a1f273c1fa0c77f7da",
+        "checksum": "adler32:70d113d3",
         "description": "LminusNubarVBF_Mqq-120_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 54417,
         "type": "index.txt",
@@ -16156,14 +16156,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0155ce604057b74f043ec36361b394769c7d4b12",
+        "checksum": "adler32:80ac7807",
         "description": "LNuGG_enhanced_FSR_8TeV_madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 29147,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LNuGG_enhanced_FSR_8TeV_madgraph/AODSIM/PU_RD1_START53_V7N_ext1-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LNuGG_enhanced_FSR_8TeV_madgraph_AODSIM_PU_RD1_START53_V7N_ext1-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:bd58964916d6ada0c9be4351f0a15b06b67bc921",
+        "checksum": "adler32:af0ed224",
         "description": "LNuGG_enhanced_FSR_8TeV_madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 16356,
         "type": "index.txt",
@@ -16268,28 +16268,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6cdc65c64f466ca8e533299eaa6148828682d1b9",
+        "checksum": "adler32:404c5a2d",
         "description": "LNuGG_enhanced_FSR_8TeV_madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 10562,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LNuGG_enhanced_FSR_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LNuGG_enhanced_FSR_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:6842702889a54a7d6fe0310bd886b8396ddfa94d",
+        "checksum": "adler32:b9ac44d1",
         "description": "LNuGG_enhanced_FSR_8TeV_madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 24422,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LNuGG_enhanced_FSR_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LNuGG_enhanced_FSR_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:ac9f586bf2e0c34875d57d11ea4d221e4a3b479d",
+        "checksum": "adler32:49a60cd6",
         "description": "LNuGG_enhanced_FSR_8TeV_madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 5856,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LNuGG_enhanced_FSR_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LNuGG_enhanced_FSR_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:6bcbe7a573fe184f8f6f00713417248920686c9a",
+        "checksum": "adler32:d3644d51",
         "description": "LNuGG_enhanced_FSR_8TeV_madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 13542,
         "type": "index.txt",
@@ -16394,14 +16394,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0ac522000c1e05123ee13f42a7dc05a42e5a80c1",
+        "checksum": "adler32:d70c9fd4",
         "description": "LNuGG_enhanced_ISR_8TeV_madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 30362,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LNuGG_enhanced_ISR_8TeV_madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LNuGG_enhanced_ISR_8TeV_madgraph_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:0653e53eeed0d002e91e39cfe5c2577b0489bdce",
+        "checksum": "adler32:54cd4c73",
         "description": "LNuGG_enhanced_ISR_8TeV_madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 16836,
         "type": "index.txt",
@@ -16506,28 +16506,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:34babb001c289201c5fc89935b9485d557177604",
+        "checksum": "adler32:1dd10603",
         "description": "LNuGG_enhanced_ISR_8TeV_madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 30692,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LNuGG_enhanced_ISR_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LNuGG_enhanced_ISR_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:6d5e5a4ddb71b3e11cdb11ad88c9350529ca5a8d",
+        "checksum": "adler32:53d18b22",
         "description": "LNuGG_enhanced_ISR_8TeV_madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 3302,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LNuGG_enhanced_ISR_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LNuGG_enhanced_ISR_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:51b6d44a1a3bf25ce9e40e88fe51562dd5046a07",
+        "checksum": "adler32:113d7e03",
         "description": "LNuGG_enhanced_ISR_8TeV_madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 17019,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LNuGG_enhanced_ISR_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LNuGG_enhanced_ISR_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:8880d55ac455af81ce6c7fbd7084ffcc117f3ee0",
+        "checksum": "adler32:6b02334b",
         "description": "LNuGG_enhanced_ISR_8TeV_madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 1830,
         "type": "index.txt",
@@ -16632,28 +16632,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2bf8e723e140fd413c64045de323f171b9f767f6",
+        "checksum": "adler32:eab966e4",
         "description": "LplusNuVBF_Mqq-120_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 19141,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LplusNuVBF_Mqq-120_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LplusNuVBF_Mqq-120_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:7dfbb72f4ddeb88069c7c8c32a56e11459739bcc",
+        "checksum": "adler32:815f32b1",
         "description": "LplusNuVBF_Mqq-120_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 258390,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LplusNuVBF_Mqq-120_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LplusNuVBF_Mqq-120_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:57d3d59e0c4e5ef656986640f335046e0ac5b862",
+        "checksum": "adler32:fd7c9bea",
         "description": "LplusNuVBF_Mqq-120_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 10614,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/LplusNuVBF_Mqq-120_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_LplusNuVBF_Mqq-120_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:1c01826e0cc0e4a623c44451c03906ea244a1590",
+        "checksum": "adler32:86d9219a",
         "description": "LplusNuVBF_Mqq-120_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 143289,
         "type": "index.txt",
@@ -16755,28 +16755,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dec95c74b19410ee6914c9bf3431ab2291245a2a",
+        "checksum": "adler32:1fa21a08",
         "description": "Neutrino_Pt_2to20_gun AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 126005,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/Neutrino_Pt_2to20_gun/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_Neutrino_Pt_2to20_gun_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:15a07a2262be3089b6f727b8196d7dd8e22ac02f",
+        "checksum": "adler32:6a889433",
         "description": "Neutrino_Pt_2to20_gun AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 61568,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/Neutrino_Pt_2to20_gun/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_Neutrino_Pt_2to20_gun_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:ed8a0c0b2d10cd5f29718fe51a38198423f8cd71",
+        "checksum": "adler32:0df233c5",
         "description": "Neutrino_Pt_2to20_gun AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 67940,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/Neutrino_Pt_2to20_gun/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_Neutrino_Pt_2to20_gun_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:948a43f09b928aeaad01f1cd4e10d1911d68e2ea",
+        "checksum": "adler32:b69cb28a",
         "description": "Neutrino_Pt_2to20_gun AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 33196,
         "type": "index.txt",
@@ -16881,14 +16881,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fc80c308fdd9258120d556f5f4a3979eb19a82dd",
+        "checksum": "adler32:455cdd04",
         "description": "QCD4Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 9209,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD4Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD4Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:9fad63256a5ac3f37d528d3ebbc5befa566aa07e",
+        "checksum": "adler32:63f33afc",
         "description": "QCD4Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5238,
         "type": "index.txt",
@@ -16993,28 +16993,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0a6df1db0bbad49e68b054fd5bbc58dc5b2c0192",
+        "checksum": "adler32:cfebd692",
         "description": "QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 5458,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:6e458c721e61ad1c663e8f655c6a8b1b873be0bb",
+        "checksum": "adler32:bbe37a63",
         "description": "QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 5117,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:6489c4c93962724cb93567dd0e306a56711789da",
+        "checksum": "adler32:dad0b028",
         "description": "QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 3104,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:d6df06003e1f1b4ac23e7ad052b6a7853292f832",
+        "checksum": "adler32:80147503",
         "description": "QCD4Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2910,
         "type": "index.txt",
@@ -17119,14 +17119,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:32f9629de30847b7b97460408e07f78d46db9d3f",
+        "checksum": "adler32:522486e0",
         "description": "QCD4Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 26600,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD4Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD4Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:164fdc453242a48a4af1633bf29ecf753285fc14",
+        "checksum": "adler32:860301c2",
         "description": "QCD4Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 15132,
         "type": "index.txt",
@@ -17231,14 +17231,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1f9b1d46319c34d67bd11421f94b538d0e22a112",
+        "checksum": "adler32:99c6cc48",
         "description": "QCD4Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 18470,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD4Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD4Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:139120ab6fb5448cd40993cfb68ef2e2dd1136b3",
+        "checksum": "adler32:53408304",
         "description": "QCD4Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10530,
         "type": "index.txt",
@@ -17343,14 +17343,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d5770a1d0e10e2248cc5fb3aa0b0e3bae5b77ae8",
+        "checksum": "adler32:967cedbf",
         "description": "QCD6Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2730,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD6Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD6Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:7137ab364ff6396a38b340b38d640f244d4917ae",
+        "checksum": "adler32:44a4d8fd",
         "description": "QCD6Jets_Pt-100to180_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 1552,
         "type": "index.txt",
@@ -17455,14 +17455,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3cf0f3cd7a5a8d32fbe565040c18744df9c3c408",
+        "checksum": "adler32:4f313348",
         "description": "QCD6Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2048,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD6Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD6Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:7587e22c54b91ec9e91e79d59fe546630f0d3447",
+        "checksum": "adler32:0bc162d7",
         "description": "QCD6Jets_Pt-180to250_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 1164,
         "type": "index.txt",
@@ -17567,14 +17567,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a39ac46c6306feb5e4cfc847bc7a4bb859966583",
+        "checksum": "adler32:d8fd06e0",
         "description": "QCD6Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3753,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD6Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD6Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:6e40bca1affe32e7c3fe8d4678f511154fe120c1",
+        "checksum": "adler32:96488aa9",
         "description": "QCD6Jets_Pt-250to400_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2134,
         "type": "index.txt",
@@ -17679,14 +17679,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6135dbdd3106463d7abb7284cad65e0bfc3c4794",
+        "checksum": "adler32:77a1ee14",
         "description": "QCD6Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2738,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD6Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD6Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:7230e59569dbcfd5aac112ccf55281108cca2e9f",
+        "checksum": "adler32:087ada77",
         "description": "QCD6Jets_Pt-400to5600_TuneZ2Star_8TeV-alpgen AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 1560,
         "type": "index.txt",
@@ -17791,14 +17791,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:83fec32be0a479b2943c963a445a5be35ab4330f",
+        "checksum": "adler32:1aaf210c",
         "description": "QCD_Pt-1000_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 8633,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-1000_CTEQ6L1_8TeV_herwig6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-1000_CTEQ6L1_8TeV_herwig6_AODSIM_NoPileUp_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:f0027a8e35ee20f42abfcefd49811d92c41e1c4d",
+        "checksum": "adler32:1466a6e4",
         "description": "QCD_Pt-1000_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4810,
         "type": "index.txt",
@@ -17903,14 +17903,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d1fd7cc80fd2aa3ebac3fd7756891ada368639c0",
+        "checksum": "adler32:7376e44e",
         "description": "QCD_Pt_120to170_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12097,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_120to170_CTEQ6L1_8TeV_herwig6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_120to170_CTEQ6L1_8TeV_herwig6_AODSIM_NoPileUp_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:32002e571685a5bf73a477e5e2ce764477de0b59",
+        "checksum": "adler32:4e7e0fbb",
         "description": "QCD_Pt_120to170_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6804,
         "type": "index.txt",
@@ -18015,14 +18015,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:29d9ac2e0ca9fcba675e9ed370d2ed08b180ce67",
+        "checksum": "adler32:5e2fc446",
         "description": "QCD_Pt-15to3000_Tune4C_Flat_8TeV_pythia8 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 38762,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-15to3000_Tune4C_Flat_8TeV_pythia8/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-15to3000_Tune4C_Flat_8TeV_pythia8_AODSIM_NoPileUp_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:043b8d78cd63b4a271eeb05cd1bde19e3539b80a",
+        "checksum": "adler32:eae4699f",
         "description": "QCD_Pt-15to3000_Tune4C_Flat_8TeV_pythia8 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 22002,
         "type": "index.txt",
@@ -18127,28 +18127,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0e7258c9ad4105125eafa40fcdfcd2e84e48ab26",
+        "checksum": "adler32:3c95fe4d",
         "description": "QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 46098,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6/AODSIM/NoPileUp_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6_AODSIM_NoPileUp_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:087fd8e2c69b8a1524f678f1155584291f5f87a8",
+        "checksum": "adler32:14f8d3d4",
         "description": "QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 70865,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6/AODSIM/NoPileUp_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6_AODSIM_NoPileUp_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:0b70a057438b3ff609a80b799857a582154e90e1",
+        "checksum": "adler32:a5cbff90",
         "description": "QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 26398,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6/AODSIM/NoPileUp_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6_AODSIM_NoPileUp_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:9716332991c4246a8c586b3562b58a5d83e92f0d",
+        "checksum": "adler32:b8ef31c7",
         "description": "QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 40582,
         "type": "index.txt",
@@ -18253,28 +18253,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d013719f3cca0b498a6b589348489d6ed74b3600",
+        "checksum": "adler32:88913f39",
         "description": "QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 213752,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:9dbb0c51977e3a6c78027de8e22c1a4fc1170cf2",
+        "checksum": "adler32:6181805d",
         "description": "QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 162109,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:8638cc1422338152d3f630e2e56f87a5cec976bf",
+        "checksum": "adler32:023c41e5",
         "description": "QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 121875,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:780d1adaf481d9fc2f010c2fde578b6baad371b2",
+        "checksum": "adler32:c45ae154",
         "description": "QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 92430,
         "type": "index.txt",
@@ -18379,14 +18379,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3f51ed226067f5aa7e513ef9614d6042c5e5a848",
+        "checksum": "adler32:efb7f1f0",
         "description": "QCD_Pt_15to30_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 17704,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_15to30_CTEQ6L1_8TeV_herwig6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_15to30_CTEQ6L1_8TeV_herwig6_AODSIM_NoPileUp_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:e5c572016bc169dce5b28e4fefa3b4c101d8c6ea",
+        "checksum": "adler32:0216cdd7",
         "description": "QCD_Pt_15to30_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 9911,
         "type": "index.txt",
@@ -18491,392 +18491,392 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:04b408d7bd377fd5b10ee688a8efa53ceb0e724c",
+        "checksum": "adler32:b16c669b",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 28) for access to data via CMS virtual machine",
         "size": 169542,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:35de6dc662eefaf03b0bfdf5e2fa1ea3533d9818",
+        "checksum": "adler32:267f7aae",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 28) for access to data via CMS virtual machine",
         "size": 333469,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010000_file_index.json"
       },
       {
-        "checksum": "sha1:6f598d54d1ff2613a48204ad0a57f81089f5c4d6",
+        "checksum": "adler32:adeca894",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (3 of 28) for access to data via CMS virtual machine",
         "size": 332775,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010001_file_index.json"
       },
       {
-        "checksum": "sha1:0b8dfa8470b50b89ae37b3ea8c16b0e5ebae59fb",
+        "checksum": "adler32:0732cd2d",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (4 of 28) for access to data via CMS virtual machine",
         "size": 338327,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010002_file_index.json"
       },
       {
-        "checksum": "sha1:a55aca6180a7bf170eca0e16d708081da2b58af9",
+        "checksum": "adler32:4361aca7",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (5 of 28) for access to data via CMS virtual machine",
         "size": 337286,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010003_file_index.json"
       },
       {
-        "checksum": "sha1:9fa12c16d90f1ec8dd1fc6f0b5c8c581c5872d6e",
+        "checksum": "adler32:965782f9",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (6 of 28) for access to data via CMS virtual machine",
         "size": 340756,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010004_file_index.json"
       },
       {
-        "checksum": "sha1:81202a29f1165cf6db1a2bcbc093f3ef3a7b5685",
+        "checksum": "adler32:1e4dcd66",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (7 of 28) for access to data via CMS virtual machine",
         "size": 341103,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010005_file_index.json"
       },
       {
-        "checksum": "sha1:dee76438ab59fe1c6eda45184f92ae001fb941cd",
+        "checksum": "adler32:8527a9e8",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (8 of 28) for access to data via CMS virtual machine",
         "size": 342838,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010006_file_index.json"
       },
       {
-        "checksum": "sha1:a54c5f397ce19467cc98ecf9decbe475481f5b10",
+        "checksum": "adler32:98648eca",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (9 of 28) for access to data via CMS virtual machine",
         "size": 342838,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010007_file_index.json"
       },
       {
-        "checksum": "sha1:e9feb9a81c9b31e903ddb99bb9f18b7b0c05cbd0",
+        "checksum": "adler32:b3b8880d",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (10 of 28) for access to data via CMS virtual machine",
         "size": 341797,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010008_file_index.json"
       },
       {
-        "checksum": "sha1:1f1f581c9703afdfa932b433ba3a01fb90bb5e82",
+        "checksum": "adler32:9cdc2ece",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (11 of 28) for access to data via CMS virtual machine",
         "size": 344226,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010009_file_index.json"
       },
       {
-        "checksum": "sha1:bdf1f5f4c2d719539ee5d77645f86aa811093e67",
+        "checksum": "adler32:fa78fae7",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (12 of 28) for access to data via CMS virtual machine",
         "size": 342491,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010010_file_index.json"
       },
       {
-        "checksum": "sha1:8bcdd2ca7c494154d08cb91a2016bed6ddea3918",
+        "checksum": "adler32:731a06ec",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (13 of 28) for access to data via CMS virtual machine",
         "size": 343532,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010011_file_index.json"
       },
       {
-        "checksum": "sha1:fe0ad331abc13999eaec6977c48d1ad05a80532b",
+        "checksum": "adler32:041a4165",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (14 of 28) for access to data via CMS virtual machine",
         "size": 342838,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010012_file_index.json"
       },
       {
-        "checksum": "sha1:6cb7e1751dd98846b9170497794f3581395a0eee",
+        "checksum": "adler32:a0c1a1ce",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (15 of 28) for access to data via CMS virtual machine",
         "size": 343185,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010013_file_index.json"
       },
       {
-        "checksum": "sha1:5fae5eddafd506979d02bbfb8354fd1a990c05f6",
+        "checksum": "adler32:0ce9e546",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (16 of 28) for access to data via CMS virtual machine",
         "size": 336939,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010014_file_index.json"
       },
       {
-        "checksum": "sha1:6e74cdd1ae56090484809e504a42b579a56bc28f",
+        "checksum": "adler32:945f835b",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (17 of 28) for access to data via CMS virtual machine",
         "size": 335551,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010015_file_index.json"
       },
       {
-        "checksum": "sha1:b5b361d6d16a3f07f3b51131f3edde42d6efe879",
+        "checksum": "adler32:51d47a0b",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (18 of 28) for access to data via CMS virtual machine",
         "size": 345614,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010016_file_index.json"
       },
       {
-        "checksum": "sha1:aa043e7a7b044081e6ef5e483364763396480ad3",
+        "checksum": "adler32:c58fe9f4",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (19 of 28) for access to data via CMS virtual machine",
         "size": 347002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010017_file_index.json"
       },
       {
-        "checksum": "sha1:1badeebd9742f6a0d4a9e3cc541e3cc511427cd2",
+        "checksum": "adler32:c77aca26",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (20 of 28) for access to data via CMS virtual machine",
         "size": 343185,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010018_file_index.json"
       },
       {
-        "checksum": "sha1:b331555701df20dd4fd93dc89cd3eebf725cb7e4",
+        "checksum": "adler32:ff6a0d2e",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (21 of 28) for access to data via CMS virtual machine",
         "size": 339715,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010019_file_index.json"
       },
       {
-        "checksum": "sha1:9c9282da0535e8805f35db2a4ed1eb0eb9a53e71",
+        "checksum": "adler32:4a5a6c74",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (22 of 28) for access to data via CMS virtual machine",
         "size": 343879,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010020_file_index.json"
       },
       {
-        "checksum": "sha1:4bfbe14b9c705bba303c8f28eb15e014172c5383",
+        "checksum": "adler32:e1918eb4",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (23 of 28) for access to data via CMS virtual machine",
         "size": 341103,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010021_file_index.json"
       },
       {
-        "checksum": "sha1:7534d422ec5e92adfd0dc6cd90550da68c016464",
+        "checksum": "adler32:dc49ee44",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (24 of 28) for access to data via CMS virtual machine",
         "size": 341450,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010022_file_index.json"
       },
       {
-        "checksum": "sha1:bb770dac04d04a1b5ea080c7bcdf92c8b60d001f",
+        "checksum": "adler32:4286209c",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (25 of 28) for access to data via CMS virtual machine",
         "size": 342491,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010023_file_index.json"
       },
       {
-        "checksum": "sha1:1ed8796c18f0c2abed6f2c4bbabf76ea87d6d9ca",
+        "checksum": "adler32:cb143427",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (26 of 28) for access to data via CMS virtual machine",
         "size": 337980,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010024_file_index.json"
       },
       {
-        "checksum": "sha1:c37c824e4e54fe49f928e32edcc9feab6bfd33f9",
+        "checksum": "adler32:9c6408a6",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (27 of 28) for access to data via CMS virtual machine",
         "size": 335898,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010025_file_index.json"
       },
       {
-        "checksum": "sha1:9c783d610d9e9a572196dca9596b25f2814bbade",
+        "checksum": "adler32:83e38198",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (28 of 28) for access to data via CMS virtual machine",
         "size": 326182,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010026_file_index.json"
       },
       {
-        "checksum": "sha1:017e70266e218236d10b203faca059416bb49a61",
+        "checksum": "adler32:e7931b6a",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 28) for access to data via CMS virtual machine",
         "size": 98000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:410140752471508416796a075187961d290ce8ee",
+        "checksum": "adler32:174e5f16",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 28) for access to data via CMS virtual machine",
         "size": 193161,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010000_file_index.txt"
       },
       {
-        "checksum": "sha1:351ebb871edcf546b6c4de91973e0aacbdb4ae1a",
+        "checksum": "adler32:32aadf48",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (3 of 28) for access to data via CMS virtual machine",
         "size": 192759,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010001_file_index.txt"
       },
       {
-        "checksum": "sha1:dca9a208251727b2904f5d0574237bc9264bcb34",
+        "checksum": "adler32:9a51cb93",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (4 of 28) for access to data via CMS virtual machine",
         "size": 195975,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010002_file_index.txt"
       },
       {
-        "checksum": "sha1:50dff4e0afd8d593affd311ab7b1351bd4f3a4ea",
+        "checksum": "adler32:28f01ecd",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (5 of 28) for access to data via CMS virtual machine",
         "size": 195372,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010003_file_index.txt"
       },
       {
-        "checksum": "sha1:a8a1ab870574b119b40cac95ed03f85c53642494",
+        "checksum": "adler32:9e658a20",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (6 of 28) for access to data via CMS virtual machine",
         "size": 197382,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010004_file_index.txt"
       },
       {
-        "checksum": "sha1:a843512cf23fb840abf164c11a1e0eb914438c95",
+        "checksum": "adler32:84d9c864",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (7 of 28) for access to data via CMS virtual machine",
         "size": 197583,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010005_file_index.txt"
       },
       {
-        "checksum": "sha1:b2a159e5a508cda0157b92c98626f9d0d2cec061",
+        "checksum": "adler32:59a4fe21",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (8 of 28) for access to data via CMS virtual machine",
         "size": 198588,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010006_file_index.txt"
       },
       {
-        "checksum": "sha1:3a54096f64e5abc07ee86cf5ce575cc71b4fb619",
+        "checksum": "adler32:6f9af4e9",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (9 of 28) for access to data via CMS virtual machine",
         "size": 198588,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010007_file_index.txt"
       },
       {
-        "checksum": "sha1:18c885557aed28776da9501c1655619678be989e",
+        "checksum": "adler32:7a7644b0",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (10 of 28) for access to data via CMS virtual machine",
         "size": 197985,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010008_file_index.txt"
       },
       {
-        "checksum": "sha1:d9e1bd3e656851311727ab4ad1be842838ebf806",
+        "checksum": "adler32:bfe4fd49",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (11 of 28) for access to data via CMS virtual machine",
         "size": 199392,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010009_file_index.txt"
       },
       {
-        "checksum": "sha1:b74586d883b4aee3b2ee68ed48b907f23ac235e4",
+        "checksum": "adler32:04528c02",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (12 of 28) for access to data via CMS virtual machine",
         "size": 198387,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010010_file_index.txt"
       },
       {
-        "checksum": "sha1:8dd1b9fe82f0b4dc1d4b47401d505adf463df3af",
+        "checksum": "adler32:62903c5c",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (13 of 28) for access to data via CMS virtual machine",
         "size": 198990,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010011_file_index.txt"
       },
       {
-        "checksum": "sha1:8b3f8748629a585cbd5f01b85f438cc5b146c1ae",
+        "checksum": "adler32:accbbbe9",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (14 of 28) for access to data via CMS virtual machine",
         "size": 198588,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010012_file_index.txt"
       },
       {
-        "checksum": "sha1:6cb7ea99b778bb9e9f0180a9b21b004df3915a3e",
+        "checksum": "adler32:d7b80514",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (15 of 28) for access to data via CMS virtual machine",
         "size": 198789,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010013_file_index.txt"
       },
       {
-        "checksum": "sha1:e268abfd6c59763f4206716d9373add023358106",
+        "checksum": "adler32:eb71b4b7",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (16 of 28) for access to data via CMS virtual machine",
         "size": 195171,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010014_file_index.txt"
       },
       {
-        "checksum": "sha1:8af121239085c81bc2320541deedfffa39c8db7e",
+        "checksum": "adler32:e0d6c5ba",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (17 of 28) for access to data via CMS virtual machine",
         "size": 194367,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010015_file_index.txt"
       },
       {
-        "checksum": "sha1:fec4409a0e43cec067a280f6858109fc720c7ee4",
+        "checksum": "adler32:6f06cc4c",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (18 of 28) for access to data via CMS virtual machine",
         "size": 200196,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010016_file_index.txt"
       },
       {
-        "checksum": "sha1:e2ef2c8400f5d43fa991cdc63ed75c34147077b6",
+        "checksum": "adler32:14d2c4a0",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (19 of 28) for access to data via CMS virtual machine",
         "size": 201000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010017_file_index.txt"
       },
       {
-        "checksum": "sha1:263d96c926d26c9f9ef2d17c5a844744a3a5a183",
+        "checksum": "adler32:8a9d2238",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (20 of 28) for access to data via CMS virtual machine",
         "size": 198789,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010018_file_index.txt"
       },
       {
-        "checksum": "sha1:63152f04f0fb1aefcc5ca100f1973f4cb8531d94",
+        "checksum": "adler32:2c4db8de",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (21 of 28) for access to data via CMS virtual machine",
         "size": 196779,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010019_file_index.txt"
       },
       {
-        "checksum": "sha1:fd897c555129bada595cd28b9906891b6426f69a",
+        "checksum": "adler32:17d18293",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (22 of 28) for access to data via CMS virtual machine",
         "size": 199191,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010020_file_index.txt"
       },
       {
-        "checksum": "sha1:a8fa53822f7dc28b98cd46947007e313377e48ec",
+        "checksum": "adler32:af2e9f5c",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (23 of 28) for access to data via CMS virtual machine",
         "size": 197583,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010021_file_index.txt"
       },
       {
-        "checksum": "sha1:503df83b46d245a67bd071d3f6098810693696ad",
+        "checksum": "adler32:4b02decd",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (24 of 28) for access to data via CMS virtual machine",
         "size": 197784,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010022_file_index.txt"
       },
       {
-        "checksum": "sha1:fc3c20ac95ff0809294ce4aace7bf9e91d866525",
+        "checksum": "adler32:1868a34d",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (25 of 28) for access to data via CMS virtual machine",
         "size": 198387,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010023_file_index.txt"
       },
       {
-        "checksum": "sha1:63396f47d9af3cbee7655191c79f56cc4573ab85",
+        "checksum": "adler32:610f7ccc",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (26 of 28) for access to data via CMS virtual machine",
         "size": 195774,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010024_file_index.txt"
       },
       {
-        "checksum": "sha1:a996b00a680d1ced9b226a404733487d80c65fe8",
+        "checksum": "adler32:37ec1740",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (27 of 28) for access to data via CMS virtual machine",
         "size": 194568,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_010025_file_index.txt"
       },
       {
-        "checksum": "sha1:f8a7e3f0b0211eed4fd324c42731c39aeb96d73c",
+        "checksum": "adler32:841f56d3",
         "description": "QCD_Pt_170_250_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (28 of 28) for access to data via CMS virtual machine",
         "size": 188940,
         "type": "index.txt",
@@ -18981,14 +18981,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:69548ef6a9366acad65c3568bf9209861e682b10",
+        "checksum": "adler32:a85a4893",
         "description": "QCD_Pt_170to300_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12434,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_170to300_CTEQ6L1_8TeV_herwig6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_170to300_CTEQ6L1_8TeV_herwig6_AODSIM_NoPileUp_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:0a5a8ea09c9dd8ccf56ad799871cc3185b1bd846",
+        "checksum": "adler32:e7fc4c12",
         "description": "QCD_Pt_170to300_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6993,
         "type": "index.txt",
@@ -19093,28 +19093,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:559473b93cc99eb3a0307a94e2700846711be1c5",
+        "checksum": "adler32:d346f9d5",
         "description": "QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 1039961,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:67a14f18bc2516abd8bcda7cf731b94ec9ee8da5",
+        "checksum": "adler32:d13e6338",
         "description": "QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 725925,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6_AODSIM_PU_S10_START53_V19-v1_00001_file_index.json"
       },
       {
-        "checksum": "sha1:2e79b713dfed194138ea76a2c15d0e524fe3cac6",
+        "checksum": "adler32:d760e6ab",
         "description": "QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 599400,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:5a938f70f8f866f826ab3215f06d7529ed6e95df",
+        "checksum": "adler32:70c11a02",
         "description": "QCD_Pt_20_MuEnrichedPt_15_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 418400,
         "type": "index.txt",
@@ -19219,70 +19219,70 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b3d89d8c217db675e78e79bc7c099bbb724b000a",
+        "checksum": "adler32:9781d2f7",
         "description": "QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
         "size": 256433,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v4/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v4_00000_file_index.json"
       },
       {
-        "checksum": "sha1:c58813e7a11a4eca97253871daf7f71c8c5645d6",
+        "checksum": "adler32:d8e5b39a",
         "description": "QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
         "size": 237696,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v4/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v4_10000_file_index.json"
       },
       {
-        "checksum": "sha1:a0f01534043dd838e26f713c336503e9e94cdf6b",
+        "checksum": "adler32:d84a1089",
         "description": "QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
         "size": 179747,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v4/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v4_20000_file_index.json"
       },
       {
-        "checksum": "sha1:fc5f7cd39eaaeb76284d1832ef7215e9431bed95",
+        "checksum": "adler32:48f237b4",
         "description": "QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
         "size": 346655,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v4/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v4_30000_file_index.json"
       },
       {
-        "checksum": "sha1:a7d44775f5acc5637a230fa69318a98ad1634b6b",
+        "checksum": "adler32:2c2061e7",
         "description": "QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
         "size": 30884,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v4/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v4_30001_file_index.json"
       },
       {
-        "checksum": "sha1:2c1e33c52c18fa604e9d65d91a2a90526e9e6741",
+        "checksum": "adler32:97f8f5c3",
         "description": "QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 5) for access to data via CMS virtual machine",
         "size": 147800,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v4/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v4_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:dce3ab6b5fcb921d9f08edd74e9230b5af239d6e",
+        "checksum": "adler32:e2a00191",
         "description": "QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 5) for access to data via CMS virtual machine",
         "size": 137000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v4/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v4_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:b3bfe8d89301dcfacd91036366f10c51bd80c65e",
+        "checksum": "adler32:59f8bfa4",
         "description": "QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (3 of 5) for access to data via CMS virtual machine",
         "size": 103600,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v4/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v4_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:07c2ad1b002d8682ac1ff5d97e99317a3e91a35b",
+        "checksum": "adler32:fc309a65",
         "description": "QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (4 of 5) for access to data via CMS virtual machine",
         "size": 199800,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v4/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v4_30000_file_index.txt"
       },
       {
-        "checksum": "sha1:715abb709862957237de2710c858468746698ba0",
+        "checksum": "adler32:3d0d7343",
         "description": "QCD_Pt_250_350_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (5 of 5) for access to data via CMS virtual machine",
         "size": 17800,
         "type": "index.txt",
@@ -19387,14 +19387,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:86a7a713d4545a4485cffaba0f4c034bfd873d0e",
+        "checksum": "adler32:cdc17de9",
         "description": "QCD_Pt-300to470_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 16465,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-300to470_CTEQ6L1_8TeV_herwig6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-300to470_CTEQ6L1_8TeV_herwig6_AODSIM_NoPileUp_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:43bf519665d80a22d997bfa78494438c4146d995",
+        "checksum": "adler32:ad0cebbe",
         "description": "QCD_Pt-300to470_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 9261,
         "type": "index.txt",
@@ -19499,42 +19499,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:79c2dc63f28140b41af05d835af051ca6f919da7",
+        "checksum": "adler32:887511e8",
         "description": "QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 316366,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:09af31ae2a0c3c7f0f56cbad797ebc0e219dd533",
+        "checksum": "adler32:9bbebfd0",
         "description": "QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 344657,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:3836b8f5cd57a2caa302ad34d00f5dd040d8735c",
+        "checksum": "adler32:f9ea85af",
         "description": "QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 143866,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:b0ae49bdc3593f44ceb7d756ef5fca8c9f4b5809",
+        "checksum": "adler32:c4bf6349",
         "description": "QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 181566,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:7a8b5d61c8b23999ad9f44502461b66df7204b34",
+        "checksum": "adler32:3f85139e",
         "description": "QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 197802,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:6d153b895febcf283f5d29fbf86a0b23dc7c06c7",
+        "checksum": "adler32:d490c33b",
         "description": "QCD_Pt_30_80_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 82566,
         "type": "index.txt",
@@ -19639,14 +19639,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:498dedb3ca5cd09494600ddd18eab90cdfe6cf39",
+        "checksum": "adler32:b34c0946",
         "description": "QCD_Pt-30to40_doubleEMEnriched_TuneZ2star_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 196418,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-30to40_doubleEMEnriched_TuneZ2star_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-30to40_doubleEMEnriched_TuneZ2star_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:64e7cdd03e50bc34a5e00b1fdcfc0ce2bb3ce8d4",
+        "checksum": "adler32:e73b4167",
         "description": "QCD_Pt-30to40_doubleEMEnriched_TuneZ2star_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 114390,
         "type": "index.txt",
@@ -19751,14 +19751,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:12f8a43c64223aa6b70d537e4886a1e434c14433",
+        "checksum": "adler32:71dfa681",
         "description": "QCD_Pt_30to50_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 18371,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_30to50_CTEQ6L1_8TeV_herwig6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_30to50_CTEQ6L1_8TeV_herwig6_AODSIM_NoPileUp_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:308aabc4a986acf1c58cc37d675b314e79f49368",
+        "checksum": "adler32:2a363f36",
         "description": "QCD_Pt_30to50_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10285,
         "type": "index.txt",
@@ -19863,14 +19863,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:549b203b2ba1fb433180ef8386abafbd0b382556",
+        "checksum": "adler32:b806145a",
         "description": "QCD_Pt-40_doubleEMEnriched_TuneZ2star_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 325382,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-40_doubleEMEnriched_TuneZ2star_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-40_doubleEMEnriched_TuneZ2star_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:c753aff69be06a92d723ecf46bf032dd05d353d1",
+        "checksum": "adler32:d0cec087",
         "description": "QCD_Pt-40_doubleEMEnriched_TuneZ2star_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 187935,
         "type": "index.txt",
@@ -19975,14 +19975,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:073720a089511f6dbaca9da591b3733fd266a072",
+        "checksum": "adler32:a1fff6ec",
         "description": "QCD_Pt-470to600_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 18818,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-470to600_CTEQ6L1_8TeV_herwig6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-470to600_CTEQ6L1_8TeV_herwig6_AODSIM_NoPileUp_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:5cd63cb945b8ae9f52b868c512206499c00062b6",
+        "checksum": "adler32:b17d7903",
         "description": "QCD_Pt-470to600_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10584,
         "type": "index.txt",
@@ -20087,14 +20087,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f42b64a76fc440e98011367db9a6539753e01b05",
+        "checksum": "adler32:835ef296",
         "description": "QCD_Pt_50to80_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 13027,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_50to80_CTEQ6L1_8TeV_herwig6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_50to80_CTEQ6L1_8TeV_herwig6_AODSIM_NoPileUp_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:0b8d3bff20aecac215be14174a10fe8e0c7cc953",
+        "checksum": "adler32:12bfb116",
         "description": "QCD_Pt_50to80_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 7293,
         "type": "index.txt",
@@ -20199,14 +20199,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1fbb4759fdb5cb221162ce380f2692defce11d7a",
+        "checksum": "adler32:70d80d06",
         "description": "QCD_Pt-600to800_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10418,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-600to800_CTEQ6L1_8TeV_herwig6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-600to800_CTEQ6L1_8TeV_herwig6_AODSIM_NoPileUp_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:a23084855e67feb278244c589daa55aa63068f91",
+        "checksum": "adler32:ec10e64c",
         "description": "QCD_Pt-600to800_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5859,
         "type": "index.txt",
@@ -20311,14 +20311,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3d63099e4f46908a75ff6333c91d8828fbc5b2ad",
+        "checksum": "adler32:e587b603",
         "description": "QCD_Pt-800to1000_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10112,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt-800to1000_CTEQ6L1_8TeV_herwig6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt-800to1000_CTEQ6L1_8TeV_herwig6_AODSIM_NoPileUp_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:d77ba172adbc69dafd4c1f2a616ac6fc01603553",
+        "checksum": "adler32:92eab203",
         "description": "QCD_Pt-800to1000_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5700,
         "type": "index.txt",
@@ -20423,154 +20423,154 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d9dcdf83ff27f595babf9ab3d8d9b4b782d9c106",
+        "checksum": "adler32:121af068",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
         "size": 1035965,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_00000_file_index.json"
       },
       {
-        "checksum": "sha1:d8d60a6a0b07832f1b9137566793156a1795034c",
+        "checksum": "adler32:ca02e864",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
         "size": 469907,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_00001_file_index.json"
       },
       {
-        "checksum": "sha1:9f578ea7847e7afe707a29fbc2de87bbc7662a1b",
+        "checksum": "adler32:abb0909b",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
         "size": 345002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_00002_file_index.json"
       },
       {
-        "checksum": "sha1:5d6f763fc81b11694f4ec188e4d64f7361445c9d",
+        "checksum": "adler32:bc83c8ef",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
         "size": 345002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_00003_file_index.json"
       },
       {
-        "checksum": "sha1:3e465dde4691d9d823b898df6e0574c417f18977",
+        "checksum": "adler32:fb7147e5",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
         "size": 91772,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_00004_file_index.json"
       },
       {
-        "checksum": "sha1:3d43f5df21cfe5590beeec12e86076d3be99e568",
+        "checksum": "adler32:cba5cf44",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
         "size": 52594,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_010000_file_index.json"
       },
       {
-        "checksum": "sha1:b49b89912584643c41738168c1b74b08a2525a87",
+        "checksum": "adler32:3d3312bc",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
         "size": 54670,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_010001_file_index.json"
       },
       {
-        "checksum": "sha1:5509968865122841a0d87421cb3c32ede4356c0b",
+        "checksum": "adler32:2987e96e",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
         "size": 56400,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_010002_file_index.json"
       },
       {
-        "checksum": "sha1:aef64e22dded56c406e5828eb59f68984cc8e97e",
+        "checksum": "adler32:de4c90c1",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
         "size": 53286,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_010003_file_index.json"
       },
       {
-        "checksum": "sha1:226e07b3003513b40f462022b00848aea52ccb3a",
+        "checksum": "adler32:447df461",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
         "size": 50864,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_010004_file_index.json"
       },
       {
-        "checksum": "sha1:489dcb3c5ed52f1f887b9a79f8850304b0390299",
+        "checksum": "adler32:0a159f6a",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
         "size": 2424,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_010005_file_index.json"
       },
       {
-        "checksum": "sha1:7b949248de6cd114c1f52eb577ce8e89b4b8683a",
+        "checksum": "adler32:f9681f7d",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (1 of 11) for access to data via CMS virtual machine",
         "size": 596403,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:75eb37f8dba89a88f460760f7964136b96420682",
+        "checksum": "adler32:6cd52c57",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (2 of 11) for access to data via CMS virtual machine",
         "size": 270839,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_00001_file_index.txt"
       },
       {
-        "checksum": "sha1:be03bf9e54090533ff981e71ea328d69147ec2bc",
+        "checksum": "adler32:e42b5e74",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (3 of 11) for access to data via CMS virtual machine",
         "size": 199000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_00002_file_index.txt"
       },
       {
-        "checksum": "sha1:394f3eaccf32154c86513a26e51754ab5a3263f7",
+        "checksum": "adler32:37cd78f0",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (4 of 11) for access to data via CMS virtual machine",
         "size": 199000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_00003_file_index.txt"
       },
       {
-        "checksum": "sha1:4de628362586e6c5c1a8cc3354243f3a8f5138e6",
+        "checksum": "adler32:393fe447",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (5 of 11) for access to data via CMS virtual machine",
         "size": 52934,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_00004_file_index.txt"
       },
       {
-        "checksum": "sha1:822db48e05c9dfb446ecc73227a58afdf737127b",
+        "checksum": "adler32:f75f9937",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (6 of 11) for access to data via CMS virtual machine",
         "size": 30400,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_010000_file_index.txt"
       },
       {
-        "checksum": "sha1:0dcb2f609ea6e17cdbaa790bd8e3ae85b93e7420",
+        "checksum": "adler32:8308101a",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (7 of 11) for access to data via CMS virtual machine",
         "size": 31600,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_010001_file_index.txt"
       },
       {
-        "checksum": "sha1:6f6b5b82b57c90b2a3b10349350d8d7e08a1e9ef",
+        "checksum": "adler32:c4dc41db",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (8 of 11) for access to data via CMS virtual machine",
         "size": 32600,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_010002_file_index.txt"
       },
       {
-        "checksum": "sha1:c3d88a5a4c14c49aaa59f4abd8bc78bbabe932a4",
+        "checksum": "adler32:c4db182a",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (9 of 11) for access to data via CMS virtual machine",
         "size": 30800,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_010003_file_index.txt"
       },
       {
-        "checksum": "sha1:b8d1a97f79ea10e35527b10cc4a72fdd368f5c44",
+        "checksum": "adler32:032f69f8",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (10 of 11) for access to data via CMS virtual machine",
         "size": 29400,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6_AODSIM_PU_RD1_START53_V7N-v3_010004_file_index.txt"
       },
       {
-        "checksum": "sha1:95e9f2af75fe894a660f079fbfe3b19b43994f89",
+        "checksum": "adler32:a181afda",
         "description": "QCD_Pt_80_170_EMEnriched_TuneZ2star_8TeV_pythia6 AOD dataset file index (11 of 11) for access to data via CMS virtual machine",
         "size": 1400,
         "type": "index.txt",
@@ -20675,14 +20675,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c3cf985f418daeda52d92b44bb4b11bf610d1703",
+        "checksum": "adler32:c46bce99",
         "description": "QCD_Pt_80to120_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 15747,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/QCD_Pt_80to120_CTEQ6L1_8TeV_herwig6/AODSIM/NoPileUp_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_QCD_Pt_80to120_CTEQ6L1_8TeV_herwig6_AODSIM_NoPileUp_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:d7beb9bec19b4ad83cefb956759ac4a4365502c8",
+        "checksum": "adler32:4f217e37",
         "description": "QCD_Pt_80to120_CTEQ6L1_8TeV_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 8836,
         "type": "index.txt",
@@ -20787,14 +20787,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:50688be383734eb02b192d0db6f30f7ef10f5891",
+        "checksum": "adler32:2966d208",
         "description": "SMHiggsToZZTo4L_M-125_8TeV-powheg15-JHUgenV3-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 11902,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/SMHiggsToZZTo4L_M-125_8TeV-powheg15-JHUgenV3-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_SMHiggsToZZTo4L_M-125_8TeV-powheg15-JHUgenV3-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:a646708a41354d456b70bbd084adde210d7de345",
+        "checksum": "adler32:b9863bfa",
         "description": "SMHiggsToZZTo4L_M-125_8TeV-powheg15-JHUgenV3-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6902,
         "type": "index.txt",
@@ -20899,14 +20899,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:812f23868ea32a1ac03633d39b09103ed660c2a2",
+        "checksum": "adler32:0ac86290",
         "description": "T4QZ_8TeV-aMCatNLO-herwig AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 101746,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/T4QZ_8TeV-aMCatNLO-herwig/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_T4QZ_8TeV-aMCatNLO-herwig_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:f004f5719fdbd2f4b9267cd7b6d4c7d101134024",
+        "checksum": "adler32:84a72231",
         "description": "T4QZ_8TeV-aMCatNLO-herwig AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 55440,
         "type": "index.txt",
@@ -21011,14 +21011,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8b483e277dab7a82c6f83259f5dba0ba33c741fb",
+        "checksum": "adler32:5fead816",
         "description": "TBarToLeptons_t-channel_8TeV-herwig-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 87040,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TBarToLeptons_t-channel_8TeV-herwig-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TBarToLeptons_t-channel_8TeV-herwig-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:439b939ebc72f13df2d7abc2b77da16c7cbb716b",
+        "checksum": "adler32:bb517e83",
         "description": "TBarToLeptons_t-channel_8TeV-herwig-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 49408,
         "type": "index.txt",
@@ -21123,14 +21123,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1cacd66148d59071301b4bba42c8f0a977f7990d",
+        "checksum": "adler32:eb401b59",
         "description": "TBarToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 78401,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TBarToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TBarToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:a4230c4ac4e514e65768ee5d6013fdfebbaa90e8",
+        "checksum": "adler32:83e4ed2b",
         "description": "TBarToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 45472,
         "type": "index.txt",
@@ -21235,14 +21235,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:522f57b72469fe652cc2506a82cd644bd14e582d",
+        "checksum": "adler32:6d1c7b1a",
         "description": "TBarToLeptons_t-channel_Pythia8_8TeV-aMCatNLO-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 72800,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TBarToLeptons_t-channel_Pythia8_8TeV-aMCatNLO-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TBarToLeptons_t-channel_Pythia8_8TeV-aMCatNLO-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:685a58247859638f796bfc7ccc6881d337672263",
+        "checksum": "adler32:fb9ca634",
         "description": "TBarToLeptons_t-channel_Pythia8_8TeV-aMCatNLO-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 42224,
         "type": "index.txt",
@@ -21347,14 +21347,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9dec6574c1c572206b208a90d0dca59c1214f482",
+        "checksum": "adler32:fccc2667",
         "description": "TBZ_8TeV-Madspin_aMCatNLO-herwig AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 112531,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TBZ_8TeV-Madspin_aMCatNLO-herwig/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TBZ_8TeV-Madspin_aMCatNLO-herwig_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:f07b468a621cc72384b2631b99e6ba9bb4fcdea2",
+        "checksum": "adler32:14f966d2",
         "description": "TBZ_8TeV-Madspin_aMCatNLO-herwig AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 62403,
         "type": "index.txt",
@@ -21459,28 +21459,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:253952cc7cbd1356eb3111f2e981237ba2de6c55",
+        "checksum": "adler32:bc98ad80",
         "description": "tGamma_8TeV_madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 637,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/tGamma_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_tGamma_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:d447f7a9228887bfadf40e3c989770ca2729bd17",
+        "checksum": "adler32:b0340b15",
         "description": "tGamma_8TeV_madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 3816,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/tGamma_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_tGamma_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:4355fc654a28fce0a42fdc3bcad4e0ed61bcc28c",
+        "checksum": "adler32:330a6833",
         "description": "tGamma_8TeV_madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 342,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/tGamma_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_tGamma_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:f34050bb8910790c200c4eab89569befb7b3207b",
+        "checksum": "adler32:8b1d7096",
         "description": "tGamma_8TeV_madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2052,
         "type": "index.txt",
@@ -21585,28 +21585,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:df42b6fea812aa06686dc64e844771c81dcc3034",
+        "checksum": "adler32:1570dd1b",
         "description": "tGamma_FCNC_tGc_8TeV_protos AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 13002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/tGamma_FCNC_tGc_8TeV_protos/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_tGamma_FCNC_tGc_8TeV_protos_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:5ab0d6df46a826c0831a39fb45363c42e6af3428",
+        "checksum": "adler32:87f8b0f3",
         "description": "tGamma_FCNC_tGc_8TeV_protos AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 651,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/tGamma_FCNC_tGc_8TeV_protos/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_tGamma_FCNC_tGc_8TeV_protos_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:f0c551ddb7648beeb1cca84cd41e823d067b9db4",
+        "checksum": "adler32:6d6d8005",
         "description": "tGamma_FCNC_tGc_8TeV_protos AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 7120,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/tGamma_FCNC_tGc_8TeV_protos/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_tGamma_FCNC_tGc_8TeV_protos_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:a4aed8cddd83c938f733921c7b2a8f8d5a51f6cf",
+        "checksum": "adler32:7db36cc2",
         "description": "tGamma_FCNC_tGc_8TeV_protos AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 356,
         "type": "index.txt",
@@ -21711,14 +21711,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:277ef52b143df0bf8d7bb623236f99530642f5bd",
+        "checksum": "adler32:300e08a1",
         "description": "tGamma_FCNC_tGu_8TeV_protos AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 16901,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/tGamma_FCNC_tGu_8TeV_protos/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_tGamma_FCNC_tGu_8TeV_protos_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:863ec918f1b0b13e85fa9805c6fb3a598dccb37a",
+        "checksum": "adler32:eca012b5",
         "description": "tGamma_FCNC_tGu_8TeV_protos AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 9256,
         "type": "index.txt",
@@ -21823,28 +21823,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:02a05b3875dbdda74e838272358216c80d2c4067",
+        "checksum": "adler32:b4675b19",
         "description": "tGG_8TeV-whizard-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 10628,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/tGG_8TeV-whizard-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_tGG_8TeV-whizard-pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:943c889e31572e20dad3dcd3502095a981924134",
+        "checksum": "adler32:28a6bf8b",
         "description": "tGG_8TeV-whizard-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2576,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/tGG_8TeV-whizard-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_tGG_8TeV-whizard-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:1178f3dc2155c5cafcaf61c71fafcec19d19a97a",
+        "checksum": "adler32:63e2e92d",
         "description": "tGG_8TeV-whizard-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 5775,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/tGG_8TeV-whizard-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_tGG_8TeV-whizard-pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:6e4cf29d06a41912233eee9f9a98a4700f066033",
+        "checksum": "adler32:afb6abfb",
         "description": "tGG_8TeV-whizard-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 1400,
         "type": "index.txt",
@@ -21949,28 +21949,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d89c0c185f7860b4ce6cd109428673df62ece231",
+        "checksum": "adler32:14a4cebc",
         "description": "TTbar_8TeV-Madspin_aMCatNLO-herwig AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 123837,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTbar_8TeV-Madspin_aMCatNLO-herwig/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTbar_8TeV-Madspin_aMCatNLO-herwig_AODSIM_PU_S10_START53_V19-v2_00000_file_index.json"
       },
       {
-        "checksum": "sha1:f8a7e8820424bd01e6ead4aebdd2602183d36a09",
+        "checksum": "adler32:8ad8f1d1",
         "description": "TTbar_8TeV-Madspin_aMCatNLO-herwig AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 107238,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTbar_8TeV-Madspin_aMCatNLO-herwig/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTbar_8TeV-Madspin_aMCatNLO-herwig_AODSIM_PU_S10_START53_V19-v2_20000_file_index.json"
       },
       {
-        "checksum": "sha1:92f529db27ddd8370869c9e14aa2168453842239",
+        "checksum": "adler32:3a42b7de",
         "description": "TTbar_8TeV-Madspin_aMCatNLO-herwig AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 69005,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTbar_8TeV-Madspin_aMCatNLO-herwig/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTbar_8TeV-Madspin_aMCatNLO-herwig_AODSIM_PU_S10_START53_V19-v2_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:fd2ecd2744a18378908b1d522e041f611e9ceec6",
+        "checksum": "adler32:b7f1a055",
         "description": "TTbar_8TeV-Madspin_aMCatNLO-herwig AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 59755,
         "type": "index.txt",
@@ -22075,14 +22075,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f4fe662eb9d1680084d106d9fc443cbf3bf6a8a9",
+        "checksum": "adler32:0fb26c07",
         "description": "ttbarZ_8TeV-Madspin_aMCatNLO-herwig AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 36632,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ttbarZ_8TeV-Madspin_aMCatNLO-herwig/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ttbarZ_8TeV-Madspin_aMCatNLO-herwig_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:fcb079ccc2e5725c258f4238557604bd21a164d1",
+        "checksum": "adler32:c7afa99b",
         "description": "ttbarZ_8TeV-Madspin_aMCatNLO-herwig AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 20460,
         "type": "index.txt",
@@ -22187,56 +22187,56 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:459dd3f6a28cfeac9a9908a9fd0d131551bbeb55",
+        "checksum": "adler32:10a03f02",
         "description": "TT_CT10_AUET2_8TeV-powheg-herwig AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 329672,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_CT10_AUET2_8TeV-powheg-herwig/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_CT10_AUET2_8TeV-powheg-herwig_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:a8bd3f63b96fffdd2135c877b0c9f6b80ff3909d",
+        "checksum": "adler32:913656ed",
         "description": "TT_CT10_AUET2_8TeV-powheg-herwig AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 330002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_CT10_AUET2_8TeV-powheg-herwig/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_CT10_AUET2_8TeV-powheg-herwig_AODSIM_PU_S10_START53_V19-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:90f8caf8736a31b29f8cde1c798dfa3f6f5c47cb",
+        "checksum": "adler32:f8fe7b9a",
         "description": "TT_CT10_AUET2_8TeV-powheg-herwig AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 330002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_CT10_AUET2_8TeV-powheg-herwig/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_CT10_AUET2_8TeV-powheg-herwig_AODSIM_PU_S10_START53_V19-v1_10002_file_index.json"
       },
       {
-        "checksum": "sha1:9ac5e7977362db3f8270fd019ae2f5531a8ab6e4",
+        "checksum": "adler32:8a203cbb",
         "description": "TT_CT10_AUET2_8TeV-powheg-herwig AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 67982,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_CT10_AUET2_8TeV-powheg-herwig/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_CT10_AUET2_8TeV-powheg-herwig_AODSIM_PU_S10_START53_V19-v1_10003_file_index.json"
       },
       {
-        "checksum": "sha1:098575a593c3a7682fb5c3f0da05d0757513e4ce",
+        "checksum": "adler32:4e4711bb",
         "description": "TT_CT10_AUET2_8TeV-powheg-herwig AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 182817,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_CT10_AUET2_8TeV-powheg-herwig/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_CT10_AUET2_8TeV-powheg-herwig_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:9be285a2f6106c3dc2f9a9922f65e1869be27a86",
+        "checksum": "adler32:bf682c28",
         "description": "TT_CT10_AUET2_8TeV-powheg-herwig AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 183000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_CT10_AUET2_8TeV-powheg-herwig/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_CT10_AUET2_8TeV-powheg-herwig_AODSIM_PU_S10_START53_V19-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:e758a4934c5d383388a0cfbae6e4f0bdd326ba06",
+        "checksum": "adler32:149f3b99",
         "description": "TT_CT10_AUET2_8TeV-powheg-herwig AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 183000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_CT10_AUET2_8TeV-powheg-herwig/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_CT10_AUET2_8TeV-powheg-herwig_AODSIM_PU_S10_START53_V19-v1_10002_file_index.txt"
       },
       {
-        "checksum": "sha1:a8e61e5d39e968531448a6888ef039abdc334848",
+        "checksum": "adler32:048a944a",
         "description": "TT_CT10_AUET2_8TeV-powheg-herwig AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 37698,
         "type": "index.txt",
@@ -22341,14 +22341,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2d3f1df0db82f9de2c4888eff4f3852174816b1a",
+        "checksum": "adler32:958dcd95",
         "description": "TTGamma_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 34712,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTGamma_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTGamma_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:14fc823db5d40476b41501ba9078c8a78aefdeff",
+        "checksum": "adler32:b34bebf8",
         "description": "TTGamma_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 19570,
         "type": "index.txt",
@@ -22453,14 +22453,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:93d63c49677588e7c1510cfe63eb531e321c4827",
+        "checksum": "adler32:e2af42cf",
         "description": "ttGG_8TeV-whizard-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6783,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ttGG_8TeV-whizard-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ttGG_8TeV-whizard-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:295e528d9aca891bd4e15b448e640858c2ff43ee",
+        "checksum": "adler32:077e6e90",
         "description": "ttGG_8TeV-whizard-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3696,
         "type": "index.txt",
@@ -22565,28 +22565,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:839c301d0338cf0060b2a66dd3e4be2088962caf",
+        "checksum": "adler32:ac70a2ac",
         "description": "TTGJets_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 21375,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTGJets_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTGJets_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:c60b9c8071546718e9ac79870596af90033e37ee",
+        "checksum": "adler32:5bffa51a",
         "description": "TTGJets_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 44980,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTGJets_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTGJets_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:6b6766b18b627cd3fd102dbe378de23e0cd7b36b",
+        "checksum": "adler32:99cdac11",
         "description": "TTGJets_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 11524,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTGJets_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTGJets_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:21d17f4002efed30f65bb7425d22b38b7cd42774",
+        "checksum": "adler32:0111c584",
         "description": "TTGJets_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 24252,
         "type": "index.txt",
@@ -22691,28 +22691,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a07cbed8b3773c239354c453ac18c3dbd641067b",
+        "checksum": "adler32:2eef7e68",
         "description": "TTGJets_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 10848,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTGJets_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTGJets_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:f094d4cafdbf60b2e6a468c70c135bc468f8a67b",
+        "checksum": "adler32:2f5fff33",
         "description": "TTGJets_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 66991,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTGJets_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTGJets_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:c1ac206468bea99c4bfa2e3f22144ab547171cb0",
+        "checksum": "adler32:4824ed8d",
         "description": "TTGJets_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 5848,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTGJets_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTGJets_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:b410c1fe39a7c1bc5595753b230023ff1b02c2c5",
+        "checksum": "adler32:aaeacd64",
         "description": "TTGJets_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 36120,
         "type": "index.txt",
@@ -22810,56 +22810,56 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:13ff57243a90d74db80e4bd2b26f87b010905d55",
+        "checksum": "adler32:9fdd0cb6",
         "description": "TTH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 54118,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_00000_file_index.json"
       },
       {
-        "checksum": "sha1:9b5e47e50dd894f7bbcca97fbf9808663d0be40a",
+        "checksum": "adler32:1db1c345",
         "description": "TTH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 54770,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_10000_file_index.json"
       },
       {
-        "checksum": "sha1:ab04ac16b4ae9df03849e7e7048bea3c01db2105",
+        "checksum": "adler32:0aa9e864",
         "description": "TTH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 49226,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_20000_file_index.json"
       },
       {
-        "checksum": "sha1:e60c49e55699fbc481166a00fa1b1e2bf602c4a3",
+        "checksum": "adler32:77eb9a1a",
         "description": "TTH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 50858,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_30000_file_index.json"
       },
       {
-        "checksum": "sha1:83f720d0ad03d9a05cf5dfbe71b6b40a9dd71298",
+        "checksum": "adler32:eed2c773",
         "description": "TTH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 29714,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:438e5a7930fc3c26c99f37b5bfca75b2a158dd44",
+        "checksum": "adler32:cd9936ef",
         "description": "TTH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 30072,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:9199c743baad904655b3801bd69e64e59bbe3c95",
+        "checksum": "adler32:2bfda7b7",
         "description": "TTH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 27029,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:5f5897e9060a2ff54dc680d21aff67ee750cfde9",
+        "checksum": "adler32:186cb1f7",
         "description": "TTH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 27924,
         "type": "index.txt",
@@ -22964,14 +22964,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0e51e617273a07f65ef80be09836ff3b4fb81333",
+        "checksum": "adler32:92e6309b",
         "description": "TTH_HToZG_M-125_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5869,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTH_HToZG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTH_HToZG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v2_00000_file_index.json"
       },
       {
-        "checksum": "sha1:d99a9a1f83890b35bc4916d7aa6ff123752d19e0",
+        "checksum": "adler32:7f45c66e",
         "description": "TTH_HToZG_M-125_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3222,
         "type": "index.txt",
@@ -23076,14 +23076,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ac809c0239e89781e90ca4c7f718005a99cbbf8f",
+        "checksum": "adler32:9ae73ad2",
         "description": "TTH_HToZG_M-125_8TeV-pythia8175 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5922,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTH_HToZG_M-125_8TeV-pythia8175/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTH_HToZG_M-125_8TeV-pythia8175_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:f291853fb52c156ebeac04d6780de17c87c23fa8",
+        "checksum": "adler32:7e2ad16a",
         "description": "TTH_HToZG_M-125_8TeV-pythia8175 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3276,
         "type": "index.txt",
@@ -23188,42 +23188,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e5432ce6e2869ca65d9fae58a58ec33d05d17d7c",
+        "checksum": "adler32:f62a2281",
         "description": "TTJets_DileptDecays_8TeV-sherpa AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 177003,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_DileptDecays_8TeV-sherpa/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_DileptDecays_8TeV-sherpa_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:ad7a87b8ee9a97f80f7151b0442670e52067277e",
+        "checksum": "adler32:b50b7e56",
         "description": "TTJets_DileptDecays_8TeV-sherpa AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 389538,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_DileptDecays_8TeV-sherpa/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_DileptDecays_8TeV-sherpa_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:c01ddb52afa61bc2d16c44598a9854e03ee393dd",
+        "checksum": "adler32:265c34d3",
         "description": "TTJets_DileptDecays_8TeV-sherpa AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 149368,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_DileptDecays_8TeV-sherpa/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_DileptDecays_8TeV-sherpa_AODSIM_PU_S10_START53_V19-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:46a06ea8763d50dc8978343a1c76e09261f40553",
+        "checksum": "adler32:15ff8629",
         "description": "TTJets_DileptDecays_8TeV-sherpa AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 97916,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_DileptDecays_8TeV-sherpa/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_DileptDecays_8TeV-sherpa_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:3a018c079a5ba3de9ecee34f6ed2a9b674cd28dd",
+        "checksum": "adler32:06cacf07",
         "description": "TTJets_DileptDecays_8TeV-sherpa AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 215488,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_DileptDecays_8TeV-sherpa/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_DileptDecays_8TeV-sherpa_AODSIM_PU_S10_START53_V19-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:a2dbb5cf603e2e3bd34a58ca947b0cf4f393bf5b",
+        "checksum": "adler32:cccc0231",
         "description": "TTJets_DileptDecays_8TeV-sherpa AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 82628,
         "type": "index.txt",
@@ -23328,28 +23328,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0ea36acce3ba899fafa6fbd4b5e01d8a897b070c",
+        "checksum": "adler32:202208c3",
         "description": "TTJets_FullLeptMGDecays_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 334667,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_FullLeptMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_FullLeptMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:e0b878df7381b848793ad04df2144ab58c485ae8",
+        "checksum": "adler32:8b7fbf56",
         "description": "TTJets_FullLeptMGDecays_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 107536,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_FullLeptMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_FullLeptMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:fd00518dee8953ee6a4e12dd82f6f892163263b7",
+        "checksum": "adler32:1c85a107",
         "description": "TTJets_FullLeptMGDecays_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 187812,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_FullLeptMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_FullLeptMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:c1275f6d19112507c00ee1c6bb2a3db405b079aa",
+        "checksum": "adler32:77b2864e",
         "description": "TTJets_FullLeptMGDecays_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 60348,
         "type": "index.txt",
@@ -23454,14 +23454,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6b159c3d53c1880977124bf240f980a9c1463250",
+        "checksum": "adler32:a4103010",
         "description": "TTJets_FullLeptMGDecays_TuneP11_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 242551,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_FullLeptMGDecays_TuneP11_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_FullLeptMGDecays_TuneP11_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:fc67855b947762fc1fd5fa8d99ee380b9b078873",
+        "checksum": "adler32:bc6c5650",
         "description": "TTJets_FullLeptMGDecays_TuneP11_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 140679,
         "type": "index.txt",
@@ -23566,14 +23566,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:60c90a2cd3828f8ad4642c9f65d0effdbb38f472",
+        "checksum": "adler32:d7969f39",
         "description": "TTJets_FullLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 151587,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_FullLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_FullLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:584198d3f6d878f016283144bb971329e5321ccd",
+        "checksum": "adler32:1c036e2f",
         "description": "TTJets_FullLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 88816,
         "type": "index.txt",
@@ -23678,14 +23678,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e198fbb238e666da06a25b50c861b643724056cf",
+        "checksum": "adler32:031470a1",
         "description": "TTJets_FullLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 241076,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_FullLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_FullLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:305841b272028193eb40c98525b05f14b5c4cae4",
+        "checksum": "adler32:d07c2fae",
         "description": "TTJets_FullLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 140967,
         "type": "index.txt",
@@ -23790,14 +23790,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3ec80396fcb2ed3b411edd535467d63f2321bbd9",
+        "checksum": "adler32:1f9f2d71",
         "description": "TTJets_FullLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 172619,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_FullLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_FullLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:31d31840cc3855a015c7b1bba398e18dbc681de6",
+        "checksum": "adler32:cd139f3a",
         "description": "TTJets_FullLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 100734,
         "type": "index.txt",
@@ -23902,56 +23902,56 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cda8059a476225921dd14a43f61b6ea4ad74166c",
+        "checksum": "adler32:9038e26d",
         "description": "TTJets_HadronicMGDecays_8TeV-madgraph AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 334667,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:0e98a34cc719a8a15b4c62767da1f5f1fac2c546",
+        "checksum": "adler32:a4cb8284",
         "description": "TTJets_HadronicMGDecays_8TeV-madgraph AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 335002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:c73eb612beefeda28e80b3fdff0abe19173de259",
+        "checksum": "adler32:36bbe11d",
         "description": "TTJets_HadronicMGDecays_8TeV-madgraph AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 335002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10002_file_index.json"
       },
       {
-        "checksum": "sha1:a5e35e5710f6dd1ebf7c2021a32246de40461ac6",
+        "checksum": "adler32:9c5449d5",
         "description": "TTJets_HadronicMGDecays_8TeV-madgraph AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 138355,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10003_file_index.json"
       },
       {
-        "checksum": "sha1:8c91a28f6a61ffa3dc4d7700bd44d269603129dc",
+        "checksum": "adler32:96c49164",
         "description": "TTJets_HadronicMGDecays_8TeV-madgraph AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 187812,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:c5e1ad2ab069abf39424a0fe644c22e732628abb",
+        "checksum": "adler32:feafe864",
         "description": "TTJets_HadronicMGDecays_8TeV-madgraph AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 188000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:5f98b4a828c62af817a948cb499770f64b0fcf85",
+        "checksum": "adler32:c1e91f40",
         "description": "TTJets_HadronicMGDecays_8TeV-madgraph AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 188000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10002_file_index.txt"
       },
       {
-        "checksum": "sha1:c669c16257acec6c873509f16cb8130be1af2216",
+        "checksum": "adler32:531da0ca",
         "description": "TTJets_HadronicMGDecays_8TeV-madgraph AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 77644,
         "type": "index.txt",
@@ -24056,28 +24056,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0a635f79c75283cb1ecfe7d2e15c855d6c371820",
+        "checksum": "adler32:0f4f1fca",
         "description": "TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 242552,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:f7b4f46df1711c65b00abaf8d35cb9e3ce909c38",
+        "checksum": "adler32:7d298da1",
         "description": "TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 250252,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:21df42a0d8ebb7832bf93527bc6e2243804b2dee",
+        "checksum": "adler32:904a4623",
         "description": "TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 140679,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:f11b6dba48a5dd6e828a4b28995ad53ae0990cfb",
+        "checksum": "adler32:e646c19e",
         "description": "TTJets_HadronicMGDecays_TuneP11_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 145145,
         "type": "index.txt",
@@ -24182,14 +24182,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e17a982ee333aa8b20b25af288b0c7d4973619fc",
+        "checksum": "adler32:86bbd4e4",
         "description": "TTJets_HadronicMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 345416,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:dadb54fd04b1802c8225ec02964956fa7a510155",
+        "checksum": "adler32:d9c7699b",
         "description": "TTJets_HadronicMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 202384,
         "type": "index.txt",
@@ -24294,28 +24294,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b00d46e7c65523282d82dcce232e051a75a36620",
+        "checksum": "adler32:ecbfe8c8",
         "description": "TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 353648,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:17fd77e1ed6821def1f8c80611c23ced2870bfd7",
+        "checksum": "adler32:33457d4d",
         "description": "TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 150806,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:2e45c8ac5c9102906546c6b1b832350bf88fa66a",
+        "checksum": "adler32:b3090f69",
         "description": "TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 206793,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:268f0580f3186b9d12ab6173ace2ad31493cda8f",
+        "checksum": "adler32:30335d01",
         "description": "TTJets_HadronicMGDecays_TuneP11noCR_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 88182,
         "type": "index.txt",
@@ -24420,14 +24420,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:51e89f0e92954f92719e667cb43ea777193d2031",
+        "checksum": "adler32:9047f16d",
         "description": "TTJets_HadronicMGDecays_TuneP11TeV_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 338529,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_HadronicMGDecays_TuneP11TeV_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_HadronicMGDecays_TuneP11TeV_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:6bf02a73db7039f9b691fc3affa16faaead5da57",
+        "checksum": "adler32:bc8b7402",
         "description": "TTJets_HadronicMGDecays_TuneP11TeV_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 197554,
         "type": "index.txt",
@@ -24532,126 +24532,126 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1114cdea69a10e5bb32a267e990024818e41b1fd",
+        "checksum": "adler32:4c303c1b",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 9) for access to data via CMS virtual machine",
         "size": 352649,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:f906eca2bbec2b85bbfdf242a79a9b10b3a0dc8d",
+        "checksum": "adler32:53006885",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (2 of 9) for access to data via CMS virtual machine",
         "size": 353001,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00001_file_index.json"
       },
       {
-        "checksum": "sha1:ef82a7fa807123793d09abc820ddfba5fea6e533",
+        "checksum": "adler32:13b4fcda",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (3 of 9) for access to data via CMS virtual machine",
         "size": 353001,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00002_file_index.json"
       },
       {
-        "checksum": "sha1:bd5de033f9c1d2662981040c039e4881a17bb0c4",
+        "checksum": "adler32:fdcb9bd3",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (4 of 9) for access to data via CMS virtual machine",
         "size": 111549,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00003_file_index.json"
       },
       {
-        "checksum": "sha1:c4c95891ba29c36ceaab7189b1b919614f4448e6",
+        "checksum": "adler32:7db31bba",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (5 of 9) for access to data via CMS virtual machine",
         "size": 352649,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:33b812b5bbdb6522f7867ff1af54579ddfd9cb2d",
+        "checksum": "adler32:978ea2e8",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (6 of 9) for access to data via CMS virtual machine",
         "size": 352296,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:addd541e48b139e6045a64abe029ff22885f5645",
+        "checksum": "adler32:0f79cf9c",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (7 of 9) for access to data via CMS virtual machine",
         "size": 353002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:939702073507d0a42aa3c04220d18218eb65bdd6",
+        "checksum": "adler32:33de17f1",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (8 of 9) for access to data via CMS virtual machine",
         "size": 353002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20003_file_index.json"
       },
       {
-        "checksum": "sha1:ac32f368752fb0c196224e2bb6b6423c2bd6e1f7",
+        "checksum": "adler32:deb87930",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (9 of 9) for access to data via CMS virtual machine",
         "size": 4944,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20004_file_index.json"
       },
       {
-        "checksum": "sha1:403e3f7ff508f1c4903f6e866fd15ba5eeb3fffa",
+        "checksum": "adler32:ac6ec336",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 9) for access to data via CMS virtual machine",
         "size": 205794,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:00eb56bb22aa05e73239a0ecc49ae36e495bd6ae",
+        "checksum": "adler32:89dfee5f",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (2 of 9) for access to data via CMS virtual machine",
         "size": 206000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00001_file_index.txt"
       },
       {
-        "checksum": "sha1:487217d6dbfcebcebb256a8e72c25473bc44bea2",
+        "checksum": "adler32:fb813bab",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (3 of 9) for access to data via CMS virtual machine",
         "size": 206000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00002_file_index.txt"
       },
       {
-        "checksum": "sha1:e032a039fd81322a507707354bcb75d7c9741795",
+        "checksum": "adler32:2afcff79",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (4 of 9) for access to data via CMS virtual machine",
         "size": 65096,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00003_file_index.txt"
       },
       {
-        "checksum": "sha1:3ce5e64a39717189c6e3edc1cd05e06644469b76",
+        "checksum": "adler32:f7b3b5f1",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (5 of 9) for access to data via CMS virtual machine",
         "size": 205794,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:5b74a957582f206b8f2508e92bd6a216a1c0de73",
+        "checksum": "adler32:e0b372db",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (6 of 9) for access to data via CMS virtual machine",
         "size": 205588,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:6a0ffa5d546977f86a163135af443eb10e72ddc4",
+        "checksum": "adler32:83482a11",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (7 of 9) for access to data via CMS virtual machine",
         "size": 206000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20002_file_index.txt"
       },
       {
-        "checksum": "sha1:bda70e8b4db706c208ad996ba881b99a63571723",
+        "checksum": "adler32:ede24bfb",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (8 of 9) for access to data via CMS virtual machine",
         "size": 206000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20003_file_index.txt"
       },
       {
-        "checksum": "sha1:950a99721cc458eb694de56682acdf330ab6427f",
+        "checksum": "adler32:fda295c1",
         "description": "TTJets_MSDecays_central_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (9 of 9) for access to data via CMS virtual machine",
         "size": 2884,
         "type": "index.txt",
@@ -24756,14 +24756,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:8ffbac475ef85c9fee911082d23c2897ae7e00cf",
+        "checksum": "adler32:89481140",
         "description": "TTJets_MSDecays_width_x5_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 513302,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_MSDecays_width_x5_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_MSDecays_width_x5_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:82003bfd935393b678d80e3c8f043d043b0bf336",
+        "checksum": "adler32:7bffd15e",
         "description": "TTJets_MSDecays_width_x5_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 300150,
         "type": "index.txt",
@@ -24868,42 +24868,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:697b89abda8ed1e398e18823d8c75c1552501d85",
+        "checksum": "adler32:ff214b68",
         "description": "TTJets_SemiLeptDecays_8TeV-sherpa AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 330671,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptDecays_8TeV-sherpa/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptDecays_8TeV-sherpa_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:b68f38a28a11e7c5a312aac4769c6d24e2e1f79f",
+        "checksum": "adler32:0001c448",
         "description": "TTJets_SemiLeptDecays_8TeV-sherpa AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 331002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptDecays_8TeV-sherpa/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptDecays_8TeV-sherpa_AODSIM_PU_S10_START53_V19-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:7e011a93c3eca5ee9d2d2792eb135b152f2be266",
+        "checksum": "adler32:4d848093",
         "description": "TTJets_SemiLeptDecays_8TeV-sherpa AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 88379,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptDecays_8TeV-sherpa/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptDecays_8TeV-sherpa_AODSIM_PU_S10_START53_V19-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:0cce6d1f0fd7338b1db35af2796bd4d47ce3b7bb",
+        "checksum": "adler32:2924ca69",
         "description": "TTJets_SemiLeptDecays_8TeV-sherpa AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 183816,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptDecays_8TeV-sherpa/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptDecays_8TeV-sherpa_AODSIM_PU_S10_START53_V19-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:c102cec8bc391b8591addf804f918a3127b63795",
+        "checksum": "adler32:f18c149b",
         "description": "TTJets_SemiLeptDecays_8TeV-sherpa AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 184000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptDecays_8TeV-sherpa/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptDecays_8TeV-sherpa_AODSIM_PU_S10_START53_V19-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:b367fce25f18be5f3740324cc320808b76419ebe",
+        "checksum": "adler32:a2ab8bd7",
         "description": "TTJets_SemiLeptDecays_8TeV-sherpa AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 49128,
         "type": "index.txt",
@@ -25008,42 +25008,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e08209b794dde470a1bd34c35a4be24b06a3955b",
+        "checksum": "adler32:b5de2916",
         "description": "TTJets_SemiLeptMGDecays_8TeV-madgraph AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 330981,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:7bebfedd2b2654a0e3e2aee9666466b507e6c09e",
+        "checksum": "adler32:6b88a49f",
         "description": "TTJets_SemiLeptMGDecays_8TeV-madgraph AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 335002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:a23ce369d2c5d6629010d2bdb436bafee702f430",
+        "checksum": "adler32:7eb07c90",
         "description": "TTJets_SemiLeptMGDecays_8TeV-madgraph AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 290447,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10002_file_index.json"
       },
       {
-        "checksum": "sha1:b14186b237de535d3d814e95e3e5cd28cffce03b",
+        "checksum": "adler32:732aaa68",
         "description": "TTJets_SemiLeptMGDecays_8TeV-madgraph AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 185744,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:7b7951dd5d085714431cd7674e83683c138a7997",
+        "checksum": "adler32:69897e14",
         "description": "TTJets_SemiLeptMGDecays_8TeV-madgraph AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 188000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:27f2b8259f1ca6a637b02699e306689fb811fc95",
+        "checksum": "adler32:a8c91db0",
         "description": "TTJets_SemiLeptMGDecays_8TeV-madgraph AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 162996,
         "type": "index.txt",
@@ -25148,28 +25148,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:72f01bd8330e4878c70aad74b50d83336d1b24b7",
+        "checksum": "adler32:be699c1a",
         "description": "TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 349652,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:c78d83c99a9a25cb4cb16f8e28bd6949b26a7312",
+        "checksum": "adler32:77ebf912",
         "description": "TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 104302,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:91383f5fe3dc7daa9e1d33b969bba82c3363beb6",
+        "checksum": "adler32:2ae0849b",
         "description": "TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 202797,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:2ddb5473361d3bb00096c42094152d7956a48d5b",
+        "checksum": "adler32:7a7d0dd1",
         "description": "TTJets_SemiLeptMGDecays_TuneP11_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 60494,
         "type": "index.txt",
@@ -25274,14 +25274,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9b70ef137c76b398a002691e4223ddd6518d2d9a",
+        "checksum": "adler32:40056300",
         "description": "TTJets_SemiLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 296426,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:12dc5f871609513d8cd0fce6c291883f22375098",
+        "checksum": "adler32:9b8e359a",
         "description": "TTJets_SemiLeptMGDecays_TuneP11mpiHi_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 173680,
         "type": "index.txt",
@@ -25386,28 +25386,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0fec5d328ebf478915a59cc892a5a258d9c1063e",
+        "checksum": "adler32:2236ea41",
         "description": "TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 353648,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:61e5a65c718bc4276c0944bdf597001a4f29206b",
+        "checksum": "adler32:3ebaed4f",
         "description": "TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 136645,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:247713f62b7ac0c8acbd7bced2f56f169cd5ac94",
+        "checksum": "adler32:e23eff92",
         "description": "TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 206793,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:607b61a4bf2b5afa9fc20ea3189cfcc5b8ab6f15",
+        "checksum": "adler32:63f72b60",
         "description": "TTJets_SemiLeptMGDecays_TuneP11noCR_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 79902,
         "type": "index.txt",
@@ -25512,28 +25512,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a24ce99b755d4d6e5b8fd6c20ab516b61ee3a11b",
+        "checksum": "adler32:b3f6d457",
         "description": "TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 149674,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:3bf078e2a0617873d9eb79a9287faed3a9e029f7",
+        "checksum": "adler32:ecc79bec",
         "description": "TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 161322,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:410a3948346fbf748897354b885a556d3b7ad316",
+        "checksum": "adler32:a0df1359",
         "description": "TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 87344,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:f4079890d87a438a67b10c98656e369111e9d830",
+        "checksum": "adler32:294a6e86",
         "description": "TTJets_SemiLeptMGDecays_TuneP11TeV_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 94142,
         "type": "index.txt",
@@ -25638,28 +25638,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:800e1bddd7c18f52fbc27decee8fa7ffc0e4efa5",
+        "checksum": "adler32:5944d05b",
         "description": "TTJets_WToBC_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 11917,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_WToBC_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_WToBC_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:8a54744a0926545963b806f34eb2589a7ed1cb83",
+        "checksum": "adler32:72f2c7a1",
         "description": "TTJets_WToBC_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 1657,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_WToBC_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_WToBC_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:89c04695fa8b7512c9c75c07156b405183cb620d",
+        "checksum": "adler32:a8e6f7e7",
         "description": "TTJets_WToBC_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 6624,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTJets_WToBC_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTJets_WToBC_8TeV-madgraph-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:66ceac2857761f9d9e0cf1503802f95950375778",
+        "checksum": "adler32:83131b0f",
         "description": "TTJets_WToBC_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 920,
         "type": "index.txt",
@@ -25764,14 +25764,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b5fccccbb590b977fe0e77363612b10f5bfe4359",
+        "checksum": "adler32:886c917a",
         "description": "TToBLNuJ_FCNC_kc_TuneZ2star_8TeV-comphep-ext1 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 178018,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TToBLNuJ_FCNC_kc_TuneZ2star_8TeV-comphep-ext1/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TToBLNuJ_FCNC_kc_TuneZ2star_8TeV-comphep-ext1_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:2444f3ce95adcf08e06da4d0a9d20c9d5a0356a7",
+        "checksum": "adler32:0607dbbb",
         "description": "TToBLNuJ_FCNC_kc_TuneZ2star_8TeV-comphep-ext1 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 101724,
         "type": "index.txt",
@@ -25876,14 +25876,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cefd0f90b8b7de64408349c66cfbbefd6f16e2d7",
+        "checksum": "adler32:ac85d0bf",
         "description": "TToBLNuJ_FCNC_ku_TuneZ2star_8TeV-comphep-ext1 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 182820,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TToBLNuJ_FCNC_ku_TuneZ2star_8TeV-comphep-ext1/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TToBLNuJ_FCNC_ku_TuneZ2star_8TeV-comphep-ext1_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:d8f27549f5301825aefc3395c2cebfd08b8fceaa",
+        "checksum": "adler32:ad894296",
         "description": "TToBLNuJ_FCNC_ku_TuneZ2star_8TeV-comphep-ext1 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 104468,
         "type": "index.txt",
@@ -25988,14 +25988,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e9001c193886eb2d1da4d2f8d46d4173c6787614",
+        "checksum": "adler32:f865e9d8",
         "description": "TToLeptons_t-channel_8TeV-herwig-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 168163,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TToLeptons_t-channel_8TeV-herwig-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TToLeptons_t-channel_8TeV-herwig-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:f8633edfcd7b22ab53fd9001f53f105ee6704178",
+        "checksum": "adler32:a371dc2d",
         "description": "TToLeptons_t-channel_8TeV-herwig-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 94810,
         "type": "index.txt",
@@ -26100,14 +26100,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:14665d980ed7b2fec7d12d431cf5760a085d0397",
+        "checksum": "adler32:9338fd97",
         "description": "TToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 124921,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:9d0256e915019c3b6cd3e899c8dab7cbf1965e05",
+        "checksum": "adler32:acdb6465",
         "description": "TToLeptons_t-channel_herwig6_8TeV-aMCatNLO-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 72000,
         "type": "index.txt",
@@ -26212,14 +26212,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0d4c9f53c78a8115ca6c129543ebf7a061ea8a9f",
+        "checksum": "adler32:9060f3e1",
         "description": "TToLeptons_t-channel_Pythia8_8TeV-aMCatNLO AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 147222,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TToLeptons_t-channel_Pythia8_8TeV-aMCatNLO/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TToLeptons_t-channel_Pythia8_8TeV-aMCatNLO_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:e7f4aad4dc9224cd75651d69eb2bd057dbd57129",
+        "checksum": "adler32:9723907b",
         "description": "TToLeptons_t-channel_Pythia8_8TeV-aMCatNLO AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 83569,
         "type": "index.txt",
@@ -26324,56 +26324,56 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:df59a8aeecb5f4a308f09c4c294d7bde04b21186",
+        "checksum": "adler32:cafe20fa",
         "description": "TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 337664,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola_AODSIM_PU_S10_START53_V19-v2_010000_file_index.json"
       },
       {
-        "checksum": "sha1:f2b5779398245adf3b4944b36b761440602e72bf",
+        "checksum": "adler32:0f707cf2",
         "description": "TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 338002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola_AODSIM_PU_S10_START53_V19-v2_010001_file_index.json"
       },
       {
-        "checksum": "sha1:397a7f5e4dae6eaba7d4de1094c3a7406ed59dfd",
+        "checksum": "adler32:88e361b4",
         "description": "TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 337967,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola_AODSIM_PU_S10_START53_V19-v2_010002_file_index.json"
       },
       {
-        "checksum": "sha1:fcd87b2e75166f497ad958279c0cb3f0aa7d2565",
+        "checksum": "adler32:446af3e7",
         "description": "TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 119968,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola_AODSIM_PU_S10_START53_V19-v2_010003_file_index.json"
       },
       {
-        "checksum": "sha1:d363bcdb2edc12c3b8b3e69469bd85ba735f3ca0",
+        "checksum": "adler32:75810784",
         "description": "TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 191808,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola_AODSIM_PU_S10_START53_V19-v2_010000_file_index.txt"
       },
       {
-        "checksum": "sha1:11a78ebdf6aa31492ee0c79f9f6429302381287c",
+        "checksum": "adler32:ef0c4ccd",
         "description": "TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 192000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola_AODSIM_PU_S10_START53_V19-v2_010001_file_index.txt"
       },
       {
-        "checksum": "sha1:d2f745ccc882bcf979e6fd018e1285dc734d4f1a",
+        "checksum": "adler32:9e4248ed",
         "description": "TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 192000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola_AODSIM_PU_S10_START53_V19-v2_010002_file_index.txt"
       },
       {
-        "checksum": "sha1:f4e3eedd1735c3782094bcb4ba66a2aee1aef6dd",
+        "checksum": "adler32:dc3bbd96",
         "description": "TT_SC_CT10_TuneZ2star_8TeV-powheg-tauola AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 68160,
         "type": "index.txt",
@@ -26478,28 +26478,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dfa7e3f500efd6ba675c0f20b194a6e1e01ed43d",
+        "checksum": "adler32:b86bba16",
         "description": "TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 341660,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg_AODSIM_PU_S10_START53_V19-v2_20000_file_index.json"
       },
       {
-        "checksum": "sha1:aad925868299e98b6724294071ee880fd2fa0b76",
+        "checksum": "adler32:3ef9c54a",
         "description": "TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 294464,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg_AODSIM_PU_S10_START53_V19-v2_20001_file_index.json"
       },
       {
-        "checksum": "sha1:7cb3b11b04da40874ee9d7a36ddd1c6aa4392307",
+        "checksum": "adler32:164dceaa",
         "description": "TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 194805,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg_AODSIM_PU_S10_START53_V19-v2_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:3016d5e205f83945a8003e93e823409073c013cc",
+        "checksum": "adler32:906f30cb",
         "description": "TT_SemiLept_nogg_CT10_TuneZ2star_8TeV-powheg AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 167895,
         "type": "index.txt",
@@ -26604,14 +26604,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9d7b63b556ebb526a70bfcc4c340125054ffdcf3",
+        "checksum": "adler32:68b8f383",
         "description": "TTZJets_8TeV-madgraph_v2 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 8371,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TTZJets_8TeV-madgraph_v2/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TTZJets_8TeV-madgraph_v2_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:c5a71090234a7bc3e2b537627a1b08986968c080",
+        "checksum": "adler32:4a6372a3",
         "description": "TTZJets_8TeV-madgraph_v2 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4550,
         "type": "index.txt",
@@ -26716,28 +26716,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:34c2baeb05e4196b11b5b34712945d3520347539",
+        "checksum": "adler32:94ad7335",
         "description": "TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 9606,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:d59d5240c20e93fef076e8c1325b6aef97553fe8",
+        "checksum": "adler32:e8111a4a",
         "description": "TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 6518,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:d165a46ea284d2919410da224d65da3438a2a9ba",
+        "checksum": "adler32:33fab4e8",
         "description": "TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 5488,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:17555f8d15620baae90f3b823c0fe1bc7e4408ac",
+        "checksum": "adler32:f98e8e30",
         "description": "TZJetsTo2LNuB_8TeV_TuneZ2Star_madgraph_tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 3724,
         "type": "index.txt",
@@ -26842,28 +26842,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e750ff166c3ad87a661a57c6f32791e4c559887b",
+        "checksum": "adler32:14e2f166",
         "description": "TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 24698,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:b25828d1708b4e1918a0d90a5959a418a8d62df7",
+        "checksum": "adler32:298156bf",
         "description": "TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 19553,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:6c886228cc3037fd57d1e3f78e39ec496cf6316d",
+        "checksum": "adler32:d0c344fe",
         "description": "TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 14112,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:8ac86ce776014d27ecce93d89a3d96ae4b0435a6",
+        "checksum": "adler32:f55faceb",
         "description": "TZJetsTo3LNuB_8TeV_TuneZ2Star_madgraph_tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 11172,
         "type": "index.txt",
@@ -26968,14 +26968,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ed73c9af49cd6c4d0495f5b17708cc6c579daa7a",
+        "checksum": "adler32:295d3769",
         "description": "TZJetsTo3LNuB_FCNC_kappa_gut_8TeV_madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 26862,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TZJetsTo3LNuB_FCNC_kappa_gut_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TZJetsTo3LNuB_FCNC_kappa_gut_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:68c1c5c66874f8bd726e2a6e1fdcab08aa0ec9d2",
+        "checksum": "adler32:11358f6a",
         "description": "TZJetsTo3LNuB_FCNC_kappa_gut_8TeV_madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 15247,
         "type": "index.txt",
@@ -27080,14 +27080,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:73d1205fbb033315f9fe89c4889d37f2f33afb6e",
+        "checksum": "adler32:48c2c77d",
         "description": "TZJetsTo3LNuB_FCNC_kappa_zct_8TeV_madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 65266,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TZJetsTo3LNuB_FCNC_kappa_zct_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TZJetsTo3LNuB_FCNC_kappa_zct_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v2_00000_file_index.json"
       },
       {
-        "checksum": "sha1:6becb7706b557bfa70ae8e6c81fee2bd6730b9c2",
+        "checksum": "adler32:e5b8fe4c",
         "description": "TZJetsTo3LNuB_FCNC_kappa_zct_8TeV_madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 37056,
         "type": "index.txt",
@@ -27192,28 +27192,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e013167afd4133cefed099a09d33f4258ec9969c",
+        "checksum": "adler32:eceb78a4",
         "description": "TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 1358,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v2_00000_file_index.json"
       },
       {
-        "checksum": "sha1:b8b9f79c1785d59c354ecf78caf6f723b94d4ed2",
+        "checksum": "adler32:3add5055",
         "description": "TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 63239,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v2_010000_file_index.json"
       },
       {
-        "checksum": "sha1:99193cf5aa66bc29b1196a7247d45d38438c6e7e",
+        "checksum": "adler32:13c2ee5d",
         "description": "TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 768,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v2_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:ca661b0d7bc4693bc539ccbd21e2aab567cc9d6a",
+        "checksum": "adler32:c039676c",
         "description": "TZJetsTo3LNuB_FCNC_zeta_zct_8TeV_madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 35898,
         "type": "index.txt",
@@ -27318,14 +27318,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:032df95da3bcf6755cd3f864e418d24bb641cba5",
+        "checksum": "adler32:cc3fc82a",
         "description": "TZJetsTo3LNuB_FCNC_zeta_zut_8TeV_madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 30172,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/TZJetsTo3LNuB_FCNC_zeta_zut_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_TZJetsTo3LNuB_FCNC_zeta_zut_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:3f8353e1aa4ab1b4dc88117170db04e2acf3f4da",
+        "checksum": "adler32:ee4aca96",
         "description": "TZJetsTo3LNuB_FCNC_zeta_zut_8TeV_madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 17088,
         "type": "index.txt",
@@ -27430,14 +27430,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f11e296396bfcaf366f4a56e9ec2b08b764dd854",
+        "checksum": "adler32:1c785c7a",
         "description": "VBF_HToBB_125GeV_aMCatNLO_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 32439,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/VBF_HToBB_125GeV_aMCatNLO_herwig6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_VBF_HToBB_125GeV_aMCatNLO_herwig6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:ada31b884917598cb150441bbecc46302d1e21e3",
+        "checksum": "adler32:b7253aac",
         "description": "VBF_HToBB_125GeV_aMCatNLO_herwig6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 18032,
         "type": "index.txt",
@@ -27535,42 +27535,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bd248b29660ab8ac22bcdd4af39000a1cd922ebf",
+        "checksum": "adler32:e4e54c40",
         "description": "VBF_HToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 36965,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/VBF_HToGG_M-125_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_VBF_HToGG_M-125_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v2_00000_file_index.json"
       },
       {
-        "checksum": "sha1:e7eeefd6f67e2d089f302d1debd3d092794f6097",
+        "checksum": "adler32:5782e155",
         "description": "VBF_HToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 84582,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/VBF_HToGG_M-125_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_VBF_HToGG_M-125_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v2_10000_file_index.json"
       },
       {
-        "checksum": "sha1:2ff91477025de0d3b9ee79cdfa7c31714518e735",
+        "checksum": "adler32:d07c250e",
         "description": "VBF_HToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 66934,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/VBF_HToGG_M-125_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_VBF_HToGG_M-125_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v2_20000_file_index.json"
       },
       {
-        "checksum": "sha1:e4895a864ca9bbf529656269f20fcbf7a336d550",
+        "checksum": "adler32:c18a6769",
         "description": "VBF_HToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 20646,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/VBF_HToGG_M-125_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_VBF_HToGG_M-125_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v2_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:70ae35a08c178fbdb018ef0b9b80b0962dab32d7",
+        "checksum": "adler32:0e83d757",
         "description": "VBF_HToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 47244,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/VBF_HToGG_M-125_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_VBF_HToGG_M-125_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v2_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:e7d832c4e29a9ccb52fb7c55b43c105773781bde",
+        "checksum": "adler32:32d831b9",
         "description": "VBF_HToGG_M-125_8TeV-powheg-pythia6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 37386,
         "type": "index.txt",
@@ -27675,14 +27675,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:75f6c0fa007a44f312ef015682e7c539b3a17541",
+        "checksum": "adler32:4d72741b",
         "description": "VBFHToGG_M-125_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4227,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/VBFHToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_VBFHToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:a76168c899aaec7a59e666c2425c0eb6759873e3",
+        "checksum": "adler32:aefab3f0",
         "description": "VBFHToGG_M-125_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2314,
         "type": "index.txt",
@@ -27787,14 +27787,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bb2f9db9d0923e7956fa29467665b49a4fbdbeaa",
+        "checksum": "adler32:258c0ef2",
         "description": "VBF_HToTauTau_M-125_8TeV-powheg-pythia6-tauola-tauPolarOff AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 19226,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/VBF_HToTauTau_M-125_8TeV-powheg-pythia6-tauola-tauPolarOff/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_VBF_HToTauTau_M-125_8TeV-powheg-pythia6-tauola-tauPolarOff_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:07b931dd4dc94931a9764f7d1ce9f40d1878b144",
+        "checksum": "adler32:4ee0c680",
         "description": "VBF_HToTauTau_M-125_8TeV-powheg-pythia6-tauola-tauPolarOff AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 11286,
         "type": "index.txt",
@@ -27899,14 +27899,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:63d2b27476e2dbb3d3f2b85bed19d1cf6d4ec9e4",
+        "checksum": "adler32:f1c64cec",
         "description": "VBF_HToZG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4995,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/VBF_HToZG_M-125_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_VBF_HToZG_M-125_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:3dc669f6f1140834a58bc45492c2be4553090aad",
+        "checksum": "adler32:8ade4b7a",
         "description": "VBF_HToZG_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2790,
         "type": "index.txt",
@@ -28011,14 +28011,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9529ecca7dfa3da7bde23d61deeb64ab05f6f053",
+        "checksum": "adler32:88c20e06",
         "description": "VBFToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12147,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/VBFToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_VBFToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:0b8409e3cea2fe2379c9c6eec2e4db1a1f4a08a0",
+        "checksum": "adler32:9ff95f0b",
         "description": "VBFToHToWWToLAndTauNuQQ_M-125_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 7000,
         "type": "index.txt",
@@ -28123,14 +28123,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:fa857ddd040155c4783ca9217df6ed82eccff7b6",
+        "checksum": "adler32:7871b9b6",
         "description": "VBFToHToZG_M-125_8TeV-powheg-pythia8175 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5389,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/VBFToHToZG_M-125_8TeV-powheg-pythia8175/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_VBFToHToZG_M-125_8TeV-powheg-pythia8175_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:4afb07685cef04e4a5a11599ef34a59b33a212d8",
+        "checksum": "adler32:69ce9561",
         "description": "VBFToHToZG_M-125_8TeV-powheg-pythia8175 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3040,
         "type": "index.txt",
@@ -28235,42 +28235,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:850ef27ec16dfd99fa82cc4ad23a0ce6246c48c0",
+        "checksum": "adler32:eb0fa1ad",
         "description": "W1JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 333668,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W1JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W1JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:8d701bb1e9b231e0a2bb8fd01a33fa720cc4a5ea",
+        "checksum": "adler32:390afca4",
         "description": "W1JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 334002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W1JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W1JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10001_file_index.json"
       },
       {
-        "checksum": "sha1:2ffc250d4a0145a9e77e571c3087216865511ad5",
+        "checksum": "adler32:c1e554b9",
         "description": "W1JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 258518,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W1JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W1JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10002_file_index.json"
       },
       {
-        "checksum": "sha1:c36b250accc0e9d7d186868197908ed571b79ebf",
+        "checksum": "adler32:c1d5df5a",
         "description": "W1JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 186813,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W1JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W1JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:c4faa1ffc4ece0d3adee55e43d11b3b86efaab2f",
+        "checksum": "adler32:641e14f9",
         "description": "W1JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 187000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W1JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W1JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:d5a26ca590f4dffc83a16da8fb5478e6b5b33a06",
+        "checksum": "adler32:3d54fa1a",
         "description": "W1JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 144738,
         "type": "index.txt",
@@ -28375,42 +28375,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d65217e9cc1eeac02102b05a3d571dd4327caffa",
+        "checksum": "adler32:9d35ef59",
         "description": "W2JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 333668,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W2JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W2JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:0b9b5386d0e84bf44c6ee15d01965c54e26cc07b",
+        "checksum": "adler32:c3604390",
         "description": "W2JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 334002,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W2JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W2JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20001_file_index.json"
       },
       {
-        "checksum": "sha1:4d0410ef8e801438beae9e8c8f85bd09664fd8b9",
+        "checksum": "adler32:24b50f47",
         "description": "W2JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 202740,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W2JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W2JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20002_file_index.json"
       },
       {
-        "checksum": "sha1:dd6704290ea551f2eb3e3a863f13fc15506a3ed0",
+        "checksum": "adler32:99100587",
         "description": "W2JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 186813,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W2JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W2JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:58aabde4c8ce3d5e0b030fd8d19d6aba4c52f5a8",
+        "checksum": "adler32:a9e14087",
         "description": "W2JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 187000,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W2JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W2JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20001_file_index.txt"
       },
       {
-        "checksum": "sha1:4fd21d1e901809c5e86f538cadea8a1db7774322",
+        "checksum": "adler32:d740b746",
         "description": "W2JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 113509,
         "type": "index.txt",
@@ -28515,28 +28515,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1691f45e06297e440c1102a7dda8f2310ead52fe",
+        "checksum": "adler32:d3ca69e9",
         "description": "W3JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 270206,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W3JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W3JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:6102e9e8f7544e68b2bae769b3560688813f69e3",
+        "checksum": "adler32:a75f4015",
         "description": "W3JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 302605,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W3JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W3JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:b71286b7995c1a5e7f143f61f4877765398a7526",
+        "checksum": "adler32:4f809d98",
         "description": "W3JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 151283,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/W3JetsToLNu_TuneZ2Star_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_W3JetsToLNu_TuneZ2Star_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:a7a1112913ba9f25fc6bdb5e8714464f6b72ec94",
+        "checksum": "adler32:cb827510",
         "description": "W3JetsToLNu_TuneZ2Star_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 169422,
         "type": "index.txt",
@@ -28641,28 +28641,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e34a423fa245720def47f3f713be969b30607201",
+        "checksum": "adler32:b8ecbbf6",
         "description": "WGToLNuG_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 677,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WGToLNuG_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:009b440fe41767ce2b6e210dba3563023d49e499",
+        "checksum": "adler32:88879998",
         "description": "WGToLNuG_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 112211,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WGToLNuG_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_RD1_START53_V7N-v1_210000_file_index.json"
       },
       {
-        "checksum": "sha1:bff4b120c7e69bea7f6ef66ca9f908d55865b8e2",
+        "checksum": "adler32:b2be76da",
         "description": "WGToLNuG_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 382,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WGToLNuG_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WGToLNuG_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:bcac5afeeab8cfa6e5392525c023e1c365397ee0",
+        "checksum": "adler32:7d0f2efb",
         "description": "WGToLNuG_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 63552,
         "type": "index.txt",
@@ -28767,28 +28767,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:62b25b67cc6840cc3ce8de7f092663097881a135",
+        "checksum": "adler32:8a4b220c",
         "description": "WH_WToQQ_HToInv_M-125_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 7638,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_WToQQ_HToInv_M-125_8TeV_pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_WToQQ_HToInv_M-125_8TeV_pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:0259b8081b65bb0ee867f412ec2a68b1fc2617b6",
+        "checksum": "adler32:460c6ab8",
         "description": "WH_WToQQ_HToInv_M-125_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 12618,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_WToQQ_HToInv_M-125_8TeV_pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_WToQQ_HToInv_M-125_8TeV_pythia6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:4cfcfefd9c4e1470f30e269f3d30076b7d2382cb",
+        "checksum": "adler32:ff120a40",
         "description": "WH_WToQQ_HToInv_M-125_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 4255,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_WToQQ_HToInv_M-125_8TeV_pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_WToQQ_HToInv_M-125_8TeV_pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:a5ade583597ea2ae10ada9c51a842895168005bd",
+        "checksum": "adler32:c1d15152",
         "description": "WH_WToQQ_HToInv_M-125_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 7030,
         "type": "index.txt",
@@ -28886,56 +28886,56 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bfa493d4d8ff2ba19a612621e04a5cfb0fdba42b",
+        "checksum": "adler32:3f4bd588",
         "description": "WH_ZH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 56745,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v3_00000_file_index.json"
       },
       {
-        "checksum": "sha1:57aaa8981a02a71544ae04894aaf226cffc75d7f",
+        "checksum": "adler32:08ed15c6",
         "description": "WH_ZH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 54120,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v3_10000_file_index.json"
       },
       {
-        "checksum": "sha1:864fb4e0e5b0c620fdbc74638d096a0dc4bcc012",
+        "checksum": "adler32:3122a4ce",
         "description": "WH_ZH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 50842,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v3_20000_file_index.json"
       },
       {
-        "checksum": "sha1:d2871e0bea59eb00bd4e202c3367730fb6712d99",
+        "checksum": "adler32:23a7411b",
         "description": "WH_ZH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 15418,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v3_30000_file_index.json"
       },
       {
-        "checksum": "sha1:61ac5f1ec2f227c1f7ae915b98aaaaccf7cd86d1",
+        "checksum": "adler32:55ecae6d",
         "description": "WH_ZH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (1 of 4) for access to data via CMS virtual machine",
         "size": 31313,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v3_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:aa593fea01abb7da30e94aa4e2ea93991316e382",
+        "checksum": "adler32:5a0fff01",
         "description": "WH_ZH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (2 of 4) for access to data via CMS virtual machine",
         "size": 29865,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v3_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:1264f8241fe2b36480549f141842634c9c041bf3",
+        "checksum": "adler32:da1be008",
         "description": "WH_ZH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (3 of 4) for access to data via CMS virtual machine",
         "size": 28055,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_HToGG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v3/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_HToGG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v3_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:14ffd4364840d412628024472412c54416875999",
+        "checksum": "adler32:79eaf6d9",
         "description": "WH_ZH_HToGG_M-125_8TeV-pythia6 AOD dataset file index (4 of 4) for access to data via CMS virtual machine",
         "size": 8507,
         "type": "index.txt",
@@ -29040,14 +29040,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eb4ef160e377aac523269f62fb4a8dd9fb950df7",
+        "checksum": "adler32:6002a827",
         "description": "WH_ZH_HToZG_M-125_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 29848,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_HToZG_M-125_8TeV-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_HToZG_M-125_8TeV-pythia6_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:c22ac2a1e2abf328b40e43690ead4d76ac545d13",
+        "checksum": "adler32:413b6436",
         "description": "WH_ZH_HToZG_M-125_8TeV-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 16471,
         "type": "index.txt",
@@ -29152,14 +29152,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:31625df760a747ec75d56c3590424b79d7c11bf8",
+        "checksum": "adler32:ed703d15",
         "description": "WH_ZH_HToZG_M-125_8TeV-pythia8175 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4966,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_HToZG_M-125_8TeV-pythia8175/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_HToZG_M-125_8TeV-pythia8175_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:ee309b2e3776b22da18850592d00558edb7e1dc6",
+        "checksum": "adler32:cb1939ab",
         "description": "WH_ZH_HToZG_M-125_8TeV-pythia8175 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2760,
         "type": "index.txt",
@@ -29264,28 +29264,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:18065fe0a0632db8a4b2b8e1dc02932e44cf1897",
+        "checksum": "adler32:c237bc4e",
         "description": "WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 683,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:7f23e413c3b9fe92ba2331fab8677ffb8dc18536",
+        "checksum": "adler32:03f89ced",
         "description": "WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 6140,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:1cdbc747e2ba96d4fde88e088dfb60ebb7ab6b5d",
+        "checksum": "adler32:2dcf76cd",
         "description": "WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 388,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:aafa5ce34d52ae3970e994993af496343305e7ec",
+        "checksum": "adler32:d00b2cf7",
         "description": "WH_ZH_TTH_HToWW_M-125_lepdecay_8TeV-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 3492,
         "type": "index.txt",
@@ -29390,14 +29390,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:84338f9955575af035abd3665fe882b75fe9861a",
+        "checksum": "adler32:2266b5a8",
         "description": "WH_ZH_WZToAll_HToZG_M-125_8TeV-pythia8 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5376,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WH_ZH_WZToAll_HToZG_M-125_8TeV-pythia8/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WH_ZH_WZToAll_HToZG_M-125_8TeV-pythia8_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:c69afa0c4b23a3bc29fb80e01e29f79c02d56e57",
+        "checksum": "adler32:51ab90fb",
         "description": "WH_ZH_WZToAll_HToZG_M-125_8TeV-pythia8 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3024,
         "type": "index.txt",
@@ -29502,42 +29502,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ac9a5b038f94816c4e2925542aa1679f40a16a16",
+        "checksum": "adler32:4dbef76e",
         "description": "WLNubbar_8TeV-massive_amcatnlo-herwig6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 335666,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WLNubbar_8TeV-massive_amcatnlo-herwig6/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WLNubbar_8TeV-massive_amcatnlo-herwig6_AODSIM_PU_S10_START53_V19-v2_10000_file_index.json"
       },
       {
-        "checksum": "sha1:a88ef5296a2c2fe634a62b807c68b3d1c0f3fa9f",
+        "checksum": "adler32:f5377055",
         "description": "WLNubbar_8TeV-massive_amcatnlo-herwig6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 32594,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WLNubbar_8TeV-massive_amcatnlo-herwig6/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WLNubbar_8TeV-massive_amcatnlo-herwig6_AODSIM_PU_S10_START53_V19-v2_10001_file_index.json"
       },
       {
-        "checksum": "sha1:2a1b5afb239ff26b52e8dbea2a50382de564f4a4",
+        "checksum": "adler32:baa8e69e",
         "description": "WLNubbar_8TeV-massive_amcatnlo-herwig6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 110209,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WLNubbar_8TeV-massive_amcatnlo-herwig6/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WLNubbar_8TeV-massive_amcatnlo-herwig6_AODSIM_PU_S10_START53_V19-v2_20000_file_index.json"
       },
       {
-        "checksum": "sha1:8f075f8b83a1e93e35c3eaa6e6c97a95f648f3aa",
+        "checksum": "adler32:6a946c9e",
         "description": "WLNubbar_8TeV-massive_amcatnlo-herwig6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 188811,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WLNubbar_8TeV-massive_amcatnlo-herwig6/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WLNubbar_8TeV-massive_amcatnlo-herwig6_AODSIM_PU_S10_START53_V19-v2_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:051aff19e5a2b6ff4832060f73d91bcb51fe3bf8",
+        "checksum": "adler32:67ce5e12",
         "description": "WLNubbar_8TeV-massive_amcatnlo-herwig6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 18333,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WLNubbar_8TeV-massive_amcatnlo-herwig6/AODSIM/PU_S10_START53_V19-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WLNubbar_8TeV-massive_amcatnlo-herwig6_AODSIM_PU_S10_START53_V19-v2_10001_file_index.txt"
       },
       {
-        "checksum": "sha1:effdd58f84a31d4fb2062186e2f5c640ad87787e",
+        "checksum": "adler32:4f87ae94",
         "description": "WLNubbar_8TeV-massive_amcatnlo-herwig6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 61992,
         "type": "index.txt",
@@ -29642,28 +29642,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:77b36935265915c391b41839290ad2f7af6453d2",
+        "checksum": "adler32:dce837a9",
         "description": "WminusToMuNu_CT10_8TeV-powheg-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 823431,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WminusToMuNu_CT10_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WminusToMuNu_CT10_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:01f91199ec09ec7638c9025b5bd215265a9e021c",
+        "checksum": "adler32:4470f798",
         "description": "WminusToMuNu_CT10_8TeV-powheg-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 19431,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WminusToMuNu_CT10_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WminusToMuNu_CT10_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_00001_file_index.json"
       },
       {
-        "checksum": "sha1:46825e86e82fcd80ddce51d8cf6aa2e4d132772f",
+        "checksum": "adler32:966cfe7e",
         "description": "WminusToMuNu_CT10_8TeV-powheg-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 462104,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WminusToMuNu_CT10_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WminusToMuNu_CT10_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:ed463c9a98eba0bd6b913e87aff546ef8962c02c",
+        "checksum": "adler32:c978283d",
         "description": "WminusToMuNu_CT10_8TeV-powheg-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 10904,
         "type": "index.txt",
@@ -29768,14 +29768,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2e72721be058e432e3ad747f1623d2248af81b40",
+        "checksum": "adler32:7457bb85",
         "description": "WminusToTauNu_CT10_8TeV-powheg-pythia6-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 148178,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WminusToTauNu_CT10_8TeV-powheg-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WminusToTauNu_CT10_8TeV-powheg-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:06c69a32ab71b09e7149abdd095f5d6f8158f871",
+        "checksum": "adler32:4ed2654d",
         "description": "WminusToTauNu_CT10_8TeV-powheg-pythia6-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 84672,
         "type": "index.txt",
@@ -29880,42 +29880,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:43522848cac6ba7b37a24f00577c8e2b2f6402f2",
+        "checksum": "adler32:5f1c9f8b",
         "description": "WplusToMuNu_CT10_8TeV-powheg-pythia6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 1000659,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WplusToMuNu_CT10_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WplusToMuNu_CT10_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:dbfc9f01596fd77eb79f61026f1b28ae5569df67",
+        "checksum": "adler32:08b3edb2",
         "description": "WplusToMuNu_CT10_8TeV-powheg-pythia6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 272880,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WplusToMuNu_CT10_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WplusToMuNu_CT10_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_00001_file_index.json"
       },
       {
-        "checksum": "sha1:c6a93a646154b99cf9bad083a54890e1a84bb94c",
+        "checksum": "adler32:53e02d6e",
         "description": "WplusToMuNu_CT10_8TeV-powheg-pythia6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 111891,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WplusToMuNu_CT10_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WplusToMuNu_CT10_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:c351fae26060c9131d8aba4dd0d09cd70c54ca0c",
+        "checksum": "adler32:f392b0fd",
         "description": "WplusToMuNu_CT10_8TeV-powheg-pythia6 AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 560252,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WplusToMuNu_CT10_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WplusToMuNu_CT10_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:28b5901b49c75a13e5bb72b218d6c2713ff7b652",
+        "checksum": "adler32:c3fd88fd",
         "description": "WplusToMuNu_CT10_8TeV-powheg-pythia6 AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 152779,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WplusToMuNu_CT10_8TeV-powheg-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WplusToMuNu_CT10_8TeV-powheg-pythia6_AODSIM_PU_S10_START53_V19-v1_00001_file_index.txt"
       },
       {
-        "checksum": "sha1:b5e44e94a59d2b76af3076065320112a591e40d9",
+        "checksum": "adler32:95fa4b1a",
         "description": "WplusToMuNu_CT10_8TeV-powheg-pythia6 AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 62645,
         "type": "index.txt",
@@ -30020,14 +30020,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:700090cae1fcaa5a02e802bc309939e0a32b9f5e",
+        "checksum": "adler32:faac6bc7",
         "description": "WplusToTauNu_CT10_8TeV-powheg-pythia6-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 282492,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WplusToTauNu_CT10_8TeV-powheg-pythia6-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WplusToTauNu_CT10_8TeV-powheg-pythia6-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:126a16cbb488d549c45e2a04820d130c8729716b",
+        "checksum": "adler32:f638320f",
         "description": "WplusToTauNu_CT10_8TeV-powheg-pythia6-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 161070,
         "type": "index.txt",
@@ -30132,28 +30132,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ff67bba781467a0c630f6648985c22d36b9c1f2c",
+        "checksum": "adler32:5c3a0028",
         "description": "WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 9236,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:344068140b960f588ef228cddc9ad2ddfb3623c1",
+        "checksum": "adler32:942b303d",
         "description": "WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 4790,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:e5d2eea0771d65f6b312d8cb1f1cb67e0738bc89",
+        "checksum": "adler32:9059635d",
         "description": "WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 5265,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:c915ce9c024f289563b7b2f8341500bf15ef3c03",
+        "checksum": "adler32:101e505a",
         "description": "WpWmJJToLNuQQ_TuneZ2star_8TeV-vbfnlo-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2730,
         "type": "index.txt",
@@ -30258,14 +30258,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:863f8a30b9a68f4a8fa225abcb3d390dca50dd91",
+        "checksum": "adler32:d3bd5f19",
         "description": "WpWmJJToQQLNuBar_TuneZ2star_8TeV-vbfnlo-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 14146,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WpWmJJToQQLNuBar_TuneZ2star_8TeV-vbfnlo-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WpWmJJToQQLNuBar_TuneZ2star_8TeV-vbfnlo-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:ace1c4749e64a6bc206ff4389f173ca68d9cdcd6",
+        "checksum": "adler32:c623e189",
         "description": "WpWmJJToQQLNuBar_TuneZ2star_8TeV-vbfnlo-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 8118,
         "type": "index.txt",
@@ -30370,28 +30370,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:28d5ef79d944db3a5cc2afe503a9e5c8b7c2202d",
+        "checksum": "adler32:1a87f209",
         "description": "WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 47386,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:5b85b5a98ab4f23340d826bfc640efcf6e1b529d",
+        "checksum": "adler32:2118c74d",
         "description": "WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 18955,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:a722b84d31d07c90d316ec51ccac9882cf06ef16",
+        "checksum": "adler32:f06eccb4",
         "description": "WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 27540,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:76d02a65475bb7c820cd3ddf68d6d17267b5ee07",
+        "checksum": "adler32:6d4485f7",
         "description": "WW2Jets_EW6-lvlvSS-noH_TuneZ2star_8TeV_phantom-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 11016,
         "type": "index.txt",
@@ -30496,28 +30496,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0c77d5a7fb9bfd87907e604531d065c4ae07113f",
+        "checksum": "adler32:5de9f4bd",
         "description": "WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 37450,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:67f309192adc45d30aec448a4e6d9ee483892b73",
+        "checksum": "adler32:51026eba",
         "description": "WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 28702,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:fb2b8111139806e6a2b7a6a324556ec817ead0af",
+        "checksum": "adler32:03c29986",
         "description": "WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 21721,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:5b7ef3f44668257cc40ae2904f4067a291fa625f",
+        "checksum": "adler32:40b967be",
         "description": "WW2Jets_EW6-lvlvSS-wH_TuneZ2star_8TeV_phantom-tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 16646,
         "type": "index.txt",
@@ -30622,14 +30622,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:69aa15e936f444de2eac71cf97885d02a1939095",
+        "checksum": "adler32:daddeec6",
         "description": "WW2JetsTo2L2Nu_EW4_QCD2_8TeV-madgraph-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 9262,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WW2JetsTo2L2Nu_EW4_QCD2_8TeV-madgraph-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WW2JetsTo2L2Nu_EW4_QCD2_8TeV-madgraph-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:51b5dccbbe82f01b10948f79013707fb3b20752e",
+        "checksum": "adler32:c3654f84",
         "description": "WW2JetsTo2L2Nu_EW4_QCD2_8TeV-madgraph-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5292,
         "type": "index.txt",
@@ -30734,14 +30734,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d8ceaf308a7b198273800bc992f3785ff34259d2",
+        "checksum": "adler32:47c40644",
         "description": "WWGJets_8TeV-madgraph_v2 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12238,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WWGJets_8TeV-madgraph_v2/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WWGJets_8TeV-madgraph_v2_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:f68dcb663f47b4c7b039a809671b52eb501eb67d",
+        "checksum": "adler32:fc15ec7d",
         "description": "WWGJets_8TeV-madgraph_v2 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6650,
         "type": "index.txt",
@@ -30846,14 +30846,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9fa8f5d0e5048ee3debc4c2a972938885ec01630",
+        "checksum": "adler32:8dab03e2",
         "description": "WWJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 70660,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WWJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WWJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:6569e0028f320a751826e923891faced6aa1cdcd",
+        "checksum": "adler32:97e453eb",
         "description": "WWJetsTo2L2Nu_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 40376,
         "type": "index.txt",
@@ -30958,14 +30958,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4e70c2378f8d91ac25978635926d7919f2895a20",
+        "checksum": "adler32:c7400117",
         "description": "WWjjTo2L2Nu_8TeV_madgraph_qed6_qcd0 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4663,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WWjjTo2L2Nu_8TeV_madgraph_qed6_qcd0/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WWjjTo2L2Nu_8TeV_madgraph_qed6_qcd0_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:9f7242d5ea124bc24021fdf1f8d0d79d3e9c4c51",
+        "checksum": "adler32:be6b2009",
         "description": "WWjjTo2L2Nu_8TeV_madgraph_qed6_qcd0 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2604,
         "type": "index.txt",
@@ -31070,14 +31070,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d9c106065ac40f3e6bba2133e05bfcc978787ef9",
+        "checksum": "adler32:d2bf345f",
         "description": "WWWJets_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10528,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WWWJets_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WWWJets_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:6e2b6c6aa7351152c3766452f9f806f6b8123e88",
+        "checksum": "adler32:1a1cc3c8",
         "description": "WWWJets_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5676,
         "type": "index.txt",
@@ -31179,14 +31179,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b1fd294e9856ba2cc67b9381b713ffe88ac70de4",
+        "checksum": "adler32:b6e468fa",
         "description": "WWZNoGstarJets_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 7825,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WWZNoGstarJets_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WWZNoGstarJets_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:376eff0576d330062bfa1c25c1594a40c0e999d2",
+        "checksum": "adler32:6da52ec3",
         "description": "WWZNoGstarJets_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4296,
         "type": "index.txt",
@@ -31291,14 +31291,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:4871b392234db6f5e8e142a0ea5fda258df1dc8d",
+        "checksum": "adler32:394974d1",
         "description": "WZJetsTo2L2Q_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 111490,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WZJetsTo2L2Q_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WZJetsTo2L2Q_TuneZ2star_8TeV-madgraph-tauola_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:c65ffb8f465e32d6a035d93c15c43931d4d9363e",
+        "checksum": "adler32:47f89319",
         "description": "WZJetsTo2L2Q_TuneZ2star_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 63570,
         "type": "index.txt",
@@ -31403,28 +31403,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:212cea876218e620dcceb6437237251d81730281",
+        "checksum": "adler32:3c010dcb",
         "description": "WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 32149,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:6832e3aa1ed991c06062bdc396aac36c7e30f529",
+        "checksum": "adler32:04051d9d",
         "description": "WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 53353,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:9f6e43dc2d72d86a6c0bc504a10200acfca54289",
+        "checksum": "adler32:eef4736d",
         "description": "WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 18330,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:8c95a2cd39264d116c2e0f8865098b0e0921579a",
+        "checksum": "adler32:2b4338de",
         "description": "WZJetsTo3LNu_8TeV_TuneZ2Star_madgraph_tauola AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 30420,
         "type": "index.txt",
@@ -31529,14 +31529,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f383aff5b2b891f36fdf3d06083f46ad38fedb1e",
+        "checksum": "adler32:f7f90d95",
         "description": "WZJetsTo3LNu_TuneZ2_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 62870,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WZJetsTo3LNu_TuneZ2_8TeV-madgraph-tauola/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WZJetsTo3LNu_TuneZ2_8TeV-madgraph-tauola_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:5c71d6a1ba49177e139db6cf2205e07ca453f5fd",
+        "checksum": "adler32:9fc518d6",
         "description": "WZJetsTo3LNu_TuneZ2_8TeV-madgraph-tauola AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 35526,
         "type": "index.txt",
@@ -31638,14 +31638,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b5444dc5faed9eada323d6234b063687be9ad4f5",
+        "checksum": "adler32:f908314d",
         "description": "WZZNoGstarJets_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10434,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/WZZNoGstarJets_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_WZZNoGstarJets_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:6c49c938e3faffab66553f5836cdc6d3594a8f9e",
+        "checksum": "adler32:1745e5e7",
         "description": "WZZNoGstarJets_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5728,
         "type": "index.txt",
@@ -31750,14 +31750,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d52b793dfa3c7add90b392d60996ec66d0a3ba57",
+        "checksum": "adler32:099e9ad2",
         "description": "Zbb_4F_8TeV_madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 233414,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/Zbb_4F_8TeV_madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_Zbb_4F_8TeV_madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:78216bbba17c8f1c4e2bc5df5c6af0c34a0a2e37",
+        "checksum": "adler32:f77d49a0",
         "description": "Zbb_4F_8TeV_madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 125514,
         "type": "index.txt",
@@ -31862,42 +31862,42 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d14295e4cd9c153b7e1340e8a504d7fb24e89470",
+        "checksum": "adler32:19079284",
         "description": "ZG3JetsToLL_8TeV-madgraph AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 62664,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZG3JetsToLL_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZG3JetsToLL_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:d217f3ebf25dfb8d2c518da8ce3fb4757a9b50e9",
+        "checksum": "adler32:6e863511",
         "description": "ZG3JetsToLL_8TeV-madgraph AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 83013,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZG3JetsToLL_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZG3JetsToLL_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:68b97d4ebee20f7bd099cef00a894684e5b5dafd",
+        "checksum": "adler32:15c907d4",
         "description": "ZG3JetsToLL_8TeV-madgraph AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 77199,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZG3JetsToLL_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZG3JetsToLL_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_30000_file_index.json"
       },
       {
-        "checksum": "sha1:191548075f08ca020ce67b244fb53bfe1de12e4f",
+        "checksum": "adler32:bdf981a8",
         "description": "ZG3JetsToLL_8TeV-madgraph AOD dataset file index (1 of 3) for access to data via CMS virtual machine",
         "size": 34144,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZG3JetsToLL_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZG3JetsToLL_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:f0ccdcc88eee5190ef69bcbd93e4fbfd93ffb273",
+        "checksum": "adler32:6a81ac37",
         "description": "ZG3JetsToLL_8TeV-madgraph AOD dataset file index (2 of 3) for access to data via CMS virtual machine",
         "size": 45232,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZG3JetsToLL_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZG3JetsToLL_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.txt"
       },
       {
-        "checksum": "sha1:9849f3f848cc3d99564bdccc4f38d8e6b79ad4e4",
+        "checksum": "adler32:387de463",
         "description": "ZG3JetsToLL_8TeV-madgraph AOD dataset file index (3 of 3) for access to data via CMS virtual machine",
         "size": 42064,
         "type": "index.txt",
@@ -32002,14 +32002,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:59dbc10c98b874255ee328fda91301c077a962eb",
+        "checksum": "adler32:1a9fae2b",
         "description": "ZGToLLG_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 183426,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZGToLLG_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZGToLLG_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:03ac47cdae6c124bb3ed248630d758f1c11ad0a3",
+        "checksum": "adler32:1c573bab",
         "description": "ZGToLLG_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 98900,
         "type": "index.txt",
@@ -32114,14 +32114,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:37cd9efef07a56e7a2298e89e6cd6f6e07e9236f",
+        "checksum": "adler32:bffb653b",
         "description": "ZH_HToMuMu_M-125_8TeV-powheg-herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5026,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZH_HToMuMu_M-125_8TeV-powheg-herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZH_HToMuMu_M-125_8TeV-powheg-herwigpp_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:4635b63b23f5d7a418344afc9dcdbed6869858c8",
+        "checksum": "adler32:98c35fe0",
         "description": "ZH_HToMuMu_M-125_8TeV-powheg-herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2820,
         "type": "index.txt",
@@ -32226,28 +32226,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ccbadb78f90e3531874e33aff905cc7a2daf4606",
+        "checksum": "adler32:60c401af",
         "description": "ZH_ZToQQ_HToInv_M-125_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 16934,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZH_ZToQQ_HToInv_M-125_8TeV_pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZH_ZToQQ_HToInv_M-125_8TeV_pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:417e7e7a722816a851d3113575f860c04f72991e",
+        "checksum": "adler32:cd233bac",
         "description": "ZH_ZToQQ_HToInv_M-125_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 3985,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZH_ZToQQ_HToInv_M-125_8TeV_pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZH_ZToQQ_HToInv_M-125_8TeV_pythia6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:16907a31b584e2ac5cf32c6331f8aa6ebcd3ccaf",
+        "checksum": "adler32:15d72bfa",
         "description": "ZH_ZToQQ_HToInv_M-125_8TeV_pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 9435,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZH_ZToQQ_HToInv_M-125_8TeV_pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZH_ZToQQ_HToInv_M-125_8TeV_pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:e0f15a8dc57ae313a7a0ddd4fe23d7b14107491d",
+        "checksum": "adler32:efb1a07b",
         "description": "ZH_ZToQQ_HToInv_M-125_8TeV_pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 2220,
         "type": "index.txt",
@@ -32352,28 +32352,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f4e508df693d86b5b7dd4e3abbc8b145e555ae66",
+        "checksum": "adler32:fec3923f",
         "description": "ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 108500,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:6e6983b3dab949cfc2bc36d2919a365667dece8a",
+        "checksum": "adler32:433ce172",
         "description": "ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 107823,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:8cd7af22a54137b58475492f9b06179823f0630b",
+        "checksum": "adler32:912d6ebc",
         "description": "ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 61311,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:c1e7b075fdd5a5d772b8cfcda56c6a25cd9f323c",
+        "checksum": "adler32:8b7cfd2e",
         "description": "ZJetToEE_Pt-0to15_TuneEE3C_8TeV_herwigpp AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 60929,
         "type": "index.txt",
@@ -32478,28 +32478,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:88914ffa6504cc54aab3ece771e923212ea8356e",
+        "checksum": "adler32:7b0e6236",
         "description": "ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 4094,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:fd405d3eddbd428bf2aa66619164ca1ac888ff82",
+        "checksum": "adler32:76195de6",
         "description": "ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 344,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_110000_file_index.json"
       },
       {
-        "checksum": "sha1:3ca0d9885e1918f0b1a164bb4301e4c18948882f",
+        "checksum": "adler32:dddfc54e",
         "description": "ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 2328,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:bf95916e91f73f2fed2650f635b68d9735d763ba",
+        "checksum": "adler32:b5063b2e",
         "description": "ZJetToEE_Pt-120to170_TuneEE3C_8TeV_herwigpp AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 195,
         "type": "index.txt",
@@ -32604,28 +32604,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3bbb7af102929125a10c32adfb948e804a64ce62",
+        "checksum": "adler32:af525b2f",
         "description": "ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 7799,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:07bcedbdcc2c06360d8ecb767fa2ed8a5b1bea52",
+        "checksum": "adler32:6e1c5d7a",
         "description": "ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 342,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_110000_file_index.json"
       },
       {
-        "checksum": "sha1:36df3b7a22f22262c469f8c21c7be188da9d1198",
+        "checksum": "adler32:8ae14567",
         "description": "ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 4416,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:2a3e855f7dc27e574d0b455bbafaf49c3855eee9",
+        "checksum": "adler32:57013b11",
         "description": "ZJetToEE_Pt-15to20_TuneEE3C_8TeV_herwigpp AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 193,
         "type": "index.txt",
@@ -32730,14 +32730,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a6d7b71a4704b3cbcb0101f28a230a576f05610d",
+        "checksum": "adler32:6e34c0c1",
         "description": "ZJetToEE_Pt-170to230_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4435,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-170to230_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-170to230_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:443624dbbd2a8398f0afb58b4deb65c0aae33a51",
+        "checksum": "adler32:5916011e",
         "description": "ZJetToEE_Pt-170to230_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2522,
         "type": "index.txt",
@@ -32842,14 +32842,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:2bd37badab87669d0ff786876ddefea90c842e8e",
+        "checksum": "adler32:fd6e60ad",
         "description": "ZJetToEE_Pt-230to300_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4092,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-230to300_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-230to300_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:dc8889feb69dddcf43e0dee7442b386804116d43",
+        "checksum": "adler32:f370c451",
         "description": "ZJetToEE_Pt-230to300_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2328,
         "type": "index.txt",
@@ -32954,14 +32954,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:9e3aca4ac9066e5d346ff59fe079bc0c24a014a2",
+        "checksum": "adler32:1ef8668d",
         "description": "ZJetToEE_Pt-300_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5041,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-300_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-300_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:1d04874cbb83c719cc8fa93a8c4eb268775c6b4e",
+        "checksum": "adler32:1057620f",
         "description": "ZJetToEE_Pt-300_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2835,
         "type": "index.txt",
@@ -33066,28 +33066,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3745e1d94d3b00c4c7fed51d1072d963506659f5",
+        "checksum": "adler32:8ac5e5f5",
         "description": "ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 6441,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:a9d6a3cae6b33549774a3082bd434824f42d6600",
+        "checksum": "adler32:421c5d0e",
         "description": "ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 341,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_110000_file_index.json"
       },
       {
-        "checksum": "sha1:d6a8ebb76d39924f34340bd51cd6c3b0b5b1f7aa",
+        "checksum": "adler32:b30a5ada",
         "description": "ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 3648,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:d536b76c58b6b030592b0946e012386648a9cf37",
+        "checksum": "adler32:4c3c3ab9",
         "description": "ZJetToEE_Pt-30to50_TuneEE3C_8TeV_herwigpp AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 193,
         "type": "index.txt",
@@ -33192,14 +33192,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:33b4dd40795cde243a69de824ee6203fb9e08722",
+        "checksum": "adler32:e21b1f8d",
         "description": "ZJetToEE_Pt-80to120_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 4761,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToEE_Pt-80to120_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToEE_Pt-80to120_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:9f9fe4029e30de28b7663062db1fcb9703c27234",
+        "checksum": "adler32:9b5a3ae9",
         "description": "ZJetToEE_Pt-80to120_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2702,
         "type": "index.txt",
@@ -33304,28 +33304,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:f6fb475783ad3ddda1c10f67870a0ba82a88eabd",
+        "checksum": "adler32:026659df",
         "description": "ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 120702,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:c04f3b70d7f01d5bab865190262bb8b3423ced3a",
+        "checksum": "adler32:76fe2503",
         "description": "ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 77861,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:6420ee27635e182d2487950a2acc3cb2bfcdb8bd",
+        "checksum": "adler32:db2297a5",
         "description": "ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 68515,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:4565613fb9034be9b2b23a052153785daf7209a1",
+        "checksum": "adler32:16674ed5",
         "description": "ZJetToMuMu_Pt-0to15_TuneEE3C_8TeV_herwigpp AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 44197,
         "type": "index.txt",
@@ -33430,14 +33430,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:e834de8315fc47296bb6433b2602df670548f6aa",
+        "checksum": "adler32:4d3e8905",
         "description": "ZJetToMuMu_Pt-120to170_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5145,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToMuMu_Pt-120to170_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToMuMu_Pt-120to170_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:1cd674f9a812251dc8adbf20684c4d7a77d3029a",
+        "checksum": "adler32:af1985ad",
         "description": "ZJetToMuMu_Pt-120to170_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2940,
         "type": "index.txt",
@@ -33542,28 +33542,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3a08bb02ef905400396b320d33e07229722716aa",
+        "checksum": "adler32:a285fab4",
         "description": "ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 6480,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:60c5652dbd2425cf5c59c183ed2a8dbe53736fce",
+        "checksum": "adler32:05175f3a",
         "description": "ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 343,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_110000_file_index.json"
       },
       {
-        "checksum": "sha1:0e1cfe1893bc576fb7dff9aa8fe87482a6e2be89",
+        "checksum": "adler32:de056e0d",
         "description": "ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 3686,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:19f358553c072fb3824f9bfc64b54158f7ab5ca3",
+        "checksum": "adler32:03c03c36",
         "description": "ZJetToMuMu_Pt-15to20_TuneEE3C_8TeV_herwigpp AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 195,
         "type": "index.txt",
@@ -33668,14 +33668,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0b4502fb92927c98e1583bfa348a3702f21ff8ee",
+        "checksum": "adler32:2e6b893c",
         "description": "ZJetToMuMu_Pt-170to230_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5146,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToMuMu_Pt-170to230_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToMuMu_Pt-170to230_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:cc5ef9e374bc71ed2a6507f63c70afc2f6db5d6d",
+        "checksum": "adler32:4402867e",
         "description": "ZJetToMuMu_Pt-170to230_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2940,
         "type": "index.txt",
@@ -33780,14 +33780,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:96b99f4fc18be11bbcb0c561f892787e538c7866",
+        "checksum": "adler32:f48ee6b8",
         "description": "ZJetToMuMu_Pt-230to300_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5489,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToMuMu_Pt-230to300_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToMuMu_Pt-230to300_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:d00e94f283cbb7454390ebfb371b86e9491d517a",
+        "checksum": "adler32:791fc16d",
         "description": "ZJetToMuMu_Pt-230to300_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3136,
         "type": "index.txt",
@@ -33892,14 +33892,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:98b7cde68f8fcfe44c7b559e240fae94da1ccf16",
+        "checksum": "adler32:c11f71bc",
         "description": "ZJetToMuMu_Pt-300_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5070,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToMuMu_Pt-300_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToMuMu_Pt-300_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:9a6bb9e7f5c73111621416372318306230732ff4",
+        "checksum": "adler32:a0c76e7a",
         "description": "ZJetToMuMu_Pt-300_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 2865,
         "type": "index.txt",
@@ -34004,14 +34004,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:408af4913889a61dbd3dff768357047e2c0494c0",
+        "checksum": "adler32:c9f05b81",
         "description": "ZJetToMuMu_Pt-30to50_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 6820,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToMuMu_Pt-30to50_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToMuMu_Pt-30to50_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:3208eb2f0412722e29ca84cdc9c6612f0f3a7e68",
+        "checksum": "adler32:21afabb4",
         "description": "ZJetToMuMu_Pt-30to50_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3880,
         "type": "index.txt",
@@ -34116,14 +34116,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:79d87964edb160d76d299b3ac144f9f4418b3e8e",
+        "checksum": "adler32:d93de471",
         "description": "ZJetToMuMu_Pt-80to120_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5474,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZJetToMuMu_Pt-80to120_TuneEE3C_8TeV_herwigpp/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZJetToMuMu_Pt-80to120_TuneEE3C_8TeV_herwigpp_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:6b366d281da73eab3a76c165c1cf410683bb5430",
+        "checksum": "adler32:a07bbe22",
         "description": "ZJetToMuMu_Pt-80to120_TuneEE3C_8TeV_herwigpp AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 3120,
         "type": "index.txt",
@@ -34228,28 +34228,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ba82d5fcebcc91dea295e2eda6714808447a36fb",
+        "checksum": "adler32:aa53e45d",
         "description": "ZVBF_Mqq-120_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 69014,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZVBF_Mqq-120_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZVBF_Mqq-120_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:c7b680a0fc7536ba823ef0b670ff89da84e8974d",
+        "checksum": "adler32:d78dc8d5",
         "description": "ZVBF_Mqq-120_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 28189,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZVBF_Mqq-120_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZVBF_Mqq-120_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:99436dad83a2a17694b56a5d8013a2ed54653889",
+        "checksum": "adler32:033c5767",
         "description": "ZVBF_Mqq-120_8TeV-madgraph AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 37701,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZVBF_Mqq-120_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZVBF_Mqq-120_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_00000_file_index.txt"
       },
       {
-        "checksum": "sha1:147d0cb9b161fd4783f5ea3fda51c8294173d5e4",
+        "checksum": "adler32:ccaf1e48",
         "description": "ZVBF_Mqq-120_8TeV-madgraph AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 15399,
         "type": "index.txt",
@@ -34354,14 +34354,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:81800e140d65c5c5f6a64b508a7f4791a39ec760",
+        "checksum": "adler32:19c1707e",
         "description": "ZVBF_Mqq-120_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 103682,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZVBF_Mqq-120_8TeV-madgraph/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZVBF_Mqq-120_8TeV-madgraph_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:ed49558eea3b8581e2357dcf9948fac6cc6e1a45",
+        "checksum": "adler32:37bf74b3",
         "description": "ZVBF_Mqq-120_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 56640,
         "type": "index.txt",
@@ -34466,28 +34466,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5bbd0b26778f02999ca976bbc1d4070ae981d48f",
+        "checksum": "adler32:99cfe48c",
         "description": "ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 67081,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:181fea6150ca223d6f522a4907b438a8e25d78f7",
+        "checksum": "adler32:3bab1e8b",
         "description": "ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 62609,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:22dc23ac53da14e7dc64b508670990e33086c25f",
+        "checksum": "adler32:a463ae92",
         "description": "ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 38415,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:2c9a5d8f8b60481a10aa1591a619b2f1b6109b79",
+        "checksum": "adler32:8d52a41a",
         "description": "ZZTo2e2mu_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 35854,
         "type": "index.txt",
@@ -34592,14 +34592,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6433b953acf19d7084cc3d7128f83aa6c2646698",
+        "checksum": "adler32:8c147c59",
         "description": "ZZTo2e2mu_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 52649,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2e2mu_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2e2mu_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v2_10000_file_index.json"
       },
       {
-        "checksum": "sha1:b6d25d9035fae30bdb3db897993c1fddbc2a12eb",
+        "checksum": "adler32:5629c96c",
         "description": "ZZTo2e2mu_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 28980,
         "type": "index.txt",
@@ -34704,14 +34704,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:06a38d6cb4f7053d121d5ad5f3ff2dc8d9270fcc",
+        "checksum": "adler32:8d75885a",
         "description": "ZZTo2e2muJJ_Contin_8TeV-phantom-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 68076,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2e2muJJ_Contin_8TeV-phantom-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2e2muJJ_Contin_8TeV-phantom-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:7252b302e47df85314a6a3d5377515dc7f1e8cbb",
+        "checksum": "adler32:d7d26511",
         "description": "ZZTo2e2muJJ_Contin_8TeV-phantom-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 38380,
         "type": "index.txt",
@@ -34816,14 +34816,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:a6abbb421b5340fc644d1aaf4d7a9743bd36c5ee",
+        "checksum": "adler32:6bebeedc",
         "description": "ZZTo2e2muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 86377,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2e2muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2e2muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:2c45e3f4a3cba8cab13f4fafbf2e552f87b97e05",
+        "checksum": "adler32:c6fe2e0e",
         "description": "ZZTo2e2muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 50508,
         "type": "index.txt",
@@ -34928,28 +34928,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c97ef418700ec8f610ef17131fe349ca80230273",
+        "checksum": "adler32:3d7c733e",
         "description": "ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 39677,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:8971666f205fcb314585f6c882fbca81a228f663",
+        "checksum": "adler32:f3d84770",
         "description": "ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 75901,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:64d993a18b231393156f804a266a957b582f4f10",
+        "checksum": "adler32:5f3a126f",
         "description": "ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 22770,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:0651fbe3b9500f4ea1692bc9ccd3dfafd1f9df4e",
+        "checksum": "adler32:9a26ce6d",
         "description": "ZZTo2e2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 43560,
         "type": "index.txt",
@@ -35054,14 +35054,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:5b938555f42a9435ec486e08a94c19eeac75ddf0",
+        "checksum": "adler32:1af012dc",
         "description": "ZZTo2e2tau_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 23289,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2e2tau_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2e2tau_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:29d277eb8e874dbd5640f9c3802ef2b579bbfc8e",
+        "checksum": "adler32:cc2378e9",
         "description": "ZZTo2e2tau_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 12851,
         "type": "index.txt",
@@ -35166,28 +35166,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:522b5a1b5993ec06b5e88fd4602623dc3081183a",
+        "checksum": "adler32:0c7450fa",
         "description": "ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 70931,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:201dd63fad22e76f3dc66f02a78b81b113695d66",
+        "checksum": "adler32:c2d402cf",
         "description": "ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 62281,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:6487dba2b89f61e98da467a36550454e94703183",
+        "checksum": "adler32:0879c247",
         "description": "ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 40795,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:22a8836d7e8074736d0d1f07d83eb01aadad5d36",
+        "checksum": "adler32:40bad241",
         "description": "ZZTo2mu2tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 35820,
         "type": "index.txt",
@@ -35292,14 +35292,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:70e5eac85819b308e5c6458e57df78644aee09ff",
+        "checksum": "adler32:f3f3b5d4",
         "description": "ZZTo2mu2tau_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 26651,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo2mu2tau_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo2mu2tau_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:952ebd4b263f0f390381859fba1986668150135f",
+        "checksum": "adler32:6a32c8a6",
         "description": "ZZTo2mu2tau_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 14742,
         "type": "index.txt",
@@ -35404,28 +35404,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:17f14c4e9a4d18528888ba203eae67cc62a0b087",
+        "checksum": "adler32:f4ddf922",
         "description": "ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 69225,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:2d87d7a0b2bcaf8a88ef7decdb91a0c9bf9ced56",
+        "checksum": "adler32:ba9ed32b",
         "description": "ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 5458,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:3ad304b9a76acbf521abe6f3a331fb31e9c1145c",
+        "checksum": "adler32:e2cdb141",
         "description": "ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 39382,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:4ba8fa0029b55c82e9caf8a2ff3ed1fc004764f7",
+        "checksum": "adler32:8ad4acf6",
         "description": "ZZTo4e_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 3104,
         "type": "index.txt",
@@ -35530,14 +35530,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:aa1622f954a893646570a702063e62cf6fd07c85",
+        "checksum": "adler32:da2288cd",
         "description": "ZZTo4e_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 46333,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4e_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v2/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4e_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v2_20000_file_index.json"
       },
       {
-        "checksum": "sha1:412697b8350fec2b53f8cf44c9705790756da74a",
+        "checksum": "adler32:a4cd4856",
         "description": "ZZTo4e_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 25311,
         "type": "index.txt",
@@ -35642,14 +35642,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:bef33b6ec287f5258facf4f7ca4049d89e6a714b",
+        "checksum": "adler32:908c2656",
         "description": "ZZTo4eJJ_Contin_8TeV-phantom-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 35405,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4eJJ_Contin_8TeV-phantom-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4eJJ_Contin_8TeV-phantom-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:90267a518e81ae086fdfc25b4a552a4d2fe1044c",
+        "checksum": "adler32:f745e8f6",
         "description": "ZZTo4eJJ_Contin_8TeV-phantom-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 19822,
         "type": "index.txt",
@@ -35754,14 +35754,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:c8cc675fdfcaa0b6c7ce69edae36d52164b0b997",
+        "checksum": "adler32:3b8233bc",
         "description": "ZZTo4eJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 40716,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4eJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4eJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:7b86e4a6a900081b220c11bd79cafcb7e788bc5c",
+        "checksum": "adler32:4b319c6d",
         "description": "ZZTo4eJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 23664,
         "type": "index.txt",
@@ -35866,28 +35866,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7d4cae563bc3844ea13a0dd9a40d327d490a3c32",
+        "checksum": "adler32:c7871c57",
         "description": "ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 84133,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:f27128776fe8d63801f8424e4a45803e88349c56",
+        "checksum": "adler32:ce5aca49",
         "description": "ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 8209,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:2a7bdb5ef32382e42cc023d547d11af0909eb27f",
+        "checksum": "adler32:86d80f23",
         "description": "ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 47970,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:34ea90849af141dbb5c87bd0e798a977706e15d5",
+        "checksum": "adler32:ef0491ba",
         "description": "ZZTo4mu_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 4680,
         "type": "index.txt",
@@ -35992,14 +35992,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eb90933c146939698579545a8ef77867216c603a",
+        "checksum": "adler32:7510a428",
         "description": "ZZTo4mu_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 49077,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4mu_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4mu_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:dc387cd6a918c68e3ca4b1d129f52ef59b32feb2",
+        "checksum": "adler32:aaa747d5",
         "description": "ZZTo4mu_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 26878,
         "type": "index.txt",
@@ -36104,14 +36104,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d4f093df673c43f75fb2f36f0fc258670629c7b6",
+        "checksum": "adler32:6a4859c5",
         "description": "ZZTo4muJJ_Contin_8TeV-phantom-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 39196,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4muJJ_Contin_8TeV-phantom-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4muJJ_Contin_8TeV-phantom-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:d458bfbbe6804d68a6046fd242aa8337f5d71398",
+        "checksum": "adler32:77e79d66",
         "description": "ZZTo4muJJ_Contin_8TeV-phantom-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 21996,
         "type": "index.txt",
@@ -36216,14 +36216,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:eb2a7e0280f747bf0cb0888b6b08ea9221d073ed",
+        "checksum": "adler32:ecc175a4",
         "description": "ZZTo4muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 45409,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6_AODSIM_PU_S10_START53_V19-v1_00000_file_index.json"
       },
       {
-        "checksum": "sha1:39ca1201e5f1d751051c768eb095573f6b537d95",
+        "checksum": "adler32:06351b4d",
         "description": "ZZTo4muJJ_SMHContinInterf_M-125p6_8TeV-phantom-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 26445,
         "type": "index.txt",
@@ -36328,28 +36328,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dcce7076b0d8ea667fda7a9d65ec1c8465f35c3c",
+        "checksum": "adler32:58ca80bd",
         "description": "ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 24697,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.json"
       },
       {
-        "checksum": "sha1:88f02f363fe2dce6e3666ca2799e03a719dc5d9c",
+        "checksum": "adler32:92360257",
         "description": "ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 42875,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:40c14f08724697dbcf3ab78094e55f4dbc0046d7",
+        "checksum": "adler32:c364d2fe",
         "description": "ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (1 of 2) for access to data via CMS virtual machine",
         "size": 14112,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6/AODSIM/PU_S10_START53_V19-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6_AODSIM_PU_S10_START53_V19-v1_10000_file_index.txt"
       },
       {
-        "checksum": "sha1:bcf3d4e37c6c7a5b2ac78a4c39042c7fbabc2497",
+        "checksum": "adler32:a00735b3",
         "description": "ZZTo4tau_8TeV_mll8_mZZ95-160-powheg15-pythia6 AOD dataset file index (2 of 2) for access to data via CMS virtual machine",
         "size": 24500,
         "type": "index.txt",
@@ -36454,14 +36454,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b9b3889eca762462db351b4502490dbccfae3d9b",
+        "checksum": "adler32:1100cee5",
         "description": "ZZTo4tau_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 27711,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZTo4tau_8TeV-powheg-pythia6/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZTo4tau_8TeV-powheg-pythia6_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:354c9fae22c5befd2e4d0be41a0927d328658300",
+        "checksum": "adler32:824455ca",
         "description": "ZZTo4tau_8TeV-powheg-pythia6 AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 15215,
         "type": "index.txt",
@@ -36563,14 +36563,14 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0ee9379c7e1f034ffaf69795cda19c05b78137d8",
+        "checksum": "adler32:8ae38b0d",
         "description": "ZZZNoGstarJets_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 10758,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2012/Summer12_DR53X/ZZZNoGstarJets_8TeV-madgraph/AODSIM/PU_RD1_START53_V7N-v1/file-indexes/CMS_MonteCarlo2012_Summer12_DR53X_ZZZNoGstarJets_8TeV-madgraph_AODSIM_PU_RD1_START53_V7N-v1_20000_file_index.json"
       },
       {
-        "checksum": "sha1:d366e154990e00f017eb3f53106f59c2bd14e2b5",
+        "checksum": "adler32:312e1da5",
         "description": "ZZZNoGstarJets_8TeV-madgraph AOD dataset file index (1 of 1) for access to data via CMS virtual machine",
         "size": 5907,
         "type": "index.txt",

--- a/cernopendata/modules/fixtures/data/records/cms-tools-ana.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-ana.json
@@ -27,7 +27,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:d4b2d789b502e90316cefe5dc8c46ac6b5f75255",
+        "checksum": "adler32:e7278f6b",
         "size": 110612,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/ayrodrig-pattuples2010/pattuples2012-1.0.2.tar.gz"
       }
@@ -130,17 +130,17 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:aba0f2395762cbd2d57712bd4ba4ce7f28ebb3c0",
+        "checksum": "adler32:2f17d889",
         "size": 21107,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/ayrodrig-OutreachExercise2010/OutreachExercise2010-1.0.0.tar.gz"
       },
       {
-        "checksum": "sha1:65610ba2dd6319f4571bce3db301f5651b612816",
+        "checksum": "adler32:59ac1f6e",
         "size": 44709,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/ayrodrig-OutreachExercise2010/OutreachExercise2010-massZ.png"
       },
       {
-        "checksum": "sha1:c376cd91f3ed94ee5142b17a58bd5aad0290a31b",
+        "checksum": "adler32:c5124011",
         "size": 50465,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/ayrodrig-OutreachExercise2010/OutreachExercise2010-massZZ.png"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-filter.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-filter.json
@@ -27,7 +27,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:86fec3767750ed038257cbff4d3b51b6a07e5b59",
+        "checksum": "adler32:baa56ba5",
         "size": 52792,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/SUSYBSMAnalysis-RazorFilter/SUSYBSMAnalysis-RazorFilter-1.0.0.tar.gz"
       }
@@ -110,7 +110,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:ba925025b812392abe2aa716f681e6f9582f5d08",
+        "checksum": "adler32:dc24f38d",
         "size": 52754,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-filter/dimuon-filter-1.0.0.tar.gz"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-spectrum-2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-dimuon-spectrum-2010.json
@@ -37,22 +37,22 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:cf95f881471657d5807905291705f28e6e03c29e",
+        "checksum": "adler32:a73671b8",
         "size": 342,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-spectrum-2010/BuildFile.xml"
       },
       {
-        "checksum": "sha1:eabdd35487945176f65b3b3f69c8ebfdb1dbf215",
+        "checksum": "adler32:327d8f5d",
         "size": 14689,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-spectrum-2010/DemoAnalyzer.cc"
       },
       {
-        "checksum": "sha1:8e6b39334d50d06713cdd396df119024a7663997",
+        "checksum": "adler32:4142e77c",
         "size": 3525,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-spectrum-2010/demoanalyzer_cfg.py"
       },
       {
-        "checksum": "sha1:30e5d594bd2e341f9c998ce5a311328c3d2b2673",
+        "checksum": "adler32:8d4a98cf",
         "size": 14935,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/dimuon-spectrum-2010/Mudemo.root"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-tools-reco.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-reco.json
@@ -28,7 +28,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:5d7ec38e",
         "size": 14566,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/2011-minimumbias-raw-recotest/2011-minimumbias-raw-recotest-1.0.0.tar.gz"
       }
@@ -97,7 +97,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:714143c5",
         "size": 17076,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/2011-minimumbias-compare-rereco/2011-minimumbias-compare-rereco-1.0.0.tar.gz"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image-Run2011A.json
@@ -31,7 +31,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7ea617ce250cb3794c6e3b57a0eff38c15fa5938",
+        "checksum": "adler32:d4cf2672",
         "size": 18145280,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2011/CMS-Open-Data-1.2.0.ova"
       },
@@ -110,18 +110,18 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:36392732a8f4b391ff2dab0e00cbbcbb8f778be7",
-        "size": 182,
+        "checksum": "adler32:e3d73b04",
+        "size": 184,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2011/cernvm-script"
       },
       {
-        "checksum": "sha1:63c718d5106c3a4a1482d46f37f7ef2db21f7f0f",
-        "size": 3756,
+        "checksum": "adler32:9756d2a4",
+        "size": 2993,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2011/cms-user-data.txt"
       },
       {
-        "checksum": "sha1:3248e8702168d4f3389eee14e31df330e27089ac",
-        "size": 153,
+        "checksum": "adler32:786f33c7",
+        "size": 152,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2011/opendata-desktop-settings"
       }
     ],

--- a/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-vm-image.json
@@ -107,17 +107,17 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:36392732a8f4b391ff2dab0e00cbbcbb8f778be7",
+        "checksum": "adler32:90033a83",
         "size": 182,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/cernvm-script"
       },
       {
-        "checksum": "sha1:63c718d5106c3a4a1482d46f37f7ef2db21f7f0f",
+        "checksum": "adler32:de139229",
         "size": 3756,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/cms-user-data.txt"
       },
       {
-        "checksum": "sha1:3248e8702168d4f3389eee14e31df330e27089ac",
+        "checksum": "adler32:ac4033d1",
         "size": 153,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/environment/2010/opendata-desktop-settings"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-trigger-examples.json
+++ b/cernopendata/modules/fixtures/data/records/cms-trigger-examples.json
@@ -27,7 +27,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3164b6530e1a90fecbe0d742baec61114555b378",
+        "checksum": "adler32:77c62edf",
         "size": 8759,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/trigger_examples/trigger_examples-10.0.0.tar.gz"
       }
@@ -87,7 +87,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:6ebac43316112666a9a3eac8a44f4f43b6d9c638",
+        "checksum": "adler32:c731af2f",
         "size": 9102,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/trigger_examples/trigger_examples-11.0.0.tar.gz"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-validated-runs-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validated-runs-Run2012B.json
@@ -25,7 +25,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:b24efcfb1050b083aff2390df01fc16d6b67b836",
+        "checksum": "adler32:a8fd4964",
         "size": 36630,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/2012/Cert_190456-208686_8TeV_22Jan2013ReReco_Collisions12_JSON.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-validated-runs.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validated-runs.json
@@ -25,7 +25,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0eefeb12a61efb2faeeb2a3e7b8fb387556a8350",
+        "checksum": "adler32:b829579f",
         "size": 8873,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/2010/Cert_136033-149442_7TeV_Apr21ReReco_Collisions10_JSON_v2.txt"
       }
@@ -90,7 +90,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:dd2122be57d2c5ad297283820d66b2313de95f64",
+        "checksum": "adler32:468809e3",
         "size": 19347,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/2011/Cert_160404-180252_7TeV_ReRecoNov08_Collisions11_JSON.txt"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-validation-code-Run2010B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validation-code-Run2010B.json
@@ -39,67 +39,67 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3db193e02aaf2353702962f3988afe8b8461ae7d",
+        "checksum": "adler32:ea0004f2",
         "size": 3161,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/readme.txt"
       },
       {
-        "checksum": "sha1:cf95f881471657d5807905291705f28e6e03c29e",
+        "checksum": "adler32:a73671b8",
         "size": 342,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/BuildFile.xml"
       },
       {
-        "checksum": "sha1:eabdd35487945176f65b3b3f69c8ebfdb1dbf215",
+        "checksum": "adler32:92fbffdf",
         "size": 29227,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/DemoAnalyzer.cc"
       },
       {
-        "checksum": "sha1:8e6b39334d50d06713cdd396df119024a7663997",
+        "checksum": "adler32:2131e4d1",
         "size": 5088,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/demoanalyzer_cfg.py"
       },
       {
-        "checksum": "sha1:cd71a4adf5d271c3ac525b59cc84ed3c60f8d6f5",
+        "checksum": "adler32:4e45be4e",
         "size": 6520,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/mergeMu.C"
       },
       {
-        "checksum": "sha1:3485a7f4bbe931354c8597988359c2daec66eae1",
+        "checksum": "adler32:00841505",
         "size": 27652,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/Mu00val.root"
       },
       {
-        "checksum": "sha1:283c10eb8401553cbebfa94b5266c237f4e88521",
+        "checksum": "adler32:1645e88f",
         "size": 24866,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/Mu01val.root"
       },
       {
-        "checksum": "sha1:b4575eba4c16efd2f18fbf8db878086134956023",
+        "checksum": "adler32:1ca25b36",
         "size": 24974,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/Mu02val.root"
       },
       {
-        "checksum": "sha1:46bcff4375ae31003f5476c99b1f12f1bade9dfa",
+        "checksum": "adler32:028d0b90",
         "size": 27294,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/Mu03val.root"
       },
       {
-        "checksum": "sha1:1933ba8f87feb256cda768d5b7a99c5021edcfcc",
+        "checksum": "adler32:c6655993",
         "size": 23793,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/Mu04val.root"
       },
       {
-        "checksum": "sha1:87e04662bf4a3c0c0c38b4ada4f9de33998a28c7",
+        "checksum": "adler32:8cd425f3",
         "size": 24515,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/Mu05val.root"
       },
       {
-        "checksum": "sha1:0c291100eb91e4ed7b4acd3546c9daad95570a0d",
+        "checksum": "adler32:046b1d11",
         "size": 30798,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/MuAllval.root"
       },
       {
-        "checksum": "sha1:dde185fa7692a427a5ae6c3999aa534c1ed4e61d",
+        "checksum": "adler32:2389ca71",
         "size": 27277,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Mu/MuMonitorval.root"
       }
@@ -187,52 +187,52 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3db193e02aaf2353702962f3988afe8b8461ae7d",
+        "checksum": "adler32:81b8daee",
         "size": 2971,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/readme.txt"
       },
       {
-        "checksum": "sha1:cf95f881471657d5807905291705f28e6e03c29e",
+        "checksum": "adler32:a73671b8",
         "size": 342,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/BuildFile.xml"
       },
       {
-        "checksum": "sha1:eabdd35487945176f65b3b3f69c8ebfdb1dbf215",
+        "checksum": "adler32:ddee34c1",
         "size": 29410,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/DemoAnalyzer.cc"
       },
       {
-        "checksum": "sha1:8e6b39334d50d06713cdd396df119024a7663997",
+        "checksum": "adler32:539d0cc0",
         "size": 5228,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/demoanalyzer_cfg.py"
       },
       {
-        "checksum": "sha1:4fe00dda18d5d38d87d57c983554faf824e0aa74",
+        "checksum": "adler32:8b97bd22",
         "size": 6492,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/mergeCommissioning.C"
       },
       {
-        "checksum": "sha1:ca8005c0a8be7797165a7e5583f83596f854e453",
+        "checksum": "adler32:a7e287a8",
         "size": 27352,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/Commissioning00val.root"
       },
       {
-        "checksum": "sha1:ed0fb21a65999b3b2bbca2d8c289fecc7a970471",
+        "checksum": "adler32:c75948be",
         "size": 13126,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/Commissioning02val.root"
       },
       {
-        "checksum": "sha1:0d7044e5b5bbe4d9821da24b3676b0dfcfcb850a",
+        "checksum": "adler32:6f3f2710",
         "size": 17156,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/Commissioning03val.root"
       },
       {
-        "checksum": "sha1:9f58835feedc78e82f40e56f1679b07de021fb6b",
+        "checksum": "adler32:e1db35ec",
         "size": 14857,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/Commissioning04val.root"
       },
       {
-        "checksum": "sha1:3eb21dfdfdecbba56a1a6f169289e2cec76eba84",
+        "checksum": "adler32:2bb3b196",
         "size": 29766,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-Commissioning/CommissioningAllval.root"
       }
@@ -317,67 +317,67 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:3db193e02aaf2353702962f3988afe8b8461ae7d",
+        "checksum": "adler32:c3cdd0e2",
         "size": 2980,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/readme.txt"
       },
       {
-        "checksum": "sha1:cf95f881471657d5807905291705f28e6e03c29e",
+        "checksum": "adler32:a73671b8",
         "size": 342,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/BuildFile.xml"
       },
       {
-        "checksum": "sha1:eabdd35487945176f65b3b3f69c8ebfdb1dbf215",
+        "checksum": "adler32:f7566bc6",
         "size": 35250,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/DemoAnalyzer.cc"
       },
       {
-        "checksum": "sha1:8e6b39334d50d06713cdd396df119024a7663997",
+        "checksum": "adler32:102ee6a5",
         "size": 5093,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/demoanalyzer_cfg.py"
       },
       {
-        "checksum": "sha1:de37b52c5803e4435f9f3db22560c07c2917d461",
+        "checksum": "adler32:0a7edda7",
         "size": 6612,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/mergeMinBias.C"
       },
       {
-        "checksum": "sha1:4e7d5590c7e5538a35f95c1950a3b9c19b35152d",
+        "checksum": "adler32:a20839f6",
         "size": 39167,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias00val.root"
       },
       {
-        "checksum": "sha1:048cb2d27a5d7599acd0efe597f93d817651a53e",
+        "checksum": "adler32:0d7acbc3",
         "size": 32569,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias01val.root"
       },
       {
-        "checksum": "sha1:797f93b85c9b2d927a2b26a9d47084be0abf7a44",
+        "checksum": "adler32:361ed3c8",
         "size": 33286,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias02val.root"
       },
       {
-        "checksum": "sha1:f72690821f3d3bc50d73a6fbd2cf7cd153e55ac9",
+        "checksum": "adler32:e263d283",
         "size": 27977,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias03val.root"
       },
       {
-        "checksum": "sha1:8d045ce9a30b98a90d462f375f02e7e19c43affa",
+        "checksum": "adler32:8a9d38d9",
         "size": 34695,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias04val.root"
       },
       {
-        "checksum": "sha1:7855abac09eef94a9123b72cc2518a9bb5ae9554",
+        "checksum": "adler32:bb57e44a",
         "size": 31223,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias05val.root"
       },
       {
-        "checksum": "sha1:967938d36e456272babfd5ead74b676531c25f7a",
+        "checksum": "adler32:9991f3e6",
         "size": 31683,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBias06val.root"
       },
       {
-        "checksum": "sha1:bb817cde1b7244702f88fb9959272714767686a4",
+        "checksum": "adler32:a4643622",
         "size": 41131,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/validation-2010-MinimumBias/MinBiasAllval.root"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-validation-code-jet-tuple.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validation-code-jet-tuple.json
@@ -30,7 +30,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:1361f245ac6f9e909ff530c75a5db0e2ef84a348",
+        "checksum": "adler32:88a9a20d",
         "size": 16966,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/2011-jet-inclusivecrosssection-ntupleproduction-optimized/2011-jet-inclusivecrosssection-ntupleproduction-optimized-1.0.0.tar.gz"
       }

--- a/cernopendata/modules/fixtures/data/records/cms-validation-code-ttbar.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validation-code-ttbar.json
@@ -27,7 +27,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:82c1d9bc3204ee8d106acab68d1aa56a1bc3e4fb",
+        "checksum": "adler32:d919df9e",
         "size": 1288913,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/2011-doubleelectron-doublemu-mueg-ttbar/2011-doubleelectron-doublemu-mueg-ttbar-1.0.0.tar.gz"
       }

--- a/cernopendata/modules/fixtures/data/records/data-policies.json
+++ b/cernopendata/modules/fixtures/data/records/data-policies.json
@@ -26,7 +26,7 @@
     "experiment": "LHCb",
     "files": [
       {
-        "checksum": "sha1:5e48e8042c8edc2f828770b41e21562b5570d689",
+        "checksum": "adler32:303cbf52",
         "size": 254288,
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/documentation/LHCb-Data-Policy.pdf"
       }
@@ -69,7 +69,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0f0a2a6d8d1c0dc29e65f75a1d709d458e345cfb",
+        "checksum": "adler32:3b6a8a76",
         "size": 79005,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/CMS-Data-Policy.pdf"
       }
@@ -119,7 +119,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7d6888b9",
+        "checksum": "adler32:7d6888b9",
         "size": 95934,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/CMS-Data-Policy-1.2.pdf"
       }
@@ -161,7 +161,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:e08357793eb426d68c44b87e11adc77893f73ac0",
+        "checksum": "adler32:8a23eff8",
         "size": 480778,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/documentation/ALICE-Data-Policy.pdf"
       }
@@ -203,7 +203,7 @@
     "experiment": "ATLAS",
     "files": [
       {
-        "checksum": "sha1:0b34414d395228d6ae12834f0a0c5f5fd8dd4ce1",
+        "checksum": "adler32:3a659c7f",
         "size": 345466,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/documentation/ATLAS-Data-Policy.pdf"
       }

--- a/cernopendata/modules/fixtures/data/records/lhcb-antimatter-matters-2017.json
+++ b/cernopendata/modules/fixtures/data/records/lhcb-antimatter-matters-2017.json
@@ -28,17 +28,17 @@
     "experiment": "LHCb",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:b25f68bf",
         "size": 666484974,
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/AntimatterMatters2017/data/B2HHH_MagnetDown.root"
       },
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:0568274c",
         "size": 444723234,
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/AntimatterMatters2017/data/B2HHH_MagnetUp.root"
       },
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:0207f71f",
         "size": 2272072,
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/AntimatterMatters2017/data/PhaseSpaceSimulation.root"
       }
@@ -103,7 +103,7 @@
     "experiment": "LHCb",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:88b9f48e",
         "size": 496943,
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/AntimatterMatters2017/documentation/Matter-Antimatter_Instructions_LHCb.pdf"
       }
@@ -153,7 +153,7 @@
     "experiment": "LHCb",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:95384d65",
         "size": 5204130,
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/AntimatterMatters2017/software/opendata-project-1.0.tar.gz"
       }


### PR DESCRIPTION
* Verifies all CMS file sizes and sets file checksums to Adler32.
  (closes #2528)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>