### PR TITLE
nginx: more file types for EOS HTTP gateway

### DIFF
--- a/nginx/cernopendata.conf
+++ b/nginx/cernopendata.conf
@@ -57,8 +57,8 @@ server {
     }
 
     # Old reverse proxy to EOS locations used from COD2 times. (Not advertised
-    # much in COD3 times anymore, but it is good to keep it to serve old URLs.)
-    location ~* /eos/opendata/(alice|atlas|lhcb|cms|opera)/.*\.(root|tgz|zip)$ {
+    # much in COD3 times anymore, but still useful to have.)
+    location ~* /eos/opendata/(alice|atlas|lhcb|cms|opera)/.*\.[a-zA-Z0-9]+$ {
         proxy_cache off;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header Host $host;


### PR DESCRIPTION
* Accepts more file types when using the EOS HTTP gateway. (closes #2658)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>