### PR TITLE
records: CMS MC file size and checksum fixes

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2-datascience.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2-datascience.json
@@ -38,9 +38,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:0e35a49d",
+        "checksum": "adler32:aa65acfd",
         "description": "BulkGravTohhTohbbhbb_narrow_M-600_13TeV-madgraphMINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 6651,
+        "size": 6718,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-600_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-600_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1_60000_file_index.json"
       },
@@ -192,9 +192,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:99c03e61",
+        "checksum": "adler32:ebb74ac1",
         "description": "BulkGravTohhTohbbhbb_narrow_M-1000_13TeV-madgraphMINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 9797,
+        "size": 9896,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-1000_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-1000_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1_60000_file_index.json"
       },
@@ -346,9 +346,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:f55de3fb",
+        "checksum": "adler32:eb6be4db",
         "description": "BulkGravTohhTohbbhbb_narrow_M-1200_13TeV-madgraphMINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 778,
+        "size": 785,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-1200_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-1200_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_60000_file_index.json"
       },
@@ -513,9 +513,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:29747223",
+        "checksum": "adler32:de447283",
         "description": "BulkGravTohhTohbbhbb_narrow_M-1400_13TeV-madgraphMINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 391,
+        "size": 394,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-1400_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-1400_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_80000_file_index.json"
       },
@@ -680,9 +680,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:c834e436",
+        "checksum": "adler32:be51e516",
         "description": "BulkGravTohhTohbbhbb_narrow_M-1600_13TeV-madgraphMINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 778,
+        "size": 785,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-1600_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-1600_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_70000_file_index.json"
       },
@@ -847,16 +847,16 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:8ae971b5",
+        "checksum": "adler32:3dfd7215",
         "description": "BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraphMINIAODSIM dataset file index (1 of 2) for access to data via CMS virtual machine",
-        "size": 391,
+        "size": 394,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_120000_file_index.json"
       },
       {
-        "checksum": "adler32:dc5ce3fd",
+        "checksum": "adler32:d028e4dd",
         "description": "BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraphMINIAODSIM dataset file index (2 of 2) for access to data via CMS virtual machine",
-        "size": 778,
+        "size": 785,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-1800_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_70000_file_index.json"
       },
@@ -1028,9 +1028,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:81e4e474",
+        "checksum": "adler32:79bbe554",
         "description": "BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraphMINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 778,
+        "size": 785,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_70000_file_index.json"
       },
@@ -1195,9 +1195,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:2d9b8714",
+        "checksum": "adler32:19a19a74",
         "description": "BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraphMINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 15284,
+        "size": 15439,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-2000_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1_70000_file_index.json"
       },
@@ -1349,9 +1349,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:3934e490",
+        "checksum": "adler32:306de570",
         "description": "BulkGravTohhTohbbhbb_narrow_M-2500_13TeV-madgraphMINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 778,
+        "size": 785,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-2500_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-2500_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_80000_file_index.json"
       },
@@ -1516,9 +1516,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:7b1df0e1",
+        "checksum": "adler32:23da0050",
         "description": "BulkGravTohhTohbbhbb_narrow_M-3000_13TeV-madgraphMINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 12152,
+        "size": 12275,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-3000_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-3000_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6_ext1-v1_70000_file_index.json"
       },
@@ -1670,9 +1670,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:1449e455",
+        "checksum": "adler32:0a31e535",
         "description": "BulkGravTohhTohbbhbb_narrow_M-4000_13TeV-madgraphMINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 779,
+        "size": 786,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-4000_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-4000_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_70000_file_index.json"
       },
@@ -1837,9 +1837,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:ce4ee40b",
+        "checksum": "adler32:c0fee4eb",
         "description": "BulkGravTohhTohbbhbb_narrow_M-4500_13TeV-madgraphMINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 778,
+        "size": 785,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/BulkGravTohhTohbbhbb_narrow_M-4500_13TeV-madgraph/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_BulkGravTohhTohbbhbb_narrow_M-4500_13TeV-madgraph_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_70000_file_index.json"
       },
@@ -2004,9 +2004,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:b1faf352",
+        "checksum": "adler32:dfec1641",
         "description": "QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8MINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 26671,
+        "size": 26950,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt_300to470_TuneCUETP8M1_13TeV_pythia8_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_80000_file_index.json"
       },
@@ -2164,9 +2164,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:43fa9392",
+        "checksum": "adler32:d7b1aef2",
         "description": "QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8MINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 20958,
+        "size": 21177,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt_470to600_TuneCUETP8M1_13TeV_pythia8_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_60000_file_index.json"
       },
@@ -2324,9 +2324,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:12ac155f",
+        "checksum": "adler32:4bc43abf",
         "description": "QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8MINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 28568,
+        "size": 28867,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt_600to800_TuneCUETP8M1_13TeV_pythia8_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_70000_file_index.json"
       },
@@ -2484,9 +2484,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:e77a3738",
+        "checksum": "adler32:7a0f5598",
         "description": "QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8MINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 23364,
+        "size": 23607,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt_800to1000_TuneCUETP8M1_13TeV_pythia8_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_120000_file_index.json"
       },
@@ -2644,9 +2644,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:3f690ad2",
+        "checksum": "adler32:246e26b2",
         "description": "QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8MINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 21451,
+        "size": 21674,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt_1000to1400_TuneCUETP8M1_13TeV_pythia8_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_80000_file_index.json"
       },
@@ -2804,9 +2804,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:036802a3",
+        "checksum": "adler32:e5eb0603",
         "description": "QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8MINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 2690,
+        "size": 2717,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt_1400to1800_TuneCUETP8M1_13TeV_pythia8_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_110000_file_index.json"
       },
@@ -2964,9 +2964,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:aec00117",
+        "checksum": "adler32:7e9c0477",
         "description": "QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8MINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 2684,
+        "size": 2711,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt_1800to2400_TuneCUETP8M1_13TeV_pythia8_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_70000_file_index.json"
       },
@@ -3124,9 +3124,9 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:f250df45",
+        "checksum": "adler32:7440e3a5",
         "description": "QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8MINIAODSIM dataset file index (1 of 1) for access to data via CMS virtual machine",
-        "size": 3457,
+        "size": 3492,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt_2400to3200_TuneCUETP8M1_13TeV_pythia8_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_110000_file_index.json"
       },
@@ -3284,16 +3284,16 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:bafb0c99",
+        "checksum": "adler32:612f16f9",
         "description": "QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8MINIAODSIM dataset file index (1 of 2) for access to data via CMS virtual machine",
-        "size": 8011,
+        "size": 8094,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3_60000_file_index.json"
       },
       {
-        "checksum": "adler32:5625dcb6",
+        "checksum": "adler32:34aadd96",
         "description": "QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8MINIAODSIM dataset file index (2 of 2) for access to data via CMS virtual machine",
-        "size": 765,
+        "size": 772,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt_3200toInf_TuneCUETP8M1_13TeV_pythia8_MINIAODSIM_PUMoriond17_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v3_80000_file_index.json"
       },
@@ -3442,23 +3442,23 @@
     "experiment": "CMS",
     "files": [
       {
-        "checksum": "adler32:cd503717",
+        "checksum": "adler32:34dd3ef7",
         "description": "QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8MINIAODSIM dataset file index (1 of 3) for access to data via CMS virtual machine",
-        "size": 6337,
+        "size": 6400,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/MINIAODSIM/PUMoriond17_magnetOn_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8_MINIAODSIM_PUMoriond17_magnetOn_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_100000_file_index.json"
       },
       {
-        "checksum": "adler32:3634f306",
+        "checksum": "adler32:16b71675",
         "description": "QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8MINIAODSIM dataset file index (2 of 3) for access to data via CMS virtual machine",
-        "size": 28118,
+        "size": 28401,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/MINIAODSIM/PUMoriond17_magnetOn_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8_MINIAODSIM_PUMoriond17_magnetOn_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_110000_file_index.json"
       },
       {
-        "checksum": "adler32:d441b873",
+        "checksum": "adler32:ddbec9d3",
         "description": "QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8MINIAODSIM dataset file index (3 of 3) for access to data via CMS virtual machine",
-        "size": 13823,
+        "size": 13962,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2016/RunIISummer16MiniAODv2/QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8/MINIAODSIM/PUMoriond17_magnetOn_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1/file-indexes/CMS_MonteCarlo2016_RunIISummer16MiniAODv2_QCD_Pt-15to7000_TuneCUETP8M1_Flat_13TeV_pythia8_MINIAODSIM_PUMoriond17_magnetOn_80X_mcRun2_asymptotic_2016_TrancheIV_v6-v1_80000_file_index.json"
       },


### PR DESCRIPTION
* Fixes incorrect file sizes and checksums for CMS MC datasets that were added
  in 524cf69a8 and 9063ee1e7. The incorrect file sizes made the file index
  download to be terminated prematurely, causing troubles in "List of files"
  display facility. (closes #2689)

* Checked complete ALICE, ATLAS, CMS, LHCb fixtures for rich index files to
  ensure there are no other similar troubles of this kind.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>
