### PR TITLE
docs: add a non-md short_description to docker guide

### DIFF
--- a/cernopendata/modules/fixtures/data/docs/cms-guide-docker/cms-guide-docker.json
+++ b/cernopendata/modules/fixtures/data/docs/cms-guide-docker/cms-guide-docker.json
@@ -13,8 +13,8 @@
       }
     ],
     "experiment": "CMS",
-    "short description": {
-      "content": ""
+    "short_description": {
+      "content": "As an alternative to using a virtual machine, you can run CMS analysis code in a Docker container. If you have not already installed Docker..."
     },
     "slug": "cms-guide-docker",
       "tags": [


### PR DESCRIPTION
(closes #2695)

Add text to be shown in the search view without md

