### PR TITLE
records: CMS MC provenance configuration file updates

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010.json
@@ -58,6 +58,11 @@
               "script": "import FWCore.ParameterSet.Config as cms\n\ndef customise(process): # Using SL instead GFlash AND turn on castor and compensation\n    process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)\n    process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)\n    process.g4SimHits.HCalSD.UseFibreBundleHits = cms.bool(False)\n    process.g4SimHits.HFShower.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)\n    process.g4SimHits.HFShower.ApplyFiducialCut = cms.bool(False)\n    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)\n    process.g4SimHits.CastorSD.nonCompensationFactor = cms.double(0.77)\n\n    return(process)\n\n\n\n",
               "title": "Generator parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py"
+            },
+            {
+              "cms_confdb_id": "065c6764b943c992bab22c0731db34f6",
+              "process": "SIM",
+              "title": "Configuration file"
             }
           ],
           "generators": [
@@ -188,20 +193,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/CS_Pt_120to9999_CTEQ6L1_HFshowerLibrary_7TeV_herwig6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -638,6 +643,11 @@
               "script": "import FWCore.ParameterSet.Config as cms\n\ndef customise(process): # Using SL instead GFlash AND turn on castor and compensation\n    process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)\n    process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)\n    process.g4SimHits.HCalSD.UseFibreBundleHits = cms.bool(False)\n    process.g4SimHits.HFShower.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)\n    process.g4SimHits.HFShower.ApplyFiducialCut = cms.bool(False)\n    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)\n    process.g4SimHits.CastorSD.nonCompensationFactor = cms.double(0.77)\n\n    return(process)\n\n\n\n",
               "title": "Generator parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py"
+            },
+            {
+              "cms_confdb_id": "065c6764b943c992bab22c0731e67920",
+              "process": "SIM",
+              "title": "Configuration file"
             }
           ],
           "generators": [
@@ -655,20 +665,20 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/DPEDijets_Pt30_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v2/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -881,20 +891,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/DYToEE_M_50To130_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -994,20 +1004,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
-              "process": "RECO",
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/DYToMuMu_M-20_TuneZ2Star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -1107,20 +1117,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005b191",
-              "process": "RECO",
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005b191",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/MinBias_Tune4C_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -1333,20 +1343,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005b191",
-              "process": "RECO",
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005b191",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/MinBias_Tune4C_Castor_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -1446,20 +1456,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005963c",
-              "process": "RECO",
+              "cms_confdb_id": "950a1c715eb6d4293d88162a10058d09",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a10058d09",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005963c",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17C::All",
           "output_dataset": "/MinBias_Tune4C_Castor_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17C-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -1672,20 +1682,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "70d6766611f8d0924ace67e606b0c1df",
-              "process": "RECO",
+              "cms_confdb_id": "70d6766611f8d0924ace67e606ab6006",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "70d6766611f8d0924ace67e606ab6006",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "70d6766611f8d0924ace67e606b0c1df",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17C::All",
           "output_dataset": "/MinBias_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_NoPileUp_START42_V17C-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -2011,20 +2021,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005b191",
-              "process": "RECO",
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005a238",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005b191",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/MinBias_TuneZ2star_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -2124,20 +2134,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a1005963c",
-              "process": "RECO",
+              "cms_confdb_id": "950a1c715eb6d4293d88162a10058d09",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "950a1c715eb6d4293d88162a10058d09",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "950a1c715eb6d4293d88162a1005963c",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17C::All",
           "output_dataset": "/MinBias_TuneZ2star_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17C-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -2576,20 +2586,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "fe35a6e3bcf89a49c7b3140c99b5e37e",
-              "process": "RECO",
+              "cms_confdb_id": "fe35a6e3bcf89a49c7b3140c99b59cde",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "fe35a6e3bcf89a49c7b3140c99b59cde",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "fe35a6e3bcf89a49c7b3140c99b5e37e",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/MinBias_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v2/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -2724,20 +2734,20 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_HT-1000ToInf_TuneZ2Star_7TeV-madgraph-pythia6/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -3020,20 +3030,20 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_HT-250To500_TuneZ2Star_7TeV-madgraph-pythia6/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -3316,20 +3326,20 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_HT-50To100_TuneZ2Star_7TeV-madgraph-pythia6/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -3562,20 +3572,20 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt-15to1000_TuneEE3C_Flat_7TeV_herwigpp/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -3690,20 +3700,20 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
-              "process": "RECO",
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt-15to1000_fwdJet_bwdJet_Tune4C_Flat_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -4185,13 +4195,13 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
@@ -4201,7 +4211,7 @@
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt-15to3000_Tune4C_Flat_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -5220,20 +5230,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "34b5be84d9a7c90a4924f7cf9c8dbe86",
-              "process": "RECO",
+              "cms_confdb_id": "34b5be84d9a7c90a4924f7cf9c8d81f9",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "34b5be84d9a7c90a4924f7cf9c8d81f9",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "34b5be84d9a7c90a4924f7cf9c8dbe86",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt-50to80_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -5333,20 +5343,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "8bf830006a8493f7e7b1551d16783853",
-              "process": "RECO",
+              "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "8bf830006a8493f7e7b1551d16782ade",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "8bf830006a8493f7e7b1551d16783853",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt-600to800_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -6011,20 +6021,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
-              "process": "RECO",
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_10to25_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -6463,20 +6473,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "1cce1be4ff841028987380e485d2fce6",
-              "process": "RECO",
+              "cms_confdb_id": "1cce1be4ff841028987380e485d2f0fe",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "1cce1be4ff841028987380e485d2f0fe",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "1cce1be4ff841028987380e485d2fce6",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_150toInf_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -6576,20 +6586,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "20df86a8d2a6767511e8c70c16761285",
-              "process": "RECO",
+              "cms_confdb_id": "20df86a8d2a6767511e8c70c16760806",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "20df86a8d2a6767511e8c70c16760806",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "20df86a8d2a6767511e8c70c16761285",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_150toInf_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v2/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -6689,20 +6699,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
-              "process": "RECO",
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_150toInf_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -6915,20 +6925,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
-              "process": "RECO",
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_15to30_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -7141,20 +7151,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "ffda6faab4a5706f819a52c5152b9f93",
-              "process": "RECO",
+              "cms_confdb_id": "ffda6faab4a5706f819a52c5152b89f8",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "ffda6faab4a5706f819a52c5152b89f8",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "ffda6faab4a5706f819a52c5152b9f93",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_170to300_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -7254,20 +7264,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "d6f77e87e94b455d49e4e5982ed2ab3a",
-              "process": "RECO",
+              "cms_confdb_id": "d6f77e87e94b455d49e4e5982eca7b74",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "d6f77e87e94b455d49e4e5982eca7b74",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "d6f77e87e94b455d49e4e5982ed2ab3a",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_25to40_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -7367,20 +7377,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "1cce1be4ff841028987380e485d2fce6",
-              "process": "RECO",
+              "cms_confdb_id": "1cce1be4ff841028987380e485d2f0fe",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "1cce1be4ff841028987380e485d2f0fe",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "1cce1be4ff841028987380e485d2fce6",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_25to40_fwdJet_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -7706,20 +7716,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "fa09878571c00c1f0d62c320e484c511",
-              "process": "RECO",
+              "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "fa09878571c00c1f0d62c320e484c511",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_300to470_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -7932,20 +7942,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "69014bd02166e652ad8e145474a68b74",
-              "process": "RECO",
+              "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "69014bd02166e652ad8e145474a68b74",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_30to50_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -8045,20 +8055,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "69014bd02166e652ad8e145474a68b74",
-              "process": "RECO",
+              "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "69014bd02166e652ad8e145474a68b74",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_30to50_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -8158,20 +8168,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_40to80_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -8384,20 +8394,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "70ed77c68a7d31d941249f48606d9eab",
-              "process": "RECO",
+              "cms_confdb_id": "70ed77c68a7d31d941249f48606d1941",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "70ed77c68a7d31d941249f48606d1941",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "70ed77c68a7d31d941249f48606d9eab",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_40to80_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -8497,20 +8507,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
-              "process": "RECO",
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_40to80_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -8610,20 +8620,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "429e00f769683de0712feb6c5ba765ab",
-              "process": "RECO",
+              "cms_confdb_id": "429e00f769683de0712feb6c5ba663b2",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "429e00f769683de0712feb6c5ba663b2",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "429e00f769683de0712feb6c5ba765ab",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_470to600_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -8836,20 +8846,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
-              "process": "RECO",
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0447",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "e9bd6a6ef1f54b9e06526fad200c0700",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_50to80_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -8949,20 +8959,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "fa09878571c00c1f0d62c320e484c511",
-              "process": "RECO",
+              "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "fa09878571c00c1f0d62c320e484c511",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_50to80_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -9062,20 +9072,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "86795293e0f0a28c0259541ea4a8e6a9",
-              "process": "RECO",
+              "cms_confdb_id": "86795293e0f0a28c0259541ea4a8e57f",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "86795293e0f0a28c0259541ea4a8e57f",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "86795293e0f0a28c0259541ea4a8e6a9",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_5to15_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -9288,20 +9298,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "fa09878571c00c1f0d62c320e484c511",
-              "process": "RECO",
+              "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "fa09878571c00c1f0d62c320e484a464",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "fa09878571c00c1f0d62c320e484c511",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_600to800_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -9401,20 +9411,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "69014bd02166e652ad8e145474a68b74",
-              "process": "RECO",
+              "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "69014bd02166e652ad8e145474a66838",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "69014bd02166e652ad8e145474a68b74",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_80to120_Tune4C_HFshowerLibrary_7TeV_pythia8/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -9627,20 +9637,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
-              "process": "RECO",
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44dec4bf4",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "2f7ddb928d33dd11b2685ad44df58b69",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_80to150_fwdJet_Tune23_HFshowerLibrary_7TeV_herwigpp/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -9853,20 +9863,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "70ed77c68a7d31d941249f48606d9eab",
-              "process": "RECO",
+              "cms_confdb_id": "70ed77c68a7d31d941249f48606d1941",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "70ed77c68a7d31d941249f48606d1941",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "70ed77c68a7d31d941249f48606d9eab",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_80to150_fwdJet_TuneD6T_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -9966,20 +9976,20 @@
         {
           "configuration_files": [
             {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
-              "process": "RECO",
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1ab0ae",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "5699673a1e36526f07dc2da3fd1b006b",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/QCD_Pt_80to150_fwdJet_TuneZ2star_HFshowerLibrary_7TeV_pythia6/Summer12-LowPU2010_DR42-PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -10077,6 +10087,11 @@
               "script": "import FWCore.ParameterSet.Config as cms\n\ndef customise(process): # Using SL instead GFlash AND turn on castor and compensation\n    process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)\n    process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)\n    process.g4SimHits.HCalSD.UseFibreBundleHits = cms.bool(False)\n    process.g4SimHits.HFShower.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)\n    process.g4SimHits.HFShower.ApplyFiducialCut = cms.bool(False)\n    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)\n    process.g4SimHits.CastorSD.nonCompensationFactor = cms.double(0.77)\n\n    return(process)\n\n\n\n",
               "title": "Generator parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py"
+            },
+            {
+              "cms_confdb_id": "065c6764b943c992bab22c0731dbc204",
+              "process": "SIM",
+              "title": "Configuration file"
             }
           ],
           "generators": [
@@ -10205,6 +10220,11 @@
               "script": "import FWCore.ParameterSet.Config as cms\n\ndef customise(process): # Using SL instead GFlash AND turn on castor and compensation\n    process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)\n    process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)\n    process.g4SimHits.HCalSD.UseFibreBundleHits = cms.bool(False)\n    process.g4SimHits.HFShower.UseShowerLibrary = cms.bool(True)\n    process.g4SimHits.HFShower.UseHFGflash = cms.bool(False)\n    process.g4SimHits.HFShower.ApplyFiducialCut = cms.bool(False)\n    process.g4SimHits.Generator.MinEtaCut = cms.double(-7.0)\n    process.g4SimHits.CastorSD.nonCompensationFactor = cms.double(0.77)\n\n    return(process)\n\n\n\n",
               "title": "Generator parameters",
               "url": "https://raw.githubusercontent.com/cms-sw/genproductions/d45de22e7af5816cb5ee3b90c446eaff93ae187d/python/lowpu2010_customise.py"
+            },
+            {
+              "cms_confdb_id": "065c6764b943c992bab22c0731e1f407",
+              "process": "SIM",
+              "title": "Configuration file"
             }
           ],
           "generators": [
@@ -10355,20 +10375,20 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/SingleDiffractiveWToENu_eta-minus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -10754,20 +10774,20 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/SingleDiffractiveWToMuNu_eta-plus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -11137,13 +11157,13 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
@@ -11153,7 +11173,7 @@
           "global_tag": "START42_V17B::All",
           "output_dataset": "/SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -11273,20 +11293,20 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
-              "process": "RECO",
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/SingleDiffractiveZToMuMu_M-20_eta-minus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v2/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -11390,13 +11410,13 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
@@ -11406,7 +11426,7 @@
           "global_tag": "START42_V17B::All",
           "output_dataset": "/SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v1/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -11526,20 +11546,20 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
-              "process": "RECO",
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "42642b9c91fe93ccc4ec15da375e4d57",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "42642b9c91fe93ccc4ec15da37681bd8",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/SingleDiffractiveZToMuMu_M-20_eta-plus_7TeV-pomwig/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v2/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },
@@ -11659,20 +11679,20 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
-              "process": "RECO",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
+              "process": "DIGI2RAW",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca1dd",
-              "process": "DIGI2RAW",
+              "cms_confdb_id": "c23dc5a1674bfa99196ee5fafc3ca615",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
           "global_tag": "START42_V17B::All",
           "output_dataset": "/WToENu_TuneZ2star_7TeV-pythia6/Summer12-LowPU2010_DR42_BS2011_PU_S0_START42_V17B-v2/AODSIM",
           "release": "CMSSW_4_2_8_lowpupatch1",
-          "type": "RECO DIGI2RAW"
+          "type": "DIGI2RAW RECO"
         }
       ]
     },

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2-datascience.json
@@ -56,24 +56,29 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-600_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/AODSIM\" --fileout file:B2G-RunIISummer16MiniAODv2-01594.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename B2G-RunIISummer16MiniAODv2-01594_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            }
-          ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "configuration_files": [],
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-600_13TeV-madgraph/RunIISummer15wmLHEGS-MCRUN2_71_V1_ext1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_26",
+          "type": "SIM"
         },
         {
           "configuration_files": [
             {
               "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-600_13TeV-madgraph/RunIISummer15wmLHEGS-MCRUN2_71_V1_ext1-v1/GEN-SIM\" --fileout file:B2G-RunIISummer16DR80Premix-01592_step1.root  --pileup_input \"dbs:/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW\" --mc --eventcontent PREMIXRAW --datatier GEN-SIM-RAW --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step DIGIPREMIX_S2,DATAMIX,L1,DIGI2RAW,HLT:@frozen2016 --nThreads 4 --datamix PreMix --era Run2_2016 --python_filename B2G-RunIISummer16DR80Premix-01592_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 169 || exit $? ; \n\ncmsDriver.py step2 --filein file:B2G-RunIISummer16DR80Premix-01592_step1.root --fileout file:B2G-RunIISummer16DR80Premix-01592.root --mc --eventcontent AODSIM --runUnscheduled --datatier AODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step RAW2DIGI,RECO,EI --nThreads 4 --era Run2_2016 --python_filename B2G-RunIISummer16DR80Premix-01592_2_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 169 || exit $? ; \n\n",
               "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "9d1ace9d1b37fb0202c93baaca27aa83",
+              "process": "HLT",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "9d1ace9d1b37fb0202c93baaca27c2c7",
+              "process": "RECO",
+              "title": "Configuration file"
             }
           ],
           "generators": [
@@ -81,8 +86,26 @@
             "pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-600_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-600_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/AODSIM\" --fileout file:B2G-RunIISummer16MiniAODv2-01594.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename B2G-RunIISummer16MiniAODv2-01594_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "9d1ace9d1b37fb0202c93baaca28202d",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-600_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -184,24 +207,29 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-1000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/AODSIM\" --fileout file:B2G-RunIISummer16MiniAODv2-01591.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename B2G-RunIISummer16MiniAODv2-01591_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            }
-          ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "configuration_files": [],
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1000_13TeV-madgraph/RunIISummer15wmLHEGS-MCRUN2_71_V1_ext1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_26",
+          "type": "SIM"
         },
         {
           "configuration_files": [
             {
               "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-1000_13TeV-madgraph/RunIISummer15wmLHEGS-MCRUN2_71_V1_ext1-v1/GEN-SIM\" --fileout file:B2G-RunIISummer16DR80Premix-01589_step1.root  --pileup_input \"dbs:/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW\" --mc --eventcontent PREMIXRAW --datatier GEN-SIM-RAW --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step DIGIPREMIX_S2,DATAMIX,L1,DIGI2RAW,HLT:@frozen2016 --nThreads 4 --datamix PreMix --era Run2_2016 --python_filename B2G-RunIISummer16DR80Premix-01589_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 169 || exit $? ; \n\ncmsDriver.py step2 --filein file:B2G-RunIISummer16DR80Premix-01589_step1.root --fileout file:B2G-RunIISummer16DR80Premix-01589.root --mc --eventcontent AODSIM --runUnscheduled --datatier AODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step RAW2DIGI,RECO,EI --nThreads 4 --era Run2_2016 --python_filename B2G-RunIISummer16DR80Premix-01589_2_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 169 || exit $? ; \n\n",
               "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "9d1ace9d1b37fb0202c93baaca27aa83",
+              "process": "HLT",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "9d1ace9d1b37fb0202c93baaca27c2c7",
+              "process": "RECO",
+              "title": "Configuration file"
             }
           ],
           "generators": [
@@ -209,8 +237,26 @@
             "pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-1000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/AODSIM\" --fileout file:B2G-RunIISummer16MiniAODv2-01591.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename B2G-RunIISummer16MiniAODv2-01591_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "9d1ace9d1b37fb0202c93baaca28202d",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1000_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -312,23 +358,27 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [],
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1200_13TeV-madgraph/RunIIWinter15wmLHE-MCRUN2_71_V1-v2/LHE",
+          "release": "CMSSW_7_1_16",
+          "type": "LHE"
+        },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-1200_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-02849.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-02849_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "e0fcad7e25794ff32db7f96b8a873f7e",
-              "process": "",
+              "cms_confdb_id": "2557f311e3275b75b2e1ea1cb1b2e449",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1200_13TeV-madgraph/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_19",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -338,12 +388,12 @@
             },
             {
               "cms_confdb_id": "18df0acce05f1d95a9d86ab8241e7d33",
-              "process": "",
+              "process": "HLT",
               "title": "Configuration file"
             },
             {
               "cms_confdb_id": "18df0acce05f1d95a9d86ab8241f2b63",
-              "process": "",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
@@ -351,8 +401,26 @@
             "madgraph"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1200_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-1200_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-02849.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-02849_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "e0fcad7e25794ff32db7f96b8a873f7e",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1200_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -454,23 +522,27 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [],
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1400_13TeV-madgraph/RunIIWinter15wmLHE-MCRUN2_71_V1-v1/LHE",
+          "release": "CMSSW_7_1_16",
+          "type": "LHE"
+        },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-1400_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-00321.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-00321_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "2206482e3309b8511cb58602a76373f0",
-              "process": "",
+              "cms_confdb_id": "2557f311e3275b75b2e1ea1cb1b2e449",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1400_13TeV-madgraph/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_19",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -480,12 +552,12 @@
             },
             {
               "cms_confdb_id": "18df0acce05f1d95a9d86ab8241e7d33",
-              "process": "",
+              "process": "HLT",
               "title": "Configuration file"
             },
             {
               "cms_confdb_id": "18df0acce05f1d95a9d86ab8241f2b63",
-              "process": "",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
@@ -493,8 +565,26 @@
             "madgraph"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1400_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-1400_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-00321.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-00321_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "2206482e3309b8511cb58602a76373f0",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1400_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -596,23 +686,27 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [],
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1600_13TeV-madgraph/RunIIWinter15wmLHE-MCRUN2_71_V1-v1/LHE",
+          "release": "CMSSW_7_1_16",
+          "type": "LHE"
+        },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-1600_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-00521.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-00521_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "9646767ce02b20c08534c68603b18952",
-              "process": "",
+              "cms_confdb_id": "2557f311e3275b75b2e1ea1cb1b2e449",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1600_13TeV-madgraph/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_19",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -622,12 +716,12 @@
             },
             {
               "cms_confdb_id": "18df0acce05f1d95a9d86ab8241e7d33",
-              "process": "",
+              "process": "HLT",
               "title": "Configuration file"
             },
             {
               "cms_confdb_id": "18df0acce05f1d95a9d86ab8241f2b63",
-              "process": "",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
@@ -635,8 +729,26 @@
             "madgraph"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1600_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-1600_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-00521.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-00521_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "9646767ce02b20c08534c68603b18952",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1600_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -752,23 +864,27 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [],
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraph/RunIIWinter15wmLHE-MCRUN2_71_V1-v2/LHE",
+          "release": "CMSSW_7_1_16",
+          "type": "LHE"
+        },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-04201.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-04201_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "f059d46d5a163815a3533ab8ef4e4c68",
-              "process": "",
+              "cms_confdb_id": "2557f311e3275b75b2e1ea1cb1b2e449",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraph/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_19",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -777,13 +893,13 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "18df0acce05f1d95a9d86ab8241f2b63",
-              "process": "",
+              "cms_confdb_id": "18df0acce05f1d95a9d86ab8241e7d33",
+              "process": "HLT",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "18df0acce05f1d95a9d86ab8241e7d33",
-              "process": "",
+              "cms_confdb_id": "18df0acce05f1d95a9d86ab8241f2b63",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
@@ -791,8 +907,26 @@
             "madgraph"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-04201.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-04201_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "f059d46d5a163815a3533ab8ef4e4c68",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -894,23 +1028,27 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [],
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/RunIIWinter15wmLHE-MCRUN2_71_V1-v1/LHE",
+          "release": "CMSSW_7_1_16",
+          "type": "LHE"
+        },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-00523.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-00523_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "9646767ce02b20c08534c68603b18952",
-              "process": "",
+              "cms_confdb_id": "2557f311e3275b75b2e1ea1cb1b2e449",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_19",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -920,12 +1058,12 @@
             },
             {
               "cms_confdb_id": "18df0acce05f1d95a9d86ab8241e7d33",
-              "process": "",
+              "process": "HLT",
               "title": "Configuration file"
             },
             {
               "cms_confdb_id": "18df0acce05f1d95a9d86ab8241f2b63",
-              "process": "",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
@@ -933,8 +1071,26 @@
             "madgraph"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-00523.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-00523_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "9646767ce02b20c08534c68603b18952",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -1036,24 +1192,29 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/AODSIM\" --fileout file:B2G-RunIISummer16MiniAODv2-01592.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename B2G-RunIISummer16MiniAODv2-01592_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            }
-          ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "configuration_files": [],
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/RunIISummer15wmLHEGS-MCRUN2_71_V1_ext1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_26",
+          "type": "SIM"
         },
         {
           "configuration_files": [
             {
               "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/RunIISummer15wmLHEGS-MCRUN2_71_V1_ext1-v1/GEN-SIM\" --fileout file:B2G-RunIISummer16DR80Premix-01590_step1.root  --pileup_input \"dbs:/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW\" --mc --eventcontent PREMIXRAW --datatier GEN-SIM-RAW --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step DIGIPREMIX_S2,DATAMIX,L1,DIGI2RAW,HLT:@frozen2016 --nThreads 4 --datamix PreMix --era Run2_2016 --python_filename B2G-RunIISummer16DR80Premix-01590_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 169 || exit $? ; \n\ncmsDriver.py step2 --filein file:B2G-RunIISummer16DR80Premix-01590_step1.root --fileout file:B2G-RunIISummer16DR80Premix-01590.root --mc --eventcontent AODSIM --runUnscheduled --datatier AODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step RAW2DIGI,RECO,EI --nThreads 4 --era Run2_2016 --python_filename B2G-RunIISummer16DR80Premix-01590_2_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 169 || exit $? ; \n\n",
               "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "9d1ace9d1b37fb0202c93baaca27aa83",
+              "process": "HLT",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "9d1ace9d1b37fb0202c93baaca27c2c7",
+              "process": "RECO",
+              "title": "Configuration file"
             }
           ],
           "generators": [
@@ -1061,8 +1222,26 @@
             "pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/AODSIM\" --fileout file:B2G-RunIISummer16MiniAODv2-01592.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename B2G-RunIISummer16MiniAODv2-01592_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "9d1ace9d1b37fb0202c93baaca28202d",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -1164,23 +1343,27 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [],
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-2500_13TeV-madgraph/RunIIWinter15wmLHE-MCRUN2_71_V1-v1/LHE",
+          "release": "CMSSW_7_1_16",
+          "type": "LHE"
+        },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-2500_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-00524.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-00524_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "9646767ce02b20c08534c68603b18952",
-              "process": "",
+              "cms_confdb_id": "2557f311e3275b75b2e1ea1cb1b2e449",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-2500_13TeV-madgraph/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_19",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -1190,12 +1373,12 @@
             },
             {
               "cms_confdb_id": "18df0acce05f1d95a9d86ab8241e7d33",
-              "process": "",
+              "process": "HLT",
               "title": "Configuration file"
             },
             {
               "cms_confdb_id": "18df0acce05f1d95a9d86ab8241f2b63",
-              "process": "",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
@@ -1203,8 +1386,26 @@
             "madgraph"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-2500_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-2500_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-00524.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-00524_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "9646767ce02b20c08534c68603b18952",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-2500_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -1306,24 +1507,29 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
-          "configuration_files": [
-            {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-3000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/AODSIM\" --fileout file:B2G-RunIISummer16MiniAODv2-01593.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename B2G-RunIISummer16MiniAODv2-01593_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            }
-          ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "configuration_files": [],
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-3000_13TeV-madgraph/RunIISummer15wmLHEGS-MCRUN2_71_V1_ext1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_26",
+          "type": "SIM"
         },
         {
           "configuration_files": [
             {
               "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-3000_13TeV-madgraph/RunIISummer15wmLHEGS-MCRUN2_71_V1_ext1-v1/GEN-SIM\" --fileout file:B2G-RunIISummer16DR80Premix-01591_step1.root  --pileup_input \"dbs:/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW\" --mc --eventcontent PREMIXRAW --datatier GEN-SIM-RAW --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step DIGIPREMIX_S2,DATAMIX,L1,DIGI2RAW,HLT:@frozen2016 --nThreads 4 --datamix PreMix --era Run2_2016 --python_filename B2G-RunIISummer16DR80Premix-01591_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 169 || exit $? ; \n\ncmsDriver.py step2 --filein file:B2G-RunIISummer16DR80Premix-01591_step1.root --fileout file:B2G-RunIISummer16DR80Premix-01591.root --mc --eventcontent AODSIM --runUnscheduled --datatier AODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step RAW2DIGI,RECO,EI --nThreads 4 --era Run2_2016 --python_filename B2G-RunIISummer16DR80Premix-01591_2_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 169 || exit $? ; \n\n",
               "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "9d1ace9d1b37fb0202c93baaca27aa83",
+              "process": "HLT",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "9d1ace9d1b37fb0202c93baaca27c2c7",
+              "process": "RECO",
+              "title": "Configuration file"
             }
           ],
           "generators": [
@@ -1331,8 +1537,26 @@
             "pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-3000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-3000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/AODSIM\" --fileout file:B2G-RunIISummer16MiniAODv2-01593.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename B2G-RunIISummer16MiniAODv2-01593_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "9d1ace9d1b37fb0202c93baaca28202d",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-3000_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -1434,23 +1658,27 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [],
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-4000_13TeV-madgraph/RunIIWinter15wmLHE-MCRUN2_71_V1-v1/LHE",
+          "release": "CMSSW_7_1_16",
+          "type": "LHE"
+        },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-4000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-01815.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-01815_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "315e153b2d3225a9cd5c3ff68186ba50",
-              "process": "",
+              "cms_confdb_id": "2557f311e3275b75b2e1ea1cb1b2e449",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-4000_13TeV-madgraph/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_19",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -1459,13 +1687,13 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "18df0acce05f1d95a9d86ab8241f2b63",
-              "process": "",
+              "cms_confdb_id": "18df0acce05f1d95a9d86ab8241e7d33",
+              "process": "HLT",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "18df0acce05f1d95a9d86ab8241e7d33",
-              "process": "",
+              "cms_confdb_id": "18df0acce05f1d95a9d86ab8241f2b63",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
@@ -1473,8 +1701,26 @@
             "madgraph"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-4000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-4000_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-01815.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-01815_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "315e153b2d3225a9cd5c3ff68186ba50",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-4000_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -1576,23 +1822,27 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [],
+          "note": "To get the exact generator parameters, please see <a href=\"/docs/cms-mc-production-overview#finding-the-generator-parameters\">Finding the generator parameters</a>.",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-4500_13TeV-madgraph/RunIIWinter15wmLHE-MCRUN2_71_V1-v1/LHE",
+          "release": "CMSSW_7_1_16",
+          "type": "LHE"
+        },
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-4500_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-03778.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-03778_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "f48fdba7ddeedbdacad7b277ba72098b",
-              "process": "",
+              "cms_confdb_id": "c4d03e96b97e6067c54800f6779a6d78",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-4500_13TeV-madgraph/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_20",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -1602,12 +1852,12 @@
             },
             {
               "cms_confdb_id": "18df0acce05f1d95a9d86ab8241e7d33",
-              "process": "",
+              "process": "HLT",
               "title": "Configuration file"
             },
             {
               "cms_confdb_id": "18df0acce05f1d95a9d86ab8241f2b63",
-              "process": "",
+              "process": "RECO",
               "title": "Configuration file"
             }
           ],
@@ -1615,8 +1865,26 @@
             "madgraph"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-4500_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/BulkGravTohhTohbbhbb_narrow_M-4500_13TeV-madgraph/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:EXO-RunIISummer16MiniAODv2-03778.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename EXO-RunIISummer16MiniAODv2-03778_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "f48fdba7ddeedbdacad7b277ba72098b",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/BulkGravTohhTohbbhbb_narrow_M-4500_13TeV-madgraph/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -1718,23 +1986,20 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00058.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00058_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "2206482e3309b8511cb58602a76373f0",
-              "process": "",
+              "cms_confdb_id": "b51f8e75069872bae6c85134469190eb",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_20",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -1743,13 +2008,13 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "f03809e756223bdcac0be791dd71b654",
-              "process": "",
+              "cms_confdb_id": "3e5262e868a5cca32157c2c47bb93762",
+              "process": "RECO",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "3e5262e868a5cca32157c2c47bb93762",
-              "process": "",
+              "cms_confdb_id": "f03809e756223bdcac0be791dd71b654",
+              "process": "HLT",
               "title": "Configuration file"
             }
           ],
@@ -1757,8 +2022,26 @@
             "pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "RECO HLT"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00058.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00058_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "2206482e3309b8511cb58602a76373f0",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -1860,23 +2143,20 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00002.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00002_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "f63c282e2deedc5e7ec23a3df4d9e567",
-              "process": "",
+              "cms_confdb_id": "b51f8e75069872bae6c8513446927a37",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_20",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -1885,13 +2165,13 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "f03809e756223bdcac0be791dd71b654",
-              "process": "",
+              "cms_confdb_id": "3e5262e868a5cca32157c2c47bb93762",
+              "process": "RECO",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "3e5262e868a5cca32157c2c47bb93762",
-              "process": "",
+              "cms_confdb_id": "f03809e756223bdcac0be791dd71b654",
+              "process": "HLT",
               "title": "Configuration file"
             }
           ],
@@ -1899,8 +2179,26 @@
             "pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "RECO HLT"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00002.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00002_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "f63c282e2deedc5e7ec23a3df4d9e567",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -2002,23 +2300,20 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00043.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00043_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "f63c282e2deedc5e7ec23a3df4d9e567",
-              "process": "",
+              "cms_confdb_id": "b51f8e75069872bae6c85134469327d9",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_20",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -2028,12 +2323,12 @@
             },
             {
               "cms_confdb_id": "3e5262e868a5cca32157c2c47bb93762",
-              "process": "",
+              "process": "RECO",
               "title": "Configuration file"
             },
             {
               "cms_confdb_id": "f03809e756223bdcac0be791dd71b654",
-              "process": "",
+              "process": "HLT",
               "title": "Configuration file"
             }
           ],
@@ -2041,8 +2336,26 @@
             "pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "RECO HLT"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00043.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00043_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "f63c282e2deedc5e7ec23a3df4d9e567",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -2144,23 +2457,20 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00014.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00014_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "f63c282e2deedc5e7ec23a3df4d9e567",
-              "process": "",
+              "cms_confdb_id": "b51f8e75069872bae6c8513446a58f1b",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_20",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -2170,12 +2480,12 @@
             },
             {
               "cms_confdb_id": "3e5262e868a5cca32157c2c47bb93762",
-              "process": "",
+              "process": "RECO",
               "title": "Configuration file"
             },
             {
               "cms_confdb_id": "f03809e756223bdcac0be791dd71b654",
-              "process": "",
+              "process": "HLT",
               "title": "Configuration file"
             }
           ],
@@ -2183,8 +2493,26 @@
             "pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "RECO HLT"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00014.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00014_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "f63c282e2deedc5e7ec23a3df4d9e567",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -2286,23 +2614,20 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00016.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00016_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "46f5867b5cea01b6c3ea30a77fd1a004",
-              "process": "",
+              "cms_confdb_id": "b51f8e75069872bae6c8513446a6008d",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_20",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -2312,12 +2637,12 @@
             },
             {
               "cms_confdb_id": "3e5262e868a5cca32157c2c47bb93762",
-              "process": "",
+              "process": "RECO",
               "title": "Configuration file"
             },
             {
               "cms_confdb_id": "f03809e756223bdcac0be791dd71b654",
-              "process": "",
+              "process": "HLT",
               "title": "Configuration file"
             }
           ],
@@ -2325,8 +2650,26 @@
             "pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "RECO HLT"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00016.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00016_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "46f5867b5cea01b6c3ea30a77fd1a004",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -2428,23 +2771,20 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00018.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00018_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "f63c282e2deedc5e7ec23a3df4d9e567",
-              "process": "",
+              "cms_confdb_id": "b51f8e75069872bae6c8513446a6180f",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_20",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -2453,13 +2793,13 @@
               "title": "Production script"
             },
             {
-              "cms_confdb_id": "f03809e756223bdcac0be791dd71b654",
-              "process": "",
+              "cms_confdb_id": "3e5262e868a5cca32157c2c47bb93762",
+              "process": "RECO",
               "title": "Configuration file"
             },
             {
-              "cms_confdb_id": "3e5262e868a5cca32157c2c47bb93762",
-              "process": "",
+              "cms_confdb_id": "f03809e756223bdcac0be791dd71b654",
+              "process": "HLT",
               "title": "Configuration file"
             }
           ],
@@ -2467,8 +2807,26 @@
             "pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "RECO HLT"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00018.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00018_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "f63c282e2deedc5e7ec23a3df4d9e567",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -2570,23 +2928,20 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00019.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00019_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "f63c282e2deedc5e7ec23a3df4d9e567",
-              "process": "",
+              "cms_confdb_id": "90f43326f80fb63c4ff87f6368694948",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_20",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -2596,12 +2951,12 @@
             },
             {
               "cms_confdb_id": "3e5262e868a5cca32157c2c47bb93762",
-              "process": "",
+              "process": "RECO",
               "title": "Configuration file"
             },
             {
               "cms_confdb_id": "f03809e756223bdcac0be791dd71b654",
-              "process": "",
+              "process": "HLT",
               "title": "Configuration file"
             }
           ],
@@ -2609,8 +2964,26 @@
             "pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "RECO HLT"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00019.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00019_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "f63c282e2deedc5e7ec23a3df4d9e567",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -2712,23 +3085,20 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00034.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00034_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
-            },
-            {
-              "cms_confdb_id": "f63c282e2deedc5e7ec23a3df4d9e567",
-              "process": "",
+              "cms_confdb_id": "b51f8e75069872bae6c8513446aa50ac",
+              "process": "SIM",
               "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_20",
+          "type": "SIM"
         },
         {
           "configuration_files": [
@@ -2738,12 +3108,12 @@
             },
             {
               "cms_confdb_id": "3e5262e868a5cca32157c2c47bb93762",
-              "process": "",
+              "process": "RECO",
               "title": "Configuration file"
             },
             {
               "cms_confdb_id": "f03809e756223bdcac0be791dd71b654",
-              "process": "",
+              "process": "HLT",
               "title": "Configuration file"
             }
           ],
@@ -2751,8 +3121,26 @@
             "pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "RECO HLT"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00034.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00034_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "f63c282e2deedc5e7ec23a3df4d9e567",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -2868,25 +3256,46 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
+        {
+          "configuration_files": [
+            {
+              "cms_confdb_id": "b51f8e75069872bae6c8513446aac464",
+              "process": "SIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "",
+          "output_dataset": "/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8/RunIISummer15GS-MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_20",
+          "type": "SIM"
+        },
+        {
+          "configuration_files": [],
+          "output_dataset": "/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/AODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": ""
+        },
         {
           "configuration_files": [
             {
               "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v2/AODSIM\" --fileout file:BTV-RunIISummer16MiniAODv2-00045.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename BTV-RunIISummer16MiniAODv2-00045_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
               "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "2841cad1ab1ea0d683f04ea7b7f1f795",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
-        },
-        {
-          "configuration_files": [],
           "generators": [
             "pythia8"
           ],
-          "type": "GEN-SIM"
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },
@@ -3016,32 +3425,62 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>",
       "steps": [
         {
           "configuration_files": [
             {
-              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_magnetOn_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:JME-RunIISummer16MiniAODv2-00021.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename JME-RunIISummer16MiniAODv2-00021_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
-              "title": "Production script"
+              "cms_confdb_id": "1e816cad3c72514eb948a2551a16f00f",
+              "process": "SIM",
+              "title": "Configuration file"
             }
           ],
-          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
-          "release": "CMSSW_8_0_21",
-          "type": "RECO-HLT"
+          "global_tag": "",
+          "output_dataset": "/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/RunIISummer15GS-magnetOn_MCRUN2_71_V1-v1/GEN-SIM",
+          "release": "CMSSW_7_1_19",
+          "type": "SIM"
         },
         {
           "configuration_files": [
             {
               "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/RunIISummer15GS-magnetOn_MCRUN2_71_V1-v1/GEN-SIM\" --fileout file:JME-RunIISummer16DR80Premix-00011_step1.root  --pileup_input \"dbs:/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW\" --mc --eventcontent PREMIXRAW --datatier GEN-SIM-RAW --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step DIGIPREMIX_S2,DATAMIX,L1,DIGI2RAW,HLT:@frozen2016 --nThreads 4 --datamix PreMix --era Run2_2016 --python_filename JME-RunIISummer16DR80Premix-00011_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 169 || exit $? ; \n\ncmsDriver.py step2 --filein file:JME-RunIISummer16DR80Premix-00011_step1.root --fileout file:JME-RunIISummer16DR80Premix-00011.root --mc --eventcontent AODSIM --runUnscheduled --datatier AODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step RAW2DIGI,RECO,EI --nThreads 4 --era Run2_2016 --python_filename JME-RunIISummer16DR80Premix-00011_2_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 169 || exit $? ; \n\n",
               "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "ca6c66fc1969e8fb8ecf875d6d540598",
+              "process": "HLT",
+              "title": "Configuration file"
+            },
+            {
+              "cms_confdb_id": "ca6c66fc1969e8fb8ecf875d6d546a94",
+              "process": "RECO",
+              "title": "Configuration file"
             }
           ],
           "generators": [
             "Pythia8"
           ],
           "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_magnetOn_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM",
           "release": "CMSSW_8_0_21",
-          "type": "GEN-SIM"
+          "type": "HLT RECO"
+        },
+        {
+          "configuration_files": [
+            {
+              "script": "#!/bin/bash\nexport SCRAM_ARCH=slc6_amd64_gcc530\nsource /cvmfs/cms.cern.ch/cmsset_default.sh\nif [ -r CMSSW_8_0_21/src ] ; then \n echo release CMSSW_8_0_21 already exists\nelse\nscram p CMSSW CMSSW_8_0_21\nfi\ncd CMSSW_8_0_21/src\neval `scram runtime -sh`\n\n\nscram b\ncd ../../\ncmsDriver.py step1 --filein \"dbs:/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/RunIISummer16DR80Premix-PUMoriond17_magnetOn_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/AODSIM\" --fileout file:JME-RunIISummer16MiniAODv2-00021.root --mc --eventcontent MINIAODSIM --runUnscheduled --datatier MINIAODSIM --conditions 80X_mcRun2_asymptotic_2016_TrancheIV_v6 --step PAT --nThreads 4 --era Run2_2016 --python_filename JME-RunIISummer16MiniAODv2-00021_1_cfg.py --no_exec --customise Configuration/DataProcessing/Utils.addMonitoring -n 5760 || exit $? ; \n\n",
+              "title": "Production script"
+            },
+            {
+              "cms_confdb_id": "ca6c66fc1969e8fb8ecf875d6d54e0eb",
+              "process": "MINIAODSIM",
+              "title": "Configuration file"
+            }
+          ],
+          "global_tag": "80X_mcRun2_asymptotic_2016_TrancheIV_v6",
+          "output_dataset": "/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/RunIISummer16MiniAODv2-PUMoriond17_magnetOn_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/MINIAODSIM",
+          "release": "CMSSW_8_0_21",
+          "type": "MINIAODSIM"
         }
       ]
     },


### PR DESCRIPTION
* Updates configuration file extraction by consulting McM first and DAS second.
  Sorts configuration files alphabetically. (closes #2641)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
