### PR TITLE
records: LHCb file sizes and checksums

### DIFF
--- a/cernopendata/modules/fixtures/data/records/alice-analysis-modules.json
+++ b/cernopendata/modules/fixtures/data/records/alice-analysis-modules.json
@@ -18,7 +18,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:1c06f1e5",
         "size": 2086046,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/PtAnalysis.tgz"
       }
@@ -61,7 +61,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:49beca01",
         "size": 31139203,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/alice-mc.tgz"
       }
@@ -107,7 +107,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:154c512a",
         "size": 15469921,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/alice-raa.tgz"
       }
@@ -150,7 +150,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:695acd4e",
         "size": 42540,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/modules/bootstrap.tgz"
       }

--- a/cernopendata/modules/fixtures/data/records/alice-learning-resources.json
+++ b/cernopendata/modules/fixtures/data/records/alice-learning-resources.json
@@ -19,7 +19,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:2a6d0a372b14f4bccf62b5a658d66c3a591915d4",
+        "checksum": "adler32:9c33e07f",
         "size": 403277,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/documentation/1103106_20-A4-at-144-dpi.jpg"
       }

--- a/cernopendata/modules/fixtures/data/records/atlas-higgs-challenge-2014.json
+++ b/cernopendata/modules/fixtures/data/records/atlas-higgs-challenge-2014.json
@@ -165,7 +165,7 @@
     "experiment": "ATLAS",
     "files": [
       {
-        "checksum": "sha1:639b1dbd97a709a739122a9a5dcd99b49d55d86c",
+        "checksum": "adler32:e4717bbe",
         "size": 65630848,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/higgs-challenge-2014/atlas-higgs-challenge-2014-v2.csv.gz"
       }
@@ -248,7 +248,7 @@
     "experiment": "ATLAS",
     "files": [
       {
-        "checksum": "sha1:91d16d6e44f837083f93513d42221c71c39e81a9",
+        "checksum": "adler32:da03684c",
         "size": 381738,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/higgs-challenge-2014/atlas-higgs-challenge-2014.pdf"
       }
@@ -344,7 +344,7 @@
     "experiment": "ATLAS",
     "files": [
       {
-        "checksum": "sha1:29dbd473108a291e354b9913027714ca163e2686",
+        "checksum": "adler32:616d2faf",
         "size": 24467,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/higgs-challenge-2014/HiggsML2014-1.0.tar.gz"
       }

--- a/cernopendata/modules/fixtures/data/records/data-policies.json
+++ b/cernopendata/modules/fixtures/data/records/data-policies.json
@@ -26,7 +26,7 @@
     "experiment": "LHCb",
     "files": [
       {
-        "checksum": "sha1:5e48e8042c8edc2f828770b41e21562b5570d689",
+        "checksum": "adler32:303cbf52",
         "size": 254288,
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/documentation/LHCb-Data-Policy.pdf"
       }
@@ -69,7 +69,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:0f0a2a6d8d1c0dc29e65f75a1d709d458e345cfb",
+        "checksum": "adler32:3b6a8a76",
         "size": 79005,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/CMS-Data-Policy.pdf"
       }
@@ -119,7 +119,7 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "sha1:7d6888b9",
+        "checksum": "adler32:7d6888b9",
         "size": 95934,
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/documentation/CMS-Data-Policy-1.2.pdf"
       }
@@ -161,7 +161,7 @@
     "experiment": "ALICE",
     "files": [
       {
-        "checksum": "sha1:e08357793eb426d68c44b87e11adc77893f73ac0",
+        "checksum": "adler32:8a23eff8",
         "size": 480778,
         "uri": "root://eospublic.cern.ch//eos/opendata/alice/documentation/ALICE-Data-Policy.pdf"
       }
@@ -203,7 +203,7 @@
     "experiment": "ATLAS",
     "files": [
       {
-        "checksum": "sha1:0b34414d395228d6ae12834f0a0c5f5fd8dd4ce1",
+        "checksum": "adler32:3a659c7f",
         "size": 345466,
         "uri": "root://eospublic.cern.ch//eos/opendata/atlas/documentation/ATLAS-Data-Policy.pdf"
       }

--- a/cernopendata/modules/fixtures/data/records/lhcb-antimatter-matters-2017.json
+++ b/cernopendata/modules/fixtures/data/records/lhcb-antimatter-matters-2017.json
@@ -28,17 +28,17 @@
     "experiment": "LHCb",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:b25f68bf",
         "size": 666484974,
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/AntimatterMatters2017/data/B2HHH_MagnetDown.root"
       },
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:0568274c",
         "size": 444723234,
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/AntimatterMatters2017/data/B2HHH_MagnetUp.root"
       },
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:0207f71f",
         "size": 2272072,
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/AntimatterMatters2017/data/PhaseSpaceSimulation.root"
       }
@@ -103,7 +103,7 @@
     "experiment": "LHCb",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:88b9f48e",
         "size": 496943,
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/AntimatterMatters2017/documentation/Matter-Antimatter_Instructions_LHCb.pdf"
       }
@@ -153,7 +153,7 @@
     "experiment": "LHCb",
     "files": [
       {
-        "checksum": "sha1:0000000000000000000000000000000000000000",
+        "checksum": "adler32:95384d65",
         "size": 5204130,
         "uri": "root://eospublic.cern.ch//eos/opendata/lhcb/AntimatterMatters2017/software/opendata-project-1.0.tar.gz"
       }


### PR DESCRIPTION
* Verifies all LHCb file sizes and sets file checksums to Adler32. (addresses #2528)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>