### PR TITLE
records: add files to SW records

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-tools-Phase2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-Phase2-datascience.json
@@ -27,11 +27,19 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "gz"
+        "zip"
       ],
-      "number_files": 1
+      "number_files": 1,
+      "size": 11627574
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:ae560687",
+        "size": 11627574,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/CNNPixelSeedsProducerTool/CNNPixelSeedsProducerTool-1.0.zip"
+      }
+    ],
     "keywords": [
       "datascience"
     ],
@@ -63,7 +71,7 @@
       ]
     },
     "usage": {
-      "description": " <p>If you do not have the CERN Virtual Machine for CMS open data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2011\">How to install a CERN Virtual Machine</a>.  <p>To run the analysis, follow the instructions in <a href=\"https://github.com/cms-legacydata-analyses/CNNPixelSeedsProducerTool\">CNNPixelSeedsProducerTool documentation on Github</a>.</p>"
+      "description": " <p>If you do not have the CERN Virtual Machine for CMS open data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2011\">How to install a CERN Virtual Machine</a>.  <p>To run the analysis, follow the instructions in <a href=\"https://github.com/cms-opendata-analyses/CNNPixelSeedsProducerTool\">CNNPixelSeedsProducerTool documentation on Github</a>.</p>"
     },
     "use_with": {
       "description": "Use this with:",

--- a/cernopendata/modules/fixtures/data/records/cms-tools-Run1-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-Run1-datascience.json
@@ -33,7 +33,27 @@
       "2019"
     ],
     "date_published": "2019",
+    "distribution": {
+      "formats": [
+        "png",
+        "zip"
+      ],
+      "number_files": 2,
+      "size": 1153192
+    },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:55ee172d",
+        "size": 515026,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/TrackerRecHitProducerTool/TrackerRecHitProducerTool-12.0.0.zip"
+      },
+      {
+        "checksum": "adler32:82805097",
+        "size": 638166,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/TrackerRecHitProducerTool/production-workflow.png"
+      }
+    ],
     "keywords": [
       "datascience"
     ],
@@ -42,9 +62,6 @@
     },
     "publisher": "CERN Open Data Portal",
     "recid": "12210",
-    "run_period": [
-      "Run1"
-    ],
     "relations": [
       {
         "description": "The tracker-hit-enriched AODSIM files produced by step 2 of this software tool are available in",
@@ -56,11 +73,11 @@
         "type": "isRelatedTo"
       },
       {
-        "recid":   "12202",
+        "recid": "12202",
         "type": "isRelatedTo"
       },
       {
-        "recid":   "12203",
+        "recid": "12203",
         "type": "isRelatedTo"
       },
       {
@@ -68,6 +85,9 @@
         "recid": "12220",
         "type": "isRelatedTo"
       }
+    ],
+    "run_period": [
+      "Run1"
     ],
     "system_details": {
       "description": "Use this code with the CMS Open Data VM environment",
@@ -82,7 +102,7 @@
       ]
     },
     "usage": {
-      "description": " <p>If you do not have the CERN Virtual Machine for CMS open data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2011\">How to install a CERN Virtual Machine</a>.  <p>To run this workflow, follow the instructions in <a href=\"https://github.com/cms-legacydata-analyses/TrackerRecHitProducerTool\">TrackerRecHitProducerTool GitHub documentation</a>.</p> "
+      "description": " <p>If you do not have the CERN Virtual Machine for CMS open data installed, follow the instructions in step 1 at <a href=\"/VM/CMS/2011\">How to install a CERN Virtual Machine</a>.  <p>To run this workflow, follow the instructions in <a href=\"https://github.com/cms-opendata-analyses/TrackerRecHitProducerTool\">TrackerRecHitProducerTool GitHub documentation</a>.</p> "
     },
     "use_with": {
       "description": "The ROOT ntuple production step (step3) can be run independently using these Run1 tracker-hit-enriched AODSIM datasets:",

--- a/cernopendata/modules/fixtures/data/records/cms-tools-Run2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-Run2-datascience.json
@@ -17,7 +17,21 @@
       "2019"
     ],
     "date_published": "2019",
+    "distribution": {
+      "formats": [
+        "zip"
+      ],
+      "number_files": 1,
+      "size": 858332
+    },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:23625e68",
+        "size": 858332,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/JetNtupleProducerTool/JetNtupleProducerTool-1.0.zip"
+      }
+    ],
     "keywords": [
       "datascience"
     ],
@@ -100,7 +114,21 @@
       "2019"
     ],
     "date_published": "2019",
+    "distribution": {
+      "formats": [
+        "zip"
+      ],
+      "number_files": 1,
+      "size": 89741
+    },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:a7d6e7ee",
+        "size": 89741,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/HiggsToBBNtupleProducerTool/HiggsToBBNtupleProducerTool-1.0.1.zip"
+      }
+    ],
     "keywords": [
       "datascience"
     ],

--- a/cernopendata/modules/fixtures/data/records/cms-tools-eventproduction-examples.json
+++ b/cernopendata/modules/fixtures/data/records/cms-tools-eventproduction-examples.json
@@ -21,11 +21,20 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "gz"
+        "zip"
       ],
-      "number_files": 1
+      "number_files": 1,
+      "size": 12406566
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:db263a27",
+        "filename": "EventProductionExamplesTool-10.0.0.zip",
+        "size": 12406566,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/EventProductionExamplesTool/EventProductionExamplesTool-10.0.0.zip"
+      }
+    ],
     "license": {
       "attribution": "GNU General Public License (GPL) version 3"
     },
@@ -72,11 +81,20 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "gz"
+        "zip"
       ],
-      "number_files": 1
+      "number_files": 1,
+      "size": 34936658
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:9c532bd1",
+        "filename": "EventProductionExamplesTool-11.0.0.zip",
+        "size": 34936658,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/EventProductionExamplesTool/EventProductionExamplesTool-11.0.0.zip"
+      }
+    ],
     "license": {
       "attribution": "GNU General Public License (GPL) version 3"
     },
@@ -126,11 +144,20 @@
     "date_published": "2019",
     "distribution": {
       "formats": [
-        "gz"
+        "zip"
       ],
-      "number_files": 1
+      "number_files": 1,
+      "size": 26195628
     },
     "experiment": "CMS",
+    "files": [
+      {
+        "checksum": "adler32:47a107f7",
+        "filename": "EventProductionExamplesTool-12.0.0.zip",
+        "size": 26195628,
+        "uri": "root://eospublic.cern.ch//eos/opendata/cms/software/EventProductionExamplesTool/EventProductionExamplesTool-12.0.0.zip"
+      }
+    ],
     "license": {
       "attribution": "GNU General Public License (GPL) version 3"
     },


### PR DESCRIPTION

(closes #2344)
(closes #2588 )
(closes #2585)
(closes #2589)

Adds` files` and `distribution` to SW tools
- 3 EventProductionExamplesTool records
- 1 Run1 datascience record
- 2 Run2 datascience record
- 1 Phase datascience record

Fixes the github link in `usage` for 2 records
