### PR TITLE
records: CMS 2010 MC provenance fixes

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010.json
@@ -1,7 +1,7 @@
 [
   {
     "abstract": {
-      "description": "<p>Simulated dataset CEPDijets_M-100_7TeV-exhume in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset CEPDijets_M-100_7TeV-exhume in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -42,28 +42,53 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/CEPDijets_M-100_7TeV-exhume/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00007_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00007_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00007_step1.root --fileout file:FSQ-LowPU2010DR42-00007.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00007_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00017 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00017-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00017-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00017-fragment.py --fileout file:FSQ-LowPU2010-00017.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00017_1_cfg.py --no_exec -n 384 || exit $? ; \n\n",
               "title": "Production script"
+            },
+            {
+              "title": "Generator parameters",
+              "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00017"
+            },
+            {
+              "script": "import FWCore.ParameterSet.Config as cms\n\ndef customise(process): # Using SL instead GFlash AND turn on castor and compensation\n    process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)\n    process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)\n    process.g4SimHits.HCalSD.UseFibreBundleHits = cms.bool(False)\n    process.g4SimHits.HFShower.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)\n    process.g4SimHits.HFShower.ApplyFiducialCut = cms.bool(False)\n    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)\n    process.g4SimHits.CastorSD.nonCompensationFactor = cms.double(0.77)\n\n    return(process)\n\n\n\n",
+              "title": "Generator parameters",
+              "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py"
+            }
+          ],
+          "generators": [
+            "ExHuME"
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/CEPDijets_M-100_7TeV-exhume/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
+          "release": "CMSSW_4_2_10",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/CEPDijets_M-100_7TeV-exhume/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00007_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00007_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00007_step1.root --fileout file:FSQ-LowPU2010DR42-00007.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00007_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
             },
             {
               "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
               "process": "RECO",
               "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/CEPDijets_M-100_7TeV-exhume/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -104,7 +129,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset CS_Pt_120to9999_CTEQ6L1_HFshowerLibrary_7TeV_herwig6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset CS_Pt_120to9999_CTEQ6L1_HFshowerLibrary_7TeV_herwig6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -145,23 +170,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -170,7 +180,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/CS_Pt_120to9999_CTEQ6L1_HFshowerLibrary_7TeV_herwig6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/CS_Pt_120to9999_CTEQ6L1_HFshowerLibrary_7TeV_herwig6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -211,7 +242,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset CS_Pt_30to50_CTEQ6L1_HFshowerLibrary_7TeV_herwig6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset CS_Pt_30to50_CTEQ6L1_HFshowerLibrary_7TeV_herwig6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -252,23 +283,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -277,7 +293,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/CS_Pt_30to50_CTEQ6L1_HFshowerLibrary_7TeV_herwig6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/CS_Pt_30to50_CTEQ6L1_HFshowerLibrary_7TeV_herwig6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -318,7 +355,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset CS_Pt_50to80_CTEQ6L1_HFshowerLibrary_7TeV_herwig6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset CS_Pt_50to80_CTEQ6L1_HFshowerLibrary_7TeV_herwig6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -359,23 +396,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -384,7 +406,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/CS_Pt_50to80_CTEQ6L1_HFshowerLibrary_7TeV_herwig6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/CS_Pt_50to80_CTEQ6L1_HFshowerLibrary_7TeV_herwig6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -425,7 +468,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset CS_Pt_80to120_CTEQ6L1_HFshowerLibrary_7TeV_herwig6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset CS_Pt_80to120_CTEQ6L1_HFshowerLibrary_7TeV_herwig6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -466,23 +509,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -491,7 +519,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/CS_Pt_80to120_CTEQ6L1_HFshowerLibrary_7TeV_herwig6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/CS_Pt_80to120_CTEQ6L1_HFshowerLibrary_7TeV_herwig6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -532,7 +581,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset DPEDijets_Pt30_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset DPEDijets_Pt30_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -573,12 +622,36 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/DPEDijets_Pt30_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00008_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00008_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00008_step1.root --fileout file:FSQ-LowPU2010DR42-00008.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00008_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00016 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00016-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00016-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00016-fragment.py --fileout file:FSQ-LowPU2010-00016.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00016_1_cfg.py --no_exec -n 288 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "title": "Generator parameters",
+              "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00016"
+            },
+            {
+              "script": "import FWCore.ParameterSet.Config as cms\n\ndef customise(process): # Using SL instead GFlash AND turn on castor and compensation\n    process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)\n    process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)\n    process.g4SimHits.HCalSD.UseFibreBundleHits = cms.bool(False)\n    process.g4SimHits.HFShower.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)\n    process.g4SimHits.HFShower.ApplyFiducialCut = cms.bool(False)\n    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)\n    process.g4SimHits.CastorSD.nonCompensationFactor = cms.double(0.77)\n\n    return(process)\n\n\n\n",
+              "title": "Generator parameters",
+              "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py"
+            }
+          ],
+          "generators": [
+            "pomwig"
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/DPEDijets_Pt30_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
+          "release": "CMSSW_4_2_10",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/DPEDijets_Pt30_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00008_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00008_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00008_step1.root --fileout file:FSQ-LowPU2010DR42-00008.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00008_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
@@ -588,13 +661,14 @@
             },
             {
               "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/DPEDijets_Pt30_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v2/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -635,7 +709,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset DYToEE_M-20_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset DYToEE_M-20_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -676,23 +750,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -701,7 +760,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/DYToEE_M-20_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/DYToEE_M-20_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -742,7 +822,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset DYToEE_M_50To130_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset DYToEE_M_50To130_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -783,8 +863,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "1b1bea22a123b61b3610c800b524a35e",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/DYToEE_M_50To130_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -794,21 +887,14 @@
             },
             {
               "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "1b1bea22a123b61b3610c800b524a35e",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/DYToEE_M_50To130_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -849,7 +935,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset DYToMuMu_M-20_TuneZ2Star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset DYToMuMu_M-20_TuneZ2Star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -890,23 +976,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -915,7 +986,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/DYToMuMu_M-20_TuneZ2Star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/DYToMuMu_M-20_TuneZ2Star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -956,7 +1048,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_Tune4C_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_Tune4C_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -997,23 +1089,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005b191",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -1022,7 +1099,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005b191",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -1063,7 +1161,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_Tune4C_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_Tune4C_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1104,23 +1202,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005963c",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a10058d09",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -1129,7 +1212,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17C-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "950a1c715eb6d4293d88162a10058d09",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005963c",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17C-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -1170,7 +1274,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_Tune4C_Castor_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_Tune4C_Castor_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1211,8 +1315,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "19ab4ab1511da97ded8111f9659fc9cc",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/MinBias_Tune4C_Castor_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -1222,21 +1339,14 @@
             },
             {
               "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "19ab4ab1511da97ded8111f9659fc9cc",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/MinBias_Tune4C_Castor_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -1277,7 +1387,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_Tune4C_Castor_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_Tune4C_Castor_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1318,8 +1428,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "ac16f6ab650afd19a51167f2f8b6107c",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_Tune4C_Castor_7TeV_pythia8/Summer12-LowPU2010-START42_V17C-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -1329,21 +1452,14 @@
             },
             {
               "cms_confdb_id": "950a1c715eb6d4293d88162a10058d09",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "ac16f6ab650afd19a51167f2f8b6107c",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_Tune4C_Castor_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17C-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -1384,7 +1500,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1425,23 +1541,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "70d6766611f8d0924ace67e606b0c1df",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "70d6766611f8d0924ace67e606ab6006",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -1450,7 +1551,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17C-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "70d6766611f8d0924ace67e606ab6006",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "70d6766611f8d0924ace67e606b0c1df",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_NoPileUp_START42_V17C-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -1491,7 +1613,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_TuneD6T_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_TuneD6T_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1532,8 +1654,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "d19bda177733564ab5bd86ef3bba8bd1",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17C-v2/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -1543,21 +1678,14 @@
             },
             {
               "cms_confdb_id": "70d6766611f8d0924ace67e606ab6006",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "d19bda177733564ab5bd86ef3bba8bd1",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_NoPileUp_START42_V17C-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -1598,7 +1726,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_TuneZ1_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_TuneZ1_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1639,23 +1767,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "976574a2b6282f9fb29c47c1c8a8b86f",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "976574a2b6282f9fb29c47c1c8a8c503",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -1664,7 +1777,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_TuneZ1_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17C-v2/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "976574a2b6282f9fb29c47c1c8a8b86f",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "976574a2b6282f9fb29c47c1c8a8c503",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_TuneZ1_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_NoPileUp_START42_V17C-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -1705,7 +1839,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_TuneZ1_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_TuneZ1_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1746,23 +1880,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "bc8ccd9f9f4695486ce23d3a9f4b75c5",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "bc8ccd9f9f4695486ce23d3a9f4b81fa",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -1771,7 +1890,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_TuneZ1_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17C-v2/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "bc8ccd9f9f4695486ce23d3a9f4b75c5",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "bc8ccd9f9f4695486ce23d3a9f4b81fa",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/MinBias_TuneZ1_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -1812,7 +1952,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_TuneZ2star_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_TuneZ2star_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1853,23 +1993,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005b191",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -1878,7 +2003,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/MinBias_TuneZ2star_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005b191",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/MinBias_TuneZ2star_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -1919,7 +2065,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_TuneZ2star_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_TuneZ2star_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1960,23 +2106,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a10058d09",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005963c",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -1985,7 +2116,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_TuneZ2star_7TeV_pythia6/Summer12-LowPU2010-START42_V17C-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005963c",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "950a1c715eb6d4293d88162a10058d09",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_TuneZ2star_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17C-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -2026,7 +2178,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_TuneZ2star_Castor_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_TuneZ2star_Castor_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2067,23 +2219,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005b191",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -2092,7 +2229,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/MinBias_TuneZ2star_Castor_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005b191",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/MinBias_TuneZ2star_Castor_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -2133,7 +2291,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_TuneZ2star_Castor_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_TuneZ2star_Castor_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2174,23 +2332,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005963c",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a10058d09",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -2199,7 +2342,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_TuneZ2star_Castor_7TeV_pythia6/Summer12-LowPU2010-START42_V17C-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "950a1c715eb6d4293d88162a10058d09",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005963c",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_TuneZ2star_Castor_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17C-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -2240,7 +2404,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2281,23 +2445,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "976574a2b6282f9fb29c47c1c8a8c503",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "976574a2b6282f9fb29c47c1c8a8b86f",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -2306,7 +2455,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17C-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "976574a2b6282f9fb29c47c1c8a8b86f",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "976574a2b6282f9fb29c47c1c8a8c503",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_NoPileUp_START42_V17C-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -2347,7 +2517,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset MinBias_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2388,8 +2558,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "1cce1be4ff841028987380e485170316",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17C::All",
+          "output_dataset": "/MinBias_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17C-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -2399,21 +2582,14 @@
             },
             {
               "cms_confdb_id": "fe35a6e3bcf89a49c7b3140c99b59cde",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "1cce1be4ff841028987380e485170316",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/MinBias_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v2/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -2454,7 +2630,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_HT-1000ToInf_TuneZ2Star_7TeV-madgraph-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_HT-1000ToInf_TuneZ2Star_7TeV-madgraph-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2495,43 +2671,36 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_HT-1000ToInf_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00006_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00006_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00006_step1.root --fileout file:FSQ-LowPU2010DR42-00006.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00006_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
+              "cms_confdb_id": "c4fb56e6014a333c1824013a9a39aaff",
+              "process": "LHE",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
+          "global_tag": "START311_V2::All",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/QCD_HT-1000ToInf_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v2/GEN",
+          "release": "CMSSW_4_1_8_patch14",
+          "type": "LHE"
         },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py \n[ -s Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py ] || exit $?;\n\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --filein \"dbs:/QCD_HT-1000ToInf_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v2/GEN\" --fileout file:FSQ-LowPU2010-00004.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --inline_custom 1 --python_filename FSQ-LowPU2010-00004_1_cfg.py --no_exec --inline_custom 1 -n 185 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py \n[ -s Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py ] || exit $?;\n\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --filein \"dbs:/QCD_HT-1000ToInf_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v2/GEN\" --fileout file:FSQ-LowPU2010-00004.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --inline_custom 1 --python_filename FSQ-LowPU2010-00004_1_cfg.py --no_exec --inline_custom 1 -n 185 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
               "script": "import FWCore.ParameterSet.Config as cms\n\nfrom Configuration.Generator.PythiaUEZ2starSettings_cfi import *\nfrom GeneratorInterface.ExternalDecays.TauolaSettings_cff import *\n\ngenerator = cms.EDFilter(\"Pythia6HadronizerFilter\",\n    pythiaHepMCVerbosity = cms.untracked.bool(True),\n    maxEventsToPrint = cms.untracked.int32(0),\n    pythiaPylistVerbosity = cms.untracked.int32(1),\n    comEnergy = cms.double(7000.0),\n    ExternalDecays = cms.PSet(\n        Tauola = cms.untracked.PSet(\n            TauolaPolar,\n            TauolaDefaultInputCards\n        ),\n        parameterSets = cms.vstring('Tauola')\n    ),\n    UseExternalGenerators = cms.untracked.bool(True),\n    PythiaParameters = cms.PSet(\n        pythiaUESettingsBlock,\n        processParameters = cms.vstring('MSEL=0         ! User defined processes', \n                        'PMAS(5,1)=4.8   ! b quark mass',\n                        'PMAS(6,1)=172.5 ! t quark mass',\n\t\t\t'MSTJ(1)=1       ! Fragmentation/hadronization on or off',\n\t\t\t'MSTP(61)=1      ! Parton showering on or off'),\n        # This is a vector of ParameterSet names to be read, in this order\n        parameterSets = cms.vstring('pythiaUESettings', \n            'processParameters')\n    ),\n    jetMatching = cms.untracked.PSet(\n       scheme = cms.string(\"Madgraph\"),\n       mode = cms.string(\"auto\"),\t# soup, or \"inclusive\" / \"exclusive\"\n       MEMAIN_nqmatch = cms.int32(5),\n       MEMAIN_etaclmax = cms.double(-1),\n       MEMAIN_qcut = cms.double(-1),\n       MEMAIN_minjets = cms.int32(-1),\n       MEMAIN_maxjets = cms.int32(-1),\n       MEMAIN_showerkt = cms.double(0),   \n       MEMAIN_excres = cms.string(\"\"),\n       outTree_flag = cms.int32(0)    \n    )    \n)\n",
-              "title": "Generator parameters",
+              "title": "Hadronizer parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py"
             },
             {
               "script": "import FWCore.ParameterSet.Config as cms\n\ndef customise(process): # Using SL instead GFlash AND turn on castor and compensation\n    process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)\n    process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)\n    process.g4SimHits.HCalSD.UseFibreBundleHits = cms.bool(False)\n    process.g4SimHits.HFShower.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)\n    process.g4SimHits.HFShower.ApplyFiducialCut = cms.bool(False)\n    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)\n    process.g4SimHits.CastorSD.nonCompensationFactor = cms.double(0.77)\n\n    return(process)\n\n\n\n",
-              "title": "Generator parameters",
+              "title": "Hadronizer parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py"
             },
             {
@@ -2544,8 +2713,31 @@
             "MG5v1.5.11"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_HT-1000ToInf_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_HT-1000ToInf_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00006_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00006_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00006_step1.root --fileout file:FSQ-LowPU2010DR42-00006.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00006_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_HT-1000ToInf_TuneZ2Star_7TeV-madgraph-pythia6/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -2586,7 +2778,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_HT-100To250_TuneZ2Star_7TeV-madgraph-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_HT-100To250_TuneZ2Star_7TeV-madgraph-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2627,43 +2819,36 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_HT-100To250_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00003_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00003_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00003_step1.root --fileout file:FSQ-LowPU2010DR42-00003.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00003_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
+              "cms_confdb_id": "c4fb56e6014a333c1824013a9a39a5af",
+              "process": "LHE",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
+          "global_tag": "START311_V2::All",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/QCD_HT-100To250_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v2/GEN",
+          "release": "CMSSW_4_1_8_patch14",
+          "type": "LHE"
         },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py \n[ -s Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py ] || exit $?;\n\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --filein \"dbs:/QCD_HT-100To250_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v2/GEN\" --fileout file:FSQ-LowPU2010-00001.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --inline_custom 1 --python_filename FSQ-LowPU2010-00001_1_cfg.py --no_exec --inline_custom 1 -n 523 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py \n[ -s Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py ] || exit $?;\n\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --filein \"dbs:/QCD_HT-100To250_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v2/GEN\" --fileout file:FSQ-LowPU2010-00001.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --inline_custom 1 --python_filename FSQ-LowPU2010-00001_1_cfg.py --no_exec --inline_custom 1 -n 523 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
               "script": "import FWCore.ParameterSet.Config as cms\n\nfrom Configuration.Generator.PythiaUEZ2starSettings_cfi import *\nfrom GeneratorInterface.ExternalDecays.TauolaSettings_cff import *\n\ngenerator = cms.EDFilter(\"Pythia6HadronizerFilter\",\n    pythiaHepMCVerbosity = cms.untracked.bool(True),\n    maxEventsToPrint = cms.untracked.int32(0),\n    pythiaPylistVerbosity = cms.untracked.int32(1),\n    comEnergy = cms.double(7000.0),\n    ExternalDecays = cms.PSet(\n        Tauola = cms.untracked.PSet(\n            TauolaPolar,\n            TauolaDefaultInputCards\n        ),\n        parameterSets = cms.vstring('Tauola')\n    ),\n    UseExternalGenerators = cms.untracked.bool(True),\n    PythiaParameters = cms.PSet(\n        pythiaUESettingsBlock,\n        processParameters = cms.vstring('MSEL=0         ! User defined processes', \n                        'PMAS(5,1)=4.8   ! b quark mass',\n                        'PMAS(6,1)=172.5 ! t quark mass',\n\t\t\t'MSTJ(1)=1       ! Fragmentation/hadronization on or off',\n\t\t\t'MSTP(61)=1      ! Parton showering on or off'),\n        # This is a vector of ParameterSet names to be read, in this order\n        parameterSets = cms.vstring('pythiaUESettings', \n            'processParameters')\n    ),\n    jetMatching = cms.untracked.PSet(\n       scheme = cms.string(\"Madgraph\"),\n       mode = cms.string(\"auto\"),\t# soup, or \"inclusive\" / \"exclusive\"\n       MEMAIN_nqmatch = cms.int32(5),\n       MEMAIN_etaclmax = cms.double(-1),\n       MEMAIN_qcut = cms.double(-1),\n       MEMAIN_minjets = cms.int32(-1),\n       MEMAIN_maxjets = cms.int32(-1),\n       MEMAIN_showerkt = cms.double(0),   \n       MEMAIN_excres = cms.string(\"\"),\n       outTree_flag = cms.int32(0)    \n    )    \n)\n",
-              "title": "Generator parameters",
+              "title": "Hadronizer parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py"
             },
             {
               "script": "import FWCore.ParameterSet.Config as cms\n\ndef customise(process): # Using SL instead GFlash AND turn on castor and compensation\n    process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)\n    process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)\n    process.g4SimHits.HCalSD.UseFibreBundleHits = cms.bool(False)\n    process.g4SimHits.HFShower.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)\n    process.g4SimHits.HFShower.ApplyFiducialCut = cms.bool(False)\n    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)\n    process.g4SimHits.CastorSD.nonCompensationFactor = cms.double(0.77)\n\n    return(process)\n\n\n\n",
-              "title": "Generator parameters",
+              "title": "Hadronizer parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py"
             },
             {
@@ -2676,8 +2861,31 @@
             "MG5v1.5.11"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_HT-100To250_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_HT-100To250_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00003_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00003_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00003_step1.root --fileout file:FSQ-LowPU2010DR42-00003.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00003_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_HT-100To250_TuneZ2Star_7TeV-madgraph-pythia6/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -2718,7 +2926,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_HT-250To500_TuneZ2Star_7TeV-madgraph-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_HT-250To500_TuneZ2Star_7TeV-madgraph-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2759,43 +2967,36 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_HT-250To500_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00004_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00004_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00004_step1.root --fileout file:FSQ-LowPU2010DR42-00004.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00004_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
+              "cms_confdb_id": "c4fb56e6014a333c1824013a9a39b594",
+              "process": "LHE",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
+          "global_tag": "START311_V2::All",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/QCD_HT-250To500_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v2/GEN",
+          "release": "CMSSW_4_1_8_patch14",
+          "type": "LHE"
         },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py \n[ -s Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py ] || exit $?;\n\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --filein \"dbs:/QCD_HT-250To500_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v2/GEN\" --fileout file:FSQ-LowPU2010-00002.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --inline_custom 1 --python_filename FSQ-LowPU2010-00002_1_cfg.py --no_exec --inline_custom 1 -n 288 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py \n[ -s Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py ] || exit $?;\n\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --filein \"dbs:/QCD_HT-250To500_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v2/GEN\" --fileout file:FSQ-LowPU2010-00002.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --inline_custom 1 --python_filename FSQ-LowPU2010-00002_1_cfg.py --no_exec --inline_custom 1 -n 288 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
               "script": "import FWCore.ParameterSet.Config as cms\n\nfrom Configuration.Generator.PythiaUEZ2starSettings_cfi import *\nfrom GeneratorInterface.ExternalDecays.TauolaSettings_cff import *\n\ngenerator = cms.EDFilter(\"Pythia6HadronizerFilter\",\n    pythiaHepMCVerbosity = cms.untracked.bool(True),\n    maxEventsToPrint = cms.untracked.int32(0),\n    pythiaPylistVerbosity = cms.untracked.int32(1),\n    comEnergy = cms.double(7000.0),\n    ExternalDecays = cms.PSet(\n        Tauola = cms.untracked.PSet(\n            TauolaPolar,\n            TauolaDefaultInputCards\n        ),\n        parameterSets = cms.vstring('Tauola')\n    ),\n    UseExternalGenerators = cms.untracked.bool(True),\n    PythiaParameters = cms.PSet(\n        pythiaUESettingsBlock,\n        processParameters = cms.vstring('MSEL=0         ! User defined processes', \n                        'PMAS(5,1)=4.8   ! b quark mass',\n                        'PMAS(6,1)=172.5 ! t quark mass',\n\t\t\t'MSTJ(1)=1       ! Fragmentation/hadronization on or off',\n\t\t\t'MSTP(61)=1      ! Parton showering on or off'),\n        # This is a vector of ParameterSet names to be read, in this order\n        parameterSets = cms.vstring('pythiaUESettings', \n            'processParameters')\n    ),\n    jetMatching = cms.untracked.PSet(\n       scheme = cms.string(\"Madgraph\"),\n       mode = cms.string(\"auto\"),\t# soup, or \"inclusive\" / \"exclusive\"\n       MEMAIN_nqmatch = cms.int32(5),\n       MEMAIN_etaclmax = cms.double(-1),\n       MEMAIN_qcut = cms.double(-1),\n       MEMAIN_minjets = cms.int32(-1),\n       MEMAIN_maxjets = cms.int32(-1),\n       MEMAIN_showerkt = cms.double(0),   \n       MEMAIN_excres = cms.string(\"\"),\n       outTree_flag = cms.int32(0)    \n    )    \n)\n",
-              "title": "Generator parameters",
+              "title": "Hadronizer parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py"
             },
             {
               "script": "import FWCore.ParameterSet.Config as cms\n\ndef customise(process): # Using SL instead GFlash AND turn on castor and compensation\n    process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)\n    process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)\n    process.g4SimHits.HCalSD.UseFibreBundleHits = cms.bool(False)\n    process.g4SimHits.HFShower.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)\n    process.g4SimHits.HFShower.ApplyFiducialCut = cms.bool(False)\n    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)\n    process.g4SimHits.CastorSD.nonCompensationFactor = cms.double(0.77)\n\n    return(process)\n\n\n\n",
-              "title": "Generator parameters",
+              "title": "Hadronizer parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py"
             },
             {
@@ -2808,8 +3009,31 @@
             "MG5v1.5.11"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_HT-250To500_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_HT-250To500_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00004_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00004_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00004_step1.root --fileout file:FSQ-LowPU2010DR42-00004.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00004_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_HT-250To500_TuneZ2Star_7TeV-madgraph-pythia6/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -2850,7 +3074,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_HT-500To1000_TuneZ2Star_7TeV-madgraph-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_HT-500To1000_TuneZ2Star_7TeV-madgraph-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2891,43 +3115,36 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_HT-500To1000_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00005_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00005_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00005_step1.root --fileout file:FSQ-LowPU2010DR42-00005.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00005_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
+              "cms_confdb_id": "c4fb56e6014a333c1824013a9a69fdeb",
+              "process": "LHE",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
+          "global_tag": "START311_V2::All",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/QCD_HT-500To1000_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v2/GEN",
+          "release": "CMSSW_4_1_8_patch14",
+          "type": "LHE"
         },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py \n[ -s Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py ] || exit $?;\n\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --filein \"dbs:/QCD_HT-500To1000_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v2/GEN\" --fileout file:FSQ-LowPU2010-00003.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --inline_custom 1 --python_filename FSQ-LowPU2010-00003_1_cfg.py --no_exec --inline_custom 1 -n 174 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py \n[ -s Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py ] || exit $?;\n\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --filein \"dbs:/QCD_HT-500To1000_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v2/GEN\" --fileout file:FSQ-LowPU2010-00003.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --inline_custom 1 --python_filename FSQ-LowPU2010-00003_1_cfg.py --no_exec --inline_custom 1 -n 174 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
               "script": "import FWCore.ParameterSet.Config as cms\n\nfrom Configuration.Generator.PythiaUEZ2starSettings_cfi import *\nfrom GeneratorInterface.ExternalDecays.TauolaSettings_cff import *\n\ngenerator = cms.EDFilter(\"Pythia6HadronizerFilter\",\n    pythiaHepMCVerbosity = cms.untracked.bool(True),\n    maxEventsToPrint = cms.untracked.int32(0),\n    pythiaPylistVerbosity = cms.untracked.int32(1),\n    comEnergy = cms.double(7000.0),\n    ExternalDecays = cms.PSet(\n        Tauola = cms.untracked.PSet(\n            TauolaPolar,\n            TauolaDefaultInputCards\n        ),\n        parameterSets = cms.vstring('Tauola')\n    ),\n    UseExternalGenerators = cms.untracked.bool(True),\n    PythiaParameters = cms.PSet(\n        pythiaUESettingsBlock,\n        processParameters = cms.vstring('MSEL=0         ! User defined processes', \n                        'PMAS(5,1)=4.8   ! b quark mass',\n                        'PMAS(6,1)=172.5 ! t quark mass',\n\t\t\t'MSTJ(1)=1       ! Fragmentation/hadronization on or off',\n\t\t\t'MSTP(61)=1      ! Parton showering on or off'),\n        # This is a vector of ParameterSet names to be read, in this order\n        parameterSets = cms.vstring('pythiaUESettings', \n            'processParameters')\n    ),\n    jetMatching = cms.untracked.PSet(\n       scheme = cms.string(\"Madgraph\"),\n       mode = cms.string(\"auto\"),\t# soup, or \"inclusive\" / \"exclusive\"\n       MEMAIN_nqmatch = cms.int32(5),\n       MEMAIN_etaclmax = cms.double(-1),\n       MEMAIN_qcut = cms.double(-1),\n       MEMAIN_minjets = cms.int32(-1),\n       MEMAIN_maxjets = cms.int32(-1),\n       MEMAIN_showerkt = cms.double(0),   \n       MEMAIN_excres = cms.string(\"\"),\n       outTree_flag = cms.int32(0)    \n    )    \n)\n",
-              "title": "Generator parameters",
+              "title": "Hadronizer parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py"
             },
             {
               "script": "import FWCore.ParameterSet.Config as cms\n\ndef customise(process): # Using SL instead GFlash AND turn on castor and compensation\n    process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)\n    process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)\n    process.g4SimHits.HCalSD.UseFibreBundleHits = cms.bool(False)\n    process.g4SimHits.HFShower.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)\n    process.g4SimHits.HFShower.ApplyFiducialCut = cms.bool(False)\n    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)\n    process.g4SimHits.CastorSD.nonCompensationFactor = cms.double(0.77)\n\n    return(process)\n\n\n\n",
-              "title": "Generator parameters",
+              "title": "Hadronizer parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py"
             },
             {
@@ -2940,8 +3157,31 @@
             "MG5v1.5.11"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_HT-500To1000_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_HT-500To1000_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00005_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00005_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00005_step1.root --fileout file:FSQ-LowPU2010DR42-00005.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00005_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_HT-500To1000_TuneZ2Star_7TeV-madgraph-pythia6/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -2982,7 +3222,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_HT-50To100_TuneZ2Star_7TeV-madgraph-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_HT-50To100_TuneZ2Star_7TeV-madgraph-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -3023,43 +3263,36 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_HT-50To100_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00001_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00001_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00001_step1.root --fileout file:FSQ-LowPU2010DR42-00001.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00001_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
+              "cms_confdb_id": "9a040dc26071340e7b2ffa68c813144b",
+              "process": "LHE",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
+          "global_tag": "START311_V2::All",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/QCD_HT-50To100_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v1/GEN",
+          "release": "CMSSW_4_1_8_patch14",
+          "type": "LHE"
         },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py \n[ -s Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py ] || exit $?;\n\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --filein \"dbs:/QCD_HT-50To100_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v1/GEN\" --fileout file:FSQ-LowPU2010-00005.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --inline_custom 1 --python_filename FSQ-LowPU2010-00005_1_cfg.py --no_exec --inline_custom 1 -n 523 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py \n[ -s Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py ] || exit $?;\n\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py --filein \"dbs:/QCD_HT-50To100_TuneZ2Star_7TeV-madgraph/Summer11-START311_V2-v1/GEN\" --fileout file:FSQ-LowPU2010-00005.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --inline_custom 1 --python_filename FSQ-LowPU2010-00005_1_cfg.py --no_exec --inline_custom 1 -n 523 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
               "script": "import FWCore.ParameterSet.Config as cms\n\nfrom Configuration.Generator.PythiaUEZ2starSettings_cfi import *\nfrom GeneratorInterface.ExternalDecays.TauolaSettings_cff import *\n\ngenerator = cms.EDFilter(\"Pythia6HadronizerFilter\",\n    pythiaHepMCVerbosity = cms.untracked.bool(True),\n    maxEventsToPrint = cms.untracked.int32(0),\n    pythiaPylistVerbosity = cms.untracked.int32(1),\n    comEnergy = cms.double(7000.0),\n    ExternalDecays = cms.PSet(\n        Tauola = cms.untracked.PSet(\n            TauolaPolar,\n            TauolaDefaultInputCards\n        ),\n        parameterSets = cms.vstring('Tauola')\n    ),\n    UseExternalGenerators = cms.untracked.bool(True),\n    PythiaParameters = cms.PSet(\n        pythiaUESettingsBlock,\n        processParameters = cms.vstring('MSEL=0         ! User defined processes', \n                        'PMAS(5,1)=4.8   ! b quark mass',\n                        'PMAS(6,1)=172.5 ! t quark mass',\n\t\t\t'MSTJ(1)=1       ! Fragmentation/hadronization on or off',\n\t\t\t'MSTP(61)=1      ! Parton showering on or off'),\n        # This is a vector of ParameterSet names to be read, in this order\n        parameterSets = cms.vstring('pythiaUESettings', \n            'processParameters')\n    ),\n    jetMatching = cms.untracked.PSet(\n       scheme = cms.string(\"Madgraph\"),\n       mode = cms.string(\"auto\"),\t# soup, or \"inclusive\" / \"exclusive\"\n       MEMAIN_nqmatch = cms.int32(5),\n       MEMAIN_etaclmax = cms.double(-1),\n       MEMAIN_qcut = cms.double(-1),\n       MEMAIN_minjets = cms.int32(-1),\n       MEMAIN_maxjets = cms.int32(-1),\n       MEMAIN_showerkt = cms.double(0),   \n       MEMAIN_excres = cms.string(\"\"),\n       outTree_flag = cms.int32(0)    \n    )    \n)\n",
-              "title": "Generator parameters",
+              "title": "Hadronizer parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/SevenTeV/Hadronizer_MgmMatchTuneZ2star_7TeV_madgraph_tauola_cff.py"
             },
             {
               "script": "import FWCore.ParameterSet.Config as cms\n\ndef customise(process): # Using SL instead GFlash AND turn on castor and compensation\n    process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)\n    process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)\n    process.g4SimHits.HCalSD.UseFibreBundleHits = cms.bool(False)\n    process.g4SimHits.HFShower.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)\n    process.g4SimHits.HFShower.ApplyFiducialCut = cms.bool(False)\n    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)\n    process.g4SimHits.CastorSD.nonCompensationFactor = cms.double(0.77)\n\n    return(process)\n\n\n\n",
-              "title": "Generator parameters",
+              "title": "Hadronizer parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py"
             },
             {
@@ -3072,8 +3305,31 @@
             "MG5v1.5.11"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_HT-50To100_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_HT-50To100_TuneZ2Star_7TeV-madgraph-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00001_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00001_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00001_step1.root --fileout file:FSQ-LowPU2010DR42-00001.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00001_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_HT-50To100_TuneZ2Star_7TeV-madgraph-pythia6/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -3114,7 +3370,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-120to170_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-120to170_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -3155,23 +3411,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "8bf830006a8493f7e7b1551d16783853",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -3180,7 +3421,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-120to170_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "8bf830006a8493f7e7b1551d16783853",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-120to170_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -3221,7 +3483,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-15to1000_TuneEE3C_Flat_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-15to1000_TuneEE3C_Flat_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -3262,37 +3524,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to1000_TuneEE3C_Flat_7TeV_herwigpp/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00014_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00014_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00014_step1.root --fileout file:FSQ-LowPU2010DR42-00014.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00014_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00006 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00006-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00006-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00006-fragment.py --fileout file:FSQ-LowPU2010-00006.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00006_1_cfg.py --no_exec -n 65 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00006 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00006-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00006-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00006-fragment.py --fileout file:FSQ-LowPU2010-00006.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00006_1_cfg.py --no_exec -n 65 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\n#HerwigppDefaults_cfi.py\\nherwigDefaultsBlock = cms.PSet(\\n\\tdataLocation = cms.string('${HERWIGPATH}'),\\n\\n\\trepository = cms.string('HerwigDefaults.rpo'),\\n\\teventHandlers = cms.string('/Herwig/EventHandlers'),\\n\\tgeneratorModule = cms.string('/Herwig/Generators/LHCGenerator'),\\n\\n\\trun = cms.string('LHC'),\\n\\n\\tcmsDefaults = cms.vstring(\\n\\t\\t'+pdfMRST2001',\\n\\t\\t'+cm14TeV',\\n\\t\\t'+ue_2_3',\\n\\t\\t'+basicSetup',\\n\\t\\t'+setParticlesStableForDetector',\\n\\t),\\n\\n\\tbasicSetup = cms.vstring(\\n\\t\\t'cd /Herwig/Generators',\\n\\t\\t'create ThePEG::RandomEngineGlue /Herwig/RandomGlue',\\n\\t\\t'set LHCGenerator:RandomNumberGenerator /Herwig/RandomGlue',\\n\\t\\t'set LHCGenerator:NumberOfEvents 10000000',\\n\\t\\t'set LHCGenerator:DebugLevel 1',\\n\\t\\t'set LHCGenerator:PrintEvent 0',\\n\\t\\t'set LHCGenerator:MaxErrors 10000',\\n\\t\\t'cd /Herwig/Particles',\\n\\t\\t'set p+:PDF /Herwig/Partons/cmsPDFSet',\\n\\t\\t'set pbar-:PDF /Herwig/Partons/cmsPDFSet',\\n\\t\\t'set K0:Width 1e300*GeV',\\n\\t\\t'set Kbar0:Width 1e300*GeV',\\n\\t\\t'cd /',\\n\\t),\\n\\n\\t# PDF presets\\n\\t##############################\\n\\n\\t# Default pdf for Herwig++ 2.3\\n\\tpdfMRST2001 = cms.vstring(\\n\\t\\t'cd /Herwig/Partons',\\n\\t\\t'create Herwig::MRST MRST2001 HwMRST.so',\\n\\t\\t'setup MRST2001 ${HERWIGPATH}/PDF/mrst/2001/lo2002.dat',\\n\\t\\t'set MRST2001:RemnantHandler HadronRemnants',\\n\\t\\t'cp MRST2001 cmsPDFSet',\\n\\t\\t'cd /',\\n\\t),\\n\\t# Default pdf for Herwig++ 2.4\\n\\tpdfMRST2008LOss = cms.vstring(\\n\\t\\t'cp /Herwig/Partons/MRST /Herwig/Partons/cmsPDFSet',\\n\\t),\\n\\tpdfCTEQ5L = cms.vstring(\\n\\t\\t'cd /Herwig/Partons',\\n\\t\\t'create ThePEG::LHAPDF CTEQ5L ThePEGLHAPDF.so',\\n\\t\\t'set CTEQ5L:PDFName cteq5l.LHgrid',\\n\\t\\t'set CTEQ5L:RemnantHandler HadronRemnants',\\n\\t\\t'cp CTEQ5L cmsPDFSet',\\n\\t\\t'cd /',\\n\\t),\\n\\tpdfCTEQ6L1 = cms.vstring(\\n\\t\\t'cd /Herwig/Partons',\\n\\t\\t'create ThePEG::LHAPDF CTEQ6L1 ThePEGLHAPDF.so',\\n\\t\\t'set CTEQ6L1:PDFName cteq6ll.LHpdf',\\n\\t\\t'set CTEQ6L1:RemnantHandler HadronRemnants',\\n\\t\\t'cp CTEQ6L1 cmsPDFSet',\\n\\t\\t'cd /',\\n\\t),\\n\\n\\t# CME presets\\n\\t##############################\\n\\n\\tcm7TeV = cms.vstring(\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 7000.0',\\n\\t\\t'set /Herwig/Shower/Evolver:IntrinsicPtGaussian 2.0*GeV',\\n\\t),\\n\\tcm8TeV = cms.vstring(\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 8000.0',\\n\\t\\t'set /Herwig/Shower/Evolver:IntrinsicPtGaussian 2.0*GeV',\\n\\t),\\n\\tcm10TeV = cms.vstring(\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 10000.0',\\n\\t\\t'set /Herwig/Shower/Evolver:IntrinsicPtGaussian 2.1*GeV',\\n\\t),\\n\\tcm14TeV = cms.vstring(\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 14000.0',\\n\\t\\t'set /Herwig/Shower/Evolver:IntrinsicPtGaussian 2.2*GeV',\\n\\t),\\n\\n\\t# UE tunes\\n\\t##############################\\n\\n\\t# UE Tune from Herwig++ 2.3 (MRST2001)\\n\\tue_2_3 = cms.vstring(\\n\\t\\t'cd /Herwig/UnderlyingEvent',\\n\\t\\t'set KtCut:MinKT 4.0',\\n\\t\\t'set UECuts:MHatMin 8.0',\\n\\t\\t'set MPIHandler:InvRadius 1.5',\\n\\t\\t'cd /',\\n\\t),\\n\\t# UE Tune from Herwig++ 2.4 (MRST2008LO**)\\n\\tue_2_4 = cms.vstring(\\n\\t\\t'cd /Herwig/UnderlyingEvent',\\n\\t\\t'set KtCut:MinKT 4.3',\\n\\t\\t'set UECuts:MHatMin 8.6',\\n\\t\\t'set MPIHandler:InvRadius 1.2',\\n\\t\\t'cd /',\\n\\t),\\n\\n\\t# reweight presets\\n\\t##############################\\n\\n\\treweightConstant = cms.vstring(\\n\\t\\t'mkdir /Herwig/Weights',\\n\\t\\t'cd /Herwig/Weights',\\n\\t\\t'create ThePEG::ReweightConstant reweightConstant ReweightConstant.so',\\n\\t\\t'cd /',\\n\\t\\t'set /Herwig/Weights/reweightConstant:C 1',\\n\\t\\t'insert SimpleQCD:Reweights[0] /Herwig/Weights/reweightConstant',\\n\\t),\\n\\treweightPthat = cms.vstring(\\n\\t\\t'mkdir /Herwig/Weights',\\n\\t\\t'cd /Herwig/Weights',\\n\\t\\t'create ThePEG::ReweightMinPT reweightMinPT ReweightMinPT.so',\\n\\t\\t'cd /',\\n\\t\\t'set /Herwig/Weights/reweightMinPT:Power 4.5',\\n\\t\\t'set /Herwig/Weights/reweightMinPT:Scale 15*GeV',\\n\\t\\t'insert SimpleQCD:Reweights[0] /Herwig/Weights/reweightMinPT',\\n\\t),\\n\\n\\t# Disable decays of particles with ctau > 10mm\\n\\tsetParticlesStableForDetector = cms.vstring(\\n\\t\\t'cd /Herwig/Particles',\\n\\t\\t'set mu-:Stable Stable',\\n\\t\\t'set mu+:Stable Stable',\\n\\t\\t'set Sigma-:Stable Stable',\\n\\t\\t'set Sigmabar+:Stable Stable',\\n\\t\\t'set Lambda0:Stable Stable',\\n\\t\\t'set Lambdabar0:Stable Stable',\\n\\t\\t'set Sigma+:Stable Stable',\\n\\t\\t'set Sigmabar-:Stable Stable',\\n\\t\\t'set Xi-:Stable Stable',\\n\\t\\t'set Xibar+:Stable Stable',\\n\\t\\t'set Xi0:Stable Stable',\\n\\t\\t'set Xibar0:Stable Stable',\\n\\t\\t'set Omega-:Stable Stable',\\n\\t\\t'set Omegabar+:Stable Stable',\\n\\t\\t'set pi+:Stable Stable',\\n\\t\\t'set pi-:Stable Stable',\\n\\t\\t'set K+:Stable Stable',\\n\\t\\t'set K-:Stable Stable',\\n\\t\\t'set K_S0:Stable Stable',\\n\\t\\t'set K_L0:Stable Stable',\\n\\t\\t'cd /',\\n\\t),\\n\\n\\t# Default settings for using LHE files\\n\\tlheDefaults = cms.vstring(\\n\\t\\t'cd /Herwig/Cuts',\\n\\t\\t'create ThePEG::Cuts NoCuts',\\n\\t\\t'cd /Herwig/EventHandlers',\\n\\t\\t'create ThePEG::LesHouchesInterface LHEReader',\\n\\t\\t'set LHEReader:Cuts /Herwig/Cuts/NoCuts',\\n\\t\\t'create ThePEG::LesHouchesEventHandler LHEHandler',\\n\\t\\t'set LHEHandler:WeightOption VarWeight',\\n\\t\\t'set LHEHandler:PartonExtractor /Herwig/Partons/QCDExtractor',\\n\\t\\t'set LHEHandler:CascadeHandler /Herwig/Shower/ShowerHandler',\\n\\t\\t'set LHEHandler:HadronizationHandler /Herwig/Hadronization/ClusterHadHandler',\\n\\t\\t'set LHEHandler:DecayHandler /Herwig/Decays/DecayHandler',\\n\\t\\t'insert LHEHandler:LesHouchesReaders 0 LHEReader',\\n\\t\\t'cd /Herwig/Generators',\\n\\t\\t'set LHCGenerator:EventHandler /Herwig/EventHandlers/LHEHandler',\\n\\t\\t'cd /Herwig/Shower',\\n\\t\\t'set Evolver:HardVetoScaleSource Read',\\n\\t\\t'set Evolver:MECorrMode No',\\n\\t\\t'cd /',\\n\\t),\\n\\tlheDefaultPDFs = cms.vstring(\\n\\t\\t'cd /Herwig/EventHandlers',\\n\\t\\t'set LHEReader:PDFA /cmsPDFSet',\\n\\t\\t'set LHEReader:PDFB /cmsPDFSet',\\n\\t\\t'cd /',\\n\\t),\\n\\n\\t# Default settings for using POWHEG\\n\\tpowhegDefaults = cms.vstring(\\n\\t\\t# Need to use an NLO PDF\\n\\t\\t'cp /Herwig/Partons/MRST-NLO /cmsPDFSet',\\n\\t\\t'set /Herwig/Particles/p+:PDF    /Herwig/Partons/MRST-NLO',\\n\\t\\t'set /Herwig/Particles/pbar-:PDF /Herwig/Partons/MRST-NLO',\\n\\t\\t# and strong coupling\\n\\t\\t'create Herwig::O2AlphaS O2AlphaS',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:StandardModelParameters:QCD/RunningAlphaS O2AlphaS',\\n\\t\\t# Setup the POWHEG shower\\n\\t\\t'cd /Herwig/Shower',\\n\\t\\t# use the general recon for now\\n\\t\\t'set KinematicsReconstructor:ReconstructionOption General',\\n\\t\\t# create the Powheg evolver and use it instead of the default one\\n\\t\\t'create Herwig::PowhegEvolver PowhegEvolver HwPowhegShower.so',\\n\\t\\t'set ShowerHandler:Evolver PowhegEvolver',\\n\\t\\t'set PowhegEvolver:ShowerModel ShowerModel',\\n\\t\\t'set PowhegEvolver:SplittingGenerator SplittingGenerator',\\n\\t\\t'set PowhegEvolver:MECorrMode 0',\\n\\t\\t# create and use the Drell-yan hard emission generator\\n\\t\\t'create Herwig::DrellYanHardGenerator DrellYanHardGenerator',\\n\\t\\t'set DrellYanHardGenerator:ShowerAlpha AlphaQCD',\\n\\t\\t'insert PowhegEvolver:HardGenerator 0 DrellYanHardGenerator',\\n\\t\\t# create and use the gg->H hard emission generator\\n\\t\\t'create Herwig::GGtoHHardGenerator GGtoHHardGenerator',\\n\\t\\t'set GGtoHHardGenerator:ShowerAlpha AlphaQCD',\\n\\t\\t'insert PowhegEvolver:HardGenerator 0 GGtoHHardGenerator',\\n\\t)\\n)\\n\\n#HerwigppUE_EE_3C_cfi.py\\nherwigppUESettingsBlock = cms.PSet(\\n\\therwigppUE_EE_3C_Base = cms.vstring(\\n\\t\\t'+pdfCTEQ6L1',\\n\\n\\t\\t'cd /Herwig',\\n\\t\\t'create Herwig::O2AlphaS O2AlphaS',\\n\\t\\t'set Model:QCD/RunningAlphaS O2AlphaS',\\n\\n\\t\\t# Energy-independent MPI parameters\\n\\t\\t#   Colour reconnection settings\\n\\t\\t'set /Herwig/Hadronization/ColourReconnector:ColourReconnection Yes',\\n\\t\\t'set /Herwig/Hadronization/ColourReconnector:ReconnectionProbability 0.54',\\n\\t\\t#   Colour Disrupt settings\\n\\t\\t'set /Herwig/Partons/RemnantDecayer:colourDisrupt 0.80',\\n\\t\\t#   inverse hadron radius\\n\\t\\t'set /Herwig/UnderlyingEvent/MPIHandler:InvRadius 1.11',\\n\\t\\t#   MPI model settings\\n\\t\\t#'set /Herwig/UnderlyingEvent/MPIHandler:IdenticalToUE 0',\\n\\t\\t'set /Herwig/UnderlyingEvent/MPIHandler:softInt Yes',\\n\\t\\t'set /Herwig/UnderlyingEvent/MPIHandler:twoComp Yes',\\n\\t\\t'set /Herwig/UnderlyingEvent/MPIHandler:DLmode 2',\\n\\t\\t'cd /',\\n\\t),\\n\\n\\therwigppUE_EE_3C_900GeV = cms.vstring(\\n\\t\\t'+herwigppUE_EE_3C_Base',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 900.0',\\n\\t\\t'set /Herwig/UnderlyingEvent/KtCut:MinKT 1.55',\\n\\t\\t'set /Herwig/UnderlyingEvent/UECuts:MHatMin 3.1',\\n\\t\\t'set /Herwig/Shower/Evolver:IntrinsicPtGaussian 1.81*GeV',\\n\\t),\\n\\n\\therwigppUE_EE_3C_1800GeV = cms.vstring(\\n\\t\\t'+herwigppUE_EE_3C_Base',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 1800.0',\\n\\t\\t'set /Herwig/UnderlyingEvent/KtCut:MinKT 2.26',\\n\\t\\t'set /Herwig/UnderlyingEvent/UECuts:MHatMin 4.52',\\n\\t),\\n\\n\\therwigppUE_EE_3C_2760GeV = cms.vstring(\\n\\t\\t'+herwigppUE_EE_3C_Base',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 2760.0',\\n\\t\\t'set /Herwig/UnderlyingEvent/KtCut:MinKT 2.33',\\n\\t\\t'set /Herwig/UnderlyingEvent/UECuts:MHatMin 4.66',\\n\\t),\\n\\n\\therwigppUE_EE_3C_7000GeV = cms.vstring(\\n\\t\\t'+herwigppUE_EE_3C_Base',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 7000.0',\\n\\t\\t'set /Herwig/UnderlyingEvent/KtCut:MinKT 2.752',\\n\\t\\t'set /Herwig/UnderlyingEvent/UECuts:MHatMin 5.504',\\n\\t\\t'set /Herwig/Shower/Evolver:IntrinsicPtGaussian 2.34*GeV',\\n\\t),\\n\\n\\therwigppUE_EE_3C_8000GeV = cms.vstring(\\n\\t\\t'+herwigppUE_EE_3C_Base',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 8000.0',\\n\\t\\t'set /Herwig/UnderlyingEvent/KtCut:MinKT 2.85',\\n\\t\\t'set /Herwig/UnderlyingEvent/UECuts:MHatMin 5.7',\\n\\t),\\n\\n\\therwigppUE_EE_3C_14000GeV = cms.vstring(\\n\\t\\t'+herwigppUE_EE_3C_Base',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 14000.0',\\n\\t\\t'set /Herwig/UnderlyingEvent/KtCut:MinKT 3.53',\\n\\t\\t'set /Herwig/UnderlyingEvent/UECuts:MHatMin 7.06',\\n\\t),\\n)\\n\\n\\ngenerator = cms.EDFilter(\\\"ThePEGGeneratorFilter\\\",\\n        herwigDefaultsBlock,\\n        herwigppUESettingsBlock,\\n        crossSection = cms.untracked.double(1),\\n        filterEfficiency = cms.untracked.double(1),\\n\\n        configFiles = cms.vstring(),\\n        parameterSets = cms.vstring(\\n                'herwigppUE_EE_3C_7000GeV',\\n                'productionParameters',\\n                'basicSetup',\\n                'setParticlesStableForDetector',\\n        ),\\n        productionParameters = cms.vstring(\\n                'mkdir /Herwig/Weights',\\n                'cd /Herwig/Weights',\\n                'create ThePEG::ReweightMinPT reweightMinPT ReweightMinPT.so',\\n\\n                'cd /Herwig/MatrixElements/',\\n                'insert SimpleQCD:MatrixElements[0] MEQCD2to2',\\n                'insert SimpleQCD:Preweights[0] /Herwig/Weights/reweightMinPT',\\n\\n                'cd /',\\n                'set /Herwig/Weights/reweightMinPT:Power 4.5',\\n                'set /Herwig/Weights/reweightMinPT:Scale 15*GeV',\\n                'set /Herwig/Cuts/JetKtCut:MinKT 15 *GeV',\\n                'set /Herwig/Cuts/JetKtCut:MaxKT 1000*GeV',\\n                'set /Herwig/Cuts/QCDCuts:MHatMin 0.0*GeV',\\n                'set /Herwig/UnderlyingEvent/MPIHandler:IdenticalToUE 0',\\n        ),\\n)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00006"
             },
@@ -3311,8 +3551,31 @@
             "herwigpp"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to1000_TuneEE3C_Flat_7TeV_herwigpp/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to1000_TuneEE3C_Flat_7TeV_herwigpp/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00014_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00014_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00014_step1.root --fileout file:FSQ-LowPU2010DR42-00014.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00014_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to1000_TuneEE3C_Flat_7TeV_herwigpp/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -3353,7 +3616,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-15to1000_fwdJet_bwdJet_Tune4C_Flat_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-15to1000_fwdJet_bwdJet_Tune4C_Flat_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -3394,37 +3657,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to1000_fwdJet_bwdJet_Tune4C_Flat_7TeV_pythia8/LowPU2010-START42_V17B-v3/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00023_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00023_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00023_step1.root --fileout file:FSQ-LowPU2010DR42-00023.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00023_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10_patch2/src ] ; then \n echo release CMSSW_4_2_10_patch2 already exists\nelse\nscram p CMSSW CMSSW_4_2_10_patch2\nfi\ncd CMSSW_4_2_10_patch2/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00009 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00009-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00009-fragment.py ] || exit $?;\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00009-fragment.py --fileout file:FSQ-LowPU2010-00009.root --mc --eventcontent RAWSIM --customise SimG4Core/Application/useCastorEtaAcceptance_4_2_10.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00009_1_cfg.py --no_exec -n 9850 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10_patch2/src ] ; then \n echo release CMSSW_4_2_10_patch2 already exists\nelse\nscram p CMSSW CMSSW_4_2_10_patch2\nfi\ncd CMSSW_4_2_10_patch2/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00009 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00009-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00009-fragment.py ] || exit $?;\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00009-fragment.py --fileout file:FSQ-LowPU2010-00009.root --mc --eventcontent RAWSIM --customise SimG4Core/Application/useCastorEtaAcceptance_4_2_10.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00009_1_cfg.py --no_exec -n 9850 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\ngenerator = cms.EDFilter(\\\"Pythia8GeneratorFilter\\\",\\n        comEnergy = cms.double(7000.0),\\n        crossSection = cms.untracked.double(1.246406e+09),\\n        filterEfficiency = cms.untracked.double(1),\\n        maxEventsToPrint = cms.untracked.int32(0),\\n        pythiaHepMCVerbosity = cms.untracked.bool(False),\\n        pythiaPylistVerbosity = cms.untracked.int32(0),\\n        useUserHook = cms.bool(True),\\n\\n        PythiaParameters = cms.PSet(\\n                processParameters = cms.vstring(\\n                        'Main:timesAllowErrors = 10000',\\n                        'ParticleDecays:limitTau0 = on',\\n                        'ParticleDecays:tauMax = 10',\\n                        'HardQCD:all = on',\\n                        'PhaseSpace:pTHatMin = 15',\\n                        'PhaseSpace:pTHatMax = 1000',\\n                        'Tune:pp 5',\\n                        'Tune:ee 3',\\n\\n                ),\\n                parameterSets = cms.vstring('processParameters')\\n        )\\n)\\n\\nfrom PhysicsTools.HepMCCandAlgos.genParticles_cfi import genParticles\\nfrom RecoJets.Configuration.GenJetParticles_cff import genParticlesForJets\\nfrom RecoJets.JetProducers.ak5GenJets_cfi import ak5GenJets\\n\\ncollection = \\\"ak5GenJets\\\"\\njetfilter1 = cms.EDFilter(\\\"EtaPtMinCandViewSelector\\\",\\n    src = cms.InputTag(collection),\\n    ptMin = cms.double( 30.0 ),\\n    etaMin = cms.double( -4.7 ),\\n    etaMax = cms.double( 4.7 )\\n)\\nFilter1 = cms.EDFilter(\\\"CandViewCountFilter\\\",\\n    src = cms.InputTag(\\\"jetfilter1\\\"),\\n    minNumber = cms.uint32(2)\\n)\\n\\n#fwd events check\\nfwdplus = cms.EDFilter(\\\"EtaPtMinCandViewSelector\\\",\\n    src = cms.InputTag(collection),\\n    ptMin = cms.double( 30.0 ),\\n    etaMin = cms.double( 2.8 ),\\n    etaMax = cms.double( 4.7 )\\n)\\nfwdplusFilter = cms.EDFilter(\\\"CandViewCountFilter\\\",\\n    src = cms.InputTag(\\\"fwdplus\\\"),\\n    minNumber = cms.uint32(1)\\n)\\nfwdminus = cms.EDFilter(\\\"EtaPtMinCandViewSelector\\\",\\n    src = cms.InputTag(collection),\\n    ptMin = cms.double( 30.0 ),\\n    etaMin = cms.double( -4.7 ),\\n    etaMax = cms.double( -2.8 )\\n)\\nfwdminusFilter = cms.EDFilter(\\\"CandViewCountFilter\\\",\\n    src = cms.InputTag(\\\"fwdminus\\\"),\\n    minNumber = cms.uint32(1)\\n)\\n\\nProductionFilterSequence = cms.Sequence(generator*genParticles*genParticlesForJets*ak5GenJets\\n                                        *jetfilter1*Filter1\\n                                        *fwdplus*fwdplusFilter*fwdminus*fwdminusFilter # fwd events\\n)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00009"
             },
@@ -3438,8 +3679,31 @@
             "pythia8"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to1000_fwdJet_bwdJet_Tune4C_Flat_7TeV_pythia8/LowPU2010-START42_V17B-v3/GEN-SIM",
           "release": "CMSSW_4_2_10_patch2",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to1000_fwdJet_bwdJet_Tune4C_Flat_7TeV_pythia8/LowPU2010-START42_V17B-v3/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00023_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00023_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00023_step1.root --fileout file:FSQ-LowPU2010DR42-00023.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00023_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to1000_fwdJet_bwdJet_Tune4C_Flat_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -3480,7 +3744,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-15to1000_fwdJet_bwdJet_TuneEE3C_Flat_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-15to1000_fwdJet_bwdJet_TuneEE3C_Flat_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -3521,37 +3785,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to1000_fwdJet_bwdJet_TuneEE3C_Flat_7TeV_herwigpp/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00022_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00022_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00022_step1.root --fileout file:FSQ-LowPU2010DR42-00022.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00022_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00010 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00010-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00010-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00010-fragment.py --fileout file:FSQ-LowPU2010-00010.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00010_1_cfg.py --no_exec -n 19264 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00010 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00010-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00010-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00010-fragment.py --fileout file:FSQ-LowPU2010-00010.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00010_1_cfg.py --no_exec -n 19264 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\n\\n#HerwigppDefaults_cfi.py\\nherwigDefaultsBlock = cms.PSet(\\n\\tdataLocation = cms.string('${HERWIGPATH}'),\\n\\n\\trepository = cms.string('HerwigDefaults.rpo'),\\n\\teventHandlers = cms.string('/Herwig/EventHandlers'),\\n\\tgeneratorModule = cms.string('/Herwig/Generators/LHCGenerator'),\\n\\n\\trun = cms.string('LHC'),\\n\\n\\tcmsDefaults = cms.vstring(\\n\\t\\t'+pdfMRST2001',\\n\\t\\t'+cm14TeV',\\n\\t\\t'+ue_2_3',\\n\\t\\t'+basicSetup',\\n\\t\\t'+setParticlesStableForDetector',\\n\\t),\\n\\n\\tbasicSetup = cms.vstring(\\n\\t\\t'cd /Herwig/Generators',\\n\\t\\t'create ThePEG::RandomEngineGlue /Herwig/RandomGlue',\\n\\t\\t'set LHCGenerator:RandomNumberGenerator /Herwig/RandomGlue',\\n\\t\\t'set LHCGenerator:NumberOfEvents 10000000',\\n\\t\\t'set LHCGenerator:DebugLevel 1',\\n\\t\\t'set LHCGenerator:PrintEvent 0',\\n\\t\\t'set LHCGenerator:MaxErrors 10000',\\n\\t\\t'cd /Herwig/Particles',\\n\\t\\t'set p+:PDF /Herwig/Partons/cmsPDFSet',\\n\\t\\t'set pbar-:PDF /Herwig/Partons/cmsPDFSet',\\n\\t\\t'set K0:Width 1e300*GeV',\\n\\t\\t'set Kbar0:Width 1e300*GeV',\\n\\t\\t'cd /',\\n\\t),\\n\\n\\t# PDF presets\\n\\t##############################\\n\\n\\t# Default pdf for Herwig++ 2.3\\n\\tpdfMRST2001 = cms.vstring(\\n\\t\\t'cd /Herwig/Partons',\\n\\t\\t'create Herwig::MRST MRST2001 HwMRST.so',\\n\\t\\t'setup MRST2001 ${HERWIGPATH}/PDF/mrst/2001/lo2002.dat',\\n\\t\\t'set MRST2001:RemnantHandler HadronRemnants',\\n\\t\\t'cp MRST2001 cmsPDFSet',\\n\\t\\t'cd /',\\n\\t),\\n\\t# Default pdf for Herwig++ 2.4\\n\\tpdfMRST2008LOss = cms.vstring(\\n\\t\\t'cp /Herwig/Partons/MRST /Herwig/Partons/cmsPDFSet',\\n\\t),\\n\\tpdfCTEQ5L = cms.vstring(\\n\\t\\t'cd /Herwig/Partons',\\n\\t\\t'create ThePEG::LHAPDF CTEQ5L ThePEGLHAPDF.so',\\n\\t\\t'set CTEQ5L:PDFName cteq5l.LHgrid',\\n\\t\\t'set CTEQ5L:RemnantHandler HadronRemnants',\\n\\t\\t'cp CTEQ5L cmsPDFSet',\\n\\t\\t'cd /',\\n\\t),\\n\\tpdfCTEQ6L1 = cms.vstring(\\n\\t\\t'cd /Herwig/Partons',\\n\\t\\t'create ThePEG::LHAPDF CTEQ6L1 ThePEGLHAPDF.so',\\n\\t\\t'set CTEQ6L1:PDFName cteq6ll.LHpdf',\\n\\t\\t'set CTEQ6L1:RemnantHandler HadronRemnants',\\n\\t\\t'cp CTEQ6L1 cmsPDFSet',\\n\\t\\t'cd /',\\n\\t),\\n\\n\\t# CME presets\\n\\t##############################\\n\\n\\tcm7TeV = cms.vstring(\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 7000.0',\\n\\t\\t'set /Herwig/Shower/Evolver:IntrinsicPtGaussian 2.0*GeV',\\n\\t),\\n\\tcm8TeV = cms.vstring(\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 8000.0',\\n\\t\\t'set /Herwig/Shower/Evolver:IntrinsicPtGaussian 2.0*GeV',\\n\\t),\\n\\tcm10TeV = cms.vstring(\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 10000.0',\\n\\t\\t'set /Herwig/Shower/Evolver:IntrinsicPtGaussian 2.1*GeV',\\n\\t),\\n\\tcm14TeV = cms.vstring(\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 14000.0',\\n\\t\\t'set /Herwig/Shower/Evolver:IntrinsicPtGaussian 2.2*GeV',\\n\\t),\\n\\n\\t# UE tunes\\n\\t##############################\\n\\n\\t# UE Tune from Herwig++ 2.3 (MRST2001)\\n\\tue_2_3 = cms.vstring(\\n\\t\\t'cd /Herwig/UnderlyingEvent',\\n\\t\\t'set KtCut:MinKT 4.0',\\n\\t\\t'set UECuts:MHatMin 8.0',\\n\\t\\t'set MPIHandler:InvRadius 1.5',\\n\\t\\t'cd /',\\n\\t),\\n\\t# UE Tune from Herwig++ 2.4 (MRST2008LO**)\\n\\tue_2_4 = cms.vstring(\\n\\t\\t'cd /Herwig/UnderlyingEvent',\\n\\t\\t'set KtCut:MinKT 4.3',\\n\\t\\t'set UECuts:MHatMin 8.6',\\n\\t\\t'set MPIHandler:InvRadius 1.2',\\n\\t\\t'cd /',\\n\\t),\\n\\n\\t# reweight presets\\n\\t##############################\\n\\n\\treweightConstant = cms.vstring(\\n\\t\\t'mkdir /Herwig/Weights',\\n\\t\\t'cd /Herwig/Weights',\\n\\t\\t'create ThePEG::ReweightConstant reweightConstant ReweightConstant.so',\\n\\t\\t'cd /',\\n\\t\\t'set /Herwig/Weights/reweightConstant:C 1',\\n\\t\\t'insert SimpleQCD:Reweights[0] /Herwig/Weights/reweightConstant',\\n\\t),\\n\\treweightPthat = cms.vstring(\\n\\t\\t'mkdir /Herwig/Weights',\\n\\t\\t'cd /Herwig/Weights',\\n\\t\\t'create ThePEG::ReweightMinPT reweightMinPT ReweightMinPT.so',\\n\\t\\t'cd /',\\n\\t\\t'set /Herwig/Weights/reweightMinPT:Power 4.5',\\n\\t\\t'set /Herwig/Weights/reweightMinPT:Scale 15*GeV',\\n\\t\\t'insert SimpleQCD:Reweights[0] /Herwig/Weights/reweightMinPT',\\n\\t),\\n\\n\\t# Disable decays of particles with ctau > 10mm\\n\\tsetParticlesStableForDetector = cms.vstring(\\n\\t\\t'cd /Herwig/Particles',\\n\\t\\t'set mu-:Stable Stable',\\n\\t\\t'set mu+:Stable Stable',\\n\\t\\t'set Sigma-:Stable Stable',\\n\\t\\t'set Sigmabar+:Stable Stable',\\n\\t\\t'set Lambda0:Stable Stable',\\n\\t\\t'set Lambdabar0:Stable Stable',\\n\\t\\t'set Sigma+:Stable Stable',\\n\\t\\t'set Sigmabar-:Stable Stable',\\n\\t\\t'set Xi-:Stable Stable',\\n\\t\\t'set Xibar+:Stable Stable',\\n\\t\\t'set Xi0:Stable Stable',\\n\\t\\t'set Xibar0:Stable Stable',\\n\\t\\t'set Omega-:Stable Stable',\\n\\t\\t'set Omegabar+:Stable Stable',\\n\\t\\t'set pi+:Stable Stable',\\n\\t\\t'set pi-:Stable Stable',\\n\\t\\t'set K+:Stable Stable',\\n\\t\\t'set K-:Stable Stable',\\n\\t\\t'set K_S0:Stable Stable',\\n\\t\\t'set K_L0:Stable Stable',\\n\\t\\t'cd /',\\n\\t),\\n\\n\\t# Default settings for using LHE files\\n\\tlheDefaults = cms.vstring(\\n\\t\\t'cd /Herwig/Cuts',\\n\\t\\t'create ThePEG::Cuts NoCuts',\\n\\t\\t'cd /Herwig/EventHandlers',\\n\\t\\t'create ThePEG::LesHouchesInterface LHEReader',\\n\\t\\t'set LHEReader:Cuts /Herwig/Cuts/NoCuts',\\n\\t\\t'create ThePEG::LesHouchesEventHandler LHEHandler',\\n\\t\\t'set LHEHandler:WeightOption VarWeight',\\n\\t\\t'set LHEHandler:PartonExtractor /Herwig/Partons/QCDExtractor',\\n\\t\\t'set LHEHandler:CascadeHandler /Herwig/Shower/ShowerHandler',\\n\\t\\t'set LHEHandler:HadronizationHandler /Herwig/Hadronization/ClusterHadHandler',\\n\\t\\t'set LHEHandler:DecayHandler /Herwig/Decays/DecayHandler',\\n\\t\\t'insert LHEHandler:LesHouchesReaders 0 LHEReader',\\n\\t\\t'cd /Herwig/Generators',\\n\\t\\t'set LHCGenerator:EventHandler /Herwig/EventHandlers/LHEHandler',\\n\\t\\t'cd /Herwig/Shower',\\n\\t\\t'set Evolver:HardVetoScaleSource Read',\\n\\t\\t'set Evolver:MECorrMode No',\\n\\t\\t'cd /',\\n\\t),\\n\\tlheDefaultPDFs = cms.vstring(\\n\\t\\t'cd /Herwig/EventHandlers',\\n\\t\\t'set LHEReader:PDFA /cmsPDFSet',\\n\\t\\t'set LHEReader:PDFB /cmsPDFSet',\\n\\t\\t'cd /',\\n\\t),\\n\\n\\t# Default settings for using POWHEG\\n\\tpowhegDefaults = cms.vstring(\\n\\t\\t# Need to use an NLO PDF\\n\\t\\t'cp /Herwig/Partons/MRST-NLO /cmsPDFSet',\\n\\t\\t'set /Herwig/Particles/p+:PDF    /Herwig/Partons/MRST-NLO',\\n\\t\\t'set /Herwig/Particles/pbar-:PDF /Herwig/Partons/MRST-NLO',\\n\\t\\t# and strong coupling\\n\\t\\t'create Herwig::O2AlphaS O2AlphaS',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:StandardModelParameters:QCD/RunningAlphaS O2AlphaS',\\n\\t\\t# Setup the POWHEG shower\\n\\t\\t'cd /Herwig/Shower',\\n\\t\\t# use the general recon for now\\n\\t\\t'set KinematicsReconstructor:ReconstructionOption General',\\n\\t\\t# create the Powheg evolver and use it instead of the default one\\n\\t\\t'create Herwig::PowhegEvolver PowhegEvolver HwPowhegShower.so',\\n\\t\\t'set ShowerHandler:Evolver PowhegEvolver',\\n\\t\\t'set PowhegEvolver:ShowerModel ShowerModel',\\n\\t\\t'set PowhegEvolver:SplittingGenerator SplittingGenerator',\\n\\t\\t'set PowhegEvolver:MECorrMode 0',\\n\\t\\t# create and use the Drell-yan hard emission generator\\n\\t\\t'create Herwig::DrellYanHardGenerator DrellYanHardGenerator',\\n\\t\\t'set DrellYanHardGenerator:ShowerAlpha AlphaQCD',\\n\\t\\t'insert PowhegEvolver:HardGenerator 0 DrellYanHardGenerator',\\n\\t\\t# create and use the gg->H hard emission generator\\n\\t\\t'create Herwig::GGtoHHardGenerator GGtoHHardGenerator',\\n\\t\\t'set GGtoHHardGenerator:ShowerAlpha AlphaQCD',\\n\\t\\t'insert PowhegEvolver:HardGenerator 0 GGtoHHardGenerator',\\n\\t)\\n)\\n\\n#HerwigppUE_EE_3C_cfi.py\\nherwigppUESettingsBlock = cms.PSet(\\n\\therwigppUE_EE_3C_Base = cms.vstring(\\n\\t\\t'+pdfCTEQ6L1',\\n\\n\\t\\t'cd /Herwig',\\n\\t\\t'create Herwig::O2AlphaS O2AlphaS',\\n\\t\\t'set Model:QCD/RunningAlphaS O2AlphaS',\\n\\n\\t\\t# Energy-independent MPI parameters\\n\\t\\t#   Colour reconnection settings\\n\\t\\t'set /Herwig/Hadronization/ColourReconnector:ColourReconnection Yes',\\n\\t\\t'set /Herwig/Hadronization/ColourReconnector:ReconnectionProbability 0.54',\\n\\t\\t#   Colour Disrupt settings\\n\\t\\t'set /Herwig/Partons/RemnantDecayer:colourDisrupt 0.80',\\n\\t\\t#   inverse hadron radius\\n\\t\\t'set /Herwig/UnderlyingEvent/MPIHandler:InvRadius 1.11',\\n\\t\\t#   MPI model settings\\n\\t\\t#'set /Herwig/UnderlyingEvent/MPIHandler:IdenticalToUE 0',\\n\\t\\t'set /Herwig/UnderlyingEvent/MPIHandler:softInt Yes',\\n\\t\\t'set /Herwig/UnderlyingEvent/MPIHandler:twoComp Yes',\\n\\t\\t'set /Herwig/UnderlyingEvent/MPIHandler:DLmode 2',\\n\\t\\t'cd /',\\n\\t),\\n\\n\\therwigppUE_EE_3C_900GeV = cms.vstring(\\n\\t\\t'+herwigppUE_EE_3C_Base',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 900.0',\\n\\t\\t'set /Herwig/UnderlyingEvent/KtCut:MinKT 1.55',\\n\\t\\t'set /Herwig/UnderlyingEvent/UECuts:MHatMin 3.1',\\n\\t\\t'set /Herwig/Shower/Evolver:IntrinsicPtGaussian 1.81*GeV',\\n\\t),\\n\\n\\therwigppUE_EE_3C_1800GeV = cms.vstring(\\n\\t\\t'+herwigppUE_EE_3C_Base',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 1800.0',\\n\\t\\t'set /Herwig/UnderlyingEvent/KtCut:MinKT 2.26',\\n\\t\\t'set /Herwig/UnderlyingEvent/UECuts:MHatMin 4.52',\\n\\t),\\n\\n\\therwigppUE_EE_3C_2760GeV = cms.vstring(\\n\\t\\t'+herwigppUE_EE_3C_Base',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 2760.0',\\n\\t\\t'set /Herwig/UnderlyingEvent/KtCut:MinKT 2.33',\\n\\t\\t'set /Herwig/UnderlyingEvent/UECuts:MHatMin 4.66',\\n\\t),\\n\\n\\therwigppUE_EE_3C_7000GeV = cms.vstring(\\n\\t\\t'+herwigppUE_EE_3C_Base',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 7000.0',\\n\\t\\t'set /Herwig/UnderlyingEvent/KtCut:MinKT 2.752',\\n\\t\\t'set /Herwig/UnderlyingEvent/UECuts:MHatMin 5.504',\\n\\t\\t'set /Herwig/Shower/Evolver:IntrinsicPtGaussian 2.34*GeV',\\n\\t),\\n\\n\\therwigppUE_EE_3C_8000GeV = cms.vstring(\\n\\t\\t'+herwigppUE_EE_3C_Base',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 8000.0',\\n\\t\\t'set /Herwig/UnderlyingEvent/KtCut:MinKT 2.85',\\n\\t\\t'set /Herwig/UnderlyingEvent/UECuts:MHatMin 5.7',\\n\\t),\\n\\n\\therwigppUE_EE_3C_14000GeV = cms.vstring(\\n\\t\\t'+herwigppUE_EE_3C_Base',\\n\\t\\t'set /Herwig/Generators/LHCGenerator:EventHandler:LuminosityFunction:Energy 14000.0',\\n\\t\\t'set /Herwig/UnderlyingEvent/KtCut:MinKT 3.53',\\n\\t\\t'set /Herwig/UnderlyingEvent/UECuts:MHatMin 7.06',\\n\\t),\\n)\\n\\n\\n\\ngenerator = cms.EDFilter(\\\"ThePEGGeneratorFilter\\\",\\n        herwigDefaultsBlock,\\n        herwigppUESettingsBlock,\\n        crossSection = cms.untracked.double(1),\\n        filterEfficiency = cms.untracked.double(1),\\n\\n        configFiles = cms.vstring(),\\n        parameterSets = cms.vstring(\\n                'herwigppUE_EE_3C_7000GeV',\\n                'productionParameters',\\n                'basicSetup',\\n                'setParticlesStableForDetector',\\n        ),\\n        productionParameters = cms.vstring(\\n                'mkdir /Herwig/Weights',\\n                'cd /Herwig/Weights',\\n                'create ThePEG::ReweightMinPT reweightMinPT ReweightMinPT.so',\\n\\n                'cd /Herwig/MatrixElements/',\\n                'insert SimpleQCD:MatrixElements[0] MEQCD2to2',\\n                'insert SimpleQCD:Preweights[0] /Herwig/Weights/reweightMinPT',\\n\\n                'cd /',\\n                'set /Herwig/Weights/reweightMinPT:Power 4.5',\\n                'set /Herwig/Weights/reweightMinPT:Scale 15*GeV',\\n                'set /Herwig/Cuts/JetKtCut:MinKT 15 *GeV',\\n                'set /Herwig/Cuts/JetKtCut:MaxKT 1000*GeV',\\n                'set /Herwig/Cuts/QCDCuts:MHatMin 0.0*GeV',\\n                'set /Herwig/UnderlyingEvent/MPIHandler:IdenticalToUE 0',\\n        ),\\n)\\n\\nfrom PhysicsTools.HepMCCandAlgos.genParticles_cfi import genParticles\\nfrom RecoJets.Configuration.GenJetParticles_cff import genParticlesForJets\\nfrom RecoJets.JetProducers.ak5GenJets_cfi import ak5GenJets\\n\\ncollection = \\\"ak5GenJets\\\"\\njetfilter1 = cms.EDFilter(\\\"EtaPtMinCandViewSelector\\\",\\n    src = cms.InputTag(collection),\\n    ptMin = cms.double( 30.0 ),\\n    etaMin = cms.double( -4.7 ),\\n    etaMax = cms.double( 4.7 )\\n)\\nFilter1 = cms.EDFilter(\\\"CandViewCountFilter\\\",\\n    src = cms.InputTag(\\\"jetfilter1\\\"),\\n    minNumber = cms.uint32(2)\\n)\\n\\n#fwd events check\\nfwdplus = cms.EDFilter(\\\"EtaPtMinCandViewSelector\\\",\\n    src = cms.InputTag(collection),\\n    ptMin = cms.double( 30.0 ),\\n    etaMin = cms.double( 2.8 ),\\n    etaMax = cms.double( 4.7 )\\n)\\nfwdplusFilter = cms.EDFilter(\\\"CandViewCountFilter\\\",\\n    src = cms.InputTag(\\\"fwdplus\\\"),\\n    minNumber = cms.uint32(1)\\n)\\nfwdminus = cms.EDFilter(\\\"EtaPtMinCandViewSelector\\\",\\n    src = cms.InputTag(collection),\\n    ptMin = cms.double( 30.0 ),\\n    etaMin = cms.double( -4.7 ),\\n    etaMax = cms.double( -2.8 )\\n)\\nfwdminusFilter = cms.EDFilter(\\\"CandViewCountFilter\\\",\\n    src = cms.InputTag(\\\"fwdminus\\\"),\\n    minNumber = cms.uint32(1)\\n)\\n\\nProductionFilterSequence = cms.Sequence(generator*genParticles*genParticlesForJets*ak5GenJets\\n                                        *jetfilter1*Filter1\\n                                        *fwdplus*fwdplusFilter*fwdminus*fwdminusFilter # fwd events\\n)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00010"
             },
@@ -3570,8 +3812,31 @@
             "herwigpp"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to1000_fwdJet_bwdJet_TuneEE3C_Flat_7TeV_herwigpp/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to1000_fwdJet_bwdJet_TuneEE3C_Flat_7TeV_herwigpp/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00022_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00022_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00022_step1.root --fileout file:FSQ-LowPU2010DR42-00022.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00022_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to1000_fwdJet_bwdJet_TuneEE3C_Flat_7TeV_herwigpp/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -3612,7 +3877,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-15to3000_Tune23_Flat_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-15to3000_Tune23_Flat_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -3653,23 +3918,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -3678,7 +3928,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to3000_Tune23_Flat_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to3000_Tune23_Flat_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -3719,7 +3990,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-15to3000_Tune23_Flat_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-15to3000_Tune23_Flat_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -3767,33 +4038,12 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to3000_Tune23_Flat_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-ext-v1/GEN-SIM\" --fileout file:QCD-LowPU2010DR42-00072_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --datamix NODATAMIXER --python_filename QCD-LowPU2010DR42-00072_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 160 || exit $? ; \n\ncmsDriver.py step2 --filein file:QCD-LowPU2010DR42-00072_step1.root --fileout file:QCD-LowPU2010DR42-00072.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent AODSIM,RECOSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier AODSIM,GEN-SIM-RECO --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename QCD-LowPU2010DR42-00072_2_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 160 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "679a1c3067bf7afe4916744957edf38b",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "679a1c3067bf7afe4916744957edfcb1",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/V02-02-58/python/SevenTeV/QCD_Pt_15to3000_Tune23_Flat_7TeV_herwigpp_cff.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/SevenTeV/QCD_Pt_15to3000_Tune23_Flat_7TeV_herwigpp_cff.py \n[ -s Configuration/GenProduction/python/SevenTeV/QCD_Pt_15to3000_Tune23_Flat_7TeV_herwigpp_cff.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/SevenTeV/QCD_Pt_15to3000_Tune23_Flat_7TeV_herwigpp_cff.py --filein \"dbs:Default\" --fileout file:QCD-LowPU2010-00080.root --mc --eventcontent RAWSIM --pileup NoPileUp --customise SimG4Core/Application/useCastorShowerLibrary.customise,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --datamix NODATAMIXER --python_filename QCD-LowPU2010-00080_1_cfg.py --no_exec -n 160 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/V02-02-58/python/SevenTeV/QCD_Pt_15to3000_Tune23_Flat_7TeV_herwigpp_cff.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/SevenTeV/QCD_Pt_15to3000_Tune23_Flat_7TeV_herwigpp_cff.py \n[ -s Configuration/GenProduction/python/SevenTeV/QCD_Pt_15to3000_Tune23_Flat_7TeV_herwigpp_cff.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/SevenTeV/QCD_Pt_15to3000_Tune23_Flat_7TeV_herwigpp_cff.py --filein \"dbs:Default\" --fileout file:QCD-LowPU2010-00080.root --mc --eventcontent RAWSIM --pileup NoPileUp --customise SimG4Core/Application/useCastorShowerLibrary.customise,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --datamix NODATAMIXER --python_filename QCD-LowPU2010-00080_1_cfg.py --no_exec -n 160 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
@@ -3807,9 +4057,31 @@
               "title": "Configuration file"
             }
           ],
+          "generators": [
+            "herwigpp"
+          ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to3000_Tune23_Flat_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-ext-v1/GEN-SIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "679a1c3067bf7afe4916744957edf38b",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "679a1c3067bf7afe4916744957edfcb1",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to3000_Tune23_Flat_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v2/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -3850,7 +4122,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -3891,29 +4163,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8/LowPU2010-START42_V17B-v3/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00002_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00002_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00002_step1.root --fileout file:FSQ-LowPU2010DR42-00002.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00002_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -3922,10 +4173,35 @@
               "title": "Configuration file"
             }
           ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8/LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_10",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8/LowPU2010-START42_V17B-v3/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00002_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00002_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00002_step1.root --fileout file:FSQ-LowPU2010DR42-00002.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00002_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
           "generators": [
             "pythia8"
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -3966,7 +4242,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -4007,37 +4283,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8/LowPU2010-START42_V17B-v3/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00002_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00002_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00002_step1.root --fileout file:FSQ-LowPU2010DR42-00002.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00002_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10_patch2/src ] ; then \n echo release CMSSW_4_2_10_patch2 already exists\nelse\nscram p CMSSW CMSSW_4_2_10_patch2\nfi\ncd CMSSW_4_2_10_patch2/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00008 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00008-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00008-fragment.py ] || exit $?;\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00008-fragment.py --fileout file:FSQ-LowPU2010-00008.root --mc --eventcontent RAWSIM --customise SimG4Core/Application/useCastorEtaAcceptance_4_2_10.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00008_1_cfg.py --no_exec -n 41 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10_patch2/src ] ; then \n echo release CMSSW_4_2_10_patch2 already exists\nelse\nscram p CMSSW CMSSW_4_2_10_patch2\nfi\ncd CMSSW_4_2_10_patch2/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00008 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00008-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00008-fragment.py ] || exit $?;\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00008-fragment.py --fileout file:FSQ-LowPU2010-00008.root --mc --eventcontent RAWSIM --customise SimG4Core/Application/useCastorEtaAcceptance_4_2_10.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00008_1_cfg.py --no_exec -n 41 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\ngenerator = cms.EDFilter(\\\"Pythia8GeneratorFilter\\\",\\n        comEnergy = cms.double(7000.0),\\n        crossSection = cms.untracked.double(1.246406e+09),\\n        filterEfficiency = cms.untracked.double(1),\\n        maxEventsToPrint = cms.untracked.int32(0),\\n        pythiaHepMCVerbosity = cms.untracked.bool(False),\\n        pythiaPylistVerbosity = cms.untracked.int32(0),\\n        useUserHook = cms.bool(True),\\n\\n        PythiaParameters = cms.PSet(\\n                processParameters = cms.vstring(\\n                        'Main:timesAllowErrors = 10000',\\n                        'ParticleDecays:limitTau0 = on',\\n                        'ParticleDecays:tauMax = 10',\\n                        'HardQCD:all = on',\\n                        'PhaseSpace:pTHatMin = 15',\\n                        'PhaseSpace:pTHatMax = 3000',\\n                        'Tune:pp 5',\\n                        'Tune:ee 3',\\n\\n                ),\\n                parameterSets = cms.vstring('processParameters')\\n        )\\n)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00008"
             },
@@ -4051,8 +4305,31 @@
             "pythia8"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8/LowPU2010-START42_V17B-v3/GEN-SIM",
           "release": "CMSSW_4_2_10_patch2",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8/LowPU2010-START42_V17B-v3/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00002_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00002_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00002_step1.root --fileout file:FSQ-LowPU2010DR42-00002.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00002_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -4093,7 +4370,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-15to3000_TuneZ2star_Flat_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-15to3000_TuneZ2star_Flat_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -4134,23 +4411,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -4159,7 +4421,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to3000_TuneZ2star_Flat_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to3000_TuneZ2star_Flat_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -4200,7 +4483,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-15to3000_TuneZ2star_Flat_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-15to3000_TuneZ2star_Flat_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -4241,23 +4524,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "d3c47a7be87c7505f6e08aa44786136e",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "d3c47a7be87c7505f6e08aa447853dcb",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -4266,7 +4534,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to3000_TuneZ2star_Flat_HFshowerLibrary_7TeV_pythia6/Summer12-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "d3c47a7be87c7505f6e08aa447853dcb",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "d3c47a7be87c7505f6e08aa44786136e",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to3000_TuneZ2star_Flat_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v2/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -4307,7 +4596,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-15to30_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-15to30_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -4348,23 +4637,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "8bf830006a8493f7e7b1551d16783853",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -4373,7 +4647,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to30_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "8bf830006a8493f7e7b1551d16783853",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-15to30_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -4414,7 +4709,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-170to300_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-170to300_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -4455,23 +4750,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "34b5be84d9a7c90a4924f7cf9c8dbe86",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "34b5be84d9a7c90a4924f7cf9c8d81f9",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -4480,7 +4760,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-170to300_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "34b5be84d9a7c90a4924f7cf9c8d81f9",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "34b5be84d9a7c90a4924f7cf9c8dbe86",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-170to300_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -4521,7 +4822,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-300to470_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-300to470_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -4562,23 +4863,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "8bf830006a8493f7e7b1551d16783853",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -4587,7 +4873,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-300to470_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "8bf830006a8493f7e7b1551d16783853",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-300to470_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -4628,7 +4935,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-30to50_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-30to50_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -4669,23 +4976,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "20df86a8d2a6767511e8c70c16760806",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "20df86a8d2a6767511e8c70c16761285",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -4694,7 +4986,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-30to50_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "20df86a8d2a6767511e8c70c16760806",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "20df86a8d2a6767511e8c70c16761285",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-30to50_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -4735,7 +5048,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-470to600_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-470to600_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -4776,23 +5089,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "8bf830006a8493f7e7b1551d16783853",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -4801,7 +5099,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-470to600_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "8bf830006a8493f7e7b1551d16783853",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-470to600_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -4842,7 +5161,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-50to80_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-50to80_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -4883,8 +5202,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "f04ea603747fd810469d2faca32e2a20",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-50to80_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -4894,21 +5226,14 @@
             },
             {
               "cms_confdb_id": "34b5be84d9a7c90a4924f7cf9c8d81f9",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "f04ea603747fd810469d2faca32e2a20",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-50to80_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -4949,7 +5274,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-600to800_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-600to800_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -4990,8 +5315,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "f04ea603747fd810469d2faca31f0830",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-600to800_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -5001,21 +5339,14 @@
             },
             {
               "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "f04ea603747fd810469d2faca31f0830",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-600to800_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -5056,7 +5387,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-80to120_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt-80to120_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -5097,23 +5428,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "8bf830006a8493f7e7b1551d16783853",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -5122,7 +5438,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-80to120_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "8bf830006a8493f7e7b1551d16783853",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt-80to120_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -5163,7 +5500,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_0to5_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_0to5_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -5204,23 +5541,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -5229,7 +5551,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_0to5_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_0to5_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -5270,7 +5613,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_10to25_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_10to25_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -5311,23 +5654,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -5336,7 +5664,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_10to25_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_10to25_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -5377,7 +5726,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_10to25_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_10to25_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -5418,23 +5767,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "1cce1be4ff841028987380e485d2f0fe",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "1cce1be4ff841028987380e485d2fce6",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -5443,7 +5777,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_10to25_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "1cce1be4ff841028987380e485d2f0fe",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "1cce1be4ff841028987380e485d2fce6",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_10to25_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -5484,7 +5839,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_10to25_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_10to25_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -5525,23 +5880,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "70ed77c68a7d31d941249f48606d9eab",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "70ed77c68a7d31d941249f48606d1941",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -5550,7 +5890,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_10to25_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "70ed77c68a7d31d941249f48606d1941",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "70ed77c68a7d31d941249f48606d9eab",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_10to25_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -5591,7 +5952,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_10to25_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_10to25_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -5632,23 +5993,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -5657,7 +6003,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_10to25_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_10to25_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -5698,7 +6065,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_120to170_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_120to170_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -5739,23 +6106,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "86795293e0f0a28c0259541ea4a8e57f",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "86795293e0f0a28c0259541ea4a8e6a9",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -5764,7 +6116,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_120to170_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "86795293e0f0a28c0259541ea4a8e57f",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "86795293e0f0a28c0259541ea4a8e6a9",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_120to170_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -5805,7 +6178,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_120to170_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_120to170_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -5846,23 +6219,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "fa09878571c00c1f0d62c320e484c511",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -5871,7 +6229,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_120to170_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "fa09878571c00c1f0d62c320e484c511",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_120to170_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -5912,7 +6291,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_150toInf_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_150toInf_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -5953,23 +6332,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -5978,7 +6342,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_150toInf_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_150toInf_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -6019,7 +6404,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_150toInf_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_150toInf_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -6060,8 +6445,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "21cd9cd25a4a66e63cf5bebfb7188613",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_150toInf_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -6071,21 +6469,14 @@
             },
             {
               "cms_confdb_id": "1cce1be4ff841028987380e485d2f0fe",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "21cd9cd25a4a66e63cf5bebfb7188613",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_150toInf_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -6126,7 +6517,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_150toInf_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_150toInf_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -6167,8 +6558,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "499dd0e3999c7a3e95eb37463d980015",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_150toInf_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -6178,21 +6582,14 @@
             },
             {
               "cms_confdb_id": "20df86a8d2a6767511e8c70c16760806",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "499dd0e3999c7a3e95eb37463d980015",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_150toInf_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v2/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -6233,7 +6630,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_150toInf_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_150toInf_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -6274,23 +6671,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -6299,7 +6681,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_150toInf_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_150toInf_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -6340,7 +6743,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_15to30_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_15to30_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -6381,23 +6784,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "5399251e2a8fcc733cc1ee0ac86f75b7",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "5399251e2a8fcc733cc1ee0ac86ef0ff",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -6406,7 +6794,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_15to30_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "5399251e2a8fcc733cc1ee0ac86ef0ff",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "5399251e2a8fcc733cc1ee0ac86f75b7",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_15to30_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -6447,7 +6856,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_15to30_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_15to30_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -6488,23 +6897,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -6513,7 +6907,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_15to30_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_15to30_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -6554,7 +6969,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_170to300_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_170to300_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -6595,23 +7010,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "69014bd02166e652ad8e145474a68b74",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -6620,7 +7020,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_170to300_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "69014bd02166e652ad8e145474a68b74",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_170to300_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -6661,7 +7082,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_170to300_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_170to300_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -6702,23 +7123,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "ffda6faab4a5706f819a52c5152b89f8",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "ffda6faab4a5706f819a52c5152b9f93",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -6727,7 +7133,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_170to300_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "ffda6faab4a5706f819a52c5152b9f93",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "ffda6faab4a5706f819a52c5152b89f8",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_170to300_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -6768,7 +7195,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_25to40_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_25to40_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -6809,23 +7236,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "d6f77e87e94b455d49e4e5982eca7b74",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "d6f77e87e94b455d49e4e5982ed2ab3a",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -6834,7 +7246,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_25to40_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "d6f77e87e94b455d49e4e5982ed2ab3a",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "d6f77e87e94b455d49e4e5982eca7b74",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_25to40_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -6875,7 +7308,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_25to40_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_25to40_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -6916,8 +7349,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "21cd9cd25a4a66e63cf5bebfb718766b",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_25to40_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -6927,21 +7373,14 @@
             },
             {
               "cms_confdb_id": "1cce1be4ff841028987380e485d2f0fe",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "21cd9cd25a4a66e63cf5bebfb718766b",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_25to40_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -6982,7 +7421,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_25to40_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_25to40_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -7023,23 +7462,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "286a1ad1293c7f54ab66772630d6c60d",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "286a1ad1293c7f54ab66772630d6bd02",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -7048,7 +7472,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_25to40_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "286a1ad1293c7f54ab66772630d6bd02",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "286a1ad1293c7f54ab66772630d6c60d",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_25to40_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -7089,7 +7534,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_25to40_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_25to40_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -7130,23 +7575,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -7155,7 +7585,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_25to40_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_25to40_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -7196,7 +7647,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_300to470_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_300to470_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -7237,8 +7688,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "153fbc65b3d49ee64349d246f498f5c1",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_300to470_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -7248,21 +7712,14 @@
             },
             {
               "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "153fbc65b3d49ee64349d246f498f5c1",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_300to470_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -7303,7 +7760,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_300to470_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_300to470_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -7344,23 +7801,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "fa09878571c00c1f0d62c320e484c511",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -7369,7 +7811,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_300to470_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "fa09878571c00c1f0d62c320e484c511",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_300to470_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -7410,7 +7873,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_30to50_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_30to50_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -7451,8 +7914,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "153fbc65b3d49ee64349d246f49a9f06",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_30to50_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -7462,21 +7938,14 @@
             },
             {
               "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "153fbc65b3d49ee64349d246f49a9f06",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_30to50_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -7517,7 +7986,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_30to50_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_30to50_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -7558,8 +8027,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "153fbc65b3d49ee64349d246f4949a1a",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_30to50_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -7569,21 +8051,14 @@
             },
             {
               "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "153fbc65b3d49ee64349d246f4949a1a",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_30to50_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -7624,7 +8099,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_40to80_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_40to80_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -7665,8 +8140,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "d98b66cbbdb0555f989db579f83e630e",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_40to80_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -7676,21 +8164,14 @@
             },
             {
               "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "d98b66cbbdb0555f989db579f83e630e",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_40to80_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -7731,7 +8212,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_40to80_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_40to80_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -7772,23 +8253,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "1cce1be4ff841028987380e485d2fce6",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "1cce1be4ff841028987380e485d2f0fe",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -7797,7 +8263,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_40to80_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "1cce1be4ff841028987380e485d2f0fe",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "1cce1be4ff841028987380e485d2fce6",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_40to80_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -7838,7 +8325,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_40to80_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_40to80_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -7879,8 +8366,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "499dd0e3999c7a3e95eb37463d997364",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_40to80_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -7890,21 +8390,14 @@
             },
             {
               "cms_confdb_id": "70ed77c68a7d31d941249f48606d1941",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "499dd0e3999c7a3e95eb37463d997364",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_40to80_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -7945,7 +8438,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_40to80_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_40to80_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -7986,8 +8479,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "21cd9cd25a4a66e63cf5bebfb7185007",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_40to80_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -7997,21 +8503,14 @@
             },
             {
               "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "21cd9cd25a4a66e63cf5bebfb7185007",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_40to80_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -8052,7 +8551,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_470to600_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_470to600_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -8093,8 +8592,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "153fbc65b3d49ee64349d246f496b651",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_470to600_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -8104,21 +8616,14 @@
             },
             {
               "cms_confdb_id": "429e00f769683de0712feb6c5ba663b2",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "153fbc65b3d49ee64349d246f496b651",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_470to600_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -8159,7 +8664,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_470to600_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_470to600_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -8200,23 +8705,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "429e00f769683de0712feb6c5ba765ab",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "429e00f769683de0712feb6c5ba663b2",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -8225,7 +8715,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_470to600_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "429e00f769683de0712feb6c5ba663b2",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "429e00f769683de0712feb6c5ba765ab",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_470to600_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -8266,7 +8777,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_50to80_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_50to80_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -8307,23 +8818,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -8332,7 +8828,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_50to80_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_50to80_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -8373,7 +8890,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_50to80_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_50to80_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -8414,23 +8931,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "fa09878571c00c1f0d62c320e484c511",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -8439,7 +8941,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_50to80_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "fa09878571c00c1f0d62c320e484c511",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_50to80_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -8480,7 +9003,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_5to15_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_5to15_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -8521,23 +9044,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "86795293e0f0a28c0259541ea4a8e57f",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "86795293e0f0a28c0259541ea4a8e6a9",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -8546,7 +9054,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_5to15_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "86795293e0f0a28c0259541ea4a8e6a9",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "86795293e0f0a28c0259541ea4a8e57f",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_5to15_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -8587,7 +9116,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_600to800_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_600to800_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -8628,23 +9157,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "69014bd02166e652ad8e145474a68b74",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -8653,7 +9167,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_600to800_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "69014bd02166e652ad8e145474a68b74",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_600to800_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -8694,7 +9229,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_600to800_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_600to800_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -8735,8 +9270,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "153fbc65b3d49ee64349d246f492feca",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_600to800_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -8746,21 +9294,14 @@
             },
             {
               "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "153fbc65b3d49ee64349d246f492feca",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_600to800_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -8801,7 +9342,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_80to120_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_80to120_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -8842,8 +9383,21 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "153fbc65b3d49ee64349d246f49a910a",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_80to120_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
         {
           "configuration_files": [
             {
@@ -8853,21 +9407,14 @@
             },
             {
               "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
-              "process": "",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             }
           ],
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "153fbc65b3d49ee64349d246f49a910a",
-              "process": "SIM",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_80to120_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -8908,7 +9455,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_80to120_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_80to120_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -8949,23 +9496,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "69014bd02166e652ad8e145474a68b74",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -8974,7 +9506,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_80to120_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "69014bd02166e652ad8e145474a68b74",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_80to120_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -9015,7 +9568,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_80to150_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_80to150_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -9056,23 +9609,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -9081,7 +9619,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_80to150_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_80to150_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -9122,7 +9681,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_80to150_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_80to150_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -9163,23 +9722,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "1cce1be4ff841028987380e485d2f0fe",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "1cce1be4ff841028987380e485d2fce6",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -9188,7 +9732,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_80to150_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "1cce1be4ff841028987380e485d2f0fe",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "1cce1be4ff841028987380e485d2fce6",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_80to150_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -9229,7 +9794,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_80to150_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_80to150_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -9270,23 +9835,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "70ed77c68a7d31d941249f48606d1941",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "70ed77c68a7d31d941249f48606d9eab",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -9295,7 +9845,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_80to150_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "70ed77c68a7d31d941249f48606d9eab",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "70ed77c68a7d31d941249f48606d1941",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_80to150_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -9336,7 +9907,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_80to150_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset QCD_Pt_80to150_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -9377,23 +9948,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -9402,7 +9958,28 @@
               "title": "Configuration file"
             }
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_80to150_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/QCD_Pt_80to150_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -9443,7 +10020,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset SingleDiffractiveDijetsMinus_Pt30_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset SingleDiffractiveDijetsMinus_Pt30_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -9484,28 +10061,53 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveDijetsMinus_Pt30_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00010_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00010_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00010_step1.root --fileout file:FSQ-LowPU2010DR42-00010.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00010_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00015 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00015-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00015-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00015-fragment.py --fileout file:FSQ-LowPU2010-00015.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00015_1_cfg.py --no_exec -n 221 || exit $? ; \n\n",
               "title": "Production script"
+            },
+            {
+              "title": "Generator parameters",
+              "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00015"
+            },
+            {
+              "script": "import FWCore.ParameterSet.Config as cms\n\ndef customise(process): # Using SL instead GFlash AND turn on castor and compensation\n    process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)\n    process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)\n    process.g4SimHits.HCalSD.UseFibreBundleHits = cms.bool(False)\n    process.g4SimHits.HFShower.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)\n    process.g4SimHits.HFShower.ApplyFiducialCut = cms.bool(False)\n    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)\n    process.g4SimHits.CastorSD.nonCompensationFactor = cms.double(0.77)\n\n    return(process)\n\n\n\n",
+              "title": "Generator parameters",
+              "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py"
+            }
+          ],
+          "generators": [
+            "pomwig"
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveDijetsMinus_Pt30_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
+          "release": "CMSSW_4_2_10",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveDijetsMinus_Pt30_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00010_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00010_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00010_step1.root --fileout file:FSQ-LowPU2010DR42-00010.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00010_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
             },
             {
               "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
               "process": "RECO",
               "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveDijetsMinus_Pt30_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v2/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -9546,7 +10148,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset SingleDiffractiveDijetsPlus_Pt30_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset SingleDiffractiveDijetsPlus_Pt30_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -9587,37 +10189,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveDijetsPlus_Pt30_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v3/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00016_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00016_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00016_step1.root --fileout file:FSQ-LowPU2010DR42-00016.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00016_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00014 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00014-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00014-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00014-fragment.py --fileout file:FSQ-LowPU2010-00014.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00014_1_cfg.py --no_exec -n 120 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00014 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00014-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00014-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00014-fragment.py --fileout file:FSQ-LowPU2010-00014.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00014_1_cfg.py --no_exec -n 120 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\nherwig6Parameters = cms.PSet(\\n\\tcomEnergy = cms.double(7000.0),\\n\\tuseJimmy = cms.bool(False),\\n\\tdoMPInteraction = cms.bool(False),\\n\\n\\therwigHepMCVerbosity = cms.untracked.bool(False),\\n\\therwigVerbosity = cms.untracked.int32(1),\\n\\tprintCards = cms.untracked.bool(True),\\n\\tmaxEventsToPrint = cms.untracked.int32(2),\\n\\n\\tcrossSection = cms.untracked.double(-1.0),\\n\\tfilterEfficiency = cms.untracked.double(1.0),\\n)\\n\\nsource = cms.Source(\\\"EmptySource\\\")\\n \\ngenerator = cms.EDFilter(\\\"PomwigGeneratorFilter\\\",\\n    herwig6Parameters,\\n    HerwigParameters = cms.PSet(\\n        parameterSets = cms.vstring('SD1InclusiveJets'),\\n        SD1InclusiveJets = cms.vstring('NSTRU      = 14         ! H1 Pomeron Fit B', \\n            'Q2WWMN     = 1E-6       ! Minimum |t|', \\n            'Q2WWMX     = 4.0        ! Maximum |t|', \\n            'YWWMIN     = 1E-6       ! Minimum xi', \\n            'YWWMAX     = 0.2        ! Maximum xi', \\n            'IPROC      = 11500      ! Process PomP -> jets', \\n            'PTMIN      = 30         ! 2->2 PT min', \\n            'MODPDF(1)  = -1         ! Set MODPDF', \\n            'MODPDF(2)  = 10150      ! Set MODPDF CTEQ61')\\n    ),\\n    diffTopology = cms.int32(1),\\n    survivalProbability = cms.double(0.05),\\n    h1fit = cms.int32(2),\\n    doPDGConvert = cms.bool(False)\\n)\\n\\nProductionFilterSequence = cms.Sequence(generator)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00014"
             },
@@ -9631,8 +10211,31 @@
             "pomwig"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveDijetsPlus_Pt30_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v3/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveDijetsPlus_Pt30_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v3/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00016_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00016_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00016_step1.root --fileout file:FSQ-LowPU2010DR42-00016.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00016_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveDijetsPlus_Pt30_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -9673,7 +10276,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset SingleDiffractiveWToENu_eta-minus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset SingleDiffractiveWToENu_eta-minus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -9714,37 +10317,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveWToENu_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00015_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00015_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00015_step1.root --fileout file:FSQ-LowPU2010DR42-00015.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00015_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00022 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00022-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00022-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00022-fragment.py --fileout file:FSQ-LowPU2010-00022.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00022_1_cfg.py --no_exec -n 288 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00022 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00022-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00022-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00022-fragment.py --fileout file:FSQ-LowPU2010-00022.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00022_1_cfg.py --no_exec -n 288 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\nherwig6Parameters = cms.PSet(\\n\\tcomEnergy = cms.double(7000.0),\\n\\tuseJimmy = cms.bool(False),\\n\\tdoMPInteraction = cms.bool(False),\\n\\n\\therwigHepMCVerbosity = cms.untracked.bool(False),\\n\\therwigVerbosity = cms.untracked.int32(1),\\n\\tprintCards = cms.untracked.bool(True),\\n\\tmaxEventsToPrint = cms.untracked.int32(2),\\n\\n\\tcrossSection = cms.untracked.double(28.73),\\n\\tfilterEfficiency = cms.untracked.double(1.0),\\n)\\n\\ngenerator = cms.EDFilter(\\\"PomwigGeneratorFilter\\\",\\n    herwig6Parameters,\\n    HerwigParameters = cms.PSet(\\n        parameterSets = cms.vstring('SDInclusiveWmunu'),\\n        SDInclusiveWmunu = cms.vstring('NSTRU      = 14         ! H1 Pomeron Fit B', \\n            'Q2WWMN     = 1E-6       ! Minimum |t|', \\n            'Q2WWMX     = 4.0        ! Maximum |t|', \\n            'YWWMIN     = 1E-6       ! Minimum xi', \\n            'YWWMAX     = 0.2        ! Maximum xi', \\n            'IPROC      = 11451      ! Process PomP -> W -> Enu',\\n            'MODPDF(1)  = 10150      ! Set MODPDF CTEQ61', \\n            'MODPDF(2)  = -1         ! Set MODPDF')\\n    ),\\n    diffTopology = cms.int32(2),\\n    survivalProbability = cms.double(0.05),\\n    h1fit = cms.int32(2),\\n    doPDGConvert = cms.bool(False)\\n)\\n\\nProductionFilterSequence = cms.Sequence(generator)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00022"
             },
@@ -9763,8 +10344,31 @@
             "pomwig"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveWToENu_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveWToENu_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00015_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00015_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00015_step1.root --fileout file:FSQ-LowPU2010DR42-00015.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00015_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveWToENu_eta-minus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -9805,7 +10409,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset SingleDiffractiveWToENu_eta-plus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset SingleDiffractiveWToENu_eta-plus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -9846,37 +10450,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveWToENu_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00017_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00017_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00017_step1.root --fileout file:FSQ-LowPU2010DR42-00017.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00017_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00023 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00023-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00023-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00023-fragment.py --fileout file:FSQ-LowPU2010-00023.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00023_1_cfg.py --no_exec -n 137 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00023 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00023-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00023-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00023-fragment.py --fileout file:FSQ-LowPU2010-00023.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00023_1_cfg.py --no_exec -n 137 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\nherwig6Parameters = cms.PSet(\\n\\tcomEnergy = cms.double(7000.0),\\n\\tuseJimmy = cms.bool(False),\\n\\tdoMPInteraction = cms.bool(False),\\n\\n\\therwigHepMCVerbosity = cms.untracked.bool(False),\\n\\therwigVerbosity = cms.untracked.int32(1),\\n\\tprintCards = cms.untracked.bool(True),\\n\\tmaxEventsToPrint = cms.untracked.int32(2),\\n\\n\\tcrossSection = cms.untracked.double(28.5),\\n\\tfilterEfficiency = cms.untracked.double(1.0),\\n)\\n\\ngenerator = cms.EDFilter(\\\"PomwigGeneratorFilter\\\",\\n    herwig6Parameters,\\n    HerwigParameters = cms.PSet(\\n        parameterSets = cms.vstring('SDInclusiveWmunu'),\\n        SDInclusiveWmunu = cms.vstring('NSTRU      = 14         ! H1 Pomeron Fit B', \\n            'Q2WWMN     = 1E-6       ! Minimum |t|', \\n            'Q2WWMX     = 4.0        ! Maximum |t|', \\n            'YWWMIN     = 1E-6       ! Minimum xi', \\n            'YWWMAX     = 0.2        ! Maximum xi', \\n            'IPROC      = 11451      ! Process PomP -> W -> Enu',\\n            'MODPDF(1)  = -1         ! Set MODPDF', \\n            'MODPDF(2)  = 10150      ! Set MODPDF CTEQ61')\\n    ),\\n    diffTopology = cms.int32(1),\\n    survivalProbability = cms.double(0.05),\\n    h1fit = cms.int32(2),\\n    doPDGConvert = cms.bool(False)\\n)\\n\\nProductionFilterSequence = cms.Sequence(generator)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00023"
             },
@@ -9895,8 +10477,31 @@
             "pomwig"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveWToENu_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveWToENu_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00017_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00017_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00017_step1.root --fileout file:FSQ-LowPU2010DR42-00017.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00017_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveWToENu_eta-plus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -9937,7 +10542,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset SingleDiffractiveWToMuNu_eta-minus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset SingleDiffractiveWToMuNu_eta-minus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -9978,37 +10583,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveWToMuNu_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00013_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00013_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00013_step1.root --fileout file:FSQ-LowPU2010DR42-00013.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00013_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00024 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00024-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00024-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00024-fragment.py --fileout file:FSQ-LowPU2010-00024.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00024_1_cfg.py --no_exec -n 443 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00024 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00024-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00024-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00024-fragment.py --fileout file:FSQ-LowPU2010-00024.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00024_1_cfg.py --no_exec -n 443 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\nherwig6Parameters = cms.PSet(\\n\\tcomEnergy = cms.double(7000.0),\\n\\tuseJimmy = cms.bool(False),\\n\\tdoMPInteraction = cms.bool(False),\\n\\n\\therwigHepMCVerbosity = cms.untracked.bool(False),\\n\\therwigVerbosity = cms.untracked.int32(1),\\n\\tprintCards = cms.untracked.bool(True),\\n\\tmaxEventsToPrint = cms.untracked.int32(2),\\n\\n\\tcrossSection = cms.untracked.double(28.73),\\n\\tfilterEfficiency = cms.untracked.double(1.0),\\n)\\n \\ngenerator = cms.EDFilter(\\\"PomwigGeneratorFilter\\\",\\n    herwig6Parameters,\\n    HerwigParameters = cms.PSet(\\n        parameterSets = cms.vstring('SDInclusiveWmunu'),\\n        SDInclusiveWmunu = cms.vstring('NSTRU      = 14         ! H1 Pomeron Fit B', \\n            'Q2WWMN     = 1E-6       ! Minimum |t|', \\n            'Q2WWMX     = 4.0        ! Maximum |t|', \\n            'YWWMIN     = 1E-6       ! Minimum xi', \\n            'YWWMAX     = 0.2        ! Maximum xi', \\n            'IPROC      = 11452      ! Process PomP -> W -> munu',\\n            'MODPDF(1)  = 10150      ! Set MODPDF CTEQ61', \\n            'MODPDF(2)  = -1         ! Set MODPDF')\\n    ),\\n    diffTopology = cms.int32(2),\\n    survivalProbability = cms.double(0.05),\\n    h1fit = cms.int32(2),\\n    doPDGConvert = cms.bool(False)\\n)\\n\\nProductionFilterSequence = cms.Sequence(generator)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00024"
             },
@@ -10027,8 +10610,31 @@
             "pomwig"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveWToMuNu_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveWToMuNu_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00013_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00013_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00013_step1.root --fileout file:FSQ-LowPU2010DR42-00013.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00013_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveWToMuNu_eta-minus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -10069,7 +10675,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset SingleDiffractiveWToMuNu_eta-plus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset SingleDiffractiveWToMuNu_eta-plus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -10110,37 +10716,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveWToMuNu_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00019_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00019_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00019_step1.root --fileout file:FSQ-LowPU2010DR42-00019.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00019_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00025 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00025-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00025-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00025-fragment.py --fileout file:FSQ-LowPU2010-00025.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00025_1_cfg.py --no_exec -n 261 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00025 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00025-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00025-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00025-fragment.py --fileout file:FSQ-LowPU2010-00025.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00025_1_cfg.py --no_exec -n 261 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\nherwig6Parameters = cms.PSet(\\n\\tcomEnergy = cms.double(7000.0),\\n\\tuseJimmy = cms.bool(False),\\n\\tdoMPInteraction = cms.bool(False),\\n\\n\\therwigHepMCVerbosity = cms.untracked.bool(False),\\n\\therwigVerbosity = cms.untracked.int32(1),\\n\\tprintCards = cms.untracked.bool(True),\\n\\tmaxEventsToPrint = cms.untracked.int32(2),\\n\\n\\tcrossSection = cms.untracked.double(28.5),\\n\\tfilterEfficiency = cms.untracked.double(1.0),\\n)\\n\\ngenerator = cms.EDFilter(\\\"PomwigGeneratorFilter\\\",\\n    herwig6Parameters,\\n    HerwigParameters = cms.PSet(\\n        parameterSets = cms.vstring('SDInclusiveWmunu'),\\n        SDInclusiveWmunu = cms.vstring('NSTRU      = 14         ! H1 Pomeron Fit B', \\n            'Q2WWMN     = 1E-6       ! Minimum |t|', \\n            'Q2WWMX     = 4.0        ! Maximum |t|', \\n            'YWWMIN     = 1E-6       ! Minimum xi', \\n            'YWWMAX     = 0.2        ! Maximum xi', \\n            'IPROC      = 11452      ! Process PomP -> W -> munu',\\n            'MODPDF(1)  = -1         ! Set MODPDF', \\n            'MODPDF(2)  = 10150      ! Set MODPDF CTEQ61')\\n    ),\\n    diffTopology = cms.int32(1),\\n    survivalProbability = cms.double(0.05),\\n    h1fit = cms.int32(2),\\n    doPDGConvert = cms.bool(False)\\n)\\n\\nProductionFilterSequence = cms.Sequence(generator)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00025"
             },
@@ -10159,8 +10743,31 @@
             "pomwig"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveWToMuNu_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveWToMuNu_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00019_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00019_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00019_step1.root --fileout file:FSQ-LowPU2010DR42-00019.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00019_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveWToMuNu_eta-plus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -10201,7 +10808,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset SingleDiffractiveZToEE_M-20_eta-minus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset SingleDiffractiveZToEE_M-20_eta-minus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -10242,37 +10849,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveZToEE_M-20_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00021_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00021_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00021_step1.root --fileout file:FSQ-LowPU2010DR42-00021.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00021_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00018 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00018-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00018-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00018-fragment.py --fileout file:FSQ-LowPU2010-00018.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00018_1_cfg.py --no_exec -n 384 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00018 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00018-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00018-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00018-fragment.py --fileout file:FSQ-LowPU2010-00018.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00018_1_cfg.py --no_exec -n 384 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\nherwig6Parameters = cms.PSet(\\n\\tcomEnergy = cms.double(7000.0),\\n\\tuseJimmy = cms.bool(False),\\n\\tdoMPInteraction = cms.bool(False),\\n\\n\\therwigHepMCVerbosity = cms.untracked.bool(False),\\n\\therwigVerbosity = cms.untracked.int32(1),\\n\\tprintCards = cms.untracked.bool(True),\\n\\tmaxEventsToPrint = cms.untracked.int32(2),\\n\\n\\tcrossSection = cms.untracked.double(5.457),\\n\\tfilterEfficiency = cms.untracked.double(1.0),\\n)\\n\\ngenerator = cms.EDFilter(\\\"PomwigGeneratorFilter\\\",\\n    herwig6Parameters,\\n    HerwigParameters = cms.PSet(\\n        parameterSets = cms.vstring('SDInclusiveWmunu'),\\n        SDInclusiveWmunu = cms.vstring('NSTRU      = 14         ! H1 Pomeron Fit B', \\n            'Q2WWMN     = 1E-6       ! Minimum |t|', \\n            'Q2WWMX     = 4.0        ! Maximum |t|',\\n            'EMMIN      = 20.0       ! minimum DY Mass',\\n            'YWWMIN     = 1E-6       ! Minimum xi', \\n            'YWWMAX     = 0.2        ! Maximum xi', \\n            'IPROC      = 11351      ! Process PomP -> Z -> ee ',\\n            'MODPDF(1)  = 10150      ! Set MODPDF CTEQ61', \\n            'MODPDF(2)  = -1         ! Set MODPDF')\\n    ),\\n    diffTopology = cms.int32(2),\\n    survivalProbability = cms.double(0.05),\\n    h1fit = cms.int32(2),\\n    doPDGConvert = cms.bool(False)\\n)\\n\\nProductionFilterSequence = cms.Sequence(generator)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00018"
             },
@@ -10291,8 +10876,31 @@
             "pomwig"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveZToEE_M-20_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveZToEE_M-20_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00021_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00021_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00021_step1.root --fileout file:FSQ-LowPU2010DR42-00021.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00021_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveZToEE_M-20_eta-minus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -10333,7 +10941,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset SingleDiffractiveZToEE_M-20_eta-plus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset SingleDiffractiveZToEE_M-20_eta-plus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -10374,37 +10982,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveZToEE_M-20_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00018_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00018_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00018_step1.root --fileout file:FSQ-LowPU2010DR42-00018.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00018_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00019 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00019-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00019-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00019-fragment.py --fileout file:FSQ-LowPU2010-00019.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00019_1_cfg.py --no_exec -n 205 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00019 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00019-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00019-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00019-fragment.py --fileout file:FSQ-LowPU2010-00019.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00019_1_cfg.py --no_exec -n 205 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"\\nimport FWCore.ParameterSet.Config as cms\\n\\nherwig6Parameters = cms.PSet(\\n\\tcomEnergy = cms.double(7000.0),\\n\\tuseJimmy = cms.bool(False),\\n\\tdoMPInteraction = cms.bool(False),\\n\\n\\therwigHepMCVerbosity = cms.untracked.bool(False),\\n\\therwigVerbosity = cms.untracked.int32(1),\\n\\tprintCards = cms.untracked.bool(True),\\n\\tmaxEventsToPrint = cms.untracked.int32(2),\\n\\n\\tcrossSection = cms.untracked.double(5.271),\\n\\tfilterEfficiency = cms.untracked.double(1.0),\\n)\\n\\ngenerator = cms.EDFilter(\\\"PomwigGeneratorFilter\\\",\\n    herwig6Parameters,\\n    HerwigParameters = cms.PSet(\\n        parameterSets = cms.vstring('SDInclusiveWmunu'),\\n        SDInclusiveWmunu = cms.vstring('NSTRU      = 14         ! H1 Pomeron Fit B', \\n            'Q2WWMN     = 1E-6       ! Minimum |t|', \\n            'Q2WWMX     = 4.0        ! Maximum |t|',\\n            'EMMIN      = 20.0       ! minimum DY Mass',\\n            'YWWMIN     = 1E-6       ! Minimum xi', \\n            'YWWMAX     = 0.2        ! Maximum xi', \\n            'IPROC      = 11351      ! Process PomP -> Z ->ee',\\n            'MODPDF(1)  = -1         ! Set MODPDF', \\n            'MODPDF(2)  = 10150      ! Set MODPDF CTEQ61')\\n    ),\\n    diffTopology = cms.int32(1),\\n    survivalProbability = cms.double(0.05),\\n    h1fit = cms.int32(2),\\n    doPDGConvert = cms.bool(False)\\n)\\n\\nProductionFilterSequence = cms.Sequence(generator)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00019"
             },
@@ -10423,8 +11009,31 @@
             "pomwig"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveZToEE_M-20_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveZToEE_M-20_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00018_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00018_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00018_step1.root --fileout file:FSQ-LowPU2010DR42-00018.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00018_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveZToEE_M-20_eta-plus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -10465,7 +11074,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -10506,29 +11115,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v4/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00020_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00020_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00020_step1.root --fileout file:FSQ-LowPU2010DR42-00020.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00020_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -10537,10 +11125,35 @@
               "title": "Configuration file"
             }
           ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v2/GEN-SIM",
+          "release": "CMSSW_4_2_10",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v4/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00020_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00020_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00020_step1.root --fileout file:FSQ-LowPU2010DR42-00020.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00020_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
           "generators": [
             "pomwig"
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -10581,7 +11194,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -10622,37 +11235,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v4/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00020_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00020_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00020_step1.root --fileout file:FSQ-LowPU2010DR42-00020.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00020_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00020 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00020-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00020-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00020-fragment.py --fileout file:FSQ-LowPU2010-00020.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00020_1_cfg.py --no_exec -n 384 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00020 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00020-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00020-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00020-fragment.py --fileout file:FSQ-LowPU2010-00020.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00020_1_cfg.py --no_exec -n 384 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\nherwig6Parameters = cms.PSet(\\n\\tcomEnergy = cms.double(7000.0),\\n\\tuseJimmy = cms.bool(False),\\n\\tdoMPInteraction = cms.bool(False),\\n\\n\\therwigHepMCVerbosity = cms.untracked.bool(False),\\n\\therwigVerbosity = cms.untracked.int32(1),\\n\\tprintCards = cms.untracked.bool(True),\\n\\tmaxEventsToPrint = cms.untracked.int32(2),\\n\\n\\tcrossSection = cms.untracked.double(5.2),\\n\\tfilterEfficiency = cms.untracked.double(1.0),\\n)\\n \\ngenerator = cms.EDFilter(\\\"PomwigGeneratorFilter\\\",\\n    herwig6Parameters,\\n    HerwigParameters = cms.PSet(\\n        parameterSets = cms.vstring('SDInclusiveWmunu'),\\n        SDInclusiveWmunu = cms.vstring('NSTRU      = 14         ! H1 Pomeron Fit B', \\n            'Q2WWMN     = 1E-6       ! Minimum |t|', \\n            'Q2WWMX     = 4.0        ! Maximum |t|',\\n            'EMMIN      = 20.0       ! minimum DY Mass',\\n            'YWWMIN     = 1E-6       ! Minimum xi', \\n            'YWWMAX     = 0.2        ! Maximum xi', \\n            'IPROC      = 11353      ! Process PomP -> Z -> Mu Mu ',\\n            'MODPDF(1)  = 10150      ! Set MODPDF CTEQ61', \\n            'MODPDF(2)  = -1         ! Set MODPDF')\\n    ),\\n    diffTopology = cms.int32(2),\\n    survivalProbability = cms.double(0.05),\\n    h1fit = cms.int32(2),\\n    doPDGConvert = cms.bool(False)\\n)\\n\\nProductionFilterSequence = cms.Sequence(generator)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00020"
             },
@@ -10671,8 +11262,31 @@
             "pomwig"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v4/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v4/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00020_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00020_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00020_step1.root --fileout file:FSQ-LowPU2010DR42-00020.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00020_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v2/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -10713,7 +11327,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -10754,29 +11368,8 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v4/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00012_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00012_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00012_step1.root --fileout file:FSQ-LowPU2010DR42-00012.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00012_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
         {
           "configuration_files": [
             {
@@ -10785,10 +11378,35 @@
               "title": "Configuration file"
             }
           ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
+          "release": "CMSSW_4_2_10",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v4/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00012_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00012_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00012_step1.root --fileout file:FSQ-LowPU2010DR42-00012.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00012_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
           "generators": [
             "pomwig"
           ],
-          "type": "GEN-SIM"
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -10829,7 +11447,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -10870,37 +11488,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v4/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00012_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00012_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00012_step1.root --fileout file:FSQ-LowPU2010DR42-00012.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00012_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00021 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00021-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00021-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00021-fragment.py --fileout file:FSQ-LowPU2010-00021.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00021_1_cfg.py --no_exec -n 137 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00021 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00021-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00021-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00021-fragment.py --fileout file:FSQ-LowPU2010-00021.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00021_1_cfg.py --no_exec -n 137 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\nherwig6Parameters = cms.PSet(\\n\\tcomEnergy = cms.double(7000.0),\\n\\tuseJimmy = cms.bool(False),\\n\\tdoMPInteraction = cms.bool(False),\\n\\n\\therwigHepMCVerbosity = cms.untracked.bool(False),\\n\\therwigVerbosity = cms.untracked.int32(1),\\n\\tprintCards = cms.untracked.bool(True),\\n\\tmaxEventsToPrint = cms.untracked.int32(2),\\n\\n\\tcrossSection = cms.untracked.double(5.276),\\n\\tfilterEfficiency = cms.untracked.double(1.0),\\n)\\n\\ngenerator = cms.EDFilter(\\\"PomwigGeneratorFilter\\\",\\n    herwig6Parameters,\\n    HerwigParameters = cms.PSet(\\n        parameterSets = cms.vstring('SDInclusiveWmunu'),\\n        SDInclusiveWmunu = cms.vstring('NSTRU      = 14         ! H1 Pomeron Fit B', \\n            'Q2WWMN     = 1E-6       ! Minimum |t|', \\n            'Q2WWMX     = 4.0        ! Maximum |t|',\\n            'EMMIN      = 20.0       ! minimum DY Mass',\\n            'YWWMIN     = 1E-6       ! Minimum xi', \\n            'YWWMAX     = 0.2        ! Maximum xi', \\n            'IPROC      = 11353      ! Process PomP -> Z -> mu mu',\\n            'MODPDF(1)  = -1         ! Set MODPDF', \\n            'MODPDF(2)  = 10150      ! Set MODPDF CTEQ61')\\n    ),\\n    diffTopology = cms.int32(1),\\n    survivalProbability = cms.double(0.05),\\n    h1fit = cms.int32(2),\\n    doPDGConvert = cms.bool(False)\\n)\\n\\nProductionFilterSequence = cms.Sequence(generator)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00021"
             },
@@ -10919,8 +11515,31 @@
             "pomwig"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v4/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig/LowPU2010-START42_V17B_BS2011-v4/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00012_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00012_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00012_step1.root --fileout file:FSQ-LowPU2010DR42-00012.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00012_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v2/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -10961,7 +11580,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset WToENu_TuneZ2star_7TeV-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset WToENu_TuneZ2star_7TeV-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -11002,37 +11621,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/WToENu_TuneZ2star_7TeV-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00009_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00009_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00009_step1.root --fileout file:FSQ-LowPU2010DR42-00009.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00009_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00013 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00013-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00013-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00013-fragment.py --fileout file:FSQ-LowPU2010-00013.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00013_1_cfg.py --no_exec -n 99 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00013 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00013-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00013-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00013-fragment.py --fileout file:FSQ-LowPU2010-00013.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00013_1_cfg.py --no_exec -n 99 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\nfrom Configuration.Generator.PythiaUEZ2starSettings_cfi import *\\n\\ngenerator = cms.EDFilter(\\\"Pythia6GeneratorFilter\\\",\\n    pythiaHepMCVerbosity = cms.untracked.bool(False),\\n    maxEventsToPrint = cms.untracked.int32(0),\\n    pythiaPylistVerbosity = cms.untracked.int32(1),\\n    filterEfficiency = cms.untracked.double(1.),\\n    crossSection = cms.untracked.double(9181.),\\n    comEnergy = cms.double(7000.0),\\n    PythiaParameters = cms.PSet(\\n        pythiaUESettingsBlock,\\n        processParameters = cms.vstring('MSEL = 0 !User defined processes',\\n                                        'MSUB(2) = 1 !W production',\\n                                        'MDME(190,1) = 0 !W decay into dbar u',\\n                                        'MDME(191,1) = 0 !W decay into dbar c',\\n                                        'MDME(192,1) = 0 !W decay into dbar t',\\n                                        'MDME(194,1) = 0 !W decay into sbar u',\\n                                        'MDME(195,1) = 0 !W decay into sbar c',\\n                                        'MDME(196,1) = 0 !W decay into sbar t',\\n                                        'MDME(198,1) = 0 !W decay into bbar u',\\n                                        'MDME(199,1) = 0 !W decay into bbar c',\\n                                        'MDME(200,1) = 0 !W decay into bbar t',\\n                                        'MDME(205,1) = 0 !W decay into bbar tp',\\n                                        'MDME(206,1) = 1 !W decay into e+ nu_e',\\n                                        'MDME(207,1) = 0 !W decay into mu+ nu_mu',\\n                                        'MDME(208,1) = 0 !W decay into tau+ nu_tau'),\\n        # This is a vector of ParameterSet names to be read, in this order\\n        parameterSets = cms.vstring('pythiaUESettings',\\n            'processParameters')\\n    )\\n)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00013"
             },
@@ -11051,8 +11648,31 @@
             "pythia6"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/WToENu_TuneZ2star_7TeV-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/WToENu_TuneZ2star_7TeV-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00009_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00009_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00009_step1.root --fileout file:FSQ-LowPU2010DR42-00009.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00009_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/WToENu_TuneZ2star_7TeV-pythia6/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v2/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "RECO DIGI2RAW"
         }
       ]
     },
@@ -11093,7 +11713,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset WToMuNu_TuneZ2star_7TeV-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
+      "description": "<p>Simulated dataset WToMuNu_TuneZ2star_7TeV-pythia6 in AODSIM format for 2010 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p><p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2010.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -11134,37 +11754,15 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/WToMuNu_TuneZ2star_7TeV-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00011_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00011_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00011_step1.root --fileout file:FSQ-LowPU2010DR42-00011.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00011_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00012 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00012-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00012-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00012-fragment.py --fileout file:FSQ-LowPU2010-00012.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00012_1_cfg.py --no_exec -n 76 || exit $? ; \n\n",
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
-              "title": "Configuration file"
-            },
-            {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "",
-              "title": "Configuration file"
-            }
-          ],
-          "global_tag": "START42_V17B::All",
-          "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc5_amd64_gcc434\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_4_2_10/src ] ; then \n echo release CMSSW_4_2_10 already exists\nelse\nscram p CMSSW CMSSW_4_2_10\nfi\ncd CMSSW_4_2_10/src\neval `scram runtime -sh`\n\ncurl -s --insecure https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00012 --retry 2 --create-dirs -o Configuration/GenProduction/python/FSQ-LowPU2010-00012-fragment.py \n[ -s Configuration/GenProduction/python/FSQ-LowPU2010-00012-fragment.py ] || exit $?;\ncurl  -s https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py --retry 2 --create-dirs -o  Configuration/GenProduction/python/lowpu2010_customise.py \n[ -s Configuration/GenProduction/python/lowpu2010_customise.py ] || exit $?;\n\n\nscram b\ncd ../../\ncmsDriver.py Configuration/GenProduction/python/FSQ-LowPU2010-00012-fragment.py --fileout file:FSQ-LowPU2010-00012.root --mc --eventcontent RAWSIM --customise Configuration/GenProduction/lowpu2010_customise.py,Configuration/DataProcessing/Utils.addMonitoring --datatier GEN-SIM --conditions START42_V17B::All --beamspot Realistic7TeVCollision --step GEN,SIM --python_filename FSQ-LowPU2010-00012_1_cfg.py --no_exec -n 76 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "script": "\"import FWCore.ParameterSet.Config as cms\\n\\nfrom Configuration.Generator.PythiaUEZ2starSettings_cfi import *\\n\\ngenerator = cms.EDFilter(\\\"Pythia6GeneratorFilter\\\",\\n    pythiaHepMCVerbosity = cms.untracked.bool(False),\\n    maxEventsToPrint = cms.untracked.int32(0),\\n    pythiaPylistVerbosity = cms.untracked.int32(1),\\n    filterEfficiency = cms.untracked.double(1.),\\n    crossSection = cms.untracked.double(9181.),\\n    comEnergy = cms.double(7000.0),\\n    PythiaParameters = cms.PSet(\\n        pythiaUESettingsBlock,\\n        processParameters = cms.vstring('MSEL = 0 !User defined processes',\\n                                        'MSUB(2) = 1 !W production',\\n                                        'MDME(190,1) = 0 !W decay into dbar u',\\n                                        'MDME(191,1) = 0 !W decay into dbar c',\\n                                        'MDME(192,1) = 0 !W decay into dbar t',\\n                                        'MDME(194,1) = 0 !W decay into sbar u',\\n                                        'MDME(195,1) = 0 !W decay into sbar c',\\n                                        'MDME(196,1) = 0 !W decay into sbar t',\\n                                        'MDME(198,1) = 0 !W decay into bbar u',\\n                                        'MDME(199,1) = 0 !W decay into bbar c',\\n                                        'MDME(200,1) = 0 !W decay into bbar t',\\n                                        'MDME(205,1) = 0 !W decay into bbar tp',\\n                                        'MDME(206,1) = 0 !W decay into e+ nu_e',\\n                                        'MDME(207,1) = 1 !W decay into mu+ nu_mu',\\n                                        'MDME(208,1) = 0 !W decay into tau+ nu_tau'),\\n        # This is a vector of ParameterSet names to be read, in this order\\n        parameterSets = cms.vstring('pythiaUESettings',\\n            'processParameters')\\n    )\\n)\"\n",
               "title": "Generator parameters",
               "url": "https://cms-pdmv.cern.ch/mcm/public/restapi/requests/get_fragment/FSQ-LowPU2010-00012"
             },
@@ -11183,8 +11781,31 @@
             "pythia6"
           ],
           "global_tag": "START42_V17B::All",
+          "output_dataset": "/WToMuNu_TuneZ2star_7TeV-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM",
           "release": "CMSSW_4_2_10",
-          "type": "GEN-SIM"
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nexport SCRAM_ARCH=slc5_amd64_gcc434\nif [ -r CMSSW_4_2_8_lowpupatch1/src ] ; then \n echo release CMSSW_4_2_8_lowpupatch1 already exists\nelse\nscram p CMSSW CMSSW_4_2_8_lowpupatch1\nfi\ncd CMSSW_4_2_8_lowpupatch1/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/WToMuNu_TuneZ2star_7TeV-pythia6/LowPU2010-START42_V17B_BS2011-v1/GEN-SIM\" --fileout file:FSQ-LowPU2010DR42-00011_step1.root --pileup_input \"dbs:/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010-START42_V17B-v1/GEN-SIM\" --mc --eventcontent RAWSIM --pileup E7TeV_ProbDist_2010Data_BX156 --datatier GEN-SIM-RAW --conditions START42_V17B::All --step DIGI,L1,DIGI2RAW --python_filename FSQ-LowPU2010DR42-00011_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 1440 || exit $? ; \n\ncmsDriver.py step2 --filein file:FSQ-LowPU2010DR42-00011_step1.root --fileout file:FSQ-LowPU2010DR42-00011.root --mc --eventcontent AODSIM --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC,Configuration/DataProcessing/Utils.addMonitoring --datatier AODSIM --conditions START42_V17B::All --step RAW2DIGI,L1Reco,RECO --python_filename FSQ-LowPU2010DR42-00011_2_cfg.py --no_exec -n 1440 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "START42_V17B::All",
+          "output_dataset": "/WToMuNu_TuneZ2star_7TeV-pythia6/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v2/AODSIM",
+          "release": "CMSSW_4_2_8_lowpupatch1",
+          "type": "DIGI2RAW RECO"
         }
       ]
     },

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
@@ -74,7 +74,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -85,7 +85,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-550_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -229,7 +229,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -240,7 +240,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-550_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -396,7 +396,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -407,7 +407,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -563,7 +563,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -574,7 +574,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -718,7 +718,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -729,7 +729,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -885,7 +885,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -896,7 +896,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-600_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -1052,7 +1052,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -1063,7 +1063,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-600_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -1219,7 +1219,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -1230,7 +1230,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -1373,7 +1373,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -1384,7 +1384,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -1539,7 +1539,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -1550,7 +1550,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -1706,7 +1706,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -1717,7 +1717,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-650_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -1885,7 +1885,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -1896,7 +1896,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-650_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -2040,7 +2040,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -2051,7 +2051,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-700_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -2219,7 +2219,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -2230,7 +2230,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-700_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -2386,7 +2386,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -2397,7 +2397,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-750_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -2553,7 +2553,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -2564,7 +2564,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-800_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -2720,7 +2720,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -2731,7 +2731,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-800_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -2875,7 +2875,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -2886,7 +2886,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-850_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -3054,7 +3054,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -3065,7 +3065,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-900_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -3233,7 +3233,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -3244,7 +3244,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-900_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -3388,7 +3388,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -3399,7 +3399,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-950_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -3543,7 +3543,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -3554,7 +3554,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Graviton2PH6ToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -3710,7 +3710,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -3721,7 +3721,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0MToGGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -3865,7 +3865,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -3876,7 +3876,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0MToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -4032,7 +4032,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -4043,7 +4043,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -4199,7 +4199,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -4210,7 +4210,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -4366,7 +4366,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -4377,7 +4377,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -4533,7 +4533,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -4544,7 +4544,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0Mf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -4688,7 +4688,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -4699,7 +4699,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0PMToZGTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -4855,7 +4855,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -4866,7 +4866,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0PMToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -5010,7 +5010,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -5021,7 +5021,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/JJHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -5189,7 +5189,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -5200,7 +5200,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/JJHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -5344,7 +5344,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -5355,7 +5355,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/JJHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -5499,7 +5499,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -5510,7 +5510,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/JJHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -5678,7 +5678,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -5689,7 +5689,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/JJHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -5865,7 +5865,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -6015,7 +6015,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -6153,7 +6153,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -6291,7 +6291,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -6429,7 +6429,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -6569,7 +6569,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -6709,7 +6709,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -6849,7 +6849,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -7001,7 +7001,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -7012,7 +7012,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZJetsTo4L_TuneZ2_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -7168,7 +7168,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -7179,7 +7179,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo2e2muJJ_Contin_7TeV-phantom-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -7371,7 +7371,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -7382,7 +7382,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo2e2mu_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -7538,7 +7538,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -7549,7 +7549,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -7692,7 +7692,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -7832,7 +7832,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -7973,7 +7973,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -7984,7 +7984,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -8128,7 +8128,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -8139,7 +8139,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -8295,7 +8295,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -8306,7 +8306,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -8450,7 +8450,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -8461,7 +8461,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -8605,7 +8605,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -8616,7 +8616,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -8759,7 +8759,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -8770,7 +8770,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Tbar_TuneZ2_tW-channel-DS_7TeV-powheg-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -8913,7 +8913,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -8924,7 +8924,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Tbar_TuneZ2_tW-channel-DR_7TeV-powheg-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -9068,7 +9068,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -9079,7 +9079,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/T_TuneZ2_tW-channel-DS_7TeV-powheg-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -9223,7 +9223,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -9234,7 +9234,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/T_TuneZ2_t-channel_7TeV-powheg-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -9377,7 +9377,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -9531,7 +9531,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -9542,7 +9542,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TT_weights_CT10_7TeV-powheg/Summer11LegwmLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_22",
           "type": "LHE"
@@ -9686,7 +9686,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -9697,7 +9697,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTTo2L2Nu2B_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -9867,7 +9867,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -9878,7 +9878,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_matchingup_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -10022,7 +10022,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -10033,7 +10033,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_matchingdown_mt172_5_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_26",
           "type": "LHE"
@@ -10189,7 +10189,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -10200,7 +10200,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -10343,7 +10343,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -10495,7 +10495,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -10719,7 +10719,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -10859,7 +10859,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -10999,7 +10999,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -11139,7 +11139,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -11279,7 +11279,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -11419,7 +11419,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -11559,7 +11559,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -11699,7 +11699,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -11839,7 +11839,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -11979,7 +11979,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -12119,7 +12119,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -12259,7 +12259,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -12400,7 +12400,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -12411,7 +12411,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -12555,7 +12555,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -12566,7 +12566,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -12722,7 +12722,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -12733,7 +12733,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -12877,7 +12877,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -12888,7 +12888,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -13056,7 +13056,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -13067,7 +13067,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo2e2mu_mll4_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -13210,7 +13210,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -13221,7 +13221,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Tbar_TuneZ2_t-channel_7TeV-powheg-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -13374,7 +13374,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -13512,7 +13512,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -13662,7 +13662,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -13800,7 +13800,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -13950,7 +13950,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -14126,7 +14126,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -14137,7 +14137,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/DY1JetToLL_M-10To50_TuneZ2_7TeV-madgraph/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -14376,7 +14376,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -14387,7 +14387,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/DY2Jets_M-10To50_TuneZ2_7TeV-madgraph/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -14566,7 +14566,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -14577,7 +14577,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/DY3Jets_M-10To50_TuneZ2_7TeV-madgraph/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -14732,7 +14732,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -14743,7 +14743,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/DY4Jets_M-10To50_TuneZ2_7TeV-madgraph/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -14886,7 +14886,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -15123,7 +15123,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -15134,7 +15134,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/DYJetsToLL_M-50_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_13",
           "type": "LHE"
@@ -15469,7 +15469,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -15480,7 +15480,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/DYJetsToLL_TuneZ2_M-50_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -15623,7 +15623,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -15763,7 +15763,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -15774,7 +15774,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GJets_TuneZ2_100_HT_200_7TeV-madgraph/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -15929,7 +15929,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -15940,7 +15940,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GJets_TuneZ2_200_HT_inf_7TeV-madgraph/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -16083,7 +16083,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -16094,7 +16094,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GJets_TuneZ2_40_HT_100_7TeV-madgraph/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -16274,7 +16274,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -16285,7 +16285,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo2L2Lprime_Contin_7TeV-gg2vv315-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -16429,7 +16429,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -16440,7 +16440,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo2L2Lprime_H_M-125p6_7TeV-gg2vv315-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -16620,7 +16620,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -16631,7 +16631,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo2e2mu_Contin_7TeV-MCFM67-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -16811,7 +16811,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -16822,7 +16822,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo2e2mu_SMH_M-125p6_7TeV-MCFM67-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -16990,7 +16990,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -17001,7 +17001,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo4L_Contin_7TeV-gg2vv315-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -17145,7 +17145,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -17156,7 +17156,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo4L_H_M-125p6_7TeV-gg2vv315-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -17300,7 +17300,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -17311,7 +17311,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo4e_Contin_7TeV-MCFM67-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -17455,7 +17455,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -17466,7 +17466,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo4e_SMH_M-125p6_7TeV-MCFM67-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -17622,7 +17622,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -17633,7 +17633,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo4mu_Contin_7TeV-MCFM67-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -17801,7 +17801,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -17812,7 +17812,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo4mu_SMH_M-125p6_7TeV-MCFM67-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -17968,7 +17968,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -17979,7 +17979,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -18135,7 +18135,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -18146,7 +18146,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -18290,7 +18290,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -18301,7 +18301,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -18457,7 +18457,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -18468,7 +18468,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -18612,7 +18612,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -18623,7 +18623,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -18779,7 +18779,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -18790,7 +18790,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -18946,7 +18946,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -18957,7 +18957,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -19113,7 +19113,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -19124,7 +19124,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -19280,7 +19280,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -19291,7 +19291,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -19435,7 +19435,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -19446,7 +19446,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -19602,7 +19602,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -19613,7 +19613,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -19769,7 +19769,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -19780,7 +19780,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -19936,7 +19936,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -19947,7 +19947,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -20103,7 +20103,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -20114,7 +20114,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -20270,7 +20270,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -20281,7 +20281,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -20437,7 +20437,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -20448,7 +20448,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -20592,7 +20592,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -20603,7 +20603,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -20747,7 +20747,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -20758,7 +20758,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -20902,7 +20902,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -20913,7 +20913,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -21057,7 +21057,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -21068,7 +21068,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -21212,7 +21212,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -21223,7 +21223,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -21367,7 +21367,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -21378,7 +21378,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -21522,7 +21522,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -21533,7 +21533,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -21677,7 +21677,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -21688,7 +21688,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -21832,7 +21832,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -21843,7 +21843,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -21987,7 +21987,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -21998,7 +21998,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -22142,7 +22142,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -22153,7 +22153,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -22297,7 +22297,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -22308,7 +22308,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -22452,7 +22452,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -22463,7 +22463,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -22607,7 +22607,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -22618,7 +22618,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -22762,7 +22762,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -22773,7 +22773,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -22917,7 +22917,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -22928,7 +22928,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -23084,7 +23084,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -23095,7 +23095,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-1000_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -23239,7 +23239,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -23250,7 +23250,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-125_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -23394,7 +23394,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -23405,7 +23405,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-125_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -23549,7 +23549,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -23560,7 +23560,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-126_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -23716,7 +23716,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -23727,7 +23727,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-126_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -23883,7 +23883,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -23894,7 +23894,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-190_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -24062,7 +24062,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -24073,7 +24073,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-200_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -24229,7 +24229,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -24240,7 +24240,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-225_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -24384,7 +24384,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -24395,7 +24395,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-250_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -24539,7 +24539,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -24550,7 +24550,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-250_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -24706,7 +24706,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -24717,7 +24717,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-275_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -24861,7 +24861,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -24872,7 +24872,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-300_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -25028,7 +25028,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -25039,7 +25039,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-300_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -25183,7 +25183,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -25194,7 +25194,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-350_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -25338,7 +25338,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -25349,7 +25349,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-350_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -25493,7 +25493,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -25504,7 +25504,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-400_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -25648,7 +25648,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -25659,7 +25659,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-400_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -25815,7 +25815,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -25826,7 +25826,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-450_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -25994,7 +25994,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -26005,7 +26005,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-450_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -26161,7 +26161,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -26172,7 +26172,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-500_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -26315,7 +26315,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -26455,7 +26455,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -26595,7 +26595,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -26735,7 +26735,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -26875,7 +26875,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -27016,7 +27016,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -27027,7 +27027,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-200_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -27171,7 +27171,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -27182,7 +27182,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -27325,7 +27325,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -27466,7 +27466,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -27477,7 +27477,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-225_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -27621,7 +27621,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -27632,7 +27632,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -27776,7 +27776,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -27787,7 +27787,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -27930,7 +27930,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -28068,7 +28068,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -28206,7 +28206,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -28344,7 +28344,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -28494,7 +28494,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -28683,7 +28683,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -28694,7 +28694,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo2L2Lprime_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -28886,7 +28886,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -28897,7 +28897,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo2e2mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -29065,7 +29065,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -29076,7 +29076,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo2e2mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -29220,7 +29220,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -29231,7 +29231,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo4L_HContinInterf_M-125p6_7TeV-gg2vv315-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -29387,7 +29387,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -29398,7 +29398,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo4e_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -29566,7 +29566,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -29577,7 +29577,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo4e_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -29721,7 +29721,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -29732,7 +29732,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo4mu_BSMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -29888,7 +29888,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -29899,7 +29899,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluTo4mu_SMHContinInterf_M-125p6_7TeV-MCFM67-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -30067,7 +30067,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -30078,7 +30078,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-1000_7TeV-minloHJJ-pythia6-tauola/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -30222,7 +30222,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -30233,7 +30233,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Graviton2BPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -30401,7 +30401,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -30412,7 +30412,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Graviton2HPqqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -30568,7 +30568,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -30579,7 +30579,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Graviton2MH10qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -30723,7 +30723,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -30734,7 +30734,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Graviton2PH2qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -30878,7 +30878,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -30889,7 +30889,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Graviton2PH3qqbarToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -31045,7 +31045,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -31056,7 +31056,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0L1f01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -31224,7 +31224,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -31235,7 +31235,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0L1f05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -31379,7 +31379,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -31390,7 +31390,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0PHf01ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -31534,7 +31534,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -31545,7 +31545,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0PHf01ph90ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -31701,7 +31701,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -31712,7 +31712,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0PHf033ph0Mf033ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -31880,7 +31880,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -31891,7 +31891,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0PHf05ph0Mf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -32047,7 +32047,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -32058,7 +32058,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0PHf05ph0ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV3/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -32214,7 +32214,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -32225,7 +32225,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0PHf05ph180ToZZTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -32405,7 +32405,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -32416,7 +32416,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0PMToZZf05GGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -32560,7 +32560,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -32571,7 +32571,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0PMToZZf05ZGf05To4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -32715,7 +32715,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -32726,7 +32726,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Higgs0PMToZZfZGfGGfTo4L_M-125p6_7TeV-powheg15-JHUgenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -32882,7 +32882,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -32893,7 +32893,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/JJHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -33034,7 +33034,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -33187,7 +33187,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -33198,7 +33198,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-115_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -33342,7 +33342,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -33353,7 +33353,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-122_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -33497,7 +33497,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -33508,7 +33508,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-125_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -33688,7 +33688,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -33699,7 +33699,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-126_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -33879,7 +33879,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -33890,7 +33890,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-130_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -34046,7 +34046,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -34057,7 +34057,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-185_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -34215,7 +34215,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -34226,7 +34226,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_dileptonic_central_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_26",
           "type": "LHE"
@@ -34372,7 +34372,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -34383,7 +34383,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_26",
           "type": "LHE"
@@ -34529,7 +34529,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -34540,7 +34540,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_dileptonic_matchingdown_7TeV-madgraph/Summer11LegwmLHE-START53_LV4_ext1-v1/GEN",
           "release": "CMSSW_5_3_26",
           "type": "LHE"
@@ -34698,7 +34698,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -34709,7 +34709,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_dileptonic_matchingup_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_26",
           "type": "LHE"
@@ -34855,7 +34855,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -34866,7 +34866,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_dileptonic_mt166_5_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_26",
           "type": "LHE"
@@ -35036,7 +35036,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -35047,7 +35047,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_dileptonic_mt178_5_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_26",
           "type": "LHE"
@@ -35193,7 +35193,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -35204,7 +35204,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_dileptonic_scaledown_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_26",
           "type": "LHE"
@@ -35362,7 +35362,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -35373,7 +35373,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_dileptonic_scaleup_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_26",
           "type": "LHE"
@@ -35555,7 +35555,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -35566,7 +35566,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_scaledown_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_14_patch2",
           "type": "LHE"
@@ -35748,7 +35748,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -35759,7 +35759,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_scaledown_mt172_5_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_26",
           "type": "LHE"
@@ -35941,7 +35941,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -35952,7 +35952,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_scaleup_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_14_patch2",
           "type": "LHE"
@@ -36104,7 +36104,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -36245,7 +36245,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -36256,7 +36256,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -36412,7 +36412,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -36423,7 +36423,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -36567,7 +36567,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -36578,7 +36578,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -36722,7 +36722,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -36733,7 +36733,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -36877,7 +36877,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -36888,7 +36888,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/WHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -37044,7 +37044,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -37055,7 +37055,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZHiggs0Mf05ph0ToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -37247,7 +37247,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -37258,7 +37258,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo2e2muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -37426,7 +37426,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -37437,7 +37437,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo2e2muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -37605,7 +37605,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -37616,7 +37616,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo2e2muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -37760,7 +37760,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -37771,7 +37771,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4eJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -37927,7 +37927,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -37938,7 +37938,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4eJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -38118,7 +38118,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -38129,7 +38129,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4eJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -38297,7 +38297,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -38308,7 +38308,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4muJJ_BSM10HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -38464,7 +38464,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -38475,7 +38475,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4muJJ_BSM25HContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -38643,7 +38643,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -38654,7 +38654,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4muJJ_SMHContinInterf_M-125p6_7TeV-phantom-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -38810,7 +38810,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -38821,7 +38821,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -38964,7 +38964,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -39104,7 +39104,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -39256,7 +39256,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -39397,7 +39397,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -39408,7 +39408,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -39552,7 +39552,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -39563,7 +39563,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -39767,7 +39767,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -39778,7 +39778,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_TuneZ2_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -39922,7 +39922,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -39933,7 +39933,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/GluGluToHToZZTo4L_M-500_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -40089,7 +40089,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -40100,7 +40100,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -40244,7 +40244,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -40255,7 +40255,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -40398,7 +40398,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -40539,7 +40539,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -40550,7 +40550,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -40693,7 +40693,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -40846,7 +40846,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -40857,7 +40857,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo2e2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -41013,7 +41013,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -41024,7 +41024,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo2e2tau_mll4_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -41167,7 +41167,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -41307,7 +41307,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -41447,7 +41447,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -41587,7 +41587,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -41727,7 +41727,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -41867,7 +41867,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -42007,7 +42007,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -42147,7 +42147,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -42287,7 +42287,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -42427,7 +42427,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -42567,7 +42567,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -42707,7 +42707,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -42848,7 +42848,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -42859,7 +42859,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-120_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -43003,7 +43003,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -43014,7 +43014,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-124_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -43158,7 +43158,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -43169,7 +43169,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-128_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -43313,7 +43313,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -43324,7 +43324,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-135_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -43480,7 +43480,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -43491,7 +43491,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-140_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -43635,7 +43635,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -43646,7 +43646,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-145_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -43814,7 +43814,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -43825,7 +43825,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-150_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -44005,7 +44005,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -44016,7 +44016,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-160_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -44160,7 +44160,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -44171,7 +44171,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-400_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -44327,7 +44327,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -44338,7 +44338,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -44482,7 +44482,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -44493,7 +44493,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-170_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -44637,7 +44637,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -44648,7 +44648,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo2mu2tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -44804,7 +44804,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -44815,7 +44815,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo2mu2tau_mll4_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -44959,7 +44959,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -44970,7 +44970,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-500_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -45114,7 +45114,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -45125,7 +45125,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -45269,7 +45269,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -45280,7 +45280,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -45424,7 +45424,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -45435,7 +45435,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-650_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -45603,7 +45603,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -45614,7 +45614,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -45758,7 +45758,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -45769,7 +45769,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-700_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -45925,7 +45925,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -45936,7 +45936,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-800_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -46080,7 +46080,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -46091,7 +46091,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -46235,7 +46235,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -46246,7 +46246,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -46390,7 +46390,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -46401,7 +46401,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-175_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -46569,7 +46569,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -46580,7 +46580,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4eJJ_Contin_7TeV-phantom-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -46735,7 +46735,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -46875,7 +46875,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -47040,7 +47040,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -47051,7 +47051,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TT_weights_CT10_7TeV-powheg/Summer11LegwmLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_22",
           "type": "LHE"
@@ -47207,7 +47207,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -47218,7 +47218,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/T_TuneZ2_s-channel_7TeV-powheg-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -47362,7 +47362,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -47373,7 +47373,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-275_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -47529,7 +47529,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -47540,7 +47540,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-300_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -47696,7 +47696,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -47707,7 +47707,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-350_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -47863,7 +47863,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -47874,7 +47874,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-450_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -48018,7 +48018,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -48029,7 +48029,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-550_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -48173,7 +48173,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -48184,7 +48184,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-600_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -48340,7 +48340,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -48351,7 +48351,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-900_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -48495,7 +48495,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -48506,7 +48506,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBF_ToHToZZTo4L_M-115_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -48650,7 +48650,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -48661,7 +48661,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBF_ToHToZZTo4L_M-120_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -48805,7 +48805,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [],
@@ -48953,7 +48953,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -48964,7 +48964,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBF_ToHToZZTo4L_M-130_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -49108,7 +49108,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -49119,7 +49119,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBF_ToHToZZTo4L_M-140_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -49263,7 +49263,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -49274,7 +49274,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBF_ToHToZZTo4L_M-150_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -49418,7 +49418,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -49429,7 +49429,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBF_ToHToZZTo4L_M-160_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -49573,7 +49573,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -49584,7 +49584,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBF_ToHToZZTo4L_M-170_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -49728,7 +49728,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -49739,7 +49739,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBF_ToHToZZTo4L_M-180_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -49883,7 +49883,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -49894,7 +49894,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBF_ToHToZZTo4L_M-190_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -50038,7 +50038,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -50049,7 +50049,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBF_ToHToZZTo4L_M-200_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -50204,7 +50204,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -50215,7 +50215,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/W1Jet_TuneZ2_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -50358,7 +50358,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -50369,7 +50369,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/W2Jets_TuneZ2_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -50524,7 +50524,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -50535,7 +50535,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/W3Jets_TuneZ2_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -50678,7 +50678,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -50689,7 +50689,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/W4Jets_TuneZ2_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -50832,7 +50832,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -50984,7 +50984,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -51136,7 +51136,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -51276,7 +51276,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -51416,7 +51416,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -51556,7 +51556,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -51696,7 +51696,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -51848,7 +51848,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -52000,7 +52000,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -52140,7 +52140,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -52280,7 +52280,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -52421,7 +52421,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -52432,7 +52432,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/WHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -52588,7 +52588,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -52599,7 +52599,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/WHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -52755,7 +52755,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -52766,7 +52766,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/WHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -52910,7 +52910,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -52921,7 +52921,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/WHiggs0PHToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -53077,7 +53077,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -53088,7 +53088,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/WHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -53232,7 +53232,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -53243,7 +53243,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/WHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -53399,7 +53399,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -53410,7 +53410,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/WHiggs0PToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -53589,7 +53589,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -53600,7 +53600,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/WJetsToLNu_TuneZ2_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -53743,7 +53743,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -53754,7 +53754,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/WWJetsTo2L2Nu_TuneZ2_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -53898,7 +53898,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -54050,7 +54050,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -54061,7 +54061,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/WZJetsTo2L2Q_TuneZ2_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -54205,7 +54205,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -54216,7 +54216,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZHiggs0PHToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -54372,7 +54372,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -54383,7 +54383,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/T_TuneZ2_tW-channel-DR_7TeV-powheg-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -54565,7 +54565,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -54576,7 +54576,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_matchingdown_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -54719,7 +54719,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -54730,7 +54730,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/WZJetsTo3LNu_TuneZ2_7TeV-madgraph-tauola/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -54874,7 +54874,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -55014,7 +55014,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -55025,7 +55025,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZGToNuNuG_TuneZ2_7TeV-madgraph/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -55168,7 +55168,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -55309,7 +55309,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -55320,7 +55320,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -55475,7 +55475,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -55627,7 +55627,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -55768,7 +55768,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -55779,7 +55779,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4e_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -55983,7 +55983,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -55994,7 +55994,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4e_mll4_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -56138,7 +56138,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -56149,7 +56149,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4muJJ_Contin_7TeV-phantom-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -56293,7 +56293,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -56304,7 +56304,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4mu_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -56460,7 +56460,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -56471,7 +56471,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4mu_mll4_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -56651,7 +56651,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -56662,7 +56662,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4tau_7TeV_mll8_mZZ95-160-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -56818,7 +56818,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -56829,7 +56829,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZZTo4tau_mll4_7TeV-powheg-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -56973,7 +56973,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -57113,7 +57113,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -57254,7 +57254,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -57265,7 +57265,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-180_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -57409,7 +57409,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -57420,7 +57420,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-250_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -57563,7 +57563,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -57716,7 +57716,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -57727,7 +57727,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/SMHiggsToZZTo4L_M-200_7TeV-powheg15-JHUgenV3-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -57883,7 +57883,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -57894,7 +57894,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFToHToZZTo2L2Q_M-1000_7TeV-powheg15-pythia6/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -58037,7 +58037,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -58180,7 +58180,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -58191,7 +58191,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_central_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_14_patch2",
           "type": "LHE"
@@ -58373,7 +58373,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -58384,7 +58384,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_mass169_5_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -58527,7 +58527,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -58667,7 +58667,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -58834,7 +58834,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -58845,7 +58845,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_mass171_5_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -58988,7 +58988,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -59140,7 +59140,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -59280,7 +59280,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -59432,7 +59432,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -59573,7 +59573,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -59584,7 +59584,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZHiggs0MToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -59728,7 +59728,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -59739,7 +59739,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZHiggs0MToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -59883,7 +59883,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -59894,7 +59894,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/ZHiggs0Mf05ph0ToZZTo4L_M-125p6_7TeV-JHUGenV4/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -60050,7 +60050,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -60061,7 +60061,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Tbar_TuneZ2_s-channel_7TeV-powheg-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_11_patch6",
           "type": "LHE"
@@ -60243,7 +60243,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -60254,7 +60254,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_mass173_5_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -60421,7 +60421,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -60612,7 +60612,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -60623,7 +60623,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_mass175_5_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v2/GEN",
           "release": "CMSSW_5_3_19",
           "type": "LHE"
@@ -60767,7 +60767,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -60778,7 +60778,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/VBFHiggs0PToBB_M-125p6_7TeV-JHUGenV4-pythia6-tauola/Summer11LegpLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_14",
           "type": "LHE"
@@ -60923,7 +60923,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -60934,7 +60934,7 @@
             }
           ],
           "global_tag": "START311_V2::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/Vector1MToZZTo4L_M-125p6_7TeV-JHUGenV3-pythia6/Summer11-START311_V2-v1/GEN",
           "release": "CMSSW_4_1_8_patch14",
           "type": "LHE"
@@ -61092,7 +61092,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n",
       "steps": [
         {
           "configuration_files": [
@@ -61103,7 +61103,7 @@
             }
           ],
           "global_tag": "START53_LV4::All",
-          "note": "To get the exact LHE and generator's parameters, see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\"> CMS Monte Carlo production overview</a>.",
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
           "output_dataset": "/TTJets_MSDecays_scaleup_mt172_5_7TeV-madgraph/Summer11LegwmLHE-START53_LV4-v1/GEN",
           "release": "CMSSW_5_3_26",
           "type": "LHE"

--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -223,7 +223,9 @@
                 {% if step.get("global_tag") %}
                     Global Tag: {{ step.global_tag }}<br>
                 {% endif %}
-
+                {% if step.get("generators") %}
+                    Generators: {% for generator in step.generators %} {{generator}} {% endfor %}<br>
+                {% endif %}
                 {% for conf_file in step.get("configuration_files") %}
                     <span class="oi" data-glyph="file"></span>
                     {{ conf_file.get("title", "File #"+ loop.index|string) }}


### PR DESCRIPTION
- Fixes provenance information for CMS 2010 simulated datasets. (addresses #2613)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>


