### PR TITLE
records: CMS data science file indexes

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-Phase2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-Phase2-datascience.json
@@ -3141,9 +3141,108 @@
       "formats": [
         "h5"
       ],
-      "number_files": 472
+      "number_files": 472,
+      "size": 153564646898
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:bcbb6b7b",
+        "size": 14475,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_detachedTripletStepHitDoublets_h5_file_index.json"
+      },
+      {
+        "checksum": "adler32:c1919534",
+        "size": 7397,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_detachedTripletStepHitDoublets_h5_file_index.txt"
+      },
+      {
+        "checksum": "adler32:3f6cb3dd",
+        "size": 15533,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_highPtTripletStepHitDoublets_h5_file_index.json"
+      },
+      {
+        "checksum": "adler32:78365889",
+        "size": 7940,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_highPtTripletStepHitDoublets_h5_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c2baca71",
+        "size": 14933,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_initialStepHitDoublets_h5_file_index.json"
+      },
+      {
+        "checksum": "adler32:206ce21e",
+        "size": 7640,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_initialStepHitDoublets_h5_file_index.txt"
+      },
+      {
+        "checksum": "adler32:59f3627b",
+        "size": 13012,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_lowPtQuadStepHitDoublets_h5_file_index.json"
+      },
+      {
+        "checksum": "adler32:f8e87a77",
+        "size": 6655,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_lowPtQuadStepHitDoublets_h5_file_index.txt"
+      },
+      {
+        "checksum": "adler32:b4960f92",
+        "size": 12656,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_lowPtTripletStepHitDoublets_h5_file_index.json"
+      },
+      {
+        "checksum": "adler32:dad34140",
+        "size": 6470,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_lowPtTripletStepHitDoublets_h5_file_index.txt"
+      },
+      {
+        "checksum": "adler32:488e8774",
+        "size": 15346,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_mixedTripletStepHitDoublets_h5_file_index.json"
+      },
+      {
+        "checksum": "adler32:93c6497f",
+        "size": 7890,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_mixedTripletStepHitDoublets_h5_file_index.txt"
+      },
+      {
+        "checksum": "adler32:628c347a",
+        "size": 41684,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_pixelTracksDoublets_h5_file_index.json"
+      },
+      {
+        "checksum": "adler32:42dd55dd",
+        "size": 21338,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_pixelTracksDoublets_h5_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c8456993",
+        "size": 15283,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_tripletElectronHitDoublets_h5_file_index.json"
+      },
+      {
+        "checksum": "adler32:f7ab3881",
+        "size": 7840,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/CNNPixelSeedsProducerTool/TTbar_13TeV_PU50_PixelSeeds/file-indexes/TTbar_13TeV_PU50_PixelSeeds_tripletElectronHitDoublets_h5_file_index.txt"
+      }
+    ],
     "keywords": [
       "datascience"
     ],

--- a/cernopendata/modules/fixtures/data/records/cms-derived-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-Run1-datascience.json
@@ -471,11 +471,172 @@
     ],
     "date_published": "2019",
     "distribution": {
+      "files": 49261,
       "formats": [
         "root"
-      ]
+      ],
+      "number_events": 9430509,
+      "size": 46506200944051
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:086d958e",
+        "size": 1358722,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD300to600_RunI_8TeV/file-indexes/QCD300to600_RunI_8TeV_step2_QCD300to600_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:038de28f",
+        "size": 729416,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD300to600_RunI_8TeV/file-indexes/QCD300to600_RunI_8TeV_step2_QCD300to600_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:bcfd6024",
+        "size": 681411,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD300to600_RunI_8TeV/file-indexes/QCD300to600_RunI_8TeV_step3_QCD300to600_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:a0c569c2",
+        "size": 366912,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD300to600_RunI_8TeV/file-indexes/QCD300to600_RunI_8TeV_step3_QCD300to600_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:9a1b6a98",
+        "size": 901683,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD400to600_RunI_8TeV/file-indexes/QCD400to600_RunI_8TeV_step2_QCD400to600_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:eb1f842e",
+        "size": 483990,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD400to600_RunI_8TeV/file-indexes/QCD400to600_RunI_8TeV_step2_QCD400to600_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f81225b4",
+        "size": 904998,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD400to600_RunI_8TeV/file-indexes/QCD400to600_RunI_8TeV_step3_QCD400to600_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:77b6097d",
+        "size": 487305,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD400to600_RunI_8TeV/file-indexes/QCD400to600_RunI_8TeV_step3_QCD400to600_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:52f65fcb",
+        "size": 1524800,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step2_QCD_600to3000_01_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:9a783075",
+        "size": 827178,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step2_QCD_600to3000_01_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c81f96b5",
+        "size": 1507052,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step2_QCD_600to3000_02_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:3ade96f1",
+        "size": 817550,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step2_QCD_600to3000_02_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:da23101e",
+        "size": 1363728,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step3_QCD600to3000_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:91d081b2",
+        "size": 738891,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step3_QCD600to3000_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:2031f3d9",
+        "size": 870939,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_01_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:44dc434c",
+        "size": 458561,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_01_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:6ea4cc1a",
+        "size": 817083,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_02_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:4134eaa2",
+        "size": 430205,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_02_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:168977d6",
+        "size": 877803,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_03_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:c24682ec",
+        "size": 462175,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_03_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f1e2bcae",
+        "size": 864075,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_04_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:5d404345",
+        "size": 454947,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_04_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5fbcf729",
+        "size": 851403,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_05_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:c249ce18",
+        "size": 448275,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_05_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:a8b2ebf6",
+        "size": 1069343,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step3_ttbarOD_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:efb6e134",
+        "size": 555535,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step3_ttbarOD_root_file_index.txt"
+      }
+    ],
     "keywords": [
       "datascience"
     ],

--- a/cernopendata/modules/fixtures/data/records/cms-derived-Run2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-Run2-datascience.json
@@ -361,28 +361,28 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:4d096eae",
-        "size": 32558,
+        "checksum": "adler32:ed270190",
+        "size": 34511,
         "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/JetNTuple_QCD_RunII_13TeV_MC/file-indexes/CMS_JetNTuple_QCD_RunII_13TeV_MC_h5_file_index.json"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/JetNtupleProducerTool/JetNTuple_QCD_RunII_13TeV_MC/file-indexes/JetNTuple_QCD_RunII_13TeV_MC_h5_file_index.json"
       },
       {
-        "checksum": "adler32:7d368ee3",
-        "size": 15020,
+        "checksum": "adler32:36f85ea5",
+        "size": 17460,
         "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/JetNTuple_QCD_RunII_13TeV_MC/file-indexes/CMS_JetNTuple_QCD_RunII_13TeV_MC_h5_file_index.txt"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/JetNtupleProducerTool/JetNTuple_QCD_RunII_13TeV_MC/file-indexes/JetNTuple_QCD_RunII_13TeV_MC_h5_file_index.txt"
       },
       {
-        "checksum": "adler32:b89578d0",
-        "size": 32964,
+        "checksum": "adler32:778d5e24",
+        "size": 35161,
         "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/JetNTuple_QCD_RunII_13TeV_MC/file-indexes/CMS_JetNTuple_QCD_RunII_13TeV_MC_root_file_index.json"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/JetNtupleProducerTool/JetNTuple_QCD_RunII_13TeV_MC/file-indexes/JetNTuple_QCD_RunII_13TeV_MC_root_file_index.json"
       },
       {
-        "checksum": "adler32:c1e21b88",
-        "size": 15264,
+        "checksum": "adler32:421b3dbc",
+        "size": 17948,
         "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/JetNTuple_QCD_RunII_13TeV_MC/file-indexes/CMS_JetNTuple_QCD_RunII_13TeV_MC_root_file_index.txt"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/JetNtupleProducerTool/JetNTuple_QCD_RunII_13TeV_MC/file-indexes/JetNTuple_QCD_RunII_13TeV_MC_root_file_index.txt"
       }
     ],
     "keywords": [
@@ -1311,52 +1311,52 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:a216a983",
-        "size": 2199,
+        "checksum": "adler32:f71e044f",
+        "size": 2433,
         "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_test_h5_file_index.json"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNtupleProducerTool/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_test_h5_file_index.json"
       },
       {
-        "checksum": "adler32:92e29105",
-        "size": 1116,
+        "checksum": "adler32:0d8eebc2",
+        "size": 1350,
         "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_test_h5_file_index.txt"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNtupleProducerTool/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_test_h5_file_index.txt"
       },
       {
-        "checksum": "adler32:bf9cbd07",
-        "size": 2235,
+        "checksum": "adler32:3f3c1de8",
+        "size": 2487,
         "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_test_root_file_index.json"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNtupleProducerTool/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_test_root_file_index.json"
       },
       {
-        "checksum": "adler32:c6459b64",
-        "size": 1134,
+        "checksum": "adler32:1a0ffc36",
+        "size": 1386,
         "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_test_root_file_index.txt"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNtupleProducerTool/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/test/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_test_root_file_index.txt"
       },
       {
-        "checksum": "adler32:2d666f3e",
-        "size": 20254,
+        "checksum": "adler32:bbc2aa25",
+        "size": 22386,
         "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_train_h5_file_index.json"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNtupleProducerTool/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_train_h5_file_index.json"
       },
       {
-        "checksum": "adler32:5dbd74e3",
-        "size": 10331,
+        "checksum": "adler32:24aaafca",
+        "size": 12463,
         "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_train_h5_file_index.txt"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNtupleProducerTool/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_train_h5_file_index.txt"
       },
       {
-        "checksum": "adler32:930722bc",
-        "size": 20582,
+        "checksum": "adler32:a2eb950d",
+        "size": 22878,
         "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_train_root_file_index.json"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNtupleProducerTool/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_train_root_file_index.json"
       },
       {
-        "checksum": "adler32:c315d361",
-        "size": 10495,
+        "checksum": "adler32:3b6345c1",
+        "size": 12791,
         "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_train_root_file_index.txt"
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/HiggsToBBNtupleProducerTool/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC/train/file-indexes/HiggsToBBNTuple_HiggsToBB_QCD_RunII_13TeV_MC_train_root_file_index.txt"
       }
     ],
     "keywords": [


### PR DESCRIPTION
* Adds file indexes to CMS datascience samples. (closes #2671)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>