### PR TITLE
records: CMS Run2 Hbb derived files

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-Run2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-Run2-datascience.json
@@ -1305,10 +1305,60 @@
         "root",
         "h5"
       ],
-      "number_files": 0,
-      "size": 0
+      "number_files": 182,
+      "size": 244910603204
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:a216a983",
+        "size": 2199,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_test_h5_file_index.json"
+      },
+      {
+        "checksum": "adler32:92e29105",
+        "size": 1116,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_test_h5_file_index.txt"
+      },
+      {
+        "checksum": "adler32:bf9cbd07",
+        "size": 2235,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_test_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:c6459b64",
+        "size": 1134,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_test_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:2d666f3e",
+        "size": 20254,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_train_h5_file_index.json"
+      },
+      {
+        "checksum": "adler32:5dbd74e3",
+        "size": 10331,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_train_h5_file_index.txt"
+      },
+      {
+        "checksum": "adler32:930722bc",
+        "size": 20582,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_train_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:c315d361",
+        "size": 10495,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_train_root_file_index.txt"
+      }
+    ],
     "keywords": [
       "datascience"
     ],


### PR DESCRIPTION
* Adds file information for CMS Run2 Hbb derived record. (addresses #2574)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>