### PR TITLE
templates: fix display of pileup links

### DIFF
--- a/cernopendata/templates/cernopendata_records_ui/records/macros/links.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/macros/links.html
@@ -1,23 +1,31 @@
 {% macro link_list(links) %}
 <p>
-    {% for link in links %}
-        {% if link.title %}
-         <a href="{{link.url}}">{{link.title}}</a><br>
-        {% elif link.url %}
-        <p>
-            <a href="{{link.url}}">
-                {% if link.description %}
-                 {{link.description}}
-                {% else %}
-                 {{link.url}}
-                {% endif %}
-            </a>
-        </p>
-        {% elif link.recid %}
-        <p>
-            <a href="/record/{{link.recid}}">{{link.recid | get_record_title}}</a>
-        </p>
+  {% for link in links %}
+    {% if link.url %}
+    <p>
+      <a href="{{link.url}}">
+        {% if link.description %}
+        {{link.description}}
+        {% elif link.title %}
+        {{link.title}}
+        {% else %}
+        {{link.url}}
         {% endif %}
-    {% endfor %}
+      </a>
+    </p>
+    {% elif link.recid %}
+    <p>
+      <a href="/record/{{link.recid}}">
+        {% if link.description %}
+        {{link.description}}
+        {% elif link.title %}
+        {{link.title}}
+        {% else %}
+        {{get_record_title}}
+        {% endif %}
+      </a>
+    </p>
+    {% endif %}
+  {% endfor %}
 </p>
 {% endmacro %}


### PR DESCRIPTION
* Fixes display of pileup links and other related lists using ``recid`` for
  linking. (closes #2616)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>