### PR TITLE
templates: fix for recid-based link label

### DIFF
--- a/cernopendata/templates/cernopendata_records_ui/records/macros/links.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/macros/links.html
@@ -21,7 +21,7 @@
         {% elif link.title %}
         {{link.title}}
         {% else %}
-        {{get_record_title}}
+        {{link.recid | get_record_title}}
         {% endif %}
       </a>
     </p>


### PR DESCRIPTION
* Fixes link label for references linked via recids only. (addresses #2616)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>