### PR TITLE
templates: CMS MC configuration file links

### DIFF
--- a/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/record_detail.html
@@ -251,7 +251,10 @@
                     {% if conf_file.get('recid') %}
                         <a href="{{ url_for('invenio_records_ui.recid', pid_value=conf_file.recid ) }}"> (link)</a>
                     {% endif %}
-                    <br>
+                    {% if conf_file.get('cms_confdb_id') %}
+                        <a href="/eos/opendata/cms/configuration-files/MonteCarlo{{record.get('date_created', [''])[0]}}/{{conf_file.get('cms_confdb_id')}}.configFile.py"> (link)</a>
+                    {% endif %}
+                   <br>
                 {% endfor %}
                 {% if step.get("output_dataset") %}
                     Output dataset: {{ step.output_dataset }}<br>


### PR DESCRIPTION
* In CMS MC provenance block, link to CMS configuration files if we know CMS
  ConfDB ID.  (closes #2642)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>