### PR TITLE
Add SW record for Run2 Hbb tagging studies

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-Run2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-Run2-datascience.json
@@ -59,5 +59,145 @@
         }
       ]
     }
+  },
+  {
+    "abstract": {
+      "description": "ROOT ntuple producer for developing machine learning algorithms to differentiate jets originating from a Higgs boson decaying to a bottom quark-antiquark pair (Hbb) from quark or gluon jets originating from quantum chromodynamic (QCD) multijet production."
+    },
+    "accelerator": "CERN-LHC",
+    "authors": [
+      {
+        "name": "Duarte, Javier",
+        "orcid": "0000-0002-5076-7096"
+      },
+      {
+        "name": "Qu, Huilin",
+        "orcid": "0000-0002-0250-8655"
+      },
+      {
+        "name": "Kieseler, Jan",
+        "orcid": "0000-0003-1644-7678"
+      },
+      {
+        "name": "Verzetti, Mauro",
+        "orcid": "0000-0001-9958-0663"
+      },
+      {
+        "name": "Gouskos, Loukas"
+      },
+      {
+        "name": "Stoye, Markus"
+      },
+      {
+        "name": "Vernieri, Caterina",
+        "orcid": "0000-0002-0235-1053"
+      }
+    ],
+    "collections": [
+      "CMS-Tools"
+    ],
+    "date_created": [
+      "2019"
+    ],
+    "date_published": "2019",
+    "experiment": "CMS",
+    "keywords": [
+      "datascience"
+    ],
+    "license": {
+      "attribution": "GNU General Public License (GPL) version 3"
+    },
+    "publisher": "CERN Open Data Portal",
+    "recid": "12103",
+    "relations": [
+      {
+        "description": "The ouput dataset of this software tool is available in",
+        "recid": "12102",
+        "type": "isRelatedTo"
+      }
+    ],
+    "run_period": [
+      "Run2"
+    ],
+    "system_details": {
+      "description": "Use this code with the CMS Open Data VM environment",
+      "recid": "252",
+      "release": "CMSSW_8_0_28"
+    },
+    "title": "HiggsToBBNtupleProducerTool - ROOT ntuple producer for developing machine learning algorithms from CMS Run2 MiniAOD",
+    "type": {
+      "primary": "Software",
+      "secondary": [
+        "Tool"
+      ]
+    },
+    "usage": {
+      "description": "<p>If you do not have the CERN Virtual Machine for CMS open data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2011\">How to install a CERN Virtual Machine</a>.  <p>To run the analysis, follow the instructions in <a href=\"https://github.com/cms-opendata-analyses/HiggsToBBNtupleProducerTool\">HiggsToBBNtupleProducerTool documentation on GitHub</a>.</p>"
+    },
+    "use_with": {
+      "description": "Use this with Run2 QCD MiniAODSIM datasets",
+      "links": [
+        {
+          "recid": "12000"
+        },
+        {
+          "recid": "12002"
+        },
+        {
+          "recid": "12003"
+        },
+        {
+          "recid": "12004"
+        },
+        {
+          "recid": "12005"
+        },
+        {
+          "recid": "12006"
+        },
+        {
+          "recid": "12007"
+        },
+        {
+          "recid": "12008"
+        },
+        {
+          "recid": "12009"
+        },
+        {
+          "recid": "12010"
+        },
+        {
+          "recid": "12011"
+        },
+        {
+          "recid": "12012"
+        },
+        {
+          "recid": "12013"
+        },
+        {
+          "recid": "12014"
+        },
+        {
+          "recid": "12015"
+        },
+        {
+          "recid": "12016"
+        },
+        {
+          "recid": "12017"
+        },
+        {
+          "recid": "12018"
+        },
+        {
+          "recid": "12019"
+        },
+        {
+          "recid": "12020"
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
(addresses #2585)

Adds SW record for Run2 Hbb tagging

Needs:
- recids output ML samples
- list of datasets on which this code is run (use_with) is the same as in recid 12102

