### PR TITLE
records: Add  GTs for 2012, 2016 and upgrade MC

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-2012.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-2012.json
@@ -103,5 +103,43 @@
         "Condition"
       ]
     }
+  },
+  {
+    "abstract": {
+      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n <p> These files are needed when running a CMSSW job on the Open Data VM. They are automatically read from the /cvmfs/cms-opendata-conddb.cern.ch runtime, you do not need to download these files from here separately.</p>\n <p>START53_V7N was used to generate the simulated data used in the Higgs discovery analysis with dose-dependent detector characteristics, run-dependent pile-up and beam spot conditions.</p>\n These condition data are only needed for production of samples and not for analysis of the already available simulated data. <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p>\n <p>For 2012 CMS collision data see:</p>",
+      "links": [
+        {
+          "recid": "1803"
+        }
+      ]
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Condition-Data"
+    ],
+    "date_created": [
+      "2012"
+    ],
+    "date_published": "2019",
+    "experiment": "CMS",
+    "publisher": "CERN Open Data Portal",
+    "recid": "1805",
+    "run_period": [
+      "Run2012A",
+      "Run2012B",
+      "Run2012C",
+      "Run2012D"
+    ],
+    "title": "Condition data for 2012 run-dependent simulated data production",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "Condition"
+      ]
+    }
   }
 ]

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-Phase2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-Phase2-datascience.json
@@ -1,0 +1,32 @@
+[
+  {
+    "abstract": {
+      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n      <p> These files are needed when running a CMSSW job on the Open Data VM. They are automatically read from the /cvmfs/cms-opendata-conddb.cern.ch runtime, you do not need to download these files from here separately.</p>\n      <p>102X_upgrade2018_design_v9 is to be used with the Phase2 simulated data released for data science studies.</p>\n  <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p>\n"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Condition-Data"
+    ],
+    "date_created": [
+      "Phase2"
+    ],
+    "date_published": "2019",
+    "experiment": "CMS",
+    "publisher": "CERN Open Data Portal",
+    "recid": "1807",
+    "run_period": [
+      "Run2"
+    ],
+    "title": "Condition data for Phase2 CMS simulated datasets released for data science studies",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "Condition"
+      ]
+    }
+  }
+]

--- a/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-condition-data-Run2-datascience.json
@@ -1,0 +1,32 @@
+[
+  {
+    "abstract": {
+      "description": "<p>Condition database includes non-event-related information (Alignment, Calibration, Temperature, etc.) and parameters for simulation/reconstruction/analysis software.</p>\n      <p> These files are needed when running a CMSSW job on the Open Data VM. They are automatically read from the /cvmfs/cms-opendata-conddb.cern.ch runtime, you do not need to download these files from here separately.</p>\n      <p>80X_mcRun2_asymptotic_2016_TrancheIV_v8 is to be used with the Run2 simulated data released for data science studies.</p>\n  <p>See further information in <a href=\"/docs/cms-guide-for-condition-database\">the guide to CMS condition database</a>.</p>\n"
+    },
+    "accelerator": "CERN-LHC",
+    "collaboration": {
+      "name": "CMS collaboration",
+      "recid": "451"
+    },
+    "collections": [
+      "CMS-Condition-Data"
+    ],
+    "date_created": [
+      "2016"
+    ],
+    "date_published": "2019",
+    "experiment": "CMS",
+    "publisher": "CERN Open Data Portal",
+    "recid": "1806",
+    "run_period": [
+      "Run2"
+    ],
+    "title": "Condition data for 2016 CMS simulated datasets released for data science studies",
+    "type": {
+      "primary": "Environment",
+      "secondary": [
+        "Condition"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
(closes #2456)
(closes #2443)

Adds:
- the record for run-dependent 2012 GT START53_V7N - New recid 1805
- the record for Run2 MC GT - recid 1806
- the record for Phase2 MC GT - recid 1807

NB: "date created" for Phase2 GT : "Phase2"

Needs:
- file attachements in a similar way as for 1804?

