### PR TITLE
records: final fixes to ML records

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-Run1-datascience.json
@@ -526,7 +526,7 @@
       ]
     },
     "usage": {
-      "description": "The use of these files does not require any software specific to the CMS experiment. An <a href=\"https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/tree/master/example\">example is provided</a> with the <a href=\"https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/README.md\">instructions how to run it</a>. The code reads the ntuples and produces a scatter plot of the rechits from three events."
+      "description": "The use of these files does not require any software specific to the CMS experiment. An <a href=\"https://github.com/cernopendata-datascience/TrackerRecHitMachineLearning\">example notebook</a> is provided. The code reads the ntuples and produces a scatter plot of the rechits from three events."
     }
   }
 ]

--- a/cernopendata/modules/fixtures/data/records/cms-derived-Run2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-Run2-datascience.json
@@ -417,7 +417,7 @@
       ]
     },
     "usage": {
-      "description": "The use of these files does not require any software specific to the CMS experiment. There are two sets of equivalent files in two different formats: ROOT and H5."
+      "description": "The use of these files does not require any software specific to the CMS experiment. There are two sets of equivalent files in two different formats: ROOT and H5.  An <a href=\"https://github.com/cernopendata-datascience/QCDJetsMachineLearning\">example notebook</a> is provided."
     }
   },
   {
@@ -1491,7 +1491,7 @@
       ]
     },
     "usage": {
-      "description": "The use of these files does not require any software specific to the CMS experiment. There are two sets of files in two different formats: ROOT and H5. For the H5 files, only information for up to 100 particle candidates, up to 60 charged particles or tracks, and up to 5 secondary vertices are stored in zero-padded arrays."
+      "description": "The use of these files does not require any software specific to the CMS experiment. There are two sets of files in two different formats: ROOT and H5. For the H5 files, only information for up to 100 particle candidates, up to 60 charged particles or tracks, and up to 5 secondary vertices are stored in zero-padded arrays. An <a href=\"https://github.com/cernopendata-datascience/HiggsToBBMachineLearning\">example notebook</a> is provided."
     }
   }
 ]

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Phase2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Phase2-datascience.json
@@ -1,7 +1,7 @@
 [
   {
     "abstract": {
-      "description": "<p>Simulated dataset TTToHadronic_TuneCP5_13TeV-powheg-pythia8 in GEN-SIM (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>) format for LHC Phase2 studies. This dataset is the input to the following step in the production chain. </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data that will be collected by the CMS experiment during Phase2.</p> <p>They were released in the context of data science sample production.  </p>"
+      "description": "<p>Simulated dataset TTToHadronic_TuneCP5_13TeV-powheg-pythia8 in GEN-SIM format (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>) for LHC Phase2 studies. This dataset is the input to the following step in the production chain. </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>This simulated dataset corresponds to the collision data that will be collected by the CMS experiment during Phase2 and it was released in the context of data science sample production.  </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -22,7 +22,7 @@
       "type": "pp"
     },
     "date_created": [
-      "2019"
+      "Phase2"
     ],
     "date_published": "2019",
     "date_reprocessed": "2019",
@@ -40,7 +40,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>This is the first step in the production chain (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n                           ",
       "steps": [
         {
           "configuration_files": [
@@ -105,7 +105,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset TTToHadronic_TuneCP5_13TeV-powheg-pythia8 in FEVTDEBUGHLT format (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a> and <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideTrackingTruth\">information about FEVTDEBUG</a>) for LHC Phase2 studies. This dataset is used as the input in <a href=\"/record/12310\">ML studies</a>). </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data that will be collected by the CMS experiment during Phase2.</p> <p>They were released in the context of data science sample production.  </p>"
+      "description": "<p>Simulated dataset TTToHadronic_TuneCP5_13TeV-powheg-pythia8 in FEVTDEBUGHLT format (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a> and <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideTrackingTruth\">information about FEVTDEBUG</a>) for LHC Phase2 studies. This dataset is used as the input in <a href=\"/record/12310\">ML studies</a>. </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>This simulated dataset corresponds to the collision data that will be collected by the CMS experiment during Phase2 and it was released in the context of data science sample production.  </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -126,7 +126,7 @@
       "type": "pp"
     },
     "date_created": [
-      "2019"
+      "Phase2"
     ],
     "date_published": "2019",
     "date_reprocessed": "2019",
@@ -144,7 +144,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>). The input dataset to this step is in <a href=\"/record/12300\">Simulated dataset TTToHadronic_TuneCP5_13TeV-powheg-pythia8 in GEN-SIM format</a>, and the production step of this dataset is: </p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>). The input dataset to this step is in <a href=\"/record/12300\">Simulated dataset TTToHadronic_TuneCP5_13TeV-powheg-pythia8 in GEN-SIM format</a>, and the production step of this dataset is: </p>\n                           ",
       "steps": [
         {
           "configuration_files": [
@@ -217,7 +217,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset TTToHadronic_TuneCP5_13TeV-powheg-pythia8 in GEN-SIM-DIGI-RAW (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>) format for LHC Phase2 studies. This dataset is used as the input in <a href=\"/record/12310\">ML studies</a>). </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data that will be collected by the CMS experiment during Phase2.</p> <p>They were released in the context of data science sample production.  </p>"
+      "description": "<p>Simulated dataset TTToHadronic_TuneCP5_13TeV-powheg-pythia8 in GEN-SIM-DIGI-RAW format (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>) for LHC Phase2 studies. This dataset is used as the input in <a href=\"/record/12310\">ML studies</a>. </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>This simulated dataset corresponds to the collision data that will be collected by the CMS experiment during Phase2 and it was released in the context of data science sample production.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -238,7 +238,7 @@
       "type": "pp"
     },
     "date_created": [
-      "2019"
+      "Phase2"
     ],
     "date_published": "2019",
     "date_reprocessed": "2019",
@@ -256,7 +256,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>). The input dataset to this step is in <a href=\"/record/12300\">Simulated dataset TTToHadronic_TuneCP5_13TeV-powheg-pythia8 in FEVTDEBUGHLT format</a>, and the production step of this dataset is: </p>\n                           ",
+      "description": "<p>These data were generated in several steps (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>). The input dataset to this step is in <a href=\"/record/12300\">Simulated dataset TTToHadronic_TuneCP5_13TeV-powheg-pythia8 in FEVTDEBUGHLT format</a>, and the production step of this dataset is: </p>\n                           ",
       "steps": [
         {
           "configuration_files": [
@@ -328,7 +328,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset MinBias_TuneCP5_13TeV-pythia8 in GEN-SIM (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>) format for LHC Phase2 studies. Events are sampled from this dataset and added to simulated data to make them comparable with the Phase2 collision data, see <a href=\"/docs/cms-guide-pileup-simulation\">the guide to pile-up simulation</a>. </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data that will be collected by the CMS experiment during Phase2.</p> <p>They were released in the context of data science sample production.  </p>"
+      "description": "<p>Simulated dataset MinBias_TuneCP5_13TeV-pythia8 in GEN-SIM format (see <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>) for LHC Phase2 studies. Events are sampled from this dataset and added to simulated data to make them comparable with the Phase2 collision data, see <a href=\"/docs/cms-guide-pileup-simulation\">the guide to pile-up simulation</a>. </p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>This simulated dataset corresponds to the collision data that will be collected by the CMS experiment during Phase2 and it was released in the context of data science sample production. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -349,7 +349,7 @@
       "type": "pp"
     },
     "date_created": [
-      "2019"
+      "Phase2"
     ],
     "date_published": "2019",
     "date_reprocessed": "2019",
@@ -367,7 +367,7 @@
       "attribution": "CC0"
     },
     "methodology": {
-      "description": "<p>These data were processed with (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo Production Overview</a>):</p>\n                           ",
+      "description": "<p>These data were processed with (see also <a href=\"/docs/cms-mc-production-overview\">CMS Monte Carlo production overview</a>):</p>\n                           ",
       "steps": [
         {
           "configuration_files": [

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run1-datascience.json
@@ -1,7 +1,7 @@
 [
   {
     "abstract": {
-      "description": "<p>Simulated dataset TTJets_HadronicMGDecays_8TeV-madgraph with boosted jets, enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
+      "description": "<p>Simulated dataset TTJets_HadronicMGDecays_8TeV-madgraph with boosted jets, enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -49,7 +49,8 @@
           "configuration_files": [
             {
               "process": "SIM",
-              "title": "Modified SIM config to force all-jets decays and pT of both of the tops > 400 GeV and to keep simulated tracks from <a href=\"https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_ttbar.py\">step0_ttbar.py</a>"
+              "title": "Configuration file for SIM step step0_ttbar.py",
+              "url": "https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool/blob/v12.0.0/configs/step0_ttbar.py"
             }
           ],
           "global_tag": "START53_V27",
@@ -60,11 +61,13 @@
           "configuration_files": [
             {
               "process": "HLT",
-              "title": "Modified configuration file for HLT step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
+              "title": "Configuration file for HLT step step1.py",
+              "url": "https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool/blob/v12.0.0/configs/step1.py"
             },
             {
               "process": "RECO",
-              "title": "Modified configuration file for RECO step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
+              "title": "Configuration file for RECO step step2.py",
+              "url": "https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool/blob/v12.0.0/configs/step2.py"
             }
           ],
           "global_tag": "START53_V27",
@@ -131,7 +134,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset for the 300 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
+      "description": "<p>Simulated dataset for the 300 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -179,7 +182,8 @@
           "configuration_files": [
             {
               "process": "SIM",
-              "title": "Modified SIM config to keep simulated tracks from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_QCD300to600.py"
+              "title": "Configuration file for SIM step step0_QCD300to600.py",
+              "url": "https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool/blob/v12.0.0/configs/step0_QCD300to600.py"
             }
           ],
           "global_tag": "START53_V27",
@@ -190,11 +194,13 @@
           "configuration_files": [
             {
               "process": "HLT",
-              "title": "Modified configuration file for HLT step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
+              "title": "Configuration file for HLT step step1.py",
+              "url": "https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool/blob/v12.0.0/configs/step1.py"
             },
             {
               "process": "RECO",
-              "title": "Modified configuration file for RECO step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
+              "title": "Configuration file for RECO step step2.py",
+              "url": "https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool/blob/v12.0.0/configs/step2.py"
             }
           ],
           "global_tag": "START53_V27",
@@ -239,7 +245,7 @@
         "Simulated"
       ]
     },
-     "usage": {
+    "usage": {
       "description": "You can access these data through the CMS Virtual Machine. See the instructions below for setting up the Virtual Machine and getting started. The dataset can also be used as an input to the final step of the workflow to produce ROOT ntuples with full event information for ML studies.",
       "links": [
         {
@@ -261,7 +267,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset for the 400 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
+      "description": "<p>Simulated dataset for the 400 to 600 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -309,7 +315,8 @@
           "configuration_files": [
             {
               "process": "SIM",
-              "title": "Modified SIM config to keep simulated tracks from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_QCD400to600.py"
+              "title": "Configuration file for SIM step step0_QCD400to600.py",
+              "url": "https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool/blob/v12.0.0/configs/step0_QCD400to600.py"
             }
           ],
           "global_tag": "START53_V27",
@@ -320,11 +327,13 @@
           "configuration_files": [
             {
               "process": "HLT",
-              "title": "Modified configuration file for HLT step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
+              "title": "Configuration file for HLT step step1.py",
+              "url": "https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool/blob/v12.0.0/configs/step1.py"
             },
             {
               "process": "RECO",
-              "title": "Modified configuration file for RECO step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
+              "title": "Configuration file for RECO step step2.py",
+              "url": "https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool/blob/v12.0.0/configs/step2.py"
             }
           ],
           "global_tag": "START53_V27",
@@ -369,7 +378,7 @@
         "Simulated"
       ]
     },
-     "usage": {
+    "usage": {
       "description": "You can access these data through the CMS Virtual Machine. See the instructions below for setting up the Virtual Machine and getting started. The dataset can also be used as an input to the final step of the workflow to produce ROOT ntuples with full event information for ML studies.",
       "links": [
         {
@@ -391,7 +400,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset for the 600 to 3000 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
+      "description": "<p>Simulated dataset for the 600 to 3000 bin of QCD_Pt-15to3000_TuneZ2star_Flat_8TeV_pythia6 enriched with simulated tracks and tracker hit data for tracking algorithm studies in AODSIM format for 2012 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2012. They are in the standard CMS AODSIM format plus a series of low-level tracker-related collections that allow the extraction of the tracker hits. They were released in the context of data science sample production.</p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -439,7 +448,8 @@
           "configuration_files": [
             {
               "process": "SIM",
-              "title": "Modified SIM config to keep simulated tracks from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step0_QCD600to3000.py"
+              "title": "Configuration file for SIM step step0_QCD600to3000.py",
+              "url": "https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool/blob/v12.0.0/configs/step0_QCD600to3000.py"
             }
           ],
           "global_tag": "START53_V27",
@@ -450,11 +460,13 @@
           "configuration_files": [
             {
               "process": "HLT",
-              "title": "Modified configuration file for HLT step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step1.py"
+              "title": "Configuration file for HLT step step1.py",
+              "url": "https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool/blob/v12.0.0/configs/step1.py"
             },
             {
               "process": "RECO",
-              "title": "Modified configuration file for RECO step to keep tracker recHits from https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool/blob/master/configs/step2.py"
+              "title": "Configuration file for RECO step step2.py",
+              "url": "https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool/blob/v12.0.0/configs/step2.py"
             }
           ],
           "global_tag": "START53_V27",

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2-datascience.json
@@ -1,7 +1,7 @@
 [
   {
     "abstract": {
-      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-600_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-600_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -109,6 +109,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12000",
     "run_period": [
@@ -152,7 +155,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-1000_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-1000_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -260,6 +263,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12001",
     "run_period": [
@@ -303,7 +309,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-1200_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-1200_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -424,6 +430,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12002",
     "run_period": [
@@ -467,7 +476,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-1400_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-1400_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -588,6 +597,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12003",
     "run_period": [
@@ -631,7 +643,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-1600_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-1600_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -752,6 +764,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12004",
     "run_period": [
@@ -795,7 +810,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -930,6 +945,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12005",
     "run_period": [
@@ -973,7 +991,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1094,6 +1112,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12006",
     "run_period": [
@@ -1137,7 +1158,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1245,6 +1266,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12007",
     "run_period": [
@@ -1288,7 +1312,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-2500_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-2500_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1409,6 +1433,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12008",
     "run_period": [
@@ -1452,7 +1479,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-3000_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-3000_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1560,6 +1587,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12009",
     "run_period": [
@@ -1603,7 +1633,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-4000_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-4000_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1724,6 +1754,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12010",
     "run_period": [
@@ -1767,7 +1800,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-4500_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset BulkGravTohhTohbbhbb_narrow_M-4500_13TeV-madgraph in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -1888,6 +1921,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12011",
     "run_period": [
@@ -1931,7 +1967,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2045,6 +2081,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12012",
     "run_period": [
@@ -2088,7 +2127,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2202,6 +2241,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12013",
     "run_period": [
@@ -2245,7 +2287,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2359,6 +2401,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12014",
     "run_period": [
@@ -2402,7 +2447,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2516,6 +2561,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12015",
     "run_period": [
@@ -2559,7 +2607,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2673,6 +2721,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12016",
     "run_period": [
@@ -2716,7 +2767,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2830,6 +2881,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12017",
     "run_period": [
@@ -2873,7 +2927,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -2987,6 +3041,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12018",
     "run_period": [
@@ -3030,7 +3087,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -3144,6 +3201,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12019",
     "run_period": [
@@ -3187,7 +3247,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -3299,6 +3359,9 @@
         }
       ]
     },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
+    },
     "publisher": "CERN Open Data Portal",
     "recid": "12020",
     "run_period": [
@@ -3342,7 +3405,7 @@
   },
   {
     "abstract": {
-      "description": "<p>Simulated dataset QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated datasets correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM in these datasets may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
+      "description": "<p>Simulated dataset QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8 in <a href=\"https://twiki.cern.ch/twiki/bin/view/CMSPublic/WorkBookMiniAOD2016\">MINIAODSIM</a> format for 2016 collision data.</p><p>See the description of the simulated dataset names in: <a href=\"/about/CMS-Simulated-Dataset-Names\">About CMS simulated dataset names</a>.</p> <p>These simulated data correspond to the collision data collected by the CMS experiment in 2016.</p> <p>They were released in the context of data science sample production. The contents of MINIAODSIM may differ from the final legacy format used in CMS Run2 simulated datasets. </p>"
     },
     "accelerator": "CERN-LHC",
     "categories": {
@@ -3483,6 +3546,9 @@
           "type": "MINIAODSIM"
         }
       ]
+    },
+    "pileup": {
+      "description": "<p>To make these simulated data comparable with the collision data, <a href=\"/docs/cms-guide-pileup-simulation\">pile-up events</a> from the dataset <code>/Neutrino_E-10_gun/RunIISpring15PrePremix-PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v2-v2/GEN-SIM-DIGI-RAW</code> are added to the simulated event in this step.</p>"
     },
     "publisher": "CERN Open Data Portal",
     "recid": "12021",

--- a/cernopendata/modules/fixtures/data/records/cms-tools-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-Run1-datascience.json
@@ -1,7 +1,7 @@
 [
   {
     "abstract": {
-      "description": "An example workflow to produce CMS Run1 AODSIM enriched with tracker RecHits. All steps from event generation to reconstruction (step0-step2) are provided, including instructions how to store Tracker RecHit information from CMS full simulation events, and the tool to extract the information in a format appropriate to ML studies (step3) is included. The code can be run inside the CMS Open Data environment."
+      "description": "An example workflow to produce CMS Run1 AODSIM enriched with tracker RecHits. All steps from event generation to reconstruction (step0-step2) are provided, including instructions how to store Tracker RecHit information from CMS full simulation events, and the tool to extract the information in a format appropriate to ML studies (step3) is included. The code can be run inside the CMS Open Data environment. The following diagram shows the steps in the workflow:\n <p align=\"center\"> <img alt=\"Production workflow\" src=\"/eos/opendata/cms/software/TrackerRecHitProducerTool/production-workflow.png\"  width=\"85%\"> </p>"
     },
     "accelerator": "CERN-LHC",
     "authors": [


### PR DESCRIPTION
(addresses #2655)
(closes #2654)

Fixes to Phase2 MC records:
- date_created Phase2 (2019 makes no sense to indicate the year data taking)
- text improvements in the description

Fixes to Run1 SW record:
- add workflow figure
- add links to usage examples in cernopendata-datascience repositories

Fixes to Run1 MC records
- abstract text
- add url to configs (fixes legacydata -> opendata, and master -> v12.0.0 in config links)

Fixes to Run2 MiniAODSIM
- abstract text (plural/singular)
- add mention of pileup events