### PR TITLE
Add records for tracker-hit-enriched Run1 AOD and ML files, and SW

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-Run1-datascience.json
@@ -1,0 +1,565 @@
+[
+  {
+    "abstract": {
+      "description": "<p>Samples in this record are in a custom root ntuple format and contain the position of the hits and information from the generator-level objects associated to the tracker hits. The samples can be used to study top quark identification algorithms that use low-level detector information such as tracker hits. Machine learning algorithms are suitable for this classification task.<\p><p> They have been produced from datasets, which consists of events extracted from simulated proton-proton collision events at a center-of-mass energy of 8 TeV generated with Pythia 6 (QCD) or MadGraph2.6 and Pythia6 (top-antitop pair sample). The particles emerging from the collisions traverse through a simulation of the CMS detector. The parent datasets of these samples contain light jets (QCD) in various energy ranges (FIXME add recids), or all-hadronic high transverse momentum decays of top quarks (FIXME recid), and consist of hits from the tracking detector, reconstructed tracks, simulated tracks, generated particles, and jets clustered from the generated particles. The various objects are matched in order to reconstruct the provenance of the various hits. Samples are produced from the standard CMS format \"AODSIM\" plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. </p> <p><thead>
+<tr>
+<th align="left">Data set name</th>
+<th align="left">Description</th>
+<th align="right">Number of events</th>
+<th align="right">Number of files</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td align="left">QCD300to600</td>
+<td align="left">QCD, flat pT hat spectrum, 300 &lt; pT hat &lt; 600 GeV</td>
+<td align="right">1497600</td>
+<td align="right">2496</td>
+</tr>
+<tr>
+<td align="left">QCD400to600</td>
+<td align="left">QCD, flat pT hat spectrum, 400 &lt; pT hat &lt; 600 GeV</td>
+<td align="right">1989000</td>
+<td align="right">3315</td>
+</tr>
+<tr>
+<td align="left">QCD600to3000</td>
+<td align="left">QCD, flat pT hat spectrum, 600 &lt; pT hat &lt; 3000 GeV</td>
+<td align="right">2974800</td>
+<td align="right">4959</td>
+</tr>
+<tr>
+<td align="left">ttbar</td>
+<td align="left">ttbar, fully hadronic decays, pT of the top/antitop greater than 400 GeV</td>
+<td align="right">2969109</td>
+<td align="right">4055</td>
+</tr>
+</tbody>
+</table><\p>"
+    },
+    "accelerator": "CERN-LHC",
+    "authors": [
+      {
+        "name": "Usai, Emanuele",
+        "orcid": "0000-0001-9323-2107"
+      },
+      {
+        "name": "Andrews, Michael",
+        "orcid": "0000-0001-5537-4518"
+      },
+      {
+        "name": "Burkle, Bjorn",
+        "orcid": "0000-0003-1645-822X"
+      },
+      {
+        "name": "Gleyzer, Sergei",
+        "orcid": "0000-0002-6222-8102"
+      },
+      {
+        "name": "Narain, Meenakshi",
+        "orcid": "0000-0002-7857-7403"
+      }
+    ],
+    "collections": [
+      "CMS-Derived-Datasets"
+    ],
+    "dataset_semantics": [
+      "
+      {
+        "description": " global x position of the RecHit ",
+        "type": " `std::vector<float>` ",
+        "variable": " hit_global_x "
+      },
+      {
+        "description": " global y position of the RecHit ",
+        "type": " `std::vector<float>` ",
+        "variable": " hit_global_y "
+      },
+      {
+        "description": " global z position of the RecHit ",
+        "type": " `std::vector<float>` ",
+        "variable": " hit_global_z "
+      },
+      {
+        "description": " x pos. of the hit in the local sensor coordinate ",
+        "type": " `std::vector<float>` ",
+        "variable": " hit_local_x "
+      },
+      {
+        "description": " y pos. of the hit in the local sensor coordinate ",
+        "type": " `std::vector<float>` ",
+        "variable": " hit_local_y "
+      },
+      {
+        "description": " x error in the local sensor coordinate ",
+        "type": " `std::vector<float>` ",
+        "variable": " hit_local_x_error "
+      },
+      {
+        "description": " y error in the local sensor coordinate ",
+        "type": " `std::vector<float>` ",
+        "variable": " hit_local_y_error "
+      },
+      {
+        "description": " subdetector generating the hit [1 PixelBarrel, 2 PixelEndcap, 3 TIB, 4 TID, 5 TOB, 6 TEC] ",
+        "type": " `std::vector<unsigned int>` ",
+        "variable": " hit_sub_det "
+      },
+      {
+        "description": " layer/disk of the subdetector generating the hit ",
+        "type": " `std::vector<unsigned int>` ",
+        "variable": " hit_layer "
+      },
+      {
+        "description": " type of sistrip hit [0 Pixel hit, 1 rphiRecHit, 2 stereoRecHit, 3 rphiRecHitUnmatched, 4 stereoRecHitUnmatched] ",
+        "type": " `std::vector<unsigned int>` ",
+        "variable": " hit_type "
+      },
+      {
+        "description": " ID number of the sim track matched to the hit ",
+        "type": " `std::vector<int>` ",
+        "variable": " hit_simtrack_id "
+      },
+      {
+        "description": " index of the sim track matched to the hit ",
+        "type": " `std::vector<unsigned int>` ",
+        "variable": " hit_simtrack_index "
+      },
+      {
+        "description": " is the hit matched to a sim track? ",
+        "type": " `std::vector<bool>` ",
+        "variable": " hit_simtrack_match "
+      },
+      {
+        "description": " index of the gen particle matched to the hit ",
+        "type": " `std::vector<unsigned int>` ",
+        "variable": " hit_genparticle_id "
+      },
+      {
+        "description": " PDG ID of the gen particle matched to the hit ",
+        "type": " `std::vector<int>` ",
+        "variable": " hit_pdgid "
+      },
+      {
+        "description": " index of the reco track matched to the hit",
+        "type": " `std::vector<unsigned int>` ",
+        "variable": " hit_recotrack_id "
+      },
+      {
+        "description": " is the hit matched to a reco track? ",
+        "type": " `std::vector<bool>` ",
+        "variable": " hit_recotrack_match "
+      },
+      {
+        "description": " is the hit matched to a gen particle? ",
+        "type": " `std::vector<bool>` ",
+        "variable": " hit_genparticle_match "
+      },
+      {
+        "description": " index of the gen jet matched to the hit ",
+        "type": " `std::vector<unsigned int>` ",
+        "variable": " hit_genjet_id "
+      },
+      {
+        "description": " is the hit matched to a gen jet? ",
+        "type": " `std::vector<bool>` ",
+        "variable": " hit_genjet_match "
+      },
+      {
+        "description": " ID number of the sim track ",
+        "type": " `std::vector<unsigned int>` ",
+        "variable": " simtrack_id "
+      },
+      {
+        "description": " PDG ID of the sim track ",
+        "type": " `std::vector<int>` ",
+        "variable": " simtrack_pdgid "
+      },
+      {
+        "description": " charge of the sim track ",
+        "type": " `std::vector<int>` ",
+        "variable": " simtrack_charge "
+      },
+      {
+        "description": " momentum x component of the sim track ",
+        "type": " `std::vector<float>` ",
+        "variable": " simtrack_px "
+      },
+      {
+        "description": " momentum y component of the sim track ",
+        "type": " `std::vector<float>` ",
+        "variable": " simtrack_py "
+      },
+      {
+        "description": " momentum z component of the sim track ",
+        "type": " `std::vector<float>` ",
+        "variable": " simtrack_pz "
+      },
+      {
+        "description": " energy of the sim track ",
+        "type": " `std::vector<float>` ",
+        "variable": " simtrack_energy "
+      },
+      {
+        "description": " ID number of the sim vertex of the sim track ",
+        "type": " `std::vector<unsigned int>` ",
+        "variable": " simtrack_vtxid "
+      },
+      {
+        "description": " index of the gen particle associated to the track ",
+        "type": " `std::vector<unsigned int>` ",
+        "variable": " simtrack_genid "
+      },
+      {
+        "description": " event ID of the sim track ",
+        "type": " `std::vector<uint32_t>` ",
+        "variable": " simtrack_evtid "
+      },
+      {
+        "description": " collision ID of the gen particle ",
+        "type": " `std::vector<int>` ",
+        "variable": " genpart_collid "
+      },
+      {
+        "description": " PDG ID of the gen particle ",
+        "type": " `std::vector<int>` ",
+        "variable": " genpart_pdgid "
+      },
+      {
+        "description": " charge of the gen particle ",
+        "type": " `std::vector<int>` ",
+        "variable": " genpart_charge "
+      },
+      {
+        "description": " momentum x component of the gen particle ",
+        "type": " `std::vector<float>` ",
+        "variable": " genpart_px "
+      },
+      {
+        "description": " momentum y component of the gen particle ",
+        "type": " `std::vector<float>` ",
+        "variable": " genpart_py "
+      },
+      {
+        "description": " momentum z component of the gen particle ",
+             "type": " `std::vector<float>` ",
+        "variable": " genpart_px "
+      },
+      {
+        "description": " energy of the gen particle ",
+        "type": " `std::vector<float>` ",
+        "variable": " genpart_energy "
+      },
+      {
+        "description": " PDG status of the gen particle ",
+        "type": " `std::vector<int>` ",
+        "variable": " genpart_status "
+      },
+      {
+        "description": " momentum x component of the gen jet ",
+        "type": " `std::vector<float>` ",
+        "variable": " genjet_px "
+      },
+      {
+        "description": " momentum y component of the gen jet ",
+        "type": " `std::vector<float>` ",
+        "variable": " genjet_py "
+      },
+      {
+        "description": " momentum z component of the gen jet ",
+        "type": " `std::vector<float>` ",
+        "variable": " genjet_pz "
+      },
+      {
+        "description": " energy of the gen jet ",
+        "type": " `std::vector<float>` ",
+        "variable": " genjet_energy "
+      },
+      {
+        "description": " electromagnetic energy of the gen jet ",
+        "type": " `std::vector<float>` ",
+        "variable": " genjet_emEnergy "
+      },
+      {
+        "description": " hadronic energy of the gen jet ",
+        "type": " `std::vector<float>` ",
+        "variable": " genjet_hadEnergy "
+      },
+      {
+        "description": " invisible energy of the gen jet ",
+        "type": " `std::vector<float>` ",
+        "variable": " genjet_invisibleEnergy "
+      },
+      {
+        "description": " auxiliary energy of the gen jet ",
+        "type": " `std::vector<float>` ",
+        "variable": " genjet_auxiliaryEnergy "
+      },
+      {
+        "description": " collision ID of the constituent of the gen jet ",
+        "type": " `std::vector<std::vector<int> >` ",
+        "variable": " genjet_const_collid "
+      },
+      {
+        "description": " PDG ID of the constituent of the gen jet ",
+        "type": " `std::vector<std::vector<int> >` ",
+        "variable": " genjet_const_pdgid "
+      },
+      {
+        "description": " charge of the constituent of the gen jet ",
+        "type": " `std::vector<std::vector<int> >` ",
+        "variable": " genjet_const_charge "
+      },
+      {
+        "description": " momentum x component of the constituent of the gen jet ",
+        "type": " `std::vector<std::vector<float> >` ",
+        "variable": " genjet_const_px "
+      },
+      {
+        "description": " momentum y component of the constituent of the gen jet ",
+        "type": " `std::vector<std::vector<float> >` ",
+        "variable": " genjet_const_py "
+      },
+      {
+        "description": " momentum z component of the constituent of the gen jet ",
+        "type": " `std::vector<std::vector<float> >` ",
+        "variable": " genjet_const_pz "
+      },
+      {
+        "description": " energy of the constituent of the gen jet ",
+        "type": " `std::vector<std::vector<float> >` ",
+        "variable": " genjet_const_energy "
+      },
+      {
+        "description": " chi2 of the reco track fit ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_chi2 "
+      },
+      {
+        "description": " ndof of the reco track fit ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_ndof "
+      },
+      {
+        "description": " reduced chi2 of the reco track fit ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_chi2ndof "
+      },
+      {
+        "description": " charge of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_charge "
+      },
+      {
+        "description": " momentum of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_momentum "
+      },
+      {
+        "description": " transverse momentum of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_pt "
+      },
+      {
+        "description": " error on the transverse momentum of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_pterr "
+      },
+      {
+        "description": " number of valid hits in the reco track ",
+        "type": " `std::vector<unsigned int>`  ",
+        "variable": " track_hitsvalid "
+      },
+      {
+        "description": " number of lost hits in the reco track ",
+        "type": " `std::vector<unsigned int>`  ",
+        "variable": " track_hitslost "
+      },
+      {
+        "description": " theta angle of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_theta "
+      },
+      {
+        "description": " error on theta of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_thetaerr "
+      },
+      {
+        "description": " phi angle of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_phi "
+      },
+      {
+        "description": " error on phi of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_phierr "
+      },
+      {
+        "description": " pseudorapidity of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_eta "
+      },
+      {
+        "description": " error on pseudorapidity of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_etaerr "
+      },
+      {
+        "description": " transverse impact parameter of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_dxy "
+      },
+      {
+        "description": " error on the transverse impact parameter of the reco track ",
+        "type": " `std::vector<float>`  ",
+        "variable": " track_dxyerr "
+      },
+      {
+        "description": " longitudinal impact parameter of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_dsz "
+      },
+      {
+        "description": " error on the longitudinal impact parameter of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_dszerr "
+      },
+      {
+        "description": " charge over momentum of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_qoverp "
+      },
+      {
+        "description": " error on charge over momentum of the track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_qoverperr "
+      },
+      {
+        "description": " x position of the vertex of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_vx "
+      },
+      {
+        "description": " y position of the vertex of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_vy "
+      },
+      {
+        "description": " z position of the vertex of the reco track ",
+        "type": " `std::vector<float>` ",
+        "variable": " track_vz "
+      },
+      {
+        "description": " algorithm type of the reco track ",
+        "type": " `std::vector<Int_t>` ",
+        "variable": " track_algo "
+      },
+      {
+        "description": " global x position of the RecHit associated to the reco track ",
+        "type": " `std::vector<std::vector<float> >` ",
+        "variable": " track_hit_global_x "
+      },
+      {
+        "description": " global y position of the RecHit associated to the reco track ",
+        "type": " `std::vector<std::vector<float> >` ",
+        "variable": " track_hit_global_y "
+      },
+      {
+        "description": " global z position of the RecHit associated to the reco track ",
+        "type": " `std::vector<std::vector<float> >` ",
+        "variable": " track_hit_global_z "
+      },
+      {
+        "description": " local x position of the RecHit associated to the reco track ",
+        "type": " `std::vector<std::vector<float> >` ",
+        "variable": " track_hit_local_x "
+      },
+      {
+        "description": " local y position of the RecHit associated to the reco track ",
+        "type": " `std::vector<std::vector<float> >` ",
+        "variable": " track_hit_local_y "
+      },
+      {
+        "description": " error on local x position of the RecHit associated to the reco track ",
+        "type": " `std::vector<std::vector<float> >` ",
+        "variable": " track_hit_local_x_error "
+      },
+      {
+        "description": " error on local y position of the RecHit associated to the reco track ",
+        "type": " `std::vector<std::vector<float> >` ",
+        "variable": " track_hit_local_y_error "
+      },
+      {
+        "description": " subdetector generating the hit [1 PixelBarrel, 2 PixelEndcap, 3 TIB, 4 TID, 5 TOB, 6 TEC] associated to the reco track ",
+        "type": " `std::vector<std::vector<unsigned int> >`  ",
+        "variable": " track_hit_sub_det "
+      },
+      {
+        "description": " layer/disk of the subdetector generating the hit associated to the reco track ",
+        "type": " `std::vector<std::vector<unsigned int> >`  ",
+        "variable": " track_hit_layer "
+      }
+    ],
+    "date_published": "2019",
+    "distribution": {
+      "formats": [
+        "root"
+      ]
+    },
+    "doi": "FIXME",
+    "experiment": "CMS",
+    "keywords": [
+      "datascience"
+    ],
+    "license": {
+      "attribution": "CC0"
+    },
+    "methodology": {
+      "description": "This dataset was produced with the software available in:",
+      "links": [
+        {
+          "recid": "FIXME"
+        }
+      ]
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "FIXME",
+    "relations": [
+      {
+        "description": "QCD300to600_RunI_8TeV was derived from:",
+        "recid": "FIXME",
+        "title": "Trakcer-hit-enriched 300 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6",
+        "type": "isChildOf"
+      },
+      {
+        "description": "QCD400to600_RunI_8TeV was derived from:",
+        "recid": "FIXME",
+        "title": "Trakcer-hit-enriched 400 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6",
+        "type": "isChildOf"
+      },
+      {
+        "description": "QCD600to3000_RunI_8TeV  was derived from:",
+        "recid": "FIXME",
+        "title": "Trakcer-hit-enriched 600 to 3000 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6",
+        "type": "isChildOf"
+      },
+      {
+        "description": "ttbar_RunI_8TeV was derived from:",
+        "recid": "FIXME",
+        "title": "Trakcer-hit-enriched TTJets_HadronicMGDecays_8TeV-madgraph",
+        "type": "isChildOf"
+      }
+    ],
+    "title": "Samples with high-momentum jets for tracking, ML, and top quark tagging studies",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Derived"
+      ]
+    },
+    "usage": {
+      "description": "The use of these files does not require any software specific to the CMS experiment. An example is provided in FIXME https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/tree/master/example and instructions on how to run it are provided in FIXME https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/README.md. The code reads the ntuples and produces a scatter plot of the rechits from three events."
+    }
+  }
+]

--- a/cernopendata/modules/fixtures/data/records/cms-derived-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-Run1-datascience.json
@@ -1,41 +1,7 @@
 [
   {
     "abstract": {
-      "description": "<p>Samples in this record are in a custom root ntuple format and contain the position of the hits and information from the generator-level objects associated to the tracker hits. The samples can be used to study top quark identification algorithms that use low-level detector information such as tracker hits. Machine learning algorithms are suitable for this classification task.<\p><p> They have been produced from datasets, which consists of events extracted from simulated proton-proton collision events at a center-of-mass energy of 8 TeV generated with Pythia 6 (QCD) or MadGraph2.6 and Pythia6 (top-antitop pair sample). The particles emerging from the collisions traverse through a simulation of the CMS detector. The parent datasets of these samples contain light jets (QCD) in various energy ranges (FIXME add recids), or all-hadronic high transverse momentum decays of top quarks (FIXME recid), and consist of hits from the tracking detector, reconstructed tracks, simulated tracks, generated particles, and jets clustered from the generated particles. The various objects are matched in order to reconstruct the provenance of the various hits. Samples are produced from the standard CMS format \"AODSIM\" plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. </p> <p><thead>
-<tr>
-<th align="left">Data set name</th>
-<th align="left">Description</th>
-<th align="right">Number of events</th>
-<th align="right">Number of files</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td align="left">QCD300to600</td>
-<td align="left">QCD, flat pT hat spectrum, 300 &lt; pT hat &lt; 600 GeV</td>
-<td align="right">1497600</td>
-<td align="right">2496</td>
-</tr>
-<tr>
-<td align="left">QCD400to600</td>
-<td align="left">QCD, flat pT hat spectrum, 400 &lt; pT hat &lt; 600 GeV</td>
-<td align="right">1989000</td>
-<td align="right">3315</td>
-</tr>
-<tr>
-<td align="left">QCD600to3000</td>
-<td align="left">QCD, flat pT hat spectrum, 600 &lt; pT hat &lt; 3000 GeV</td>
-<td align="right">2974800</td>
-<td align="right">4959</td>
-</tr>
-<tr>
-<td align="left">ttbar</td>
-<td align="left">ttbar, fully hadronic decays, pT of the top/antitop greater than 400 GeV</td>
-<td align="right">2969109</td>
-<td align="right">4055</td>
-</tr>
-</tbody>
-</table><\p>"
+      "description": "<p>Samples in this record are in a custom root ntuple format and contain the position of the hits and information from the generator-level objects associated to the tracker hits. The samples can be used to study top quark identification algorithms that use low-level detector information such as tracker hits. Machine learning algorithms are suitable for this classification task.</p><p> They have been produced from datasets, which consists of events extracted from simulated proton-proton collision events at a center-of-mass energy of 8 TeV generated with Pythia 6 (QCD) or MadGraph2.6 and Pythia6 (top-antitop pair sample). The particles emerging from the collisions traverse through a simulation of the CMS detector. The parent datasets of these samples contain light jets (QCD) in various energy ranges or all-hadronic high transverse momentum decays of top quarks and consist of hits from the tracking detector, reconstructed tracks, simulated tracks, generated particles, and jets clustered from the generated particles. The various objects are matched in order to reconstruct the provenance of the various hits. Samples are produced from the standard CMS format \"AODSIM\" plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. </p> <p><table><thead> <tr> <th align=\"left\">Data set name</th> <th align=\"left\">Description</th> <th align=\"right\">Number of events</th> <th align=\"right\">Number of files</th> </tr> </thead> <tbody> <tr> <td align=\"left\">QCD300to600</td> <td align=\"left\">QCD, flat pT hat spectrum, 300 &lt; pT hat &lt; 600 GeV</td> <td align=\"right\">1497600</td> <td align=\"right\">2496</td> </tr> <tr> <td align=\"left\">QCD400to600</td> <td align=\"left\">QCD, flat pT hat spectrum, 400 &lt; pT hat &lt; 600 GeV</td> <td align=\"right\">1989000</td> <td align=\"right\">3315</td> </tr> <tr> <td align=\"left\">QCD600to3000</td> <td align=\"left\">QCD, flat pT hat spectrum, 600 &lt; pT hat &lt; 3000 GeV</td> <td align=\"right\">2974800</td> <td align=\"right\">4959</td> </tr> <tr> <td align=\"left\">ttbar</td> <td align=\"left\">ttbar, fully hadronic decays, pT of the top/antitop greater than 400 GeV</td> <td align=\"right\">2969109</td> <td align=\"right\">4055</td> </tr> </tbody> </table></p>"
     },
     "accelerator": "CERN-LHC",
     "authors": [
@@ -64,441 +30,440 @@
       "CMS-Derived-Datasets"
     ],
     "dataset_semantics": [
-      "
       {
-        "description": " global x position of the RecHit ",
-        "type": " `std::vector<float>` ",
-        "variable": " hit_global_x "
+        "description": "global x position of the RecHit",
+        "type": "std::vector<float>",
+        "variable": "hit_global_x"
       },
       {
-        "description": " global y position of the RecHit ",
-        "type": " `std::vector<float>` ",
-        "variable": " hit_global_y "
+        "description": "global y position of the RecHit",
+        "type": "std::vector<float>",
+        "variable": "hit_global_y"
       },
       {
-        "description": " global z position of the RecHit ",
-        "type": " `std::vector<float>` ",
-        "variable": " hit_global_z "
+        "description": "global z position of the RecHit",
+        "type": "std::vector<float>",
+        "variable": "hit_global_z"
       },
       {
-        "description": " x pos. of the hit in the local sensor coordinate ",
-        "type": " `std::vector<float>` ",
-        "variable": " hit_local_x "
+        "description": "x pos. of the hit in the local sensor coordinate",
+        "type": "std::vector<float>",
+        "variable": "hit_local_x"
       },
       {
-        "description": " y pos. of the hit in the local sensor coordinate ",
-        "type": " `std::vector<float>` ",
-        "variable": " hit_local_y "
+        "description": "y pos. of the hit in the local sensor coordinate",
+        "type": "std::vector<float>",
+        "variable": "hit_local_y"
       },
       {
-        "description": " x error in the local sensor coordinate ",
-        "type": " `std::vector<float>` ",
-        "variable": " hit_local_x_error "
+        "description": "x error in the local sensor coordinate",
+        "type": "std::vector<float>",
+        "variable": "hit_local_x_error"
       },
       {
-        "description": " y error in the local sensor coordinate ",
-        "type": " `std::vector<float>` ",
-        "variable": " hit_local_y_error "
+        "description": "y error in the local sensor coordinate",
+        "type": "std::vector<float>",
+        "variable": "hit_local_y_error"
       },
       {
-        "description": " subdetector generating the hit [1 PixelBarrel, 2 PixelEndcap, 3 TIB, 4 TID, 5 TOB, 6 TEC] ",
-        "type": " `std::vector<unsigned int>` ",
-        "variable": " hit_sub_det "
+        "description": "subdetector generating the hit [1 PixelBarrel, 2 PixelEndcap, 3 TIB, 4 TID, 5 TOB, 6 TEC]",
+        "type": "std::vector<unsigned int>",
+        "variable": "hit_sub_det"
       },
       {
-        "description": " layer/disk of the subdetector generating the hit ",
-        "type": " `std::vector<unsigned int>` ",
-        "variable": " hit_layer "
+        "description": "layer/disk of the subdetector generating the hit",
+        "type": "std::vector<unsigned int>",
+        "variable": "hit_layer"
       },
       {
-        "description": " type of sistrip hit [0 Pixel hit, 1 rphiRecHit, 2 stereoRecHit, 3 rphiRecHitUnmatched, 4 stereoRecHitUnmatched] ",
-        "type": " `std::vector<unsigned int>` ",
-        "variable": " hit_type "
+        "description": "type of sistrip hit [0 Pixel hit, 1 rphiRecHit, 2 stereoRecHit, 3 rphiRecHitUnmatched, 4 stereoRecHitUnmatched]",
+        "type": "std::vector<unsigned int>",
+        "variable": "hit_type"
       },
       {
-        "description": " ID number of the sim track matched to the hit ",
-        "type": " `std::vector<int>` ",
-        "variable": " hit_simtrack_id "
+        "description": "ID number of the sim track matched to the hit",
+        "type": "std::vector<int>",
+        "variable": "hit_simtrack_id"
       },
       {
-        "description": " index of the sim track matched to the hit ",
-        "type": " `std::vector<unsigned int>` ",
-        "variable": " hit_simtrack_index "
+        "description": "index of the sim track matched to the hit",
+        "type": "std::vector<unsigned int>",
+        "variable": "hit_simtrack_index"
       },
       {
-        "description": " is the hit matched to a sim track? ",
-        "type": " `std::vector<bool>` ",
-        "variable": " hit_simtrack_match "
+        "description": "is the hit matched to a sim track?",
+        "type": "std::vector<bool>",
+        "variable": "hit_simtrack_match"
       },
       {
-        "description": " index of the gen particle matched to the hit ",
-        "type": " `std::vector<unsigned int>` ",
-        "variable": " hit_genparticle_id "
+        "description": "index of the gen particle matched to the hit",
+        "type": "std::vector<unsigned int>",
+        "variable": "hit_genparticle_id"
       },
       {
-        "description": " PDG ID of the gen particle matched to the hit ",
-        "type": " `std::vector<int>` ",
-        "variable": " hit_pdgid "
+        "description": "PDG ID of the gen particle matched to the hit",
+        "type": "std::vector<int>",
+        "variable": "hit_pdgid"
       },
       {
-        "description": " index of the reco track matched to the hit",
-        "type": " `std::vector<unsigned int>` ",
-        "variable": " hit_recotrack_id "
+        "description": "index of the reco track matched to the hit",
+        "type": "std::vector<unsigned int>",
+        "variable": "hit_recotrack_id"
       },
       {
-        "description": " is the hit matched to a reco track? ",
-        "type": " `std::vector<bool>` ",
-        "variable": " hit_recotrack_match "
+        "description": "is the hit matched to a reco track?",
+        "type": "std::vector<bool>",
+        "variable": "hit_recotrack_match"
       },
       {
-        "description": " is the hit matched to a gen particle? ",
-        "type": " `std::vector<bool>` ",
-        "variable": " hit_genparticle_match "
+        "description": "is the hit matched to a gen particle?",
+        "type": "std::vector<bool>",
+        "variable": "hit_genparticle_match"
       },
       {
-        "description": " index of the gen jet matched to the hit ",
-        "type": " `std::vector<unsigned int>` ",
-        "variable": " hit_genjet_id "
+        "description": "index of the gen jet matched to the hit",
+        "type": "std::vector<unsigned int>",
+        "variable": "hit_genjet_id"
       },
       {
-        "description": " is the hit matched to a gen jet? ",
-        "type": " `std::vector<bool>` ",
-        "variable": " hit_genjet_match "
+        "description": "is the hit matched to a gen jet?",
+        "type": "std::vector<bool>",
+        "variable": "hit_genjet_match"
       },
       {
-        "description": " ID number of the sim track ",
-        "type": " `std::vector<unsigned int>` ",
-        "variable": " simtrack_id "
+        "description": "ID number of the sim track",
+        "type": "std::vector<unsigned int>",
+        "variable": "simtrack_id"
       },
       {
-        "description": " PDG ID of the sim track ",
-        "type": " `std::vector<int>` ",
-        "variable": " simtrack_pdgid "
+        "description": "PDG ID of the sim track",
+        "type": "std::vector<int>",
+        "variable": "simtrack_pdgid"
       },
       {
-        "description": " charge of the sim track ",
-        "type": " `std::vector<int>` ",
-        "variable": " simtrack_charge "
+        "description": "charge of the sim track",
+        "type": "std::vector<int>",
+        "variable": "simtrack_charge"
       },
       {
-        "description": " momentum x component of the sim track ",
-        "type": " `std::vector<float>` ",
-        "variable": " simtrack_px "
+        "description": "momentum x component of the sim track",
+        "type": "std::vector<float>",
+        "variable": "simtrack_px"
       },
       {
-        "description": " momentum y component of the sim track ",
-        "type": " `std::vector<float>` ",
-        "variable": " simtrack_py "
+        "description": "momentum y component of the sim track",
+        "type": "std::vector<float>",
+        "variable": "simtrack_py"
       },
       {
-        "description": " momentum z component of the sim track ",
-        "type": " `std::vector<float>` ",
-        "variable": " simtrack_pz "
+        "description": "momentum z component of the sim track",
+        "type": "std::vector<float>",
+        "variable": "simtrack_pz"
       },
       {
-        "description": " energy of the sim track ",
-        "type": " `std::vector<float>` ",
-        "variable": " simtrack_energy "
+        "description": "energy of the sim track",
+        "type": "std::vector<float>",
+        "variable": "simtrack_energy"
       },
       {
-        "description": " ID number of the sim vertex of the sim track ",
-        "type": " `std::vector<unsigned int>` ",
-        "variable": " simtrack_vtxid "
+        "description": "ID number of the sim vertex of the sim track",
+        "type": "std::vector<unsigned int>",
+        "variable": "simtrack_vtxid"
       },
       {
-        "description": " index of the gen particle associated to the track ",
-        "type": " `std::vector<unsigned int>` ",
-        "variable": " simtrack_genid "
+        "description": "index of the gen particle associated to the track",
+        "type": "std::vector<unsigned int>",
+        "variable": "simtrack_genid"
       },
       {
-        "description": " event ID of the sim track ",
-        "type": " `std::vector<uint32_t>` ",
-        "variable": " simtrack_evtid "
+        "description": "event ID of the sim track",
+        "type": "std::vector<uint32_t>",
+        "variable": "simtrack_evtid"
       },
       {
-        "description": " collision ID of the gen particle ",
-        "type": " `std::vector<int>` ",
-        "variable": " genpart_collid "
+        "description": "collision ID of the gen particle",
+        "type": "std::vector<int>",
+        "variable": "genpart_collid"
       },
       {
-        "description": " PDG ID of the gen particle ",
-        "type": " `std::vector<int>` ",
-        "variable": " genpart_pdgid "
+        "description": "PDG ID of the gen particle",
+        "type": "std::vector<int>",
+        "variable": "genpart_pdgid"
       },
       {
-        "description": " charge of the gen particle ",
-        "type": " `std::vector<int>` ",
-        "variable": " genpart_charge "
+        "description": "charge of the gen particle",
+        "type": "std::vector<int>",
+        "variable": "genpart_charge"
       },
       {
-        "description": " momentum x component of the gen particle ",
-        "type": " `std::vector<float>` ",
-        "variable": " genpart_px "
+        "description": "momentum x component of the gen particle",
+        "type": "std::vector<float>",
+        "variable": "genpart_px"
       },
       {
-        "description": " momentum y component of the gen particle ",
-        "type": " `std::vector<float>` ",
-        "variable": " genpart_py "
+        "description": "momentum y component of the gen particle",
+        "type": "std::vector<float>",
+        "variable": "genpart_py"
       },
       {
-        "description": " momentum z component of the gen particle ",
-             "type": " `std::vector<float>` ",
-        "variable": " genpart_px "
+        "description": "momentum z component of the gen particle",
+        "type": "std::vector<float>",
+        "variable": "genpart_px"
       },
       {
-        "description": " energy of the gen particle ",
-        "type": " `std::vector<float>` ",
-        "variable": " genpart_energy "
+        "description": "energy of the gen particle",
+        "type": "std::vector<float>",
+        "variable": "genpart_energy"
       },
       {
-        "description": " PDG status of the gen particle ",
-        "type": " `std::vector<int>` ",
-        "variable": " genpart_status "
+        "description": "PDG status of the gen particle",
+        "type": "std::vector<int>",
+        "variable": "genpart_status"
       },
       {
-        "description": " momentum x component of the gen jet ",
-        "type": " `std::vector<float>` ",
-        "variable": " genjet_px "
+        "description": "momentum x component of the gen jet",
+        "type": "std::vector<float>",
+        "variable": "genjet_px"
       },
       {
-        "description": " momentum y component of the gen jet ",
-        "type": " `std::vector<float>` ",
-        "variable": " genjet_py "
+        "description": "momentum y component of the gen jet",
+        "type": "std::vector<float>",
+        "variable": "genjet_py"
       },
       {
-        "description": " momentum z component of the gen jet ",
-        "type": " `std::vector<float>` ",
-        "variable": " genjet_pz "
+        "description": "momentum z component of the gen jet",
+        "type": "std::vector<float>",
+        "variable": "genjet_pz"
       },
       {
-        "description": " energy of the gen jet ",
-        "type": " `std::vector<float>` ",
-        "variable": " genjet_energy "
+        "description": "energy of the gen jet",
+        "type": "std::vector<float>",
+        "variable": "genjet_energy"
       },
       {
-        "description": " electromagnetic energy of the gen jet ",
-        "type": " `std::vector<float>` ",
-        "variable": " genjet_emEnergy "
+        "description": "electromagnetic energy of the gen jet",
+        "type": "std::vector<float>",
+        "variable": "genjet_emEnergy"
       },
       {
-        "description": " hadronic energy of the gen jet ",
-        "type": " `std::vector<float>` ",
-        "variable": " genjet_hadEnergy "
+        "description": "hadronic energy of the gen jet",
+        "type": "std::vector<float>",
+        "variable": "genjet_hadEnergy"
       },
       {
-        "description": " invisible energy of the gen jet ",
-        "type": " `std::vector<float>` ",
-        "variable": " genjet_invisibleEnergy "
+        "description": "invisible energy of the gen jet",
+        "type": "std::vector<float>",
+        "variable": "genjet_invisibleEnergy"
       },
       {
-        "description": " auxiliary energy of the gen jet ",
-        "type": " `std::vector<float>` ",
-        "variable": " genjet_auxiliaryEnergy "
+        "description": "auxiliary energy of the gen jet",
+        "type": "std::vector<float>",
+        "variable": "genjet_auxiliaryEnergy"
       },
       {
-        "description": " collision ID of the constituent of the gen jet ",
-        "type": " `std::vector<std::vector<int> >` ",
-        "variable": " genjet_const_collid "
+        "description": "collision ID of the constituent of the gen jet",
+        "type": "std::vector<std::vector<int> >",
+        "variable": "genjet_const_collid"
       },
       {
-        "description": " PDG ID of the constituent of the gen jet ",
-        "type": " `std::vector<std::vector<int> >` ",
-        "variable": " genjet_const_pdgid "
+        "description": "PDG ID of the constituent of the gen jet",
+        "type": "std::vector<std::vector<int> >",
+        "variable": "genjet_const_pdgid"
       },
       {
-        "description": " charge of the constituent of the gen jet ",
-        "type": " `std::vector<std::vector<int> >` ",
-        "variable": " genjet_const_charge "
+        "description": "charge of the constituent of the gen jet",
+        "type": "std::vector<std::vector<int> >",
+        "variable": "genjet_const_charge"
       },
       {
-        "description": " momentum x component of the constituent of the gen jet ",
-        "type": " `std::vector<std::vector<float> >` ",
-        "variable": " genjet_const_px "
+        "description": "momentum x component of the constituent of the gen jet",
+        "type": "std::vector<std::vector<float> >",
+        "variable": "genjet_const_px"
       },
       {
-        "description": " momentum y component of the constituent of the gen jet ",
-        "type": " `std::vector<std::vector<float> >` ",
-        "variable": " genjet_const_py "
+        "description": "momentum y component of the constituent of the gen jet",
+        "type": "std::vector<std::vector<float> >",
+        "variable": "genjet_const_py"
       },
       {
-        "description": " momentum z component of the constituent of the gen jet ",
-        "type": " `std::vector<std::vector<float> >` ",
-        "variable": " genjet_const_pz "
+        "description": "momentum z component of the constituent of the gen jet",
+        "type": "std::vector<std::vector<float> >",
+        "variable": "genjet_const_pz"
       },
       {
-        "description": " energy of the constituent of the gen jet ",
-        "type": " `std::vector<std::vector<float> >` ",
-        "variable": " genjet_const_energy "
+        "description": "energy of the constituent of the gen jet",
+        "type": "std::vector<std::vector<float> >",
+        "variable": "genjet_const_energy"
       },
       {
-        "description": " chi2 of the reco track fit ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_chi2 "
+        "description": "chi2 of the reco track fit",
+        "type": "std::vector<float>",
+        "variable": "track_chi2"
       },
       {
-        "description": " ndof of the reco track fit ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_ndof "
+        "description": "ndof of the reco track fit",
+        "type": "std::vector<float>",
+        "variable": "track_ndof"
       },
       {
-        "description": " reduced chi2 of the reco track fit ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_chi2ndof "
+        "description": "reduced chi2 of the reco track fit",
+        "type": "std::vector<float>",
+        "variable": "track_chi2ndof"
       },
       {
-        "description": " charge of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_charge "
+        "description": "charge of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_charge"
       },
       {
-        "description": " momentum of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_momentum "
+        "description": "momentum of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_momentum"
       },
       {
-        "description": " transverse momentum of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_pt "
+        "description": "transverse momentum of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_pt"
       },
       {
-        "description": " error on the transverse momentum of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_pterr "
+        "description": "error on the transverse momentum of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_pterr"
       },
       {
-        "description": " number of valid hits in the reco track ",
-        "type": " `std::vector<unsigned int>`  ",
-        "variable": " track_hitsvalid "
+        "description": "number of valid hits in the reco track",
+        "type": "std::vector<unsigned int>",
+        "variable": "track_hitsvalid"
       },
       {
-        "description": " number of lost hits in the reco track ",
-        "type": " `std::vector<unsigned int>`  ",
-        "variable": " track_hitslost "
+        "description": "number of lost hits in the reco track",
+        "type": "std::vector<unsigned int>",
+        "variable": "track_hitslost"
       },
       {
-        "description": " theta angle of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_theta "
+        "description": "theta angle of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_theta"
       },
       {
-        "description": " error on theta of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_thetaerr "
+        "description": "error on theta of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_thetaerr"
       },
       {
-        "description": " phi angle of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_phi "
+        "description": "phi angle of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_phi"
       },
       {
-        "description": " error on phi of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_phierr "
+        "description": "error on phi of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_phierr"
       },
       {
-        "description": " pseudorapidity of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_eta "
+        "description": "pseudorapidity of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_eta"
       },
       {
-        "description": " error on pseudorapidity of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_etaerr "
+        "description": "error on pseudorapidity of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_etaerr"
       },
       {
-        "description": " transverse impact parameter of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_dxy "
+        "description": "transverse impact parameter of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_dxy"
       },
       {
-        "description": " error on the transverse impact parameter of the reco track ",
-        "type": " `std::vector<float>`  ",
-        "variable": " track_dxyerr "
+        "description": "error on the transverse impact parameter of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_dxyerr"
       },
       {
-        "description": " longitudinal impact parameter of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_dsz "
+        "description": "longitudinal impact parameter of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_dsz"
       },
       {
-        "description": " error on the longitudinal impact parameter of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_dszerr "
+        "description": "error on the longitudinal impact parameter of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_dszerr"
       },
       {
-        "description": " charge over momentum of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_qoverp "
+        "description": "charge over momentum of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_qoverp"
       },
       {
-        "description": " error on charge over momentum of the track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_qoverperr "
+        "description": "error on charge over momentum of the track",
+        "type": "std::vector<float>",
+        "variable": "track_qoverperr"
       },
       {
-        "description": " x position of the vertex of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_vx "
+        "description": "x position of the vertex of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_vx"
       },
       {
-        "description": " y position of the vertex of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_vy "
+        "description": "y position of the vertex of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_vy"
       },
       {
-        "description": " z position of the vertex of the reco track ",
-        "type": " `std::vector<float>` ",
-        "variable": " track_vz "
+        "description": "z position of the vertex of the reco track",
+        "type": "std::vector<float>",
+        "variable": "track_vz"
       },
       {
-        "description": " algorithm type of the reco track ",
-        "type": " `std::vector<Int_t>` ",
-        "variable": " track_algo "
+        "description": "algorithm type of the reco track",
+        "type": "std::vector<Int_t>",
+        "variable": "track_algo"
       },
       {
-        "description": " global x position of the RecHit associated to the reco track ",
-        "type": " `std::vector<std::vector<float> >` ",
-        "variable": " track_hit_global_x "
+        "description": "global x position of the RecHit associated to the reco track",
+        "type": "std::vector<std::vector<float> >",
+        "variable": "track_hit_global_x"
       },
       {
-        "description": " global y position of the RecHit associated to the reco track ",
-        "type": " `std::vector<std::vector<float> >` ",
-        "variable": " track_hit_global_y "
+        "description": "global y position of the RecHit associated to the reco track",
+        "type": "std::vector<std::vector<float> >",
+        "variable": "track_hit_global_y"
       },
       {
-        "description": " global z position of the RecHit associated to the reco track ",
-        "type": " `std::vector<std::vector<float> >` ",
-        "variable": " track_hit_global_z "
+        "description": "global z position of the RecHit associated to the reco track",
+        "type": "std::vector<std::vector<float> >",
+        "variable": "track_hit_global_z"
       },
       {
-        "description": " local x position of the RecHit associated to the reco track ",
-        "type": " `std::vector<std::vector<float> >` ",
-        "variable": " track_hit_local_x "
+        "description": "local x position of the RecHit associated to the reco track",
+        "type": "std::vector<std::vector<float> >",
+        "variable": "track_hit_local_x"
       },
       {
-        "description": " local y position of the RecHit associated to the reco track ",
-        "type": " `std::vector<std::vector<float> >` ",
-        "variable": " track_hit_local_y "
+        "description": "local y position of the RecHit associated to the reco track",
+        "type": "std::vector<std::vector<float> >",
+        "variable": "track_hit_local_y"
       },
       {
-        "description": " error on local x position of the RecHit associated to the reco track ",
-        "type": " `std::vector<std::vector<float> >` ",
-        "variable": " track_hit_local_x_error "
+        "description": "error on local x position of the RecHit associated to the reco track",
+        "type": "std::vector<std::vector<float> >",
+        "variable": "track_hit_local_x_error"
       },
       {
-        "description": " error on local y position of the RecHit associated to the reco track ",
-        "type": " `std::vector<std::vector<float> >` ",
-        "variable": " track_hit_local_y_error "
+        "description": "error on local y position of the RecHit associated to the reco track",
+        "type": "std::vector<std::vector<float> >",
+        "variable": "track_hit_local_y_error"
       },
       {
-        "description": " subdetector generating the hit [1 PixelBarrel, 2 PixelEndcap, 3 TIB, 4 TID, 5 TOB, 6 TEC] associated to the reco track ",
-        "type": " `std::vector<std::vector<unsigned int> >`  ",
-        "variable": " track_hit_sub_det "
+        "description": "subdetector generating the hit [1 PixelBarrel, 2 PixelEndcap, 3 TIB, 4 TID, 5 TOB, 6 TEC] associated to the reco track",
+        "type": "std::vector<std::vector<unsigned int> >",
+        "variable": "track_hit_sub_det"
       },
       {
-        "description": " layer/disk of the subdetector generating the hit associated to the reco track ",
-        "type": " `std::vector<std::vector<unsigned int> >`  ",
-        "variable": " track_hit_layer "
+        "description": "layer/disk of the subdetector generating the hit associated to the reco track",
+        "type": "std::vector<std::vector<unsigned int> >",
+        "variable": "track_hit_layer"
       }
     ],
     "date_published": "2019",
@@ -507,7 +472,6 @@
         "root"
       ]
     },
-    "doi": "FIXME",
     "experiment": "CMS",
     "keywords": [
       "datascience"
@@ -519,34 +483,34 @@
       "description": "This dataset was produced with the software available in:",
       "links": [
         {
-          "recid": "FIXME"
+          "recid": "12210"
         }
       ]
     },
     "publisher": "CERN Open Data Portal",
-    "recid": "FIXME",
+    "recid": "12220",
     "relations": [
       {
         "description": "QCD300to600_RunI_8TeV was derived from:",
-        "recid": "FIXME",
+        "recid": "12201",
         "title": "Trakcer-hit-enriched 300 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6",
         "type": "isChildOf"
       },
       {
         "description": "QCD400to600_RunI_8TeV was derived from:",
-        "recid": "FIXME",
+        "recid": "12202",
         "title": "Trakcer-hit-enriched 400 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6",
         "type": "isChildOf"
       },
       {
         "description": "QCD600to3000_RunI_8TeV  was derived from:",
-        "recid": "FIXME",
+        "recid": "12203",
         "title": "Trakcer-hit-enriched 600 to 3000 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6",
         "type": "isChildOf"
       },
       {
         "description": "ttbar_RunI_8TeV was derived from:",
-        "recid": "FIXME",
+        "recid": "12200",
         "title": "Trakcer-hit-enriched TTJets_HadronicMGDecays_8TeV-madgraph",
         "type": "isChildOf"
       }
@@ -559,7 +523,7 @@
       ]
     },
     "usage": {
-      "description": "The use of these files does not require any software specific to the CMS experiment. An example is provided in FIXME https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/tree/master/example and instructions on how to run it are provided in FIXME https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/README.md. The code reads the ntuples and produces a scatter plot of the rechits from three events."
+      "description": "The use of these files does not require any software specific to the CMS experiment. An <a href=\"https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/tree/master/example\">example is provided</a> with the <a href=\"https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/README.md\">instructions how to run it</a>. The code reads the ntuples and produces a scatter plot of the rechits from three events."
     }
   }
 ]

--- a/cernopendata/modules/fixtures/data/records/cms-derived-Run2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-Run2-datascience.json
@@ -406,7 +406,7 @@
         "type": "isChildOf"
       }
     ],
-    "title": "JetNTuple_QCD_RunII_13TeV_MC",
+    "title": "Sample with jet properties for jet flavor ML studies JetNTuple_QCD_RunII_13TeV_MC",
     "type": {
       "primary": "Dataset",
       "secondary": [
@@ -419,7 +419,7 @@
   },
   {
     "abstract": {
-      "description": "<p>The dataset consists of particle jets extracted from simulated proton-proton collision events at a center-of-mass energy of 13 TeV generated with Pythia 8. The particles emerging from the collisions traverse through a simulation of the CMS detector. The particles were reconstructed from the simulated detector signals using the particle-flow (PF) algorithm. The reconstructed particles are also called PF candidates. The jets in this dataset were clustered from the PF candidates of each collision event using the anti-$k_t$ algorithm with distance parameter $R = 0.8$.</p> <p>From each collision event, only those jets with transverse momentum exceeding 30 GeV were saved to file. The jets were also required to have pseudorapidity of less than 2.5 (this indicates the jet's position in the detector). For each jet, there are variables describing the jet on a high-level, particle-level and generator-level. There are also some variables denscribing the collision event and the conditions of its simulation. All of the variables are saved on a jet-by-jet basis, which means that one row of data corresponds to one jet.</p> <p>The origin of a jet is particularly interesting. This so-called flavor of the jet is obtained from the generator-level particles by a jet flavor algorithm, which attempts to match a reconstructed jet to a single initiating particle. As a consequence, the jet flavor definition depends on the chosen algorithm. Here three different flavor definitions are available. The ‘hadron’ definition identifies b- and c-hadrons from the jet’s constituents, so it is only useful for b-tagging studies. The ‘parton’ definition extends this to include the light jet flavors (u, d, s and gluon). Finally there is the ‘physics’ definition, which looks at the quarks and gluons of the initial collision. The ‘parton’ and ‘physics’ definitions both identify all jet flavors, but the former is more biased towards b- and c-quarks. If in doubt, it is recommended to use the ‘physics’ definition.</p>"
+      "description": "<p>The dataset consists of particle jets extracted from simulated proton-proton collision events at a center-of-mass energy of 13 TeV generated with Pythia 8. It has been produced for developing machine-learning algorithms to differentiate jets originating from a Higgs boson decaying to a bottom quark-antiquark pair (Hbb) from quark or gluon jets originating from quantum chromodynamic (QCD) multijet production.</p><p>The reconstructed jets are clustered using the anti-kT algorithm with R=0.8 from particle flow (PF) candidates (AK8 jets). The standard L1+L2+L3+residual jet energy corrections are applied to the jets and pileup contamination is mitigated using the charged hadron subtraction (CHS) algorithm. Features of the AK8 jets with transverse momentum pT > 200 GeV and pseudorapidity |η| < 2.4 are provided. Selected features of inclusive (both charged and neutral) PF candidates with pT > 0.95 GeV associated to the AK8 jet are provided. Additional features of charged PF candidates (formed primarily by a charged particle track) with pT > 0.95 GeV associated to the AK8 jet are also provided. Finally, additional features of reconstructed secondary vertices (SVs) associated to the AK8 jet (within ∆R < 0.8) are also provided.</p>"
     },
     "accelerator": "CERN-LHC",
     "authors": [
@@ -1427,7 +1427,7 @@
         "type": "isChildOf"
       }
     ],
-    "title": "HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC",
+    "title": "Sample with jet properties for Hbb tagging ML studies HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC",
     "type": {
       "primary": "Dataset",
       "secondary": [

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run1-datascience.json
@@ -1,95 +1,89 @@
 [
- {
+  {
     "abstract": {
       "description": "<p>Simulated dataset TTJets_HadronicMGDecays_8TeV-madgraph with boosted jets and enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
-    }, 
-    "accelerator": "CERN-LHC", 
+    },
+    "accelerator": "CERN-LHC",
     "categories": {
-      "primary": "Standard Model Physics", 
+      "primary": "Standard Model Physics",
       "secondary": [
         "Top physics"
-      ], 
+      ],
       "source": "CMS Collaboration"
-    }, 
+    },
     "collaboration": {
-      "name": "CMS collaboration", 
+      "name": "CMS collaboration",
       "recid": "451"
-    }, 
+    },
     "collections": [
       "CMS-Simulated-Datasets"
-    ], 
+    ],
     "collision_information": {
-      "energy": "8TeV", 
+      "energy": "8TeV",
       "type": "pp"
-    }, 
-    "control_number": "FIXME", 
+    },
     "date_created": [
       "2012"
-    ], 
-    "date_published": "2019", 
-    "date_reprocessed": "2019", 
+    ],
+    "date_published": "2019",
+    "date_reprocessed": "2019",
     "distribution": {
       "formats": [
-        "aodsim", 
+        "aodsim",
         "root"
-      ], 
-      "number_events": 1497600, 
-      "number_files": 2496, 
+      ],
+      "number_events": 1497600,
+      "number_files": 2496,
       "size": 0
-    }, 
-    "doi": "FIXME", 
-    "experiment": "CMS", 
-    "files": [], 
+    },
+    "experiment": "CMS",
+    "files": [],
     "generator": {
-      "global_tag": "", 
+      "global_tag": "",
       "names": []
-    }, 
+    },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n", 
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
             {
-              "process": "SIM", 
-              "recid": "FIXME", 
-              "title": "Modified SIM config to force all-jets decays and pT of both of the tops > 400 GeV and to keep simulated tracks FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_ttbar.py"
+              "process": "SIM",
+              "title": "Modified SIM config to force all-jets decays and pT of both of the tops > 400 GeV and to keep simulated tracks from <a href=\"https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_ttbar.py\">step0_ttbar.py</a>"
             }
-          ], 
+          ],
           "global_tag": "START53_V27",
-          "release": "CMSSW_5_3_32", 
+          "release": "CMSSW_5_3_32",
           "type": "SIM"
-        }, 
+        },
         {
           "configuration_files": [
             {
-              "process": "HLT", 
-              "recid": "FIXME", 
-              "title": "Modified configuration file for HLT step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
-            }, 
+              "process": "HLT",
+              "title": "Modified configuration file for HLT step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
+            },
             {
-              "process": "RECO", 
-              "recid": "FIXME", 
-              "title": "Modified configuration file for RECO step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
+              "process": "RECO",
+              "title": "Modified configuration file for RECO step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
             }
-          ], 
-          "global_tag": "START53_V27", 
-          "output_dataset": "FIXME: these files", 
-          "release": "CMSSW_5_3_32", 
+          ],
+          "global_tag": "START53_V27",
+          "release": "CMSSW_5_3_32",
           "type": "HLT RECO"
         }
       ]
-    }, 
+    },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>", 
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "37", 
+          "recid": "37",
           "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
         }
       ]
-    }, 
-    "publisher": "CERN Open Data Portal", 
-    "recid": "FIXME", 
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "12200",
     "relations": [
       {
         "description": "This ttbar dataset has boosted jet production enhanced in the generation step, and simulated tracks and reconstructed tracker hits included, and it is a modified version of: ",
@@ -98,131 +92,125 @@
       }
     ],
     "run_period": [
-      "Run2012A", 
-      "Run2012B", 
-      "Run2012C", 
+      "Run2012A",
+      "Run2012B",
+      "Run2012C",
       "Run2012D"
-    ], 
+    ],
     "system_details": {
-      "global_tag": "START53_LV6A1::All", 
+      "global_tag": "START53_LV6A1::All",
       "release": "CMSSW_5_3_32"
-    }, 
-    "title": "Tracker-hit-enriched TTJets_HadronicMGDecays_8TeV-madgraph", 
-    "title_additional": "Simulated dataset TTJets_HadronicMGDecays_8TeV-madgraph enriched with tracker hits in AODSIM format for 2012 collision data", 
+    },
+    "title": "Tracker-hit-enriched TTJets_HadronicMGDecays_8TeV-madgraph",
+    "title_additional": "Simulated dataset TTJets_HadronicMGDecays_8TeV-madgraph enriched with tracker hits in AODSIM format for 2012 collision data",
     "type": {
-      "primary": "Dataset", 
+      "primary": "Dataset",
       "secondary": [
         "Simulated"
       ]
-    }, 
+    },
     "usage": {
-      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in", 
+      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in",
       "links": [
         {
-          "description": "How to install the CMS Virtual Machine", 
+          "description": "How to install the CMS Virtual Machine",
           "url": "/docs/cms-virtual-machine-2011"
-        }, 
+        },
         {
-          "description": "Getting started with CMS open data", 
+          "description": "Getting started with CMS open data",
           "url": "/docs/cms-getting-started-2011"
         }
       ]
-    }, 
+    },
     "validation": {
       "description": "The generation and simulation of simulated Monte Carlo data has been validated through general CMS validation procedures."
     }
-  }, 
+  },
   {
     "abstract": {
       "description": "<p>Simulated dataset for the 300 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
-    }, 
-    "accelerator": "CERN-LHC", 
+    },
+    "accelerator": "CERN-LHC",
     "categories": {
-      "primary": "Standard Model Physics", 
+      "primary": "Standard Model Physics",
       "secondary": [
         "QCD"
-      ], 
+      ],
       "source": "CMS Collaboration"
-    }, 
+    },
     "collaboration": {
-      "name": "CMS collaboration", 
+      "name": "CMS collaboration",
       "recid": "451"
-    }, 
+    },
     "collections": [
       "CMS-Simulated-Datasets"
-    ], 
+    ],
     "collision_information": {
-      "energy": "8TeV", 
+      "energy": "8TeV",
       "type": "pp"
-    }, 
-    "control_number": "FIXME", 
+    },
     "date_created": [
       "2012"
-    ], 
-    "date_published": "2019", 
-    "date_reprocessed": "2019", 
+    ],
+    "date_published": "2019",
+    "date_reprocessed": "2019",
     "distribution": {
       "formats": [
-        "aodsim", 
+        "aodsim",
         "root"
-      ], 
-      "number_events": 1989000, 
-      "number_files": 3315, 
+      ],
+      "number_events": 1989000,
+      "number_files": 3315,
       "size": 0
-    }, 
-    "doi": "FIXME", 
-    "experiment": "CMS", 
-    "files": [], 
+    },
+    "experiment": "CMS",
+    "files": [],
     "generator": {
-      "global_tag": "", 
+      "global_tag": "",
       "names": []
-    }, 
+    },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n", 
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
             {
-              "process": "SIM", 
-              "recid": "FIXME", 
-              "title": "Modified SIM config to keep simulated tracks FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_QCD300to600.py"
+              "process": "SIM",
+              "title": "Modified SIM config to keep simulated tracks from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_QCD300to600.py"
             }
-          ], 
-          "global_tag": "START53_V27", 
-          "release": "CMSSW_5_3_32", 
+          ],
+          "global_tag": "START53_V27",
+          "release": "CMSSW_5_3_32",
           "type": "SIM"
-        }, 
+        },
         {
           "configuration_files": [
             {
-              "process": "HLT", 
-              "recid": "FIXME", 
-              "title": "Modified configuration file for HLT step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
-            }, 
+              "process": "HLT",
+              "title": "Modified configuration file for HLT step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
+            },
             {
-              "process": "RECO", 
-              "recid": "FIXME", 
-              "title": "Modified configuration file for RECO step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
+              "process": "RECO",
+              "title": "Modified configuration file for RECO step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
             }
-          ], 
-          "global_tag": "START53_V27", 
-          "output_dataset": "FIXME: these files", 
-          "release": "CMSSW_5_3_32", 
+          ],
+          "global_tag": "START53_V27",
+          "release": "CMSSW_5_3_32",
           "type": "HLT RECO"
         }
       ]
-    }, 
+    },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>", 
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "37", 
+          "recid": "37",
           "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
         }
       ]
-    }, 
-    "publisher": "CERN Open Data Portal", 
-    "recid": "FIXME", 
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "12201",
     "relations": [
       {
         "description": "This QCD dataset contains pTHat bin 300-600 GeV, and has simulated tracks and reconstructed tracker hits included, and it is a modified version of: ",
@@ -231,131 +219,125 @@
       }
     ],
     "run_period": [
-      "Run2012A", 
-      "Run2012B", 
-      "Run2012C", 
+      "Run2012A",
+      "Run2012B",
+      "Run2012C",
       "Run2012D"
-    ], 
+    ],
     "system_details": {
-      "global_tag": "START53_LV6A1::All", 
+      "global_tag": "START53_LV6A1::All",
       "release": "CMSSW_5_3_32"
-    }, 
-    "title": "Tracker-hit-enriched 300 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6", 
-    "title_additional": "Simulated dataset for the 300 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with tracker hits in AODSIM format for 2012 collision data", 
+    },
+    "title": "Tracker-hit-enriched 300 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6",
+    "title_additional": "Simulated dataset for the 300 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with tracker hits in AODSIM format for 2012 collision data",
     "type": {
-      "primary": "Dataset", 
+      "primary": "Dataset",
       "secondary": [
         "Simulated"
       ]
-    }, 
+    },
     "usage": {
-      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in", 
+      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in",
       "links": [
         {
-          "description": "How to install the CMS Virtual Machine", 
+          "description": "How to install the CMS Virtual Machine",
           "url": "/docs/cms-virtual-machine-2011"
-        }, 
+        },
         {
-          "description": "Getting started with CMS open data", 
+          "description": "Getting started with CMS open data",
           "url": "/docs/cms-getting-started-2011"
         }
       ]
-    }, 
+    },
     "validation": {
       "description": "The generation and simulation of simulated Monte Carlo data has been validated through general CMS validation procedures."
     }
-  }, 
+  },
   {
     "abstract": {
       "description": "<p>Simulated dataset for the 400 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
-    }, 
-    "accelerator": "CERN-LHC", 
+    },
+    "accelerator": "CERN-LHC",
     "categories": {
-      "primary": "Standard Model Physics", 
+      "primary": "Standard Model Physics",
       "secondary": [
         "QCD"
-      ], 
+      ],
       "source": "CMS Collaboration"
-    }, 
+    },
     "collaboration": {
-      "name": "CMS collaboration", 
+      "name": "CMS collaboration",
       "recid": "451"
-    }, 
+    },
     "collections": [
       "CMS-Simulated-Datasets"
-    ], 
+    ],
     "collision_information": {
-      "energy": "8TeV", 
+      "energy": "8TeV",
       "type": "pp"
-    }, 
-    "control_number": "FIXME", 
+    },
     "date_created": [
       "2012"
-    ], 
-    "date_published": "2019", 
-    "date_reprocessed": "2019", 
+    ],
+    "date_published": "2019",
+    "date_reprocessed": "2019",
     "distribution": {
       "formats": [
-        "aodsim", 
+        "aodsim",
         "root"
-      ], 
-      "number_events": 2974800, 
-      "number_files": 4959, 
+      ],
+      "number_events": 2974800,
+      "number_files": 4959,
       "size": 0
-    }, 
-    "doi": "FIXME", 
-    "experiment": "CMS", 
-    "files": [], 
+    },
+    "experiment": "CMS",
+    "files": [],
     "generator": {
-      "global_tag": "", 
+      "global_tag": "",
       "names": []
-    }, 
+    },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n", 
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
             {
-              "process": "SIM", 
-              "recid": "FIXME", 
-              "title": "Modified SIM config to keep simulated tracks FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_QCD400to600.py"
+              "process": "SIM",
+              "title": "Modified SIM config to keep simulated tracks from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_QCD400to600.py"
             }
-          ], 
-          "global_tag": "START53_V27", 
-          "release": "CMSSW_5_3_32", 
+          ],
+          "global_tag": "START53_V27",
+          "release": "CMSSW_5_3_32",
           "type": "SIM"
-        }, 
+        },
         {
           "configuration_files": [
             {
-              "process": "HLT", 
-              "recid": "FIXME", 
-              "title": "Modified configuration file for HLT step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
-            }, 
+              "process": "HLT",
+              "title": "Modified configuration file for HLT step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
+            },
             {
-              "process": "RECO", 
-              "recid": "FIXME", 
-              "title": "Modified configuration file for RECO step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
+              "process": "RECO",
+              "title": "Modified configuration file for RECO step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
             }
-          ], 
-          "global_tag": "START53_V27", 
-          "output_dataset": "FIXME: these files", 
-          "release": "CMSSW_5_3_32", 
+          ],
+          "global_tag": "START53_V27",
+          "release": "CMSSW_5_3_32",
           "type": "HLT RECO"
         }
       ]
-    }, 
+    },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>", 
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "37", 
+          "recid": "37",
           "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
         }
       ]
-    }, 
-    "publisher": "CERN Open Data Portal", 
-    "recid": "FIXME", 
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "12202",
     "relations": [
       {
         "description": "This QCD dataset contains pTHat bin 400-600 GeV, and has simulated tracks and reconstructed tracker hits included, and it is a modified version of: ",
@@ -364,36 +346,36 @@
       }
     ],
     "run_period": [
-      "Run2012A", 
-      "Run2012B", 
-      "Run2012C", 
+      "Run2012A",
+      "Run2012B",
+      "Run2012C",
       "Run2012D"
-    ], 
+    ],
     "system_details": {
-      "global_tag": "START53_LV6A1::All", 
+      "global_tag": "START53_LV6A1::All",
       "release": "CMSSW_5_3_32"
-    }, 
-    "title": "Tracker-hit-enriched 400 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6", 
-    "title_additional": "Simulated dataset for the 400 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with tracker hits in AODSIM format for 2012 collision data", 
+    },
+    "title": "Tracker-hit-enriched 400 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6",
+    "title_additional": "Simulated dataset for the 400 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with tracker hits in AODSIM format for 2012 collision data",
     "type": {
-      "primary": "Dataset", 
+      "primary": "Dataset",
       "secondary": [
         "Simulated"
       ]
-    }, 
+    },
     "usage": {
-      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in", 
+      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in",
       "links": [
         {
-          "description": "How to install the CMS Virtual Machine", 
+          "description": "How to install the CMS Virtual Machine",
           "url": "/docs/cms-virtual-machine-2011"
-        }, 
+        },
         {
-          "description": "Getting started with CMS open data", 
+          "description": "Getting started with CMS open data",
           "url": "/docs/cms-getting-started-2011"
         }
       ]
-    }, 
+    },
     "validation": {
       "description": "The generation and simulation of simulated Monte Carlo data has been validated through general CMS validation procedures."
     }
@@ -401,135 +383,128 @@
   {
     "abstract": {
       "description": "<p>Simulated dataset for the 600 to 3000 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
-    }, 
-    "accelerator": "CERN-LHC", 
+    },
+    "accelerator": "CERN-LHC",
     "categories": {
-      "primary": "Standard Model Physics", 
+      "primary": "Standard Model Physics",
       "secondary": [
         "QCD"
-      ], 
+      ],
       "source": "CMS Collaboration"
-    }, 
+    },
     "collaboration": {
-      "name": "CMS collaboration", 
+      "name": "CMS collaboration",
       "recid": "451"
-    }, 
+    },
     "collections": [
       "CMS-Simulated-Datasets"
-    ], 
+    ],
     "collision_information": {
-      "energy": "8TeV", 
+      "energy": "8TeV",
       "type": "pp"
-    }, 
-    "control_number": "FIXME", 
+    },
     "date_created": [
       "2012"
-    ], 
-    "date_published": "2019", 
-    "date_reprocessed": "2019", 
+    ],
+    "date_published": "2019",
+    "date_reprocessed": "2019",
     "distribution": {
       "formats": [
-        "aodsim", 
+        "aodsim",
         "root"
-      ], 
-      "number_events": 2969109, 
-      "number_files": 4055, 
+      ],
+      "number_events": 2969109,
+      "number_files": 4055,
       "size": 0
-    }, 
-    "doi": "FIXME", 
-    "experiment": "CMS", 
-    "files": [], 
+    },
+    "experiment": "CMS",
+    "files": [],
     "generator": {
-      "global_tag": "", 
+      "global_tag": "",
       "names": []
-    }, 
+    },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n", 
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
             {
-              "process": "SIM", 
-              "recid": "FIXME", 
-              "title": "Modified SIM config to keep simulated tracks FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_QCD600to3000.py"
+              "process": "SIM",
+              "title": "Modified SIM config to keep simulated tracks from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_QCD600to3000.py"
             }
-          ], 
+          ],
           "global_tag": "START53_V27",
-          "release": "CMSSW_5_3_32", 
+          "release": "CMSSW_5_3_32",
           "type": "SIM"
-        }, 
+        },
         {
           "configuration_files": [
             {
-              "process": "HLT", 
-              "recid": "FIXME", 
-              "title": "Modified configuration file for HLT step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
-            }, 
+              "process": "HLT",
+              "title": "Modified configuration file for HLT step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
+            },
             {
-              "process": "RECO", 
-              "recid": "FIXME", 
-              "title": "Modified configuration file for RECO step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
+              "process": "RECO",
+              "title": "Modified configuration file for RECO step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
             }
-          ], 
-          "global_tag": "START53_V27", 
-          "output_dataset": "FIXME: these files", 
-          "release": "CMSSW_5_3_32", 
+          ],
+          "global_tag": "START53_V27",
+          "release": "CMSSW_5_3_32",
           "type": "HLT RECO"
         }
       ]
-    }, 
+    },
     "pileup": {
-      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>", 
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>",
       "links": [
         {
-          "recid": "37", 
+          "recid": "37",
           "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
         }
       ]
-    }, 
-    "publisher": "CERN Open Data Portal", 
-    "recid": "FIXME", 
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "12203",
     "relations": [
       {
-        "description": "This QCD dataset contains pTHat bin 600-3000 GeV, and has simulated tracks and reconstructed tracker hits included, and it is a modified version of: ",
+        "description": "This QCD dataset contains pTHat bin 600-3000 GeV, and has simulated tracks and reconstructed tracker hits included, and it is a modified version of:",
         "recid": "8882",
         "type": "isRelatedTo"
       }
     ],
     "run_period": [
-      "Run2012A", 
-      "Run2012B", 
-      "Run2012C", 
+      "Run2012A",
+      "Run2012B",
+      "Run2012C",
       "Run2012D"
-    ], 
+    ],
     "system_details": {
-      "global_tag": "START53_LV6A1::All", 
+      "global_tag": "START53_LV6A1::All",
       "release": "CMSSW_5_3_32"
-    }, 
-    "title": "Tracker-hit-enriched 600 to 3000 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6", 
-    "title_additional": "Simulated dataset for the 600 to 3000 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with tracker hits in AODSIM format for 2012 collision data", 
+    },
+    "title": "Tracker-hit-enriched 600 to 3000 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6",
+    "title_additional": "Simulated dataset for the 600 to 3000 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with tracker hits in AODSIM format for 2012 collision data",
     "type": {
-      "primary": "Dataset", 
+      "primary": "Dataset",
       "secondary": [
         "Simulated"
       ]
-    }, 
+    },
     "usage": {
-      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in", 
+      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in",
       "links": [
         {
-          "description": "How to install the CMS Virtual Machine", 
+          "description": "How to install the CMS Virtual Machine",
           "url": "/docs/cms-virtual-machine-2011"
-        }, 
+        },
         {
-          "description": "Getting started with CMS open data", 
+          "description": "Getting started with CMS open data",
           "url": "/docs/cms-getting-started-2011"
         }
       ]
-    }, 
+    },
     "validation": {
       "description": "The generation and simulation of simulated Monte Carlo data has been validated through general CMS validation procedures."
     }
   }
 ]
-

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run1-datascience.json
@@ -1,0 +1,535 @@
+[
+ {
+    "abstract": {
+      "description": "<p>Simulated dataset TTJets_HadronicMGDecays_8TeV-madgraph with boosted jets and enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
+    }, 
+    "accelerator": "CERN-LHC", 
+    "categories": {
+      "primary": "Standard Model Physics", 
+      "secondary": [
+        "Top physics"
+      ], 
+      "source": "CMS Collaboration"
+    }, 
+    "collaboration": {
+      "name": "CMS collaboration", 
+      "recid": "451"
+    }, 
+    "collections": [
+      "CMS-Simulated-Datasets"
+    ], 
+    "collision_information": {
+      "energy": "8TeV", 
+      "type": "pp"
+    }, 
+    "control_number": "FIXME", 
+    "date_created": [
+      "2012"
+    ], 
+    "date_published": "2019", 
+    "date_reprocessed": "2019", 
+    "distribution": {
+      "formats": [
+        "aodsim", 
+        "root"
+      ], 
+      "number_events": 1497600, 
+      "number_files": 2496, 
+      "size": 0
+    }, 
+    "doi": "FIXME", 
+    "experiment": "CMS", 
+    "files": [], 
+    "generator": {
+      "global_tag": "", 
+      "names": []
+    }, 
+    "methodology": {
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n", 
+      "steps": [
+        {
+          "configuration_files": [
+            {
+              "process": "SIM", 
+              "recid": "FIXME", 
+              "title": "Modified SIM config to force all-jets decays and pT of both of the tops > 400 GeV and to keep simulated tracks FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_ttbar.py"
+            }
+          ], 
+          "global_tag": "START53_V27",
+          "release": "CMSSW_5_3_32", 
+          "type": "SIM"
+        }, 
+        {
+          "configuration_files": [
+            {
+              "process": "HLT", 
+              "recid": "FIXME", 
+              "title": "Modified configuration file for HLT step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
+            }, 
+            {
+              "process": "RECO", 
+              "recid": "FIXME", 
+              "title": "Modified configuration file for RECO step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
+            }
+          ], 
+          "global_tag": "START53_V27", 
+          "output_dataset": "FIXME: these files", 
+          "release": "CMSSW_5_3_32", 
+          "type": "HLT RECO"
+        }
+      ]
+    }, 
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>", 
+      "links": [
+        {
+          "recid": "37", 
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
+    }, 
+    "publisher": "CERN Open Data Portal", 
+    "recid": "FIXME", 
+    "relations": [
+      {
+        "description": "This ttbar dataset has boosted jet production enhanced in the generation step, and simulated tracks and reconstructed tracker hits included, and it is a modified version of: ",
+        "recid": "9582",
+        "type": "isRelatedTo"
+      }
+    ],
+    "run_period": [
+      "Run2012A", 
+      "Run2012B", 
+      "Run2012C", 
+      "Run2012D"
+    ], 
+    "system_details": {
+      "global_tag": "START53_LV6A1::All", 
+      "release": "CMSSW_5_3_32"
+    }, 
+    "title": "Tracker-hit-enriched TTJets_HadronicMGDecays_8TeV-madgraph", 
+    "title_additional": "Simulated dataset TTJets_HadronicMGDecays_8TeV-madgraph enriched with tracker hits in AODSIM format for 2012 collision data", 
+    "type": {
+      "primary": "Dataset", 
+      "secondary": [
+        "Simulated"
+      ]
+    }, 
+    "usage": {
+      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in", 
+      "links": [
+        {
+          "description": "How to install the CMS Virtual Machine", 
+          "url": "/docs/cms-virtual-machine-2011"
+        }, 
+        {
+          "description": "Getting started with CMS open data", 
+          "url": "/docs/cms-getting-started-2011"
+        }
+      ]
+    }, 
+    "validation": {
+      "description": "The generation and simulation of simulated Monte Carlo data has been validated through general CMS validation procedures."
+    }
+  }, 
+  {
+    "abstract": {
+      "description": "<p>Simulated dataset for the 300 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
+    }, 
+    "accelerator": "CERN-LHC", 
+    "categories": {
+      "primary": "Standard Model Physics", 
+      "secondary": [
+        "QCD"
+      ], 
+      "source": "CMS Collaboration"
+    }, 
+    "collaboration": {
+      "name": "CMS collaboration", 
+      "recid": "451"
+    }, 
+    "collections": [
+      "CMS-Simulated-Datasets"
+    ], 
+    "collision_information": {
+      "energy": "8TeV", 
+      "type": "pp"
+    }, 
+    "control_number": "FIXME", 
+    "date_created": [
+      "2012"
+    ], 
+    "date_published": "2019", 
+    "date_reprocessed": "2019", 
+    "distribution": {
+      "formats": [
+        "aodsim", 
+        "root"
+      ], 
+      "number_events": 1989000, 
+      "number_files": 3315, 
+      "size": 0
+    }, 
+    "doi": "FIXME", 
+    "experiment": "CMS", 
+    "files": [], 
+    "generator": {
+      "global_tag": "", 
+      "names": []
+    }, 
+    "methodology": {
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n", 
+      "steps": [
+        {
+          "configuration_files": [
+            {
+              "process": "SIM", 
+              "recid": "FIXME", 
+              "title": "Modified SIM config to keep simulated tracks FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_QCD300to600.py"
+            }
+          ], 
+          "global_tag": "START53_V27", 
+          "release": "CMSSW_5_3_32", 
+          "type": "SIM"
+        }, 
+        {
+          "configuration_files": [
+            {
+              "process": "HLT", 
+              "recid": "FIXME", 
+              "title": "Modified configuration file for HLT step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
+            }, 
+            {
+              "process": "RECO", 
+              "recid": "FIXME", 
+              "title": "Modified configuration file for RECO step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
+            }
+          ], 
+          "global_tag": "START53_V27", 
+          "output_dataset": "FIXME: these files", 
+          "release": "CMSSW_5_3_32", 
+          "type": "HLT RECO"
+        }
+      ]
+    }, 
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>", 
+      "links": [
+        {
+          "recid": "37", 
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
+    }, 
+    "publisher": "CERN Open Data Portal", 
+    "recid": "FIXME", 
+    "relations": [
+      {
+        "description": "This QCD dataset contains pTHat bin 300-600 GeV, and has simulated tracks and reconstructed tracker hits included, and it is a modified version of: ",
+        "recid": "8882",
+        "type": "isRelatedTo"
+      }
+    ],
+    "run_period": [
+      "Run2012A", 
+      "Run2012B", 
+      "Run2012C", 
+      "Run2012D"
+    ], 
+    "system_details": {
+      "global_tag": "START53_LV6A1::All", 
+      "release": "CMSSW_5_3_32"
+    }, 
+    "title": "Tracker-hit-enriched 300 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6", 
+    "title_additional": "Simulated dataset for the 300 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with tracker hits in AODSIM format for 2012 collision data", 
+    "type": {
+      "primary": "Dataset", 
+      "secondary": [
+        "Simulated"
+      ]
+    }, 
+    "usage": {
+      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in", 
+      "links": [
+        {
+          "description": "How to install the CMS Virtual Machine", 
+          "url": "/docs/cms-virtual-machine-2011"
+        }, 
+        {
+          "description": "Getting started with CMS open data", 
+          "url": "/docs/cms-getting-started-2011"
+        }
+      ]
+    }, 
+    "validation": {
+      "description": "The generation and simulation of simulated Monte Carlo data has been validated through general CMS validation procedures."
+    }
+  }, 
+  {
+    "abstract": {
+      "description": "<p>Simulated dataset for the 400 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
+    }, 
+    "accelerator": "CERN-LHC", 
+    "categories": {
+      "primary": "Standard Model Physics", 
+      "secondary": [
+        "QCD"
+      ], 
+      "source": "CMS Collaboration"
+    }, 
+    "collaboration": {
+      "name": "CMS collaboration", 
+      "recid": "451"
+    }, 
+    "collections": [
+      "CMS-Simulated-Datasets"
+    ], 
+    "collision_information": {
+      "energy": "8TeV", 
+      "type": "pp"
+    }, 
+    "control_number": "FIXME", 
+    "date_created": [
+      "2012"
+    ], 
+    "date_published": "2019", 
+    "date_reprocessed": "2019", 
+    "distribution": {
+      "formats": [
+        "aodsim", 
+        "root"
+      ], 
+      "number_events": 2974800, 
+      "number_files": 4959, 
+      "size": 0
+    }, 
+    "doi": "FIXME", 
+    "experiment": "CMS", 
+    "files": [], 
+    "generator": {
+      "global_tag": "", 
+      "names": []
+    }, 
+    "methodology": {
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n", 
+      "steps": [
+        {
+          "configuration_files": [
+            {
+              "process": "SIM", 
+              "recid": "FIXME", 
+              "title": "Modified SIM config to keep simulated tracks FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_QCD400to600.py"
+            }
+          ], 
+          "global_tag": "START53_V27", 
+          "release": "CMSSW_5_3_32", 
+          "type": "SIM"
+        }, 
+        {
+          "configuration_files": [
+            {
+              "process": "HLT", 
+              "recid": "FIXME", 
+              "title": "Modified configuration file for HLT step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
+            }, 
+            {
+              "process": "RECO", 
+              "recid": "FIXME", 
+              "title": "Modified configuration file for RECO step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
+            }
+          ], 
+          "global_tag": "START53_V27", 
+          "output_dataset": "FIXME: these files", 
+          "release": "CMSSW_5_3_32", 
+          "type": "HLT RECO"
+        }
+      ]
+    }, 
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>", 
+      "links": [
+        {
+          "recid": "37", 
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
+    }, 
+    "publisher": "CERN Open Data Portal", 
+    "recid": "FIXME", 
+    "relations": [
+      {
+        "description": "This QCD dataset contains pTHat bin 400-600 GeV, and has simulated tracks and reconstructed tracker hits included, and it is a modified version of: ",
+        "recid": "8882",
+        "type": "isRelatedTo"
+      }
+    ],
+    "run_period": [
+      "Run2012A", 
+      "Run2012B", 
+      "Run2012C", 
+      "Run2012D"
+    ], 
+    "system_details": {
+      "global_tag": "START53_LV6A1::All", 
+      "release": "CMSSW_5_3_32"
+    }, 
+    "title": "Tracker-hit-enriched 400 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6", 
+    "title_additional": "Simulated dataset for the 400 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with tracker hits in AODSIM format for 2012 collision data", 
+    "type": {
+      "primary": "Dataset", 
+      "secondary": [
+        "Simulated"
+      ]
+    }, 
+    "usage": {
+      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in", 
+      "links": [
+        {
+          "description": "How to install the CMS Virtual Machine", 
+          "url": "/docs/cms-virtual-machine-2011"
+        }, 
+        {
+          "description": "Getting started with CMS open data", 
+          "url": "/docs/cms-getting-started-2011"
+        }
+      ]
+    }, 
+    "validation": {
+      "description": "The generation and simulation of simulated Monte Carlo data has been validated through general CMS validation procedures."
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>Simulated dataset for the 600 to 3000 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
+    }, 
+    "accelerator": "CERN-LHC", 
+    "categories": {
+      "primary": "Standard Model Physics", 
+      "secondary": [
+        "QCD"
+      ], 
+      "source": "CMS Collaboration"
+    }, 
+    "collaboration": {
+      "name": "CMS collaboration", 
+      "recid": "451"
+    }, 
+    "collections": [
+      "CMS-Simulated-Datasets"
+    ], 
+    "collision_information": {
+      "energy": "8TeV", 
+      "type": "pp"
+    }, 
+    "control_number": "FIXME", 
+    "date_created": [
+      "2012"
+    ], 
+    "date_published": "2019", 
+    "date_reprocessed": "2019", 
+    "distribution": {
+      "formats": [
+        "aodsim", 
+        "root"
+      ], 
+      "number_events": 2969109, 
+      "number_files": 4055, 
+      "size": 0
+    }, 
+    "doi": "FIXME", 
+    "experiment": "CMS", 
+    "files": [], 
+    "generator": {
+      "global_tag": "", 
+      "names": []
+    }, 
+    "methodology": {
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n", 
+      "steps": [
+        {
+          "configuration_files": [
+            {
+              "process": "SIM", 
+              "recid": "FIXME", 
+              "title": "Modified SIM config to keep simulated tracks FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_QCD600to3000.py"
+            }
+          ], 
+          "global_tag": "START53_V27",
+          "release": "CMSSW_5_3_32", 
+          "type": "SIM"
+        }, 
+        {
+          "configuration_files": [
+            {
+              "process": "HLT", 
+              "recid": "FIXME", 
+              "title": "Modified configuration file for HLT step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
+            }, 
+            {
+              "process": "RECO", 
+              "recid": "FIXME", 
+              "title": "Modified configuration file for RECO step to keep tracker recHits FIXME from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
+            }
+          ], 
+          "global_tag": "START53_V27", 
+          "output_dataset": "FIXME: these files", 
+          "release": "CMSSW_5_3_32", 
+          "type": "HLT RECO"
+        }
+      ]
+    }, 
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> are added to the simulated event in this step.</p>", 
+      "links": [
+        {
+          "recid": "37", 
+          "title": "/MinBias_TuneZ2star_8TeV-pythia6/Summer12-START50_V13-v3/GEN-SIM"
+        }
+      ]
+    }, 
+    "publisher": "CERN Open Data Portal", 
+    "recid": "FIXME", 
+    "relations": [
+      {
+        "description": "This QCD dataset contains pTHat bin 600-3000 GeV, and has simulated tracks and reconstructed tracker hits included, and it is a modified version of: ",
+        "recid": "8882",
+        "type": "isRelatedTo"
+      }
+    ],
+    "run_period": [
+      "Run2012A", 
+      "Run2012B", 
+      "Run2012C", 
+      "Run2012D"
+    ], 
+    "system_details": {
+      "global_tag": "START53_LV6A1::All", 
+      "release": "CMSSW_5_3_32"
+    }, 
+    "title": "Tracker-hit-enriched 600 to 3000 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6", 
+    "title_additional": "Simulated dataset for the 600 to 3000 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with tracker hits in AODSIM format for 2012 collision data", 
+    "type": {
+      "primary": "Dataset", 
+      "secondary": [
+        "Simulated"
+      ]
+    }, 
+    "usage": {
+      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started in", 
+      "links": [
+        {
+          "description": "How to install the CMS Virtual Machine", 
+          "url": "/docs/cms-virtual-machine-2011"
+        }, 
+        {
+          "description": "Getting started with CMS open data", 
+          "url": "/docs/cms-getting-started-2011"
+        }
+      ]
+    }, 
+    "validation": {
+      "description": "The generation and simulation of simulated Monte Carlo data has been validated through general CMS validation procedures."
+    }
+  }
+]
+

--- a/cernopendata/modules/fixtures/data/records/cms-tools-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-Run1-datascience.json
@@ -1,0 +1,90 @@
+[
+ {
+  "created": "FIXME", 
+  "id": 0, 
+  "metadata": {
+    "$schema": "http://opendata.cern.ch/schema/records/record-v1.0.0.json", 
+    "abstract": {
+      "description": " <p> An example workflow to produce CMS Run1 AODSIM enriched with tracker RecHits. All steps from event generation to reconstruction (step0-step2) are provided, including instructions how to store Tracker RecHit information from CMS full simulation events, and the tool to extract the information in a format appropriate to ML studies (step3) is included. The code can be run inside the CMS Open Data environment</p>"
+    }, 
+    "accelerator": "CERN-LHC", 
+    "authors": [
+      {
+        "name": "Usai, Emanuele",
+        "orcid": "0000-0001-9323-2107"
+      },
+      {
+        "name": "Andrews, Michael",
+        "orcid": "0000-0001-5537-4518"
+      },
+      {
+        "name": "Burkle, Bjorn",
+        "orcid": "0000-0003-1645-822X"
+      },
+      {
+        "name": "Gleyzer, Sergei",
+        "orcid": "0000-0002-6222-8102"
+      },
+      {
+        "name": "Narain, Meenakshi",
+        "orcid": "0000-0002-7857-7403"
+      }
+    ],
+    "control_number": "FIXME", 
+    "date_created": [
+      "2019"
+    ], 
+    "date_published": "2019", 
+    "distribution": {
+      "formats": [
+        "gz"
+      ], 
+      "number_files": 1, 
+      "size": FIXME
+    }, 
+    "doi": "FIXME", 
+    "experiment": "CMS", 
+    "files": [
+      {
+        "checksum": "FIXME", 
+        "filename": "FIXME check TrackerRecHitProducerTool-1.0.0.tar.gz", 
+        "size": 0, 
+        "uri_http": "FIXME", 
+        "uri_root": "FIXME"
+      }
+    ], 
+    "index_files": [], 
+    "license": {
+      "attribution": "GNU General Public License (GPL) version 3"
+    }, 
+    "publisher": "CERN Open Data Portal", 
+    "recid": "FIXME", 
+    "run_period": [
+      "Run1"
+    ], 
+    "system_details": {
+      "description": "Use this code with the CMS Open Data VM environment", 
+      "recid": "252", 
+      "release": "CMSSW_5_3_32"
+    }, 
+    "title": "TrackerRecHitProducerTool - an example workflow to add tracker hits to CMS Run1 AOD", 
+    "type": {
+      "primary": "Software", 
+      "secondary": [
+        "Tool"
+      ]
+    }, 
+    "usage": {
+      "description": " <p>If you do not have the CERN Virtual Machine for CMS open data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2011\">How to install a CERN Virtual Machine</a>.  <p>To run the analysis, follow the instructions in FIXME <a href=\"https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool\">https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool</a>.</p> "
+    }, 
+    "use_with": {
+      "description": "The ouput of step2 can be used as an input to step3 (FIXME from #2526):", 
+      "links": [
+        {
+          "recid": "FIXME"   
+        }
+      ]
+    }
+  }
+ }
+]

--- a/cernopendata/modules/fixtures/data/records/cms-tools-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-Run1-datascience.json
@@ -1,13 +1,9 @@
 [
- {
-  "created": "FIXME", 
-  "id": 0, 
-  "metadata": {
-    "$schema": "http://opendata.cern.ch/schema/records/record-v1.0.0.json", 
+  {
     "abstract": {
-      "description": " <p> An example workflow to produce CMS Run1 AODSIM enriched with tracker RecHits. All steps from event generation to reconstruction (step0-step2) are provided, including instructions how to store Tracker RecHit information from CMS full simulation events, and the tool to extract the information in a format appropriate to ML studies (step3) is included. The code can be run inside the CMS Open Data environment</p>"
-    }, 
-    "accelerator": "CERN-LHC", 
+      "description": "An example workflow to produce CMS Run1 AODSIM enriched with tracker RecHits. All steps from event generation to reconstruction (step0-step2) are provided, including instructions how to store Tracker RecHit information from CMS full simulation events, and the tool to extract the information in a format appropriate to ML studies (step3) is included. The code can be run inside the CMS Open Data environment."
+    },
+    "accelerator": "CERN-LHC",
     "authors": [
       {
         "name": "Usai, Emanuele",
@@ -30,61 +26,63 @@
         "orcid": "0000-0002-7857-7403"
       }
     ],
-    "control_number": "FIXME", 
+    "collections": [
+      "CMS-Tools"
+    ],
     "date_created": [
       "2019"
-    ], 
-    "date_published": "2019", 
-    "distribution": {
-      "formats": [
-        "gz"
-      ], 
-      "number_files": 1, 
-      "size": FIXME
-    }, 
-    "doi": "FIXME", 
-    "experiment": "CMS", 
-    "files": [
-      {
-        "checksum": "FIXME", 
-        "filename": "FIXME check TrackerRecHitProducerTool-1.0.0.tar.gz", 
-        "size": 0, 
-        "uri_http": "FIXME", 
-        "uri_root": "FIXME"
-      }
-    ], 
-    "index_files": [], 
+    ],
+    "date_published": "2019",
+    "experiment": "CMS",
+    "keywords": [
+      "datascience"
+    ],
     "license": {
       "attribution": "GNU General Public License (GPL) version 3"
-    }, 
-    "publisher": "CERN Open Data Portal", 
-    "recid": "FIXME", 
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "12210",
     "run_period": [
       "Run1"
-    ], 
+    ],
+    "relations": [
+      {
+        "description": "The ouput dataset of this software tool is available in",
+        "recid": "12220",
+        "type": "isRelatedTo"
+      }
+    ],
     "system_details": {
-      "description": "Use this code with the CMS Open Data VM environment", 
-      "recid": "252", 
+      "description": "Use this code with the CMS Open Data VM environment",
+      "recid": "252",
       "release": "CMSSW_5_3_32"
-    }, 
-    "title": "TrackerRecHitProducerTool - an example workflow to add tracker hits to CMS Run1 AOD", 
+    },
+    "title": "TrackerRecHitProducerTool - an example workflow to add tracker hits to CMS Run1 AOD",
     "type": {
-      "primary": "Software", 
+      "primary": "Software",
       "secondary": [
         "Tool"
       ]
-    }, 
+    },
     "usage": {
-      "description": " <p>If you do not have the CERN Virtual Machine for CMS open data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2011\">How to install a CERN Virtual Machine</a>.  <p>To run the analysis, follow the instructions in FIXME <a href=\"https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool\">https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool</a>.</p> "
-    }, 
+      "description": " <p>If you do not have the CERN Virtual Machine for CMS open data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2011\">How to install a CERN Virtual Machine</a>.  <p>To run the analysis, follow the instructions in <a href=\"https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool\">TrackerRecHitProducerTool GitHub documentationb</a>.</p> "
+    },
     "use_with": {
-      "description": "The ouput of step2 can be used as an input to step3 (FIXME from #2526):", 
+      "description": "Use this with Run1 QCD MiniAODSIM dataset enriched with tracker hits.",
       "links": [
         {
-          "recid": "FIXME"   
+          "recid": "12200"
+        },
+        {
+          "recid": "12201"
+        },
+        {
+          "recid": "12202"
+        },
+        {
+          "recid": "12203"
         }
       ]
     }
   }
- }
 ]


### PR DESCRIPTION
(addresses #2526 & #2575 & #2588)

Adds 4 records for tracker-hit-enriched Run1 AOD, related  records 9582 (for the 1st record), 8882 (for the 3 others)

Adds records for the resulting ML files

Adds record for the SW

For AODSIM, needs:
- modified config files from the github repo (see also  #2588 ) either as records of their own or as files attached to their own record (now links are after FIXME in the config title field
- size of filese
- file indexes: files to be moved from the `/eospublic/cms/upload/emanuele`
   - `step2_ttbarOD_0*` for the 1st record
   - `step2_QCD300to600` for the 2nd record
   - `step2_QCD400to600` for the 3rd record
   - `step2_QCD_600to3000_0*` for the 4th record

For ML files, needs:
- remove end-of-lines in table html
- remove quotes if needed for type field in the dataset semantics

@emanueleusai Is that right, all files in szep2_ttbarOD_0* directories belong together? And the same for 600to3000?