### PR TITLE
records: CMS 2011 MC WJetsToLNu missing file fix

### DIFF
--- a/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
+++ b/cernopendata/modules/fixtures/data/records/cms-simulated-datasets-Run2011A.json
@@ -53543,14 +53543,14 @@
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WJetsToLNu_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WJetsToLNu_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_00000_file_index.txt"
       },
       {
-        "checksum": "adler32:240d429c",
-        "size": 334332,
+        "checksum": "adler32:01f99f8e",
+        "size": 334667,
         "type": "index.json",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WJetsToLNu_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WJetsToLNu_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_00001_file_index.json"
       },
       {
-        "checksum": "adler32:0ede878b",
-        "size": 187624,
+        "checksum": "adler32:aa21c22e",
+        "size": 187812,
         "type": "index.txt",
         "uri": "root://eospublic.cern.ch//eos/opendata/cms/MonteCarlo2011/Summer11LegDR/WJetsToLNu_TuneZ2_7TeV-madgraph-tauola/AODSIM/PU_S13_START53_LV6-v1/file-indexes/CMS_MonteCarlo2011_Summer11LegDR_WJetsToLNu_TuneZ2_7TeV-madgraph-tauola_AODSIM_PU_S13_START53_LV6-v1_00001_file_index.txt"
       },


### PR DESCRIPTION
* Amends record fixtures after recovering missing file for CMS 2011 MC
  WJetsToLNu dataset. (closes #2531)

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>