### PR TITLE
records: remove cmsdriver script from CASTOR MC provenance

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010-commissioning.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-2010-commissioning.json
@@ -45,10 +45,6 @@
         {
           "configuration_files": [
             {
-              "script": "cmsDriver.py Configuration/GenProduction/python/MinBias_TuneZ2_900GeV_pythia6_cff.py --step GEN,SIM --beamspot Realistic900GeVCollision --conditions START311_V2::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/SimWithCastor_cff.customise --eventcontent RAWSIM --datatier GEN-SIM --no_exec  \n\n",
-              "title": "Production script (manual adjustment of CASTOR non compensation)"
-            },
-            {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/MinBias_TuneZ2_900GeV_pythia6_cff_py_GEN_SIM.py",
               "title": "Configuration file"
             }
@@ -60,16 +56,8 @@
         {
           "configuration_files": [
             {
-              "script": "cmsDriver.py REDIGI --step DIGI,L1,DIGI2RAW,HLT:GRun --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/DigiToRecoNoPU.customise --eventcontent RAWSIM --datatier GEN-SIM-RAW —no_exec  \n\n",
-              "title": "Production script"
-            },
-            {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/REDIGI_DIGI_L1_DIGI2RAW_HLT.py",
               "title": "Configuration file for HLT step"
-            },
-            {
-              "script": "cmsDriver.py STEP2 --step RAW2DIGI,L1Reco,RECO --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC --eventcontent RECOSIM --datatier GEN-SIM-RECO —no_exec  \n\n",
-              "title": "Production script (manual inclusion of specific beamspot settings)"
             },
             {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/STEP2_RAW2DIGI_L1Reco_RECO_900GeV.py",
@@ -162,10 +150,6 @@
         {
           "configuration_files": [
             {
-              "script": "cmsDriver.py Configuration/GenProduction/python/MinBias_TuneZ2_2760GeV_pythia6_cff.py --step GEN,SIM --beamspot Realistic2p76TeV2011Collision --conditions START311_V2::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/SimWithCastor_cff.customise --eventcontent RAWSIM --datatier GEN-SIM --no_exec  \n\n",
-              "title": "Production script (manual adjustment of CASTOR non compensation)"
-            },
-            {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/MinBias_TuneZ2_2760GeV_pythia6_cff_py_GEN_SIM.py",
               "title": "Configuration file"
             }
@@ -177,16 +161,8 @@
         {
           "configuration_files": [
             {
-              "script": "cmsDriver.py REDIGI --step DIGI,L1,DIGI2RAW,HLT:GRun --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/DigiToRecoNoPU.customise --eventcontent RAWSIM --datatier GEN-SIM-RAW —no_exec  \n\n",
-              "title": "Production script"
-            },
-            {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/REDIGI_DIGI_L1_DIGI2RAW_HLT.py",
               "title": "Configuration file for HLT step"
-            },
-            {
-              "script": "cmsDriver.py STEP2 --step RAW2DIGI,L1Reco,RECO --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC --eventcontent RECOSIM --datatier GEN-SIM-RECO —no_exec  \n\n",
-              "title": "Production script (manual inclusion of specific beamspot settings)"
             },
             {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/STEP2_RAW2DIGI_L1Reco_RECO_2760GeV.py",
@@ -279,10 +255,6 @@
         {
           "configuration_files": [
             {
-              "script": "cmsDriver.py Configuration/GenProduction/python/MinBias_TuneZ2_7TeV_pythia6_cff.py --step GEN,SIM --beamspot Realistic7TeVCollision --conditions START311_V2::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/SimWithCastor_cff.customise --eventcontent RAWSIM -- datatier GEN-SIM —no_exec  \n\n",
-              "title": "Production script (manual adjustment of CASTOR non compensation)"
-            },
-            {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/MinBias_TuneZ2_7TeV_pythia6_cff_py_GEN_SIM.py",
               "title": "Configuration file"
             }
@@ -294,16 +266,8 @@
         {
           "configuration_files": [
             {
-              "script": "cmsDriver.py REDIGI --step DIGI,L1,DIGI2RAW,HLT:GRun --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/DigiToRecoNoPU.customise --eventcontent RAWSIM --datatier GEN-SIM-RAW —no_exec  \n\n",
-              "title": "Production script"
-            },
-            {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/REDIGI_DIGI_L1_DIGI2RAW_HLT.py",
               "title": "Configuration file for HLT step"
-            },
-            {
-              "script": "cmsDriver.py STEP2 --step RAW2DIGI,L1Reco,RECO --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC --eventcontent RECOSIM --datatier GEN-SIM-RECO —no_exec  \n\n",
-              "title": "Production script (manual inclusion of specific beamspot settings)"
             },
             {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/STEP2_RAW2DIGI_L1Reco_RECO_7TeV.py",
@@ -396,10 +360,6 @@
         {
           "configuration_files": [
             {
-              "script": "cmsDriver.py Configuration/GenProduction/python/MinBias_Tune4C_900GeV_pythia8_cff.py --step GEN,SIM --beamspot Realistic900GeVCollision --conditions START311_V2::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/SimWithCastor_cff.customise --eventcontent RAWSIM --datatier GEN-SIM --no_exec  \n\n",
-              "title": "Production script (manual adjustment of CASTOR non compensation)"
-            },
-            {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/MinBias_Tune4C_900GeV_pythia8_cff_py_GEN_SIM.py",
               "title": "Configuration file"
             }
@@ -411,16 +371,8 @@
         {
           "configuration_files": [
             {
-              "script": "cmsDriver.py REDIGI --step DIGI,L1,DIGI2RAW,HLT:GRun --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/DigiToRecoNoPU.customise --eventcontent RAWSIM --datatier GEN-SIM-RAW —no_exec  \n\n",
-              "title": "Production script"
-            },
-            {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/REDIGI_DIGI_L1_DIGI2RAW_HLT.py",
               "title": "Configuration file for HLT step"
-            },
-            {
-              "script": "cmsDriver.py STEP2 --step RAW2DIGI,L1Reco,RECO --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC --eventcontent RECOSIM --datatier GEN-SIM-RECO —no_exec  \n\n",
-              "title": "Production script (manual inclusion of specific beamspot settings)"
             },
             {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/STEP2_RAW2DIGI_L1Reco_RECO_900GeV.py",
@@ -513,10 +465,6 @@
         {
           "configuration_files": [
             {
-              "script": "cmsDriver.py Configuration/GenProduction/python/MinBias_Tune4C_2760GeV_pythia8_cff.py --step GEN,SIM --beamspot Realistic2p76TeV2011Collision --conditions START311_V2::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/SimWithCastor_cff.customise --eventcontent RAWSIM --datatier GEN-SIM --no_exec  \n\n",
-              "title": "Production script (manual adjustment of CASTOR non compensation)"
-            },
-            {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/MinBias_Tune4C_2760GeV_pythia8_cff_py_GEN_SIM.py",
               "title": "Configuration file"
             }
@@ -528,16 +476,8 @@
         {
           "configuration_files": [
             {
-              "script": "cmsDriver.py REDIGI --step DIGI,L1,DIGI2RAW,HLT:GRun --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/DigiToRecoNoPU.customise --eventcontent RAWSIM --datatier GEN-SIM-RAW —no_exec  \n\n",
-              "title": "Production script"
-            },
-            {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/REDIGI_DIGI_L1_DIGI2RAW_HLT.py",
               "title": "Configuration file for HLT step"
-            },
-            {
-              "script": "cmsDriver.py STEP2 --step RAW2DIGI,L1Reco,RECO --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC --eventcontent RECOSIM --datatier GEN-SIM-RECO —no_exec  \n\n",
-              "title": "Production script (manual inclusion of specific beamspot settings)"
             },
             {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/STEP2_RAW2DIGI_L1Reco_RECO_2760GeV.py",
@@ -630,10 +570,6 @@
         {
           "configuration_files": [
             {
-              "script": "cmsDriver.py Configuration/GenProduction/python/MinBias_Tune4C_7TeV_pythia8_cff.py --step GEN,SIM --beamspot Realistic7TeVCollision --conditions START311_V2::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/SimWithCastor_cff.customise --eventcontent RAWSIM -- datatier GEN-SIM —no_exec  \n\n",
-              "title": "Production script (manual adjustment of CASTOR non compensation)"
-            },
-            {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/MinBias_Tune4C_7TeV_pythia8_cff_py_GEN_SIM.py",
               "title": "Configuration file"
             }
@@ -645,16 +581,8 @@
         {
           "configuration_files": [
             {
-              "script": "cmsDriver.py REDIGI --step DIGI,L1,DIGI2RAW,HLT:GRun --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/StandardSequences/DigiToRecoNoPU.customise --eventcontent RAWSIM --datatier GEN-SIM-RAW —no_exec  \n\n",
-              "title": "Production script"
-            },
-            {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/REDIGI_DIGI_L1_DIGI2RAW_HLT.py",
               "title": "Configuration file for HLT step"
-            },
-            {
-              "script": "cmsDriver.py STEP2 --step RAW2DIGI,L1Reco,RECO --conditions START42_V11::All --pileup NoPileUp --datamix NODATAMIXER --customise Configuration/GlobalRuns/reco_TLR_42X.customisePPMC --eventcontent RECOSIM --datatier GEN-SIM-RECO —no_exec  \n\n",
-              "title": "Production script (manual inclusion of specific beamspot settings)"
             },
             {
               "url": "http://opendata.cern.ch/eos/opendata/cms/configuration-files/MonteCarloCASTOR/STEP2_RAW2DIGI_L1Reco_RECO_7TeV.py",


### PR DESCRIPTION
(closes #2677)

Removes cmsdriver script from the CASTOR MC provenance (conflicts with the config files) as agreed with Hans

