### PR TITLE
records: CMS Run1 datascience file index fixes

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-derived-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-derived-Run1-datascience.json
@@ -475,23 +475,11 @@
         "root"
       ],
       "number_events": 9430509,
-      "number_files": 49261,
-      "size": 46506200944051
+      "number_files": 14825,
+      "size": 12827058597346
     },
     "experiment": "CMS",
     "files": [
-      {
-        "checksum": "adler32:086d958e",
-        "size": 1358722,
-        "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD300to600_RunI_8TeV/file-indexes/QCD300to600_RunI_8TeV_step2_QCD300to600_root_file_index.json"
-      },
-      {
-        "checksum": "adler32:038de28f",
-        "size": 729416,
-        "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD300to600_RunI_8TeV/file-indexes/QCD300to600_RunI_8TeV_step2_QCD300to600_root_file_index.txt"
-      },
       {
         "checksum": "adler32:bcfd6024",
         "size": 681411,
@@ -503,18 +491,6 @@
         "size": 366912,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD300to600_RunI_8TeV/file-indexes/QCD300to600_RunI_8TeV_step3_QCD300to600_root_file_index.txt"
-      },
-      {
-        "checksum": "adler32:9a1b6a98",
-        "size": 901683,
-        "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD400to600_RunI_8TeV/file-indexes/QCD400to600_RunI_8TeV_step2_QCD400to600_root_file_index.json"
-      },
-      {
-        "checksum": "adler32:eb1f842e",
-        "size": 483990,
-        "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD400to600_RunI_8TeV/file-indexes/QCD400to600_RunI_8TeV_step2_QCD400to600_root_file_index.txt"
       },
       {
         "checksum": "adler32:f81225b4",
@@ -529,30 +505,6 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD400to600_RunI_8TeV/file-indexes/QCD400to600_RunI_8TeV_step3_QCD400to600_root_file_index.txt"
       },
       {
-        "checksum": "adler32:52f65fcb",
-        "size": 1524800,
-        "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step2_QCD_600to3000_01_root_file_index.json"
-      },
-      {
-        "checksum": "adler32:9a783075",
-        "size": 827178,
-        "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step2_QCD_600to3000_01_root_file_index.txt"
-      },
-      {
-        "checksum": "adler32:c81f96b5",
-        "size": 1507052,
-        "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step2_QCD_600to3000_02_root_file_index.json"
-      },
-      {
-        "checksum": "adler32:3ade96f1",
-        "size": 817550,
-        "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step2_QCD_600to3000_02_root_file_index.txt"
-      },
-      {
         "checksum": "adler32:da23101e",
         "size": 1363728,
         "type": "index.json",
@@ -563,66 +515,6 @@
         "size": 738891,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step3_QCD600to3000_root_file_index.txt"
-      },
-      {
-        "checksum": "adler32:2031f3d9",
-        "size": 870939,
-        "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_01_root_file_index.json"
-      },
-      {
-        "checksum": "adler32:44dc434c",
-        "size": 458561,
-        "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_01_root_file_index.txt"
-      },
-      {
-        "checksum": "adler32:6ea4cc1a",
-        "size": 817083,
-        "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_02_root_file_index.json"
-      },
-      {
-        "checksum": "adler32:4134eaa2",
-        "size": 430205,
-        "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_02_root_file_index.txt"
-      },
-      {
-        "checksum": "adler32:168977d6",
-        "size": 877803,
-        "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_03_root_file_index.json"
-      },
-      {
-        "checksum": "adler32:c24682ec",
-        "size": 462175,
-        "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_03_root_file_index.txt"
-      },
-      {
-        "checksum": "adler32:f1e2bcae",
-        "size": 864075,
-        "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_04_root_file_index.json"
-      },
-      {
-        "checksum": "adler32:5d404345",
-        "size": 454947,
-        "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_04_root_file_index.txt"
-      },
-      {
-        "checksum": "adler32:5fbcf729",
-        "size": 851403,
-        "type": "index.json",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_05_root_file_index.json"
-      },
-      {
-        "checksum": "adler32:c249ce18",
-        "size": 448275,
-        "type": "index.txt",
-        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_05_root_file_index.txt"
       },
       {
         "checksum": "adler32:a8b2ebf6",

--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run1-datascience.json
@@ -32,12 +32,73 @@
         "aodsim",
         "root"
       ],
-      "number_events": 1497600,
-      "number_files": 2496,
-      "size": 0
+      "number_events": 2969109,
+      "number_files": 16217,
+      "size": 10932264112116
     },
     "experiment": "CMS",
-    "files": [],
+    "files": [
+      {
+        "checksum": "adler32:2031f3d9",
+        "size": 870939,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_01_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:44dc434c",
+        "size": 458561,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_01_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:6ea4cc1a",
+        "size": 817083,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_02_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:4134eaa2",
+        "size": 430205,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_02_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:168977d6",
+        "size": 877803,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_03_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:c24682ec",
+        "size": 462175,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_03_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:f1e2bcae",
+        "size": 864075,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_04_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:5d404345",
+        "size": 454947,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_04_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:5fbcf729",
+        "size": 851403,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_05_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:c249ce18",
+        "size": 448275,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/ttbar_RunI_8TeV/file-indexes/ttbar_RunI_8TeV_step2_ttbarOD_05_root_file_index.txt"
+      }
+  ],
     "generator": {
       "global_tag": "",
       "names": []
@@ -165,12 +226,25 @@
         "aodsim",
         "root"
       ],
-      "number_events": 1989000,
-      "number_files": 3315,
-      "size": 0
+      "number_events": 1498800,
+      "number_files": 4996,
+      "size": 5139966009955
     },
     "experiment": "CMS",
-    "files": [],
+    "files": [
+      {
+        "checksum": "adler32:086d958e",
+        "size": 1358722,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD300to600_RunI_8TeV/file-indexes/QCD300to600_RunI_8TeV_step2_QCD300to600_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:038de28f",
+        "size": 729416,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD300to600_RunI_8TeV/file-indexes/QCD300to600_RunI_8TeV_step2_QCD300to600_root_file_index.txt"
+      }
+    ],
     "generator": {
       "global_tag": "",
       "names": []
@@ -298,12 +372,25 @@
         "aodsim",
         "root"
       ],
-      "number_events": 2974800,
-      "number_files": 4959,
-      "size": 0
+      "number_events": 1989000,
+      "number_files": 3315,
+      "size": 6918537867180
     },
     "experiment": "CMS",
-    "files": [],
+    "files": [
+      {
+        "checksum": "adler32:9a1b6a98",
+        "size": 901683,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD400to600_RunI_8TeV/file-indexes/QCD400to600_RunI_8TeV_step2_QCD400to600_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:eb1f842e",
+        "size": 483990,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD400to600_RunI_8TeV/file-indexes/QCD400to600_RunI_8TeV_step2_QCD400to600_root_file_index.txt"
+      }
+    ],
     "generator": {
       "global_tag": "",
       "names": []
@@ -431,12 +518,37 @@
         "aodsim",
         "root"
       ],
-      "number_events": 2969109,
-      "number_files": 4055,
-      "size": 0
+      "number_events": 2975400,
+      "number_files": 9908,
+      "size": 10688374357454
     },
     "experiment": "CMS",
-    "files": [],
+    "files": [
+      {
+        "checksum": "adler32:52f65fcb",
+        "size": 1524800,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step2_QCD_600to3000_01_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:9a783075",
+        "size": 827178,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step2_QCD_600to3000_01_root_file_index.txt"
+      },
+      {
+        "checksum": "adler32:c81f96b5",
+        "size": 1507052,
+        "type": "index.json",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step2_QCD_600to3000_02_root_file_index.json"
+      },
+      {
+        "checksum": "adler32:3ade96f1",
+        "size": 817550,
+        "type": "index.txt",
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/datascience/TrackerRecHitProducerTool/QCD600to3000_RunI_8TeV/file-indexes/QCD600to3000_RunI_8TeV_step2_QCD_600to3000_02_root_file_index.txt"
+      }
+    ],
     "generator": {
       "global_tag": "",
       "names": []


### PR DESCRIPTION
* Fixes CMS Run1 datascience records to split file indexes to given datasets.
  Fixes number of events in each dataset. (addresses #2575)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>