### PR TITLE
docs: update VM version to 1.5.1

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cms-getting-started-2011/cms-getting-started-2011.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-getting-started-2011/cms-getting-started-2011.md
@@ -7,13 +7,13 @@
 
 ## <a name="vm">"I have installed the CERN Virtual Machine: now what?"</a>
 
-To analyse CMS data collected in 2011 and 2012, you need **version 5.3.32** of CMSSW, supported only on **Scientific Linux 6**. If you are unfamiliar with Linux, take a look at [this short introduction to Linux](https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookBasicLinux) or try this interactive [command-line bootcamp](http://rik.smith-unna.com/command_line_bootcamp/). Once you have installed the [CMS-specific CERN Virtual Machine](/docs/cms-virtual-machine-2011), you need to open a terminal. In the "CMS-OpenData-1.5.0" VM, always use the "CMS shell" terminal available from the "CMS Shell" icon on the desktop for all CMSSW-specific commands, such as compilation and run (only if using the VM version "CMS-OpenData-1.2.0" or "CMS-OpenData-1.3.0, open a terminal with the X terminal emulator from an icon bottom-left of the VM screen). Execute the following command in the terminal if you haven't done so before; it ensures that you have this version of CMSSW running:
+To analyse CMS data collected in 2011 and 2012, you need **version 5.3.32** of CMSSW, supported only on **Scientific Linux 6**. If you are unfamiliar with Linux, take a look at [this short introduction to Linux](https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookBasicLinux) or try this interactive [command-line bootcamp](http://rik.smith-unna.com/command_line_bootcamp/). Once you have installed the [CMS-specific CERN Virtual Machine](/docs/cms-virtual-machine-2011), you need to open a terminal. In the "CMS-OpenData-1.5.1" VM, always use the "CMS shell" terminal available from the "CMS Shell" icon on the desktop for all CMSSW-specific commands, such as compilation and run (only if using the VM version "CMS-OpenData-1.2.0" or "CMS-OpenData-1.3.0, open a terminal with the X terminal emulator from an icon bottom-left of the VM screen). Execute the following command in the terminal if you haven't done so before; it ensures that you have this version of CMSSW running:
 
 ```shell
 $ cmsrel CMSSW_5_3_32
 ```
 
-Then, make sure that you are always in the **CMSSW_5_3_32/src/** directory ((and in the "CMS Shell" terminal, if using the "CMS-OpenData-1.5.0" VM), and that the CMS analysis environment is properly setup by entering the following commands in the terminal (you must do so every time you boot the VM before you can proceed):
+Then, make sure that you are always in the **CMSSW_5_3_32/src/** directory ((and in the "CMS Shell" terminal, if using the "CMS-OpenData-1.5.1" VM), and that the CMS analysis environment is properly setup by entering the following commands in the terminal (you must do so every time you boot the VM before you can proceed):
 
 ```shell
 $ cd CMSSW_5_3_32/src/

--- a/cernopendata/modules/fixtures/data/docs/cms-guide-for-conddb/cms-guide-for-conddb.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-for-conddb/cms-guide-for-conddb.md
@@ -131,7 +131,7 @@ Note that three sets of condition data for 2011 data are provided:
 * FT53_V21A_AN6 valid for the run range of 2012 RunB (public data)
 * FT53_V21A_AN6_RUNC valid for the run range of 2012 RunC (public data)
 
-It is convenient to use FT53_V21A_AN6_FULL as instructed above, as you will not need to load RunB and RunC condition data separately. You should use the CMS Open Data VM version CMS-Open-Data-1.5.0.ova (or CMS-Open-Data-1.3.0.ova), which has a large enough cache area.
+It is convenient to use FT53_V21A_AN6_FULL as instructed above, as you will not need to load RunB and RunC condition data separately. You should use the CMS Open Data VM version CMS-Open-Data-1.5.1.ova (or CMS-Open-Data-1.3.0.ova), which has a large enough cache area.
 
 In addition, condition data for the Global Tag START53_V7N is provided. This was used to produce simulated data with dose-dependent detector characteristics, run-dependent pile-up and beam spot conditions for the Higgs boson discovery analysis. The simulated data produced with this Global Tag can be analysed with the other Global Tag above.
 

--- a/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
+++ b/cernopendata/modules/fixtures/data/docs/cms-virtual-machine-2011/cms-virtual-machine-2011.md
@@ -19,7 +19,7 @@ Note: the latest tested version of VirtualBox working with this CMS-specific Cer
 
 **Important**: Before you download the CernVM, note that the imported settings may not always work on your host machine. Please see [Issues and Limitations](#issue) or [the CMS guide to troubleshooting](/docs/cms-guide-troubleshooting) if you encounter any problems with booting the VM.
 
-Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2011 CMS Open Data][cmsvmimage2011]. It is recommended using the version "CMS-OpenData-1.5.0". This VM Image can be used for data from 2011 and 2012 (for data from 2010 follow the instruction in [CMS 2010 Virtual Machines: How to install](/docs/cms-virtual-machine-2010)).
+Next download the CMS-specific CernVM image as OVA file from: [CMS VM Image for 2011 CMS Open Data][cmsvmimage2011]. It is recommended using the version "CMS-OpenData-1.5.1". This VM Image can be used for data from 2011 and 2012 (for data from 2010 follow the instruction in [CMS 2010 Virtual Machines: How to install](/docs/cms-virtual-machine-2010)).
 
 By double clicking the downloaded file, VirtualBox imports the image with ready-to-run settings. Then, you launch the CMS-specific CernVM, which boots into the graphical user interface and sets up the CMS environment. Be patient, it will take a while.
 
@@ -30,7 +30,7 @@ The validation procedure tests that the CMS environment is installed and operati
 
 ### Set up the CMS environment and run a demo analyzer
 
-In the "CMS-OpenData-1.5.0" VM, open a terminal from the "CMS Shell" icon from the desktop (only if using the other VM versions, "CMS-Open-Data-1.2.0" or "CMS-Open-Data-1.3.0", open a terminal with the X terminal emulator from an icon bottom-left of the VM screen, in "CMS-OpenData-1.5.0" this will open a shell with an operating system incompatible with the CMS software release to be used).
+In the "CMS-OpenData-1.5.1" VM, open a terminal from the "CMS Shell" icon from the desktop (only if using the other VM versions, "CMS-Open-Data-1.2.0" or "CMS-Open-Data-1.3.0", open a terminal with the X terminal emulator from an icon bottom-left of the VM screen, in "CMS-OpenData-1.5.1" this will open a shell with an operating system incompatible with the CMS software release to be used).
 
 Execute the following command; this command builds the local release area (the directory structure) for CMSSW, and only needs to be run once (note that it may take a while):
 
@@ -165,7 +165,7 @@ Please check the validation report for the VM image for our 2010 data, which may
 
 **Question:**  When I try to compile with 'scram b', I get a warning 'SCRAM warning: You are trying to compile/build for architecture slc6_amd64_gcc530 on SLC7 OS which might not work. If you know this SCRAM_ARCH/OS combination works then please first run 'scram build --ignore-arch'.'
 
-> **Answer:** You are very likely in the wrong shell of the VM machine. When using the "CMS-OpenData-1.5.0" VM, all CMSSW-specific commands (compilation, run) must be given in the "CMS Shell", which can be opened from the desk top icon, not in the "Outer shell".
+> **Answer:** You are very likely in the wrong shell of the VM machine. When using the "CMS-OpenData-1.5.1" VM, all CMSSW-specific commands (compilation, run) must be given in the "CMS Shell", which can be opened from the desk top icon, not in the "Outer shell".
 
 **Question:** On Ubuntu running the latest version of VirtualBox, an error appears when opening the CMS-specific virtual machine: the message is about a missing path to a definition file.
 


### PR DESCRIPTION
(closes #2638 )

Updates the VM version to 1.5.1 in the instructions texts. (not in the VM record itself, it can be updated when the files are added: #2426)

