### PR TITLE
records: enrich record schema

### DIFF
--- a/cernopendata/jsonschemas/records/record-v1.0.0.json
+++ b/cernopendata/jsonschemas/records/record-v1.0.0.json
@@ -164,6 +164,14 @@
             "description": "Description or explanation for a variable",
             "type": "string"
           },
+          "type": {
+            "description": "The type of the variable",
+            "type": "string"
+          },
+          "unit": {
+            "description": "The unit of the variable",
+            "type": "string"
+          },
           "variable": {
             "description": "A variable",
             "type": "string"


### PR DESCRIPTION
* Enriches `dataset_semantics` to support `type` and `unit` (addresses #2447).

Signed-off-by: Artemis Lavasa <artemis.lavasa@cern.ch>

