### PR TITLE
Add data records related to castor

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Commissioning2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-primary-datasets-Commissioning2010.json
@@ -1,0 +1,290 @@
+[
+  {
+    "abstract": {
+      "description": "<p>MinimumBias primary dataset in RECO format from Commissioning run of 2010. This dataset includes the data from  <a href=\"http://inspirehep.net/record/1227802/\">the CASTOR calorimeter</a>, which covers the very forward region in the CMS experiment (-6.6 < eta < -5.2). </p> <p> The list of validated runs, which must be applied to all analyses, can be found in</p>",
+      "links": [
+        {
+          "recid": "FIXME"
+        }
+      ]
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "450"
+    },
+    "collections": [
+      "CMS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "0.9TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2010"
+    ],
+    "date_published": "2019",
+    "date_reprocessed": "2011",
+    "distribution": {
+      "formats": [
+        "root",
+        "reco"
+      ],
+      "number_events": 19958247,
+      "number_files": 563,
+      "size": 1863373595440
+    },
+    "experiment": "CMS",
+    "license": {
+      "attribution": "CC0"
+    },
+    "methodology": {
+      "description": "<p>Events stored in this primary dataset were selected because of presence FIXME</p><p><strong>HLT trigger paths</strong> <br/>The possible HLT trigger paths in this dataset are: <br/>FIXME</p>"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "14000",
+    "relations": [
+      {
+        "title": "/MinimumBias/Commissioning10-398patch2_900GeV_skim_TkSD-v1/RAW ",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "Commissioning2010"
+    ],
+    "system_details": {
+      "global_tag": "'FT_R_42_V10A::All",
+      "release": "CMSSW_4_2_8_lowpupatch1"
+    },
+    "title": "/MinimumBias/Commissioning10-07JunReReco_900GeV/RECO",
+    "title_additional": "MinimumBias primary dataset in RECO format from Commissioning run of 2010 (/MinimumBias/Commissioning10-07JunReReco_900GeV/RECO)",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started with CASTOR calorimeter data in",
+      "links": [
+        {
+          "description": "How to install the CMS Virtual Machine",
+          "url": "/VM/CMS"
+        },
+        {
+          "description": "Analysis recipe to use CASTOR objects with 2010 CMS OpenData",
+          "url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/CASTOROpenData2010"
+        }
+      ]
+    },
+    "validation": {
+      "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+      "links": [
+        {
+          "description": "CMS data quality monitoring: Systems and experiences",
+          "url": "http://iopscience.iop.org/1742-6596/219/7/072020/pdf/1742-6596_219_7_072020.pdf"
+        },
+        {
+          "description": "The CMS Data Quality Monitoring software experience and future improvements",
+          "url": "http://cds.cern.ch/record/1631039/files/CR2013_418.pdf"
+        },
+        {
+          "description": "The CMS data quality monitoring software: experience and future prospects",
+          "url": "http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>MinimumBias primary dataset in RECO format from Commissioning run of 2010. This dataset includes the data from <a href=\"http://inspirehep.net/record/1227802/\">the CASTOR calorimeter</a>, which covers the very forward region in the CMS experiment (-6.6 < eta < -5.2). </p> <p> The list of validated runs, which must be applied to all analyses, can be found in</p>",
+      "links": [
+        {
+          "recid": "FIXME"
+        }
+      ]
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "450"
+    },
+    "collections": [
+      "CMS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "7TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2010"
+    ],
+    "date_published": "2019",
+    "date_reprocessed": "2011",
+    "distribution": {
+      "formats": [
+        "root",
+        "reco"
+      ],
+      "number_events": 46553963,
+      "number_files": 1452,
+      "size": 5525720585210
+    },
+    "experiment": "CMS",
+    "license": {
+      "attribution": "CC0"
+    },
+    "methodology": {
+      "description": "<p>Events stored in this primary dataset were selected because of presence FIXME</p><p><strong>HLT trigger paths</strong> <br/>The possible HLT trigger paths in this dataset are: <br/>FIXME</p> "
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "14001",
+    "relations": [
+      {
+        "title": "/MinimumBias/Commissioning10-398patch2_skim_TkSD-v1/RAW",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "Commissioning2010"
+    ],
+    "system_details": {
+      "global_tag": "'FT_R_42_V10A::All",
+      "release": "CMSSW_4_2_8_lowpupatch1"
+    },
+    "title": "/MinimumBias/Commissioning10-May19ReReco-v1/RECO",
+    "title_additional": "MinimumBias primary dataset in RECO format from Commissioning run of 2010 (/MinimumBias/Commissioning10-May19ReReco-v1/RECO)",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started with CASTOR calorimeter data in",
+      "links": [
+        {
+          "description": "How to install the CMS Virtual Machine",
+          "url": "/VM/CMS"
+        },
+        {
+          "description": "Analysis recipe to use CASTOR objects with 2010 CMS OpenData",
+          "url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/CASTOROpenData2010"
+        }
+      ]
+    },
+    "validation": {
+      "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+      "links": [
+        {
+          "description": "CMS data quality monitoring: Systems and experiences",
+          "url": "http://iopscience.iop.org/1742-6596/219/7/072020/pdf/1742-6596_219_7_072020.pdf"
+        },
+        {
+          "description": "The CMS Data Quality Monitoring software experience and future improvements",
+          "url": "http://cds.cern.ch/record/1631039/files/CR2013_418.pdf"
+        },
+        {
+          "description": "The CMS data quality monitoring software: experience and future prospects",
+          "url": "http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf"
+        }
+      ]
+    }
+  },
+   {
+    "abstract": {
+      "description": "<p>ZeroBias primary dataset in RECO format from Commissioning run of 2010. This dataset includes the data from <a href=\"http://inspirehep.net/record/1227802/\">the CASTOR calorimeter</a>, which covers the very forward region in the CMS experiment (-6.6 < eta < -5.2). </p> <p> The list of validated runs, which must be applied to all analyses, can be found in</p>",
+      "links": [
+        {
+          "recid": "FIXME"
+        }
+      ]
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "450"
+    },
+    "collections": [
+      "CMS-Primary-Datasets"
+    ],
+    "collision_information": {
+      "energy": "7TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2010"
+    ],
+    "date_published": "2019",
+    "date_reprocessed": "2011",
+    "distribution": {
+      "formats": [
+        "root",
+        "reco"
+      ],
+      "number_events": 129186198,
+      "number_files": 3045,
+      "size": 10009271150212
+    },
+    "experiment": "CMS",
+    "license": {
+      "attribution": "CC0"
+    },
+    "methodology": {
+      "description": "<p>Events stored in this primary dataset were selected because of presence FIXME</p><p><strong>HLT trigger paths</strong> <br/>The possible HLT trigger paths in this dataset are: <br/>FIXME</p> "
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "14002",
+    "relations": [
+      {
+        "title": "/ZeroBias/Commissioning10-v4/RAW",
+        "type": "isChildOf"
+      }
+    ],
+    "run_period": [
+      "Commissioning2010"
+    ],
+    "system_details": {
+      "global_tag": "'FT_R_42_V10A::All",
+      "release": "CMSSW_4_2_8_lowpupatch1"
+    },
+    "title": "/ZeroBias/Commissioning10-May19ReReco-v1/RECO",
+    "title_additional": "ZeroBias primary dataset in RECO format from Commissioning run of 2010 (/ZeroBias/Commissioning10-May19ReReco-v1/RECO)",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Collision"
+      ]
+    },
+    "usage": {
+      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started with CASTOR calorimeter data in",
+      "links": [
+        {
+          "description": "How to install the CMS Virtual Machine",
+          "url": "/VM/CMS"
+        },
+        {
+          "description": "Analysis recipe to use CASTOR objects with 2010 CMS OpenData",
+          "url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/CASTOROpenData2010"
+        }
+      ]
+    },
+    "validation": {
+      "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+      "links": [
+        {
+          "description": "CMS data quality monitoring: Systems and experiences",
+          "url": "http://iopscience.iop.org/1742-6596/219/7/072020/pdf/1742-6596_219_7_072020.pdf"
+        },
+        {
+          "description": "The CMS Data Quality Monitoring software experience and future improvements",
+          "url": "http://cds.cern.ch/record/1631039/files/CR2013_418.pdf"
+        },
+        {
+          "description": "The CMS data quality monitoring software: experience and future prospects",
+          "url": "http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf"
+        }
+      ]
+    }
+  }
+]

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010-commissioning.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010-commissioning.json
@@ -1,0 +1,107 @@
+[
+  {
+    "abstract": {
+      "description": "<p>Simulated dataset MinBias_TuneZ2_900GeV_pythia6_cff_py_GEN_SIM_START311_V2_Dec11_v2 in GEN-SIM-RECO format (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>) format for 2010 Commissioning run. </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data that were collected by the CMS experiment during 2010 Commissioning run and contain the simulation of <a href=\"http://inspirehep.net/record/1227802/\">the CASTOR calorimeter</a>.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "categories": {
+      "primary": "Standard Model Physics",
+      "secondary": [
+        "Minimum Bias"
+      ],
+      "source": "CMS Collaboration"
+    },
+    "collaboration": {
+      "name": "CMS Collaboration"
+    },
+    "collections": [
+      "CMS-Simulated-Datasets"
+    ],
+    "collision_information": {
+      "energy": "0.9TeV",
+      "type": "pp"
+    },
+    "date_created": [
+      "2010"
+    ],
+    "date_published": "2019",
+    "date_reprocessed": "2011",
+    "distribution": {
+      "formats": [
+        "gen-sim-reco",
+        "root"
+      ],
+      "number_events": 20000,
+      "number_files": 4,
+      "size": 19291020935
+    },
+    "experiment": "CMS",
+    "license": {
+      "attribution": "CC0"
+    },
+    "methodology": {
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
+      "steps": [
+        {
+          "configuration_files": [
+            {
+              "script": "cmsDriver.py Configuration/GenProduction/python/MinBias_TuneZ2_900GeV_pythia6_cff.py --step GEN,SIM --beamspot Realistic7TeVCollision --conditions START311_V2::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/SimWithCastor_cff.customise --eventcontent RAWSIM -- datatier GEN-SIM —no_exec  \n\n",
+              "title": "Production script (manual adjustment of CASTOR non compensation)"
+            }
+          ],
+          "global_tag": "START311_V2::All",
+          "release": "CMSSW_4_1_6",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "cmsDriver.py REDIGI --step DIGI,L1,DIGI2RAW,HLT:GRun --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/DigiToRecoNoPU.customise --eventcontent RAWSIM --datatier GEN-SIM-RAW —no_exec  \n\n",
+              "title": "Production script"
+            },
+            {
+              "script": "cmsDriver.py STEP2 --step RAW2DIGI,L1Reco,RECO --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC --eventcontent RECOSIM --datatier GEN-SIM-RECO —no_exec  \n\n",
+              "title": "Production script (manual inclusion of specific beamspot settings)"
+            }
+          ],
+          "global_tag": "START42_V11::All",
+          "release": "CMSSW_4_2_3_patch3",
+          "type": "HLT RECO"
+        }
+      ]
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "14100",
+    "run_period": [
+      "Commissioning2010"
+    ],
+    "system_details": {
+      "global_tag": "START42_V11::All",
+      "release": "CMSSW_4_2_8_lowpupatch1"
+    },
+    "title": "/MinBias_TuneZ2_900GeV_pythia6_cff_py_GEN_SIM_START311_V2_Dec11_v2/hvanhaev-MinBias_TuneZ2_900GeV_pythia6_cff_py_Step3_START42_V11_Dec11_v3-04745fc182f9123f750cb5f7764a36c5/USER",
+    "title_additional": "Simulated dataset MinBias_TuneZ2_900GeV_pythia6_cff_py_GEN_SIM_START311_V2_Dec11_v2 in GEN-SIM-RECO format for 2010 commissioning data",
+    "type": {
+      "primary": "Dataset",
+      "secondary": [
+        "Simulated"
+      ]
+    },
+    "usage": {
+      "description": "You can access these data through the CMS Virtual Machine. See the instructions for setting up the Virtual Machine and getting started with CASTOR calorimeter data in",
+      "links": [
+        {
+          "description": "How to install the CMS Virtual Machine",
+          "url": "/VM/CMS"
+        },
+        {
+          "description": "Analysis recipe to use CASTOR objects with 2010 CMS OpenData",
+          "url": "https://twiki.cern.ch/twiki/bin/view/CMSPublic/CASTOROpenData2010"
+        }
+      ]
+    },
+    "validation": {
+      "description": "The generation and simulation of simulated Monte Carlo data has been validated through general CMS validation procedures."
+    }
+  }
+]

--- a/cernopendata/modules/fixtures/data/records/cms-validated-runs-Commissioning2010-castor.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validated-runs-Commissioning2010-castor.json
@@ -1,0 +1,116 @@
+[
+  {
+    "abstract": {
+      "description": "<p>This file describes which luminosity sections in which runs are considered good and should be processed.</p> <p>The list covers p-p data taking at 0.9 TeV in Commissioning run of 2010 and it is to be used in the analysis of data from the CASTOR calorimeter. The list includeds runs 134721 and 134725.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS Collaboration",
+      "recid": "450"
+    },
+    "collections": [
+      "CMS-Validated-Runs",
+      "CMS-Validation-Utilities"
+    ],
+    "date_created": [
+      "2011"
+    ],
+    "date_published": "2019",
+    "distribution": {
+      "formats": [
+        "txt"
+      ]
+    },
+    "experiment": "CMS",
+    "publisher": "CERN Open Data Portal",
+    "recid": "14200",
+    "run_period": [
+      "Commissioning2010"
+    ],
+    "title": "CMS list of validated runs Commissioning10-May19ReReco_900GeV.json",
+    "title_additional": "CMS list of validated runs for primary datasets of 2010 Commissioning data taking at 0.9 TeV for usage with CASTOR data",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "Validation"
+      ]
+    },
+    "usage": {
+      "description": " <p>Add the following lines in the configuration file for a cmsRun job: <br />import FWCore.ParameterSet.Config as cms <br /> import FWCore.PythonUtilities.LumiList as LumiList <br /> goodJSON = 'Commissioning10-May19ReReco_900GeV.json' <br /> myLumis = LumiList.LumiList(filename = goodJSON).getCMSSWString().split(',') </p><p> Add the file path if needed in the file name.</p><p> Add the following statements after the process.source input file definition: <br /> process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange() <br /> process.source.lumisToProcess.extend(myLumis)</p> "
+    },
+    "validation": {
+      "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+      "links": [
+        {
+          "description": "CMS data quality monitoring: Systems and experiences",
+          "url": "http://iopscience.iop.org/1742-6596/219/7/072020/pdf/1742-6596_219_7_072020.pdf"
+        },
+        {
+          "description": "The CMS Data Quality Monitoring software experience and future improvements",
+          "url": "http://cds.cern.ch/record/1631039/files/CR2013_418.pdf"
+        },
+        {
+          "description": "The CMS data quality monitoring software: experience and future prospects",
+          "url": "http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf"
+        }
+      ]
+    }
+  },
+  {
+    "abstract": {
+      "description": "<p>This file describes which luminosity sections in which runs are considered good and should be processed.</p> <p>The list covers p-p data taking at 7 TeV in Commissioning run of 2010 and it is to be used in the analysis of data from the CASTOR calorimeter. The list includeds runs between 135059 and 135575.</p>"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS Collaboration",
+      "recid": "450"
+    },
+    "collections": [
+      "CMS-Validated-Runs",
+      "CMS-Validation-Utilities"
+    ],
+    "date_created": [
+      "2011"
+    ],
+    "date_published": "2019",
+    "distribution": {
+      "formats": [
+        "txt"
+      ]
+    },
+    "experiment": "CMS",
+    "publisher": "CERN Open Data Portal",
+    "recid": "14201",
+    "run_period": [
+      "Commissioning2010"
+    ],
+    "title": "CMS list of validated runs Commissioning10-May19ReReco_7TeV.json",
+    "title_additional": "CMS list of validated runs for primary datasets of 2010 Commissioning data taking at 7 TeV for usage with CASTOR data",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "Validation"
+      ]
+    },
+    "usage": {
+      "description": "<p>Add the following lines in the configuration file for a cmsRun job: <br />import FWCore.ParameterSet.Config as cms <br /> import FWCore.PythonUtilities.LumiList as LumiList <br /> goodJSON = 'Commissioning10-May19ReReco_7TeV.json' <br /> myLumis = LumiList.LumiList(filename = goodJSON).getCMSSWString().split(',') </p><p> Add the file path if needed in the file name.</p><p> Add the following statements after the process.source input file definition: <br /> process.source.lumisToProcess = cms.untracked.VLuminosityBlockRange() <br /> process.source.lumisToProcess.extend(myLumis)</p>"
+    },
+    "validation": {
+      "description": "During data taking all the runs recorded by CMS are certified as good for physics analysis if all subdetectors, trigger, lumi and physics objects (tracking, electron, muon, photon, jet and MET) show the expected performance. Certification is based first on the offline shifters evaluation and later on the feedback provided by detector and Physics Object Group experts. Based on the above information, which is stored in a specific database called Run Registry, the Data Quality Monitoring group verifies the consistency of the certification and prepares a json file of certified runs to be used for physics analysis. For each reprocessing of the raw data, the above mentioned steps are repeated. For more information see:",
+      "links": [
+        {
+          "description": "CMS data quality monitoring: Systems and experiences",
+          "url": "http://iopscience.iop.org/1742-6596/219/7/072020/pdf/1742-6596_219_7_072020.pdf"
+        },
+        {
+          "description": "The CMS Data Quality Monitoring software experience and future improvements",
+          "url": "http://cds.cern.ch/record/1631039/files/CR2013_418.pdf"
+        },
+        {
+          "description": "The CMS data quality monitoring software: experience and future prospects",
+          "url": "http://iopscience.iop.org/1742-6596/513/3/032024/pdf/1742-6596_513_3_032024.pdf"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
(addresses #2606 & #2608 )

Adds 
- 3 records for Commissioning 2010 primary datasets
- corresponding lists of validated runs
- one of the 6 MC records (for the 1st check)

Needs:
- check if the Castor ref in abstract description is OK
- check why parent datasets for MinimumBias appear as ...skim../RAW (not available)
- complete the data selection description
- recid reference of json
- recid for the records
- files listings 
  - files are in the upload area for data records
  - the validated run lists
    - https://twiki.cern.ch/twiki/pub/CMSPublic/CASTOROpenData2010/Commissioning10-May19ReReco_900GeV.json 
    - https://twiki.cern.ch/twiki/pub/CMSPublic/CASTOROpenData2010/Commissioning10-May19ReReco_7TeV.json 
- see if the CASTOR instruction twiki (referred to in the usage) should be written as a guide page or as an example SW record (or combined) 


