### PR TITLE
records: adds files to commissioning validated runs

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-validated-runs-Commissioning2010-castor.json
+++ b/cernopendata/modules/fixtures/data/records/cms-validated-runs-Commissioning2010-castor.json
@@ -18,10 +18,19 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "txt"
-      ]
+        "json"
+      ],
+      "number_files": 1,
+      "size": 125
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:8e7b1ad8",
+        "size": 125,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/Commissioning10/Commissioning10-May19ReReco_900GeV.json"
+      }
+    ],
     "publisher": "CERN Open Data Portal",
     "recid": "14200",
     "run_period": [
@@ -75,10 +84,19 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "txt"
-      ]
+        "json"
+      ],
+      "number_files": 1,
+      "size": 609
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:8bd78053",
+        "size": 609,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/validated-runs/Commissioning10/Commissioning10-May19ReReco_900GeV.json"
+      }
+    ],
     "publisher": "CERN Open Data Portal",
     "recid": "14201",
     "run_period": [


### PR DESCRIPTION
(closes #2608)

Adds files and file sizes to Commissioning validated run records

