### PR TITLE
records: CMS RAW samples file indexes

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-Run1-datascience.json
@@ -471,11 +471,11 @@
     ],
     "date_published": "2019",
     "distribution": {
-      "files": 49261,
       "formats": [
         "root"
       ],
       "number_events": 9430509,
+      "number_files": 49261,
       "size": 46506200944051
     },
     "experiment": "CMS",

--- a/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2010B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2010B.json
@@ -29,9 +29,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2451242
+      "number_events": 2451242,
+      "number_files": 85,
+      "size": 295335424983
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:99f8a140",
+        "size": 23112,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/RAW/v1/file-indexes/CMS_Run2010B_MinimumBias_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:8586342e",
+        "size": 10625,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/MinimumBias/RAW/v1/file-indexes/CMS_Run2010B_MinimumBias_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -106,9 +122,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2102829
+      "number_events": 2102829,
+      "number_files": 84,
+      "size": 310522668777
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:408a336b",
+        "size": 22086,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/RAW/v1/file-indexes/CMS_Run2010B_Mu_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:39c6e3ea",
+        "size": 9744,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Mu/RAW/v1/file-indexes/CMS_Run2010B_Mu_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -183,9 +215,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2554874
+      "number_events": 2554874,
+      "number_files": 115,
+      "size": 411601895021
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:0ccc8ab2",
+        "size": 30918,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/RAW/v1/file-indexes/CMS_Run2010B_Electron_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:9eb407a5",
+        "size": 14030,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Electron/RAW/v1/file-indexes/CMS_Run2010B_Electron_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -260,9 +308,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2415753
+      "number_events": 2415753,
+      "number_files": 106,
+      "size": 379410532674
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:14092d6b",
+        "size": 27969,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/RAW/v1/file-indexes/CMS_Run2010B_Jet_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:8c4eebc6",
+        "size": 12402,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2010B/Jet/RAW/v1/file-indexes/CMS_Run2010B_Jet_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },

--- a/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2011A.json
@@ -123,9 +123,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2079006
+      "number_events": 2079006,
+      "number_files": 116,
+      "size": 422438600074
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:46dba423",
+        "size": 31200,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/RAW/v1/file-indexes/CMS_Run2011A_SingleMu_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:0cd40f35",
+        "size": 14152,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleMu/RAW/v1/file-indexes/CMS_Run2011A_SingleMu_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -200,9 +216,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2064298
+      "number_events": 2064298,
+      "number_files": 116,
+      "size": 424326093942
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:13aa23e7",
+        "size": 40066,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleElectron/RAW/v1/file-indexes/CMS_Run2011A_SingleElectron_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:e7ce9e73",
+        "size": 18688,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/SingleElectron/RAW/v1/file-indexes/CMS_Run2011A_SingleElectron_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -277,9 +309,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2035725
+      "number_events": 2035725,
+      "number_files": 173,
+      "size": 418956338594
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:bca0a8c6",
+        "size": 47451,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/RAW/v1/file-indexes/CMS_Run2011A_DoubleElectron_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:e9e592e5",
+        "size": 22144,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleElectron/RAW/v1/file-indexes/CMS_Run2011A_DoubleElectron_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -354,9 +402,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2070977
+      "number_events": 2070977,
+      "number_files": 119,
+      "size": 422439755939
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:6dcf680e",
+        "size": 32003,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/RAW/v1/file-indexes/CMS_Run2011A_DoubleMu_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:ce9a7538",
+        "size": 14518,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/DoubleMu/RAW/v1/file-indexes/CMS_Run2011A_DoubleMu_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -431,9 +495,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2177197
+      "number_events": 2177197,
+      "number_files": 139,
+      "size": 435693533888
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:1f31b64a",
+        "size": 36652,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Jet/RAW/v1/file-indexes/CMS_Run2011A_Jet_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:c40d2457",
+        "size": 16263,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2011A/Jet/RAW/v1/file-indexes/CMS_Run2011A_Jet_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },

--- a/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2012B.json
+++ b/cernopendata/modules/fixtures/data/records/cms-raw-datasets-Run2012B.json
@@ -29,9 +29,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2745751
+      "number_events": 2745751,
+      "number_files": 130,
+      "size": 307178605890
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:3f5a0c96",
+        "size": 35296,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MinimumBias/RAW/v1/file-indexes/CMS_Run2012B_MinimumBias_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:85bfa5d3",
+        "size": 16250,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/MinimumBias/RAW/v1/file-indexes/CMS_Run2012B_MinimumBias_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -106,9 +122,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2301668
+      "number_events": 2301668,
+      "number_files": 184,
+      "size": 673836637137
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:58b13bb6",
+        "size": 49468,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/RAW/v1/file-indexes/CMS_Run2012B_SingleMu_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:5d708833",
+        "size": 22448,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleMu/RAW/v1/file-indexes/CMS_Run2012B_SingleMu_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -183,9 +215,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2125485
+      "number_events": 2125485,
+      "number_files": 183,
+      "size": 632034645603
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:81abbb01",
+        "size": 50265,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/RAW/v1/file-indexes/CMS_Run2012B_SingleElectron_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:d6062abb",
+        "size": 23424,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/SingleElectron/RAW/v1/file-indexes/CMS_Run2012B_SingleElectron_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -260,9 +308,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2060895
+      "number_events": 2060895,
+      "number_files": 187,
+      "size": 687127607994
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:39a0cff4",
+        "size": 51385,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/RAW/v1/file-indexes/CMS_Run2012B_DoubleElectron_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:265db9d1",
+        "size": 23936,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleElectron/RAW/v1/file-indexes/CMS_Run2012B_DoubleElectron_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -337,9 +401,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2047989
+      "number_events": 2047989,
+      "number_files": 222,
+      "size": 704415160754
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:537f91ea",
+        "size": 60904,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/RAW/v1/file-indexes/CMS_Run2012B_DoubleMuParked_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:9499d487",
+        "size": 28416,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/DoubleMuParked/RAW/v1/file-indexes/CMS_Run2012B_DoubleMuParked_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },
@@ -414,9 +494,25 @@
         "root",
         "raw"
       ],
-      "number_events": 2096284
+      "number_events": 2096284,
+      "number_files": 248,
+      "size": 787916902647
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:34594f65",
+        "size": 65861,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/RAW/v1/file-indexes/CMS_Run2012B_JetHT_RAW_v1_000_file_index.json"
+      },
+      {
+        "checksum": "adler32:d17f103a",
+        "size": 29512,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/Run2012B/JetHT/RAW/v1/file-indexes/CMS_Run2012B_JetHT_RAW_v1_000_file_index.txt"
+      }
+    ],
     "license": {
       "attribution": "CC0"
     },


### PR DESCRIPTION
* Adds file indexes for all CMS RAW samples. (addresses #2439)

* Fixes number of events information for CMS Run1 data science derived dataset.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
