### PR TITLE
templates: larger file index modal window

### DIFF
--- a/cernopendata/templates/cernopendata_records_ui/records/detail.html
+++ b/cernopendata/templates/cernopendata_records_ui/records/detail.html
@@ -388,6 +388,7 @@ recordApp.controller(
           controller: 'indexFileListModalInstanceCtrl',
           controllerAs: '$ctrl',
           windowClass: 'index-file-list-modal',
+          size: 'lg',
           resolve: {
             $http: function() {
               return $http;


### PR DESCRIPTION
* Makes file index modal window larger, fixing display problems for files with
  long filenames. (closes #2572)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>